### PR TITLE
FIX: bug with units transformation between transmittance, absorbance and abs.transmittance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 #### NEW FEATURES
 * Compatibility with Python 3.10
 
+#### BUG FIXED
+* Transmittance and absorbance units now correctly handled
+
 ### version 0.3.3
 
 #### NEW FEATURES

--- a/spectrochempy/core/dataset/ndarray.py
+++ b/spectrochempy/core/dataset/ndarray.py
@@ -2317,17 +2317,19 @@ class NDArray(HasTraits):
                             udata = (new.data * new.units).to(units)
                             new._data = -np.log10(udata.m)
                             new._units = units
-                            if new.title.lower() == "transmittance":
-                                new._title = "absorbance"
+                            new._title = str(oldunits)
+
+                        elif "transmittance" in str(oldunits):
+                            new._data = (new.data * new.units).to(units)
+                            new._units = units
+                            new._title = str(oldunits)
 
                     elif str(oldunits) == "absorbance":
                         if str(units) in ["transmittance", "absolute_transmittance"]:
                             scale = Quantity(1.0, self._units).to(units).magnitude
                             new._data = 10.0 ** -new.data * scale
                             new._units = units
-                            if new.title.lower() == "absorbance":
-                                new._title = "transmittance"
-
+                            new._title = str(oldunits)
                     else:
                         new = self._unittransform(new, units)
                         # change the title for spectrocopic units change

--- a/tests/test_core/test_dataset/test_dataset.py
+++ b/tests/test_core/test_dataset/test_dataset.py
@@ -304,6 +304,35 @@ def test_nddataset_units(nd1d):
     assert nd2.units == ur.m ** 0.5
 
 
+def test_bugs_units_change():
+    # check for bug on transmittance conversion
+    X = scp.NDDataset([0.0, 0.3, 1.3, 5.0], units="absorbance")
+
+    # A to T
+    X1 = X.to("transmittance")
+    assert_array_equal(X1.data, 10 ** -np.array([0.0, 0.3, 1.3, 5.0]) * 100)
+
+    # T to abs T
+    X2 = X1.to("absolute_transmittance")
+    assert_array_equal(X2.data, 10 ** -np.array([0.0, 0.3, 1.3, 5.0]))
+
+    # A to abs T
+    X2b = X.to("absolute_transmittance")
+    assert_array_equal(X2b, X2)
+
+    # abs T to T
+    X3 = X2.to("transmittance")
+    assert_array_equal(X3, X1)
+
+    # T to A
+    X4 = X3.to("absorbance")
+    assert_array_almost_equal(X4, X)
+
+    # abs T to A
+    X5 = X2.to("absorbance")
+    assert_array_almost_equal(X5, X)
+
+
 def test_nddataset_masked_array_input():
     a = np.random.randn(100)
     marr = np.ma.masked_where(a > 0, a)


### PR DESCRIPTION
- [x] Tests have been added 
- [x] User-visible changes have been documented in `CHANGELOG.md` 