### PR TITLE
FIX issue #360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * TQDM progress bar
 
+* Issue #360 : write a dataset with a specified filename do not open a dialog except if the file already exists.
+
 ## Version 0.3.1
 
 **NEW FEATURES**

--- a/spectrochempy/utils/file.py
+++ b/spectrochempy/utils/file.py
@@ -591,14 +591,17 @@ def get_directory_name(directory, **kwargs):
 
 # ..............................................................................
 def check_filename_to_save(
-    dataset, filename=None, save_as=True, confirm=True, **kwargs
+    dataset, filename=None, save_as=False, confirm=True, **kwargs
 ):
 
     from spectrochempy import NO_DIALOG
 
     NODIAL = NO_DIALOG or "DOC_BUILDING" in environ
 
-    if not filename or save_as:
+    if filename and pathclean(filename).parent.resolve() == Path.cwd():
+        filename = Path.cwd() / filename
+
+    if not filename or save_as or filename.exists():
 
         # no filename provided
         if filename is None or (NODIAL and pathclean(filename).is_dir()):
@@ -618,9 +621,6 @@ def check_filename_to_save(
             if filename is None:
                 # this is probably due to a cancel action for an open dialog.
                 return
-
-    if pathclean(filename).parent.resolve() == Path.cwd():
-        return Path.cwd() / filename
 
     return pathclean(filename)
 

--- a/tests/test_core/test_writers/test_exporter.py
+++ b/tests/test_core/test_writers/test_exporter.py
@@ -23,8 +23,15 @@ def test_write():
         scp.write()
 
     # the simplest way to save a dataset, is to use the function write with a filename as argument
-    filename = nd.write("essai.scp")
+    if (cwd / "essai.scp").exists():
+        (cwd / "essai.scp").unlink()
+
+    filename = nd.write("essai.scp")  # should not open a DIALOG
     assert filename == cwd / "essai.scp"
+    assert filename.exists()
+
+    # try to write it again
+    filename = nd.write("essai.scp")  # should open a DIALOG to confirm
 
     nd2 = NDDataset.load(filename)
     testing.assert_dataset_equal(nd2, nd)


### PR DESCRIPTION
dataset.write('filename')
-> open dialog if 'filename' does not exists
-> overwrite if it exists,
   except if keyword save_as=True.
-> now if save_as=true and filename exists,
   and confirm=False will also overwrite without dialog.

By default
   confirm=True, save_as=False

- [ X] Closes #360 
- [ X] Tests updated 
- [ X] CHANGELOG.md updated
  
