### PR TITLE
BUG FIX #133 docrep version

### DIFF
--- a/.ci/env/scpy3.7.yml
+++ b/.ci/env/scpy3.7.yml
@@ -26,7 +26,7 @@ dependencies:
   - requests
   - jinja2
   - nmrglue
-  - docrep
+  - docrep=0.2.7
   - orderedset
   - traittypes
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - requests
     - jinja2
     - nmrglue
-    - docrep
+    - docrep = 0.2.7
     - orderedset
     - traittypes
     - xlrd

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - requests
     - jinja2
     - nmrglue
-    - docrep = 0.2.7
+    - docrep 0.2.7
     - orderedset
     - traittypes
     - xlrd

--- a/env/scpy-dev.yml
+++ b/env/scpy-dev.yml
@@ -25,7 +25,7 @@ dependencies:
   - requests
   - jinja2
   - nmrglue
-  - docrep
+  - docrep=0.2.7
   - orderedset
   - traittypes
 

--- a/env/scpy.yml
+++ b/env/scpy.yml
@@ -25,7 +25,7 @@ dependencies:
   - requests
   - jinja2
   - nmrglue
-  - docrep
+  - docrep=0.2.7
   - orderedset
   - traittypes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ brukeropusreader
 requests
 jinja2
 nmrglue
-docrep
+docrep==0.2.7
 orderedset
 traittypes
 


### PR DESCRIPTION
this provisionally fixs docrep version to 0.2.7, until the docstring
related code is modified within spectrochempy