### PR TITLE
DEV: Add the possibility of rounding linearcoord.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,27 @@
-# What's new
+---
+## VERSION 0.3
 
-## version 0.3.2
-**NEW FEATURES**
+### version 0.3.3
+
+#### NEW FEATURES
+
+* add linearcoord rounding possibility.
 
 * add `download_nist_ir()` to download IR spectra from NIST/webbook
 
 * `read_spa()` now allows extracting sample and background interferograms
 
-* Add a log file (rotating)
-
-**BUGS FIXED**
+#### BUGS FIXED
 
 * fix gettingstarted/overview.py after IRIS refactoring
+
+### version 0.3.2
+
+#### NEW FEATURES
+
+* Add a log file (rotating)
+
+#### BUGS FIXED
 
 * TQDM progress bar
 
@@ -26,10 +36,9 @@
 
 * Fix #375 : plotting issues.
 
+### Version 0.3.1
 
-## Version 0.3.1
-
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Added a `show_versions` method in the API.
 
@@ -38,9 +47,9 @@
 
 * Docs API reference has been hopefully improved.
 
-## Version 0.3.0
+### Version 0.3.0
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Package refactoring which may break previous  behaviour. This is why we
   updated the minor version number from 0.2 to 0.3.
@@ -49,33 +58,36 @@
 
 * Fitting models updated and tested.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Bug in check_updates preventing working without connection.
 
-## Version 0.2.23
+---
+## VERSION 0.2
 
-**BUGS FIXED**
+### Version 0.2.23
+
+#### BUGS FIXED
 
 * Workflow/Codeclimate issues
 
-## Version 0.2.22
+### Version 0.2.22
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * QT save_dialog.
 
 * Plot_multiple bug.
 
-## Version 0.2.21
+### Version 0.2.21
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Indexing or slicing a NDArray with quantities is now possible.
 
 * MatPlotLib Axes are subclassed in order to accept quantities for method arguments.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * NDArray constructor now accept a homogeneous list of quantities as data input. Units are set accordingly.
 
@@ -87,9 +99,9 @@
 
 * Doc display problems.
 
-## Version 0.2.18
+### Version 0.2.18
 
-**NEW TASKS**
+#### NEW FEATURES
 
 * pip installation now possible
 
@@ -99,7 +111,7 @@
 
 * Documentation improvement
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Issue #310
 
@@ -112,15 +124,15 @@
 * skipping test_sh under windows
 
 
-## Version 0.2.17
+### Version 0.2.17
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * OPUS file reader: add filenames as labels.
 
 * OMNIC file reader: Documented more .spa header keys.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Compatibility with matplotlib 3.5 (issue #316).
 
@@ -130,9 +142,9 @@
 
 * Issue #322: mean and other API reduce methods were sometimes failing.
 
-## Version 0.2.16
+### Version 0.2.16
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * IRIS: Added 1D datasets.
 
@@ -150,7 +162,7 @@
 
 * Use CodeClimate to show Coverage info
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * IRIS example after modification of readers.
 
@@ -166,15 +178,15 @@
 
 * Compatibility with newest change in Colab
 
-## Version 0.2.15
+### Version 0.2.15
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Added a baseline correction method: `basc`.
 
 * Baseline ranges can be stored in meta.regions['baseline'] - basc will recognize them.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Comparison of dataset when containing metadata in testing functions.
 
@@ -182,13 +194,13 @@
 
 * Bug in the `to` function.
 
-## Version 0.2.14
+### Version 0.2.14
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * A default coordinate can now be selected for multiple coordinates dimensions.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Alignment along several dimensions (issue #248)
 
@@ -196,15 +208,15 @@
 
 * Baseline correction works on all dimensions
 
-## Version 0.2.13
+### Version 0.2.13
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Solved the problem that reading of experimental datasets was too slow in v.0.2.12.
 
-## Version 0.2.12
+### Version 0.2.12
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * LinearCoord operations now working.
 
@@ -216,17 +228,17 @@
 
 * Alignment methods now working (except for multidimensional alignment).
 
-## Version 0.2.11
+### Version 0.2.11
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Plot2D now works when more than one coord in 'y' axis (#238).
 
 * Spectrochempy_data location has been corrected (#239).
 
-## Version 0.2.10
+### Version 0.2.10
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * All data for tests and examples are now external.
 
@@ -234,19 +246,19 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Installation in Colab with Examples is now supported.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Read_quadera() and examples now based on a correct asc file
 
-## Version 0.2.9
+### Version 0.2.9
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Hotfix regarding display of NMR x scale
 
-## Version 0.2.8
+### Version 0.2.8
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Added write_csv() dir 1D datasets
 
@@ -256,15 +268,15 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Improved displaying of Interferograms
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Problem with trapz(), simps()
 
 * interferogram x scaling
 
-## Version 0.2.7
+### Version 0.2.7
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Test and data for read_carroucell(), read_srs(), read_dso()
 
@@ -272,7 +284,7 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Added FTIR interferogram processing.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Problem with read_carroucell(), read_srs(), read_dso()
 
@@ -280,9 +292,9 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Improved check updates
 
-## Version 0.2.6
+### Version 0.2.6
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Check for new version on anaconda cloud spectrocat channel.
 
@@ -290,7 +302,7 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Improved handling of Linear coordinates.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Adding quantity to datasets with different scaling (#199).
 
@@ -298,45 +310,41 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Compatibility with python 3.6
 
-## Version 0.2.5
+### Version 0.2.5
 
-**TASKS**
+#### NEW FEATURES
 
 * Docker image building.
 
 * Instructions to use it added in the documentation.
 
-**NEW FEATURES**
-
 * Cantera installation optional.
 
 * Use of pyqt for matplotlib optional.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Added fonts in order to solve missing fonts problems on Linux and windows.
 
-## Version 0.2.4
+### Version 0.2.4
 
-**TASKS**
+#### NEW FEATURES
 
 * Documentation largely revisited and hopefully improved. *Still some work to be done*.
 
 * NDMath (mathematical and dataset creation routines) module revisited. *Still some work to be done*.
 
-**NEW FEATURES**
-
 * Changed CoordRange behavior.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Problem with importing the API.
 
 * Dim handling in processing functions.
 
-## Version 0.2.0
+### Version 0.2.0
 
-**NEW FEATURES**
+#### NEW FEATURES
 
 * Copyright update.
 
@@ -382,7 +390,7 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Comparison of datasets and projects.
 
-**BUGS FIXED**
+#### BUGS FIXED
 
 * Dtype parameter was not taken into account during initialization of NDArrays.
 
@@ -416,6 +424,9 @@ They are now located in a separate conda package: `spectrochempy_data`.
 
 * Removed dependency of isotopes.py to pandas.
 
-## Version 0.1.x
+---
+## VERSION 0.1
+
+### Version 0.1.x
 
 * Initial development versions.

--- a/spectrochempy/core/dataset/coord.py
+++ b/spectrochempy/core/dataset/coord.py
@@ -157,6 +157,7 @@ class Coord(NDMath, NDArray):
     _increment = Union((CFloat(), CInt(), Instance(Quantity)))
     _size = Integer(0)
     _linear = Bool(False)
+    _decimals = Integer(5)
 
     # ------------------------------------------------------------------------
     # initialization
@@ -172,6 +173,8 @@ class Coord(NDMath, NDArray):
         self._increment = kwargs.pop("increment", 1.0)
         self._offset = kwargs.pop("offset", 0.0)
         self._size = kwargs.pop("size", 0)
+        self._decimals = kwargs.pop("decimals", 5)
+
         # self._accuracy = kwargs.pop('accuracy', None)
 
     # ------------------------------------------------------------------------
@@ -787,10 +790,10 @@ class Coord(NDMath, NDArray):
         if data.size > 1:
             inc = np.diff(data)
             variation = (inc.max() - inc.min()) / data.ptp()
-            if variation < 1.0e-5:
-                self._increment = (
-                    data.ptp() / (data.size - 1) * np.sign(inc[0])
-                )  # np.mean(inc)  # np.round(np.mean(inc), 5)
+            if variation < 10.0 ** (-self._decimals):
+                self._increment = np.round(
+                    data.ptp() / (data.size - 1) * np.sign(inc[0]), self._decimals
+                )
                 self._offset = data[0]
                 self._size = data.size
                 self._data = None
@@ -1057,8 +1060,8 @@ class LinearCoord(Coord):
 
         if data is not None and isinstance(data, Coord) and not data.linear:
             raise ValueError(
-                "Only linear Coord (with attribute linear set to True, can be transformed into "
-                "LinearCoord class"
+                "Only linear Coord (with attribute linear set to True, "
+                "can be transformed into LinearCoord class"
             )
 
         super().__init__(data, **kwargs)

--- a/spectrochempy/core/dataset/coord.py
+++ b/spectrochempy/core/dataset/coord.py
@@ -117,6 +117,11 @@ class Coord(NDMath, NDArray):
     increment : float, optional
         Only used if linear is true.
         If omitted a value of 1.0 is taken for the coordinate increment.
+    decimals : int, optional, default=5
+        Specify a threshold for linearisation of existing data. By default, decimals=5.
+        which means that if the difference in spacing of all data is less than
+        10^(-decimals), then linearisation occurs, and inc are rounded to the number
+        of specified decimals.
 
     See Also
     --------

--- a/spectrochempy/core/dataset/coord.py
+++ b/spectrochempy/core/dataset/coord.py
@@ -799,7 +799,7 @@ class Coord(NDMath, NDArray):
                 self._increment = np.round(
                     data.ptp() / (data.size - 1) * np.sign(inc[0]), self._decimals
                 )
-                self._offset = data[0]
+                self._offset = np.round(data[0], self._decimals)
                 self._size = data.size
                 self._data = None
                 self._linear = True

--- a/spectrochempy/core/dataset/coord.py
+++ b/spectrochempy/core/dataset/coord.py
@@ -1079,7 +1079,7 @@ class LinearCoord(Coord):
 
         elif not self.linear:
             # in case it was not already a linear array
-            self.offset = offset
+            self.offset = np.round(offset, self._decimals)
             self.increment = np.round(increment, self._decimals)
             self._linear = True
 

--- a/spectrochempy/core/dataset/coord.py
+++ b/spectrochempy/core/dataset/coord.py
@@ -117,8 +117,8 @@ class Coord(NDMath, NDArray):
     increment : float, optional
         Only used if linear is true.
         If omitted a value of 1.0 is taken for the coordinate increment.
-    decimals : int, optional, default=5
-        Specify a threshold for linearisation of existing data. By default, decimals=5.
+    decimals : int, optional, default=7
+        Specify a threshold for linearisation of existing data. By default, decimals=7.
         which means that if the difference in spacing of all data is less than
         10^(-decimals), then linearisation occurs, and inc are rounded to the number
         of specified decimals.
@@ -162,7 +162,7 @@ class Coord(NDMath, NDArray):
     _increment = Union((CFloat(), CInt(), Instance(Quantity)))
     _size = Integer(0)
     _linear = Bool(False)
-    _decimals = Integer(5)
+    _decimals = Integer(7)
 
     # ------------------------------------------------------------------------
     # initialization
@@ -178,7 +178,7 @@ class Coord(NDMath, NDArray):
         self._increment = kwargs.pop("increment", 1.0)
         self._offset = kwargs.pop("offset", 0.0)
         self._size = kwargs.pop("size", 0)
-        self._decimals = kwargs.pop("decimals", 5)
+        self._decimals = kwargs.pop("decimals", 7)
 
         # self._accuracy = kwargs.pop('accuracy', None)
 

--- a/spectrochempy/core/dataset/coord.py
+++ b/spectrochempy/core/dataset/coord.py
@@ -1080,7 +1080,7 @@ class LinearCoord(Coord):
         elif not self.linear:
             # in case it was not already a linear array
             self.offset = offset
-            self.increment = increment
+            self.increment = np.round(increment, self._decimals)
             self._linear = True
 
     # ..........................................................................

--- a/spectrochempy/utils/testing.py
+++ b/spectrochempy/utils/testing.py
@@ -292,7 +292,7 @@ def compare_coords(this, other, approx=False, decimal=6, data_only=False):
                             f"equal",
                         )
 
-                elif attr == "offset" and approx:
+                elif attr in ["offset", "increment"] and approx:
                     assert_approx_equal(
                         sattr,
                         oattr,

--- a/tests/test_core/test_dataset/test_ndcoord.py
+++ b/tests/test_core/test_dataset/test_ndcoord.py
@@ -478,7 +478,7 @@ def test_linearcoord():
     coordc = coord1.copy()
     assert coord1 == coordc
 
-    assert_approx_equal(coord1.spacing.m, 0.606060606)
+    assert_approx_equal(coord1.spacing.m, 0.60606)
 
     assert coord1.author is None
     assert not coord1.history

--- a/tests/test_core/test_dataset/test_ndcoord.py
+++ b/tests/test_core/test_dataset/test_ndcoord.py
@@ -478,7 +478,7 @@ def test_linearcoord():
     coordc = coord1.copy()
     assert coord1 == coordc
 
-    assert_approx_equal(coord1.spacing.m, 0.60606)
+    assert_approx_equal(coord1.spacing.m, 0.6060606)
 
     assert coord1.author is None
     assert not coord1.history

--- a/tests/test_core/test_dataset/test_ndcoord.py
+++ b/tests/test_core/test_dataset/test_ndcoord.py
@@ -489,3 +489,12 @@ def test_linearcoord():
     assert coord1.is_1d
 
     assert coord0.transpose() == coord0
+
+
+def test_coord_linearization():
+    from spectrochempy.utils.testing import RandomSeedContext
+
+    with RandomSeedContext(12345):
+        d = np.linspace(0, 60, 100) + np.random.random(100) / 100.0
+    coord = LinearCoord(d, decimals=3, copy=True)
+    coord

--- a/tests/test_core/test_dataset/test_ndcoord.py
+++ b/tests/test_core/test_dataset/test_ndcoord.py
@@ -497,4 +497,4 @@ def test_coord_linearization():
     with RandomSeedContext(12345):
         d = np.linspace(0, 60, 100) + np.random.random(100) / 100.0
     coord = LinearCoord(d, decimals=3, copy=True)
-    coord
+    assert coord.increment == 0.606

--- a/tests/test_core/test_dataset/test_ndcoord.py
+++ b/tests/test_core/test_dataset/test_ndcoord.py
@@ -498,3 +498,4 @@ def test_coord_linearization():
         d = np.linspace(0, 60, 100) + np.random.random(100) / 100.0
     coord = LinearCoord(d, decimals=3, copy=True)
     assert coord.increment == 0.606
+    assert coord.offset == 0.009


### PR DESCRIPTION
add a new parameters in coord:

    decimals : int, optional, default=7
        Specify a threshold for linearisation of existing data. By default, decimals=7.
        which means that if the difference in spacing of all data is less than
        10^(-decimals), then linearisation occurs, and inc are rounded to the number
        of specified decimals.

(reference to discussion: https://github.com/spectrochempy/spectrochempy/discussions/398#discussion-3901404)

- [x] Tests have been added
- [x] Updated Changelog.md 
