### PR TITLE
Documented more .spa header keys.

### DIFF
--- a/spectrochempy/core/readers/readomnic.py
+++ b/spectrochempy/core/readers/readomnic.py
@@ -813,10 +813,12 @@ def _read_spa(*args, **kwargs):
     #     key: hex 03, dec  03: intensity position
     #     key: hex 04, dec  04: user text position
     #     key: hex 1B, dec  27: position of History text
+    #     key: hex 66  dec 102: sample inferogram
+    #     key: hex 67  dec 103: background inferogram
     #     key: hex 69, dec 105: ?
     #     key: hex 6a, dec 106: ?
     #     key: hex 80, dec 128: ?
-    #     key: hex 82, dec 130: ?
+    #     key: hex 82, dec 130: rotation angle
 
     gotinfos = [False, False, False]  # spectral header, intensity, history
     # scan "key values"


### PR DESCRIPTION
This is what we figured out so far. Inferograms are similar to absorbance data:
```java
int start;
int size;
skipBytes(8);
int end ;
seek(start);
int signals = size / 4;
rawSignals = new double[signals];
```

Rotation angle is:
```java
skipBytes(1);
double rotationAngle = read2BUIntegerLE();
```