### PR TITLE
FIX: the order of multicoordinates for a single dimension

### DIFF
--- a/spectrochempy/core/dataset/coordset.py
+++ b/spectrochempy/core/dataset/coordset.py
@@ -180,7 +180,7 @@ class CoordSet(HasTraits):
                 # coords follow the order of dims.
                 if not isinstance(coord, CoordSet):
                     if isinstance(coord, list):
-                        coord = CoordSet(*coord, sorted=False)
+                        coord = CoordSet(*coord[::-1], sorted=False)
                     elif not isinstance(coord, LinearCoord):  # else
                         coord = Coord(coord, copy=True)
                 else:

--- a/tests/test_dataset/test_ndcoordset.py
+++ b/tests/test_dataset/test_ndcoordset.py
@@ -135,7 +135,7 @@ def test_coordset_multicoord_for_a_single_dim():
     )
 
     # pass as a list of coord -> this become a subcoordset
-    coordsa = CoordSet([coord1, coord0])
+    coordsa = CoordSet([coord0, coord1])
     assert (
         repr(coordsa) == "CoordSet: [x:[_1:temperature, _2:wavelengths]]"
     )  # note the internal coordinates are not sorted


### PR DESCRIPTION
the order of multicoordinates for a single dimension was changed
after fixing issue #310.