### PR TITLE
refactor concatenate (see #408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### version 0.4.2
 
-
-
+#### NEW FEATURES
+* Concatenate and stack:
+  - `force_stack` keyword in concatenate() now deprecated. 
+  - `stack()` method now generates a new dim, even if a dim of size one in present  
 
 ### version 0.4.1
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -46,7 +46,8 @@ sys.path.insert(0, os.path.join(BASE_PATH))
 import spectrochempy  # isort:skip
 
 sys.path.insert(1, os.path.join(BASE_PATH, "doc", "sphinxext"))
-from numpydoc.validate import validate, Docstring  # isort:skip
+from numpydoc.docscrape import get_doc_object
+from numpydoc.validate import Validator, validate  # isort:skip
 
 
 PRIVATE_CLASSES = []
@@ -157,7 +158,13 @@ def get_api_items(api_doc_fd):
         previous_line = line
 
 
-class SpectroChemPyDocstring(Docstring):
+class SpectroChemPyDocstring(Validator):
+    def __init__(self, func_name: str, doc_obj=None) -> None:
+        self.func_name = func_name
+        if doc_obj is None:
+            doc_obj = get_doc_object(Validator._load_obj(func_name))
+        super().__init__(doc_obj)
+
     @property
     def mentioned_private_classes(self):
         return [klass for klass in PRIVATE_CLASSES if klass in self.raw_doc]

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -46,8 +46,7 @@ sys.path.insert(0, os.path.join(BASE_PATH))
 import spectrochempy  # isort:skip
 
 sys.path.insert(1, os.path.join(BASE_PATH, "doc", "sphinxext"))
-from numpydoc.docscrape import get_doc_object
-from numpydoc.validate import Validator, validate  # isort:skip
+from numpydoc.validate import validate, Docstring  # isort:skip
 
 
 PRIVATE_CLASSES = []
@@ -158,13 +157,7 @@ def get_api_items(api_doc_fd):
         previous_line = line
 
 
-class SpectroChemPyDocstring(Validator):
-    def __init__(self, func_name: str, doc_obj=None) -> None:
-        self.func_name = func_name
-        if doc_obj is None:
-            doc_obj = get_doc_object(Validator._load_obj(func_name))
-        super().__init__(doc_obj)
-
+class SpectroChemPyDocstring(Docstring):
     @property
     def mentioned_private_classes(self):
         return [klass for klass in PRIVATE_CLASSES if klass in self.raw_doc]

--- a/spectrochempy/core/dataset/coordset.py
+++ b/spectrochempy/core/dataset/coordset.py
@@ -522,6 +522,13 @@ class CoordSet(HasTraits):
         """
         return [item.labels for item in self]
 
+    @property
+    def is_labeled(self):
+        """
+        returns True if one of the coords is labeled.
+        """
+        return any([item.is_labeled for item in self])
+
     # ..........................................................................
     @property
     def units(self):

--- a/spectrochempy/core/processors/concatenate.py
+++ b/spectrochempy/core/processors/concatenate.py
@@ -149,9 +149,9 @@ def concatenate(*datasets, **kwargs):
                                 [label for label in labels[:, i]]
                             )
 
-        coords[dim]._data = np.concatenate(
-            tuple((ds.coordset[dim].data for ds in datasets))
-        )
+            coords[dim]._data = np.concatenate(
+                tuple((ds.coordset[dim].data for ds in datasets))
+            )
 
     out = dataset.copy()
     out._data = data

--- a/spectrochempy/core/processors/concatenate.py
+++ b/spectrochempy/core/processors/concatenate.py
@@ -14,13 +14,12 @@ import datetime as datetime
 from warnings import warn
 from orderedset import OrderedSet
 
-# from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.ndarray import DEFAULT_DIM_NAME
-from spectrochempy.utils import SpectroChemPyWarning, DimensionsCompatibilityError
+from spectrochempy.utils import DimensionsCompatibilityError
 
 
-def concatenate(*datasets, **kwargs):
+def concatenate(*datasets, dim="x"):
     """
     Concatenation of |NDDataset| objects along a given axis.
 
@@ -29,10 +28,9 @@ def concatenate(*datasets, **kwargs):
     to be defined the following must be true :
 
         #. all inputs must be valid |NDDataset| objects;
-        #. units of data and axis must be compatible
+        #. units of data must be compatible
         #. concatenation is along the axis specified or the last one;
-        #. along the non-concatenated dimensions, shape and units coordinates
-           must match.
+        #. along the non-concatenated dimensions, shapes must match.
 
     Parameters
     ----------
@@ -40,27 +38,18 @@ def concatenate(*datasets, **kwargs):
         The dataset(s) to be concatenated to the current dataset. The datasets
         must have the same shape, except in the dimension corresponding to axis
         (the last, by default).
-    **kwargs
-        Optional keyword parameters (see Other Parameters).
+    dim : str or int, optional, default='x'
+        The dimension along which the operation is applied.
 
     Returns
     --------
     out
         A |NDDataset| created from the contenations of the |NDDataset| input objects.
 
-    Other Parameters
-    ----------------
-    dims : str, optional, default='x'
-        The dimension along which the operation is applied.
-    force_stack : bool, optional, default=False
-        If True, the dataset are stacked instead of being concatenated. This means that a new dimension is prepended
-        to each dataset before being stacked, except if one of the dimension is of size one. If this case the datasets
-        are squeezed before stacking. The stacking is only possible is the shape of the various datasets are identical.
-        This process is equivalent of using the method `stack`.
 
     See Also
     ---------
-    stack : Stack of |NDDataset| objects along the first dimension.
+    stack : Stack of |NDDataset| objects along a new dimension
 
     Examples
     --------
@@ -80,52 +69,30 @@ def concatenate(*datasets, **kwargs):
     >>> A.shape, B.shape, E.shape
     ((55, 5549), (55, 5549), (55, 11098))
 
-    Stacking of datasets:
-    for nDimensional datasets (with the same shape), a new dimension is added
-
-    >>> F = A.concatenate(B, force_stack=True)
-    >>> A.shape, B.shape, F.shape
-    ((55, 5549), (55, 5549), (2, 55, 5549))
-
-    If one of the dimensions is of size one, then this dimension is removed before stacking
-
-    >>> G = A[0].concatenate(B[0], force_stack=True)
-    >>> A[0].shape, B[0].shape, G.shape
-    ((1, 5549), (1, 5549), (2, 5549))
     """
+    # get a copy of input datasets in order that input data are not modified
+    datasets = _get_copy(datasets)
 
-    # ------------------------------------------------------------------------
-    # checks dataset validity
-    # ------------------------------------------------------------------------
+    # get axis from arguments (or set it to the default)
+    axis, dim = datasets[0].get_axis(dim)
 
-    # We must have a list of datasets
-    if isinstance(datasets, tuple):
-        if isinstance(datasets[0], (list, tuple)):
-            datasets = datasets[0]
-
-    # make a first copy of the objects in order that input data are not modified
-    datasets = [ds.copy() for ds in datasets]
-    # and a second one in case the first run (assuming homogeneous datasets for fast processing, is failing)
-    datasets_bak = [ds.copy() for ds in datasets]
-    # a flag to force stacking of dataset instead of the default concatenation
-    force_stack = kwargs.get("force_stack", False)
-
-    if force_stack:
-        # when stacking, we add a new first dimension except if this dimension is of size one,
-        # in this case we use this dimension for stacking. Here we assume that all datasets have
-        # the same shape, if not an error will be catched below
-
-        if datasets[0].shape[0] != 1:
-            for i, dataset in enumerate(datasets):
-                datasets[i] = _prepend_dim(dataset, i)
-
-        axis, dim = datasets[0].get_axis(dim=0)
-
+    # check units
+    units = tuple(set(ds.units for ds in datasets))
+    if len(units) == 1:
+        units = datasets[0].units
     else:
-        # get axis from arguments (or set it to the default)
-        axis, dim = datasets[0].get_axis(**kwargs)
-
-    units = datasets[0].units
+        # check compatibility
+        for i, u1 in enumerate(units[:-1]):
+            for u2 in units[i + 1 :]:
+                if u1.dimensionality != u2.dimensionality:
+                    raise ValueError(
+                        f"Units of the data are {[str(u) for u in units]}. The datasets can't be concatenated"
+                    )
+        # should be compatible, so convert
+        units = datasets[0].units
+        for ds in datasets[1:]:
+            if ds.units != units:
+                ds.ito(units)
 
     # concatenate or stack the data array + mask
     # ------------------------------------------------------------------------
@@ -135,51 +102,7 @@ def concatenate(*datasets, **kwargs):
         d = dataset.masked_data
         sss.append(d)
 
-    try:
-        sconcat = np.ma.concatenate(sss, axis=axis)
-
-    except ValueError:
-        # probably a dimension mismatch, we need to get the shapes and ndims for comparison
-        datasets = datasets_bak
-        rshapes = []
-        rndims = []
-        for item in datasets:
-            sh = list(item.shape)
-            rshapes.append(sh)
-            rndims.append(len(sh))
-
-        # In any case the number of dimensions is expected to be the same for all datasets
-        if len(list(set(rndims))) > 1:
-            raise DimensionsCompatibilityError(
-                "Only NDDataset with the same number of dimensions can be concatenated."
-            )
-
-        rcompat = list(map(list, list(map(set, list(zip(*rshapes))))))
-
-        if force_stack:
-            if len(set(list(map(len, rcompat)))) != 1:
-                warn(
-                    "These datasets have not the same shape, so they cannot be stacked. By default they will be "
-                    "concatenated along the first dimension.",
-                    category=SpectroChemPyWarning,
-                )
-                axis, dim = datasets[0].get_axis(dim=0)
-
-        # now check if data shapes are compatible (all dimension must have the same size
-        # except the one to be concatenated)
-        for i, item in enumerate(zip(*rshapes)):
-            if i != axis and len(set(item)) > 1:
-                raise DimensionsCompatibilityError(
-                    "Datasets must have the same shape for all dimensions except the one along which the"
-                    " concatenation is performed"
-                )
-        sss = []
-        for i, dataset in enumerate(datasets):
-            d = dataset.masked_data
-            sss.append(d)
-
-        # retry
-        sconcat = np.ma.concatenate(sss, axis=axis)
+    sconcat = np.ma.concatenate(sss, axis=axis)
 
     data = np.asarray(sconcat)
     mask = sconcat.mask
@@ -189,27 +112,28 @@ def concatenate(*datasets, **kwargs):
 
     if coords is not None:
         # check labels, coords type and concatenate them
+        if not coords[dim].is_empty:
 
-        labels = []
-        if coords[dim].implements() in ["Coord", "LinearCoord"]:
-            if coords[dim].is_labeled:
-                for ds in datasets:
-                    labels.append(ds.coordset[dim].labels)
-                coords[dim]._labels = np.concatenate(labels)
-
-        if coords[dim].implements("CoordSet"):
-            for coord in coords[dim]:
-                if coord.is_labeled:
+            labels = []
+            if coords[dim].implements() in ["Coord", "LinearCoord"]:
+                if coords[dim].is_labeled:
                     for ds in datasets:
                         labels.append(ds.coordset[dim].labels)
+                    coords[dim]._labels = np.concatenate(labels)
 
-                for i, coord in enumerate(coords[dim]):
-                    coord._labels = np.concatenate(labels[i :: len(coords[dim])])
+            if coords[dim].implements("CoordSet"):
+                for coord in coords[dim]:
+                    if coord.is_labeled:
+                        for ds in datasets:
+                            labels.append(ds.coordset[dim].labels)
 
-        coords[dim] = Coord(coords[dim], linear=False)
-        coords[dim]._data = np.concatenate(
-            tuple((ds.coordset[dim].data for ds in datasets))
-        )
+                    for i, coord in enumerate(coords[dim]):
+                        coord._labels = np.concatenate(labels[i :: len(coords[dim])])
+
+            coords[dim] = Coord(coords[dim], linear=False)
+            coords[dim]._data = np.concatenate(
+                tuple((ds.coordset[dim].data for ds in datasets))
+            )
 
     out = dataset.copy()
     out._data = data
@@ -218,9 +142,7 @@ def concatenate(*datasets, **kwargs):
     out._mask = mask
     out._units = units
 
-    thist = "Stack" if axis == 0 else "Concatenation"
-
-    out.description = "{} of {}  datasets:\n".format(thist, len(datasets))
+    out.description = f"Concatenation of {len(datasets)}  datasets:\n"
     out.description += "( {}".format(datasets[0].name)
     out.title = datasets[0].title
     authortuple = (datasets[0].author,)
@@ -239,107 +161,14 @@ def concatenate(*datasets, **kwargs):
 
     out.description += " )"
     out._date = out._modified = datetime.datetime.now(datetime.timezone.utc)
-    out._history = [str(out.date) + ": Created by %s" % thist]
+    out._history = [str(out.date) + ": Created by concatenate"]
 
     return out
 
-    # except Exception:
-    #     # there has been an error, could be due incompatible units, missing labels...
-    #     # more checks are carried out
-    #
 
-    #     # Check unit compatibility
-    #     # ------------------------------------------------------------------------
-    #     units = datasets[0].units
-    #     for dataset in datasets:
-    #         if not dataset.is_units_compatible(datasets[0]):
-    #             raise ValueError(
-    #                 "units of the datasets to concatenate are not compatible"
-    #             )
-    #         # if needed transform to the same unit
-    #         dataset.ito(units)
-    #     # TODO: make concatenation of heterogeneous data possible by using labels
-    #
-    #     # Check coordinates compatibility
-    #     # ------------------------------------------------------------------------
-    #
-    #     # coordinates units of NDDatasets must be compatible in all dimensions
-    #     # get the coordss
-    #
-    #     coordss = [dataset.coordset for dataset in datasets]
-    #     if set(coordss) == {None}:
-    #         coordss = None
-    #
-    #     # concatenate coords if they exists
-    #     # ------------------------------------------------------------------------
-    #
-    #     if coordss is None or (len(coordss) == 1 and coordss.pop() is None):
-    #         # no coords
-    #         coords = None
-    #     else:
-    #         # we take the coords of the first dataset, and extend the coord along the concatenate axis
-    #         coords = coordss[0].copy()
-    #
-    #         try:
-    #             coords[dim] = Coord(
-    #                 coords[dim], linear=False
-    #             )  # de-linearize the coordinates
-    #             coords[dim]._data = np.concatenate(
-    #                 tuple((c[dim].data for c in coordss))
-    #             )
-    #         except (KeyError, ValueError):
-    #             pass
-    #
-    #     # check labeling
-    #     # concatenation of the labels (first check the presence of at least one labeled coordinates)
-    #
-    #     is_labeled = False
-    #     for i, c in enumerate(coordss):
-    #         if c[dim].implements() in ["Coord", "LinearCoord"]:
-    #             # this is a coord
-    #             if c[dim].is_labeled:
-    #                 # at least one of the coord is labeled
-    #                 is_labeled = True
-    #                 break
-    #         if c[dim].implements("CoordSet"):
-    #             # this is a coordset
-    #             for coord in c[dim]:
-    #                 if coord.is_labeled:
-    #                     # at least one of the coord is labeled
-    #                     is_labeled = True
-    #                     break
-    #
-    #     if is_labeled:
-    #         labels = []
-    #         # be sure that now all the coordinates have a label, or create one
-    #         for i, c in enumerate(coordss):
-    #             if c[dim].implements() in ["Coord", "LinearCoord"]:
-    #                 # this is a coord
-    #                 if c[dim].is_labeled:
-    #                     labels.append(c[dim].labels)
-    #                 else:
-    #                     labels.append(str(i))
-    #             if c[dim].implements("CoordSet"):
-    #                 # this is a coordset
-    #                 for coord in c[dim]:
-    #                     if coord.is_labeled:
-    #                         labels.append(c[dim].labels)
-    #                     else:
-    #                         labels.append(str(i))
-    #
-    #         if isinstance(coords[dim], Coord):
-    #             coords[dim]._labels = np.concatenate(labels)
-    #         if coords[dim].implements("CoordSet"):
-    #             for i, coord in enumerate(coords[dim]):
-    #                 coord._labels = np.concatenate(labels[i :: len(coords[dim])])
-    #
-    #         coords[dim]._labels = np.concatenate(labels)
-    #
-
-
-def stack(*datasets, **kwargs):
+def stack(*datasets):
     """
-    Stack of |NDDataset| objects along the first dimension.
+    Stack of |NDDataset| objects along a new dimension
 
     Any number of |NDDataset| objects can be stacked. For this operation
     to be defined the following must be true :
@@ -348,7 +177,6 @@ def stack(*datasets, **kwargs):
     #. units of data and axis must be compatible (rescaling is applied
        automatically if necessary).
 
-    The remaining dimension sizes must match along all dimension but the first.
 
     Parameters
     ----------
@@ -369,23 +197,34 @@ def stack(*datasets, **kwargs):
     >>> print(C)
     NDDataset: [float64] a.u. (shape: (z:2, y:55, x:5549))
     """
+    datasets = _get_copy(datasets)
 
-    return concatenate(*datasets, force_stack=True, **kwargs)
+    shapes = {ds.shape for ds in datasets}
+    if len(shapes) != 1:
+        raise DimensionsCompatibilityError("all input arrays must have the same shape")
+
+    # add a new dimension
+    for i, dataset in enumerate(datasets):
+        dataset._data = dataset.data[np.newaxis]
+        dataset._mask = dataset.mask[np.newaxis]
+        newcoord = Coord([i], labels=[dataset.name])
+        newcoord.name = (OrderedSet(DEFAULT_DIM_NAME) - dataset._dims).pop()
+        dataset.add_coordset(newcoord)
+        dataset.dims = [newcoord.name] + dataset.dims
+
+    return concatenate(*datasets, dim=0)
 
 
 # utility functions
 # --------------------
 
 
-def _prepend_dim(dataset, coord_value):
-    """prepend a new dimension with coords"""
-    dataset._data = dataset.data[np.newaxis]
-    dataset._mask = dataset.mask[np.newaxis]
-    newcoord = Coord([coord_value], labels=[dataset.name])
-    newcoord.name = (OrderedSet(DEFAULT_DIM_NAME) - dataset._dims).pop()
-    dataset.add_coordset(newcoord)
-    dataset.dims = [newcoord.name] + dataset.dims
-    return dataset
+def _get_copy(datasets):
+    # get a copy of datasets from the input
+    if isinstance(datasets, tuple):
+        if isinstance(datasets[0], (list, tuple)):
+            datasets = datasets[0]
+    return [ds.copy() for ds in datasets]
 
 
 if __name__ == "__main__":

--- a/spectrochempy/core/processors/concatenate.py
+++ b/spectrochempy/core/processors/concatenate.py
@@ -75,8 +75,8 @@ def concatenate(*datasets, **kwargs):
     >>> E = A.concatenate(B, axis=1)
     >>> A.shape, B.shape, E.shape
     ((55, 5549), (55, 5549), (55, 11098))
-
     """
+
     # get a copy of input datasets in order that input data are not modified
     datasets = _get_copy(datasets)
 
@@ -181,7 +181,7 @@ def concatenate(*datasets, **kwargs):
 
 def stack(*datasets):
     """
-    Stack of |NDDataset| objects along a new dimension
+    Stack of |NDDataset| objects along a new dimension.
 
     Any number of |NDDataset| objects can be stacked. For this operation
     to be defined the following must be true :
@@ -189,7 +189,6 @@ def stack(*datasets):
     #. all inputs must be valid dataset objects,
     #. units of data and axis must be compatible (rescaling is applied
        automatically if necessary).
-
 
     Parameters
     ----------
@@ -203,7 +202,7 @@ def stack(*datasets):
 
     See Also
     --------
-    concatenate : concatenate |NDDataset| objects along a given dimension.
+    concatenate : Concatenate |NDDataset| objects along a given dimension.
 
     Examples
     --------
@@ -213,8 +212,8 @@ def stack(*datasets):
     >>> C = scp.stack(A, B)
     >>> print(C)
     NDDataset: [float64] a.u. (shape: (z:2, y:55, x:5549))
-
     """
+
     datasets = _get_copy(datasets)
 
     shapes = {ds.shape for ds in datasets}

--- a/spectrochempy/core/processors/concatenate.py
+++ b/spectrochempy/core/processors/concatenate.py
@@ -16,7 +16,7 @@ from orderedset import OrderedSet
 
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.ndarray import DEFAULT_DIM_NAME
-from spectrochempy.utils import DimensionsCompatibilityError
+from spectrochempy.utils import DimensionsCompatibilityError, UnitsCompatibilityError
 
 
 def concatenate(*datasets, **kwargs):
@@ -79,7 +79,7 @@ def concatenate(*datasets, **kwargs):
 
     # check uise
     if "force_stack" in kwargs:
-        warn("force_stack not used anymore, use stack() instead")
+        warn("force_stack not used anymore, use stack() instead", DeprecationWarning)
         return stack(datasets)
 
     # get a copy of input datasets in order that input data are not modified
@@ -102,7 +102,7 @@ def concatenate(*datasets, **kwargs):
         for i, u1 in enumerate(units[:-1]):
             for u2 in units[i + 1 :]:
                 if u1.dimensionality != u2.dimensionality:
-                    raise ValueError(
+                    raise UnitsCompatibilityError(
                         f"Units of the data are {[str(u) for u in units]}. The datasets can't be concatenated"
                     )
         # should be compatible, so convert

--- a/spectrochempy/core/processors/concatenate.py
+++ b/spectrochempy/core/processors/concatenate.py
@@ -14,7 +14,7 @@ import datetime as datetime
 from warnings import warn
 from orderedset import OrderedSet
 
-from spectrochempy.core.dataset.nddataset import NDDataset
+# from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.ndarray import DEFAULT_DIM_NAME
 from spectrochempy.utils import SpectroChemPyWarning, DimensionsCompatibilityError
@@ -57,10 +57,6 @@ def concatenate(*datasets, **kwargs):
         to each dataset before being stacked, except if one of the dimension is of size one. If this case the datasets
         are squeezed before stacking. The stacking is only possible is the shape of the various datasets are identical.
         This process is equivalent of using the method `stack`.
-    homogeneous : bool, optional, default=False
-        If True, the datasets are assumed to homogeneous: same shapes, same coordinates and labels in dimensions
-        (except the deimension along which the operation is applied), same units, etc... This avoids many checks
-        and save times when hundreds or thousands datasets are contatenated.
 
     See Also
     ---------
@@ -98,8 +94,6 @@ def concatenate(*datasets, **kwargs):
     ((1, 5549), (1, 5549), (2, 5549))
     """
 
-    # a flag to check datasets  compatibility
-    homogeneous = kwargs.get("homogeneous", False)
     # ------------------------------------------------------------------------
     # checks dataset validity
     # ------------------------------------------------------------------------
@@ -112,180 +106,32 @@ def concatenate(*datasets, **kwargs):
     # make a copy of the objects (in order that input data are not modified)
     datasets = [ds.copy() for ds in datasets]
 
-    # try to cast of dataset to NDDataset
-    if not homogeneous or (homogeneous and not isinstance(datasets[0], NDDataset)):
-        for i, item in enumerate(datasets):
-            if not isinstance(item, NDDataset):
-                try:
-                    datasets[i] = NDDataset(item)
-                except Exception:
-                    raise TypeError(
-                        f"Only instance of NDDataset can be concatenated, not {type(item).__name__}, "
-                        f"but casting to this type failed. "
-                    )
-
-    if not homogeneous:
-        # get the shapes and ndims for comparison
-        rshapes = []
-        rndims = []
-        for item in datasets:
-            sh = list(item.shape)
-            rshapes.append(sh)
-            rndims.append(len(sh))
-
-        # The number of dimensions is expected to be the same for all datasets
-        if len(list(set(rndims))) > 1:
-            raise DimensionsCompatibilityError(
-                "Only NDDataset with the same number of dimensions can be concatenated."
-            )
-
-        rcompat = list(map(list, list(map(set, list(zip(*rshapes))))))
-
     # a flag to force stacking of dataset instead of the default concatenation
     force_stack = kwargs.get("force_stack", False)
-    if force_stack:
-        if not homogeneous:
-            # when stacking, we add a new first dimension except if one dimension is of size one: in this case we use this
-            # dimension for stacking
-            prepend = False
-            if len(set(list(map(len, rcompat)))) == 1:
-                # all dataset have the same shape
-                # they can be stacked by prepending a new dimension
-                prepend = True
-                # else we will try to stack them on the first dimension
 
-            if not prepend:
-                warn(
-                    "These datasets have not the same shape, so they cannot be stacked. By default they will be "
-                    "concatenated along the first dimension.",
-                    category=SpectroChemPyWarning,
-                )
+    # try assuming homogeneous NDDataset
+    try:
+        if force_stack:
+            # when stacking, we add a new first dimension except if this dimension is of size one,
+            # in this case we use this dimension for stacking
+
+            if datasets[0].shape[0] != 1:
+                for i, dataset in enumerate(datasets):
+                    datasets[i] = _prepend_dim(dataset, i)
+
+            axis, dim = datasets[0].get_axis(dim=0)
+
         else:
-            prepend = True
-
-        for i, dataset in enumerate(datasets):
-            if not prepend or dataset.shape[0] == 1:
-                continue
-            dataset._data = dataset.data[np.newaxis]
-            dataset._mask = dataset.mask[np.newaxis]
-            newcoord = Coord([i], labels=[dataset.name])
-            newcoord.name = (OrderedSet(DEFAULT_DIM_NAME) - dataset._dims).pop()
-            dataset.add_coordset(newcoord)
-            dataset.dims = [newcoord.name] + dataset.dims
-            # TODO: make a function to simplify this process of adding new dimensions with coords
-        axis, dim = datasets[0].get_axis(dim=0)
-
-    else:
-        # get axis from arguments (or set it to the default)
-        axis, dim = datasets[0].get_axis(**kwargs)
-
-    if not homogeneous:
-        # check if data shapes are compatible (all dimension must have the same size
-        # except the one to be concatenated)
-        for i, item in enumerate(zip(*rshapes)):
-            if i != axis and len(set(item)) > 1:
-                raise DimensionsCompatibilityError(
-                    "Datasets must have the same shape for all dimensions except the one along which the"
-                    " concatenation is performed"
-                )
-
-        # Check unit compatibility
-        # ------------------------------------------------------------------------
-        units = datasets[0].units
-        for dataset in datasets:
-            if not dataset.is_units_compatible(datasets[0]):
-                raise ValueError(
-                    "units of the datasets to concatenate are not compatible"
-                )
-            # if needed transform to the same unit
-            dataset.ito(units)
-        # TODO: make concatenation of heterogeneous data possible by using labels
-
-        # Check coordinates compatibility
-        # ------------------------------------------------------------------------
-
-        # coordinates units of NDDatasets must be compatible in all dimensions
-        # get the coordss
-
-        coordss = [dataset.coordset for dataset in datasets]
-        if set(coordss) == {None}:
-            coordss = None
-
-        # concatenate coords if they exists
-        # ------------------------------------------------------------------------
-
-        if coordss is None or (len(coordss) == 1 and coordss.pop() is None):
-            # no coords
-            coords = None
-        else:
-            # we take the coords of the first dataset, and extend the coord along the concatenate axis
-            coords = coordss[0].copy()
-
-            try:
-                coords[dim] = Coord(
-                    coords[dim], linear=False
-                )  # de-linearize the coordinates
-                coords[dim]._data = np.concatenate(
-                    tuple((c[dim].data for c in coordss))
-                )
-            except (KeyError, ValueError):
-                pass
-
-        # check labeling
-        # concatenation of the labels (first check the presence of at least one labeled coordinates)
-
-        is_labeled = False
-        for i, c in enumerate(coordss):
-            if c[dim].implements() in ["Coord", "LinearCoord"]:
-                # this is a coord
-                if c[dim].is_labeled:
-                    # at least one of the coord is labeled
-                    is_labeled = True
-                    break
-            if c[dim].implements("CoordSet"):
-                # this is a coordset
-                for coord in c[dim]:
-                    if coord.is_labeled:
-                        # at least one of the coord is labeled
-                        is_labeled = True
-                        break
-
-        if is_labeled:
-            labels = []
-            # be sure that now all the coordinates have a label, or create one
-            for i, c in enumerate(coordss):
-                if c[dim].implements() in ["Coord", "LinearCoord"]:
-                    # this is a coord
-                    if c[dim].is_labeled:
-                        labels.append(c[dim].labels)
-                    else:
-                        labels.append(str(i))
-                if c[dim].implements("CoordSet"):
-                    # this is a coordset
-                    for coord in c[dim]:
-                        if coord.is_labeled:
-                            labels.append(c[dim].labels)
-                        else:
-                            labels.append(str(i))
-
-            if isinstance(coords[dim], Coord):
-                coords[dim]._labels = np.concatenate(labels)
-            if coords[dim].implements("CoordSet"):
-                for i, coord in enumerate(coords[dim]):
-                    coord._labels = np.concatenate(labels[i :: len(coords[dim])])
-
-            coords[dim]._labels = np.concatenate(labels)
-
-    else:  # assume homogeneous datasets
+            # get axis from arguments (or set it to the default)
+            axis, dim = datasets[0].get_axis(**kwargs)
 
         units = datasets[0].units
         coords = datasets[0].coordset
+
         if coords is not None:
+            # check labels, coords type and concatenate them
 
-            # check labels, coàords and concatenate them
-            is_labeled = False
             labels = []
-
             if coords[dim].implements() in ["Coord", "LinearCoord"]:
                 if coords[dim].is_labeled:
                     for ds in datasets:
@@ -301,62 +147,192 @@ def concatenate(*datasets, **kwargs):
                     for i, coord in enumerate(coords[dim]):
                         coord._labels = np.concatenate(labels[i :: len(coords[dim])])
 
-            # concatenate coords if they exists
-            # ------------------------------------------------------------------------
-            try:
-                coords[dim] = Coord(
-                    coords[dim], linear=False
-                )  # de-linearize the coordinates
-                coords[dim]._data = np.concatenate(
-                    tuple((ds.coordset[dim].data for ds in datasets))
+            coords[dim] = Coord(coords[dim], linear=False)
+            coords[dim]._data = np.concatenate(
+                tuple((ds.coordset[dim].data for ds in datasets))
+            )
+
+        # concatenate or stack the data array + mask
+        # ------------------------------------------------------------------------
+
+        sss = []
+        for i, dataset in enumerate(datasets):
+            d = dataset.masked_data
+            sss.append(d)
+
+        try:
+            sconcat = np.ma.concatenate(sss, axis=axis)
+
+        except ValueError as e:
+            print(f"---err sconcat = np.ma.concatenate(sss, axis=axis): {e}")
+            # probably a dimension mismatch
+            # get the shapes and ndims for comparison
+            rshapes = []
+            rndims = []
+            for item in datasets:
+                sh = list(item.shape)
+                rshapes.append(sh)
+                rndims.append(len(sh))
+
+            # The number of dimensions is expected to be the same for all datasets
+            if len(list(set(rndims))) > 1:
+                raise DimensionsCompatibilityError(
+                    "Only NDDataset with the same number of dimensions can be concatenated."
                 )
-            except (KeyError, ValueError):
-                pass
 
-    # concatenate or stack the data array + mask
-    # ------------------------------------------------------------------------
+            rcompat = list(map(list, list(map(set, list(zip(*rshapes))))))
 
-    sss = []
-    for i, dataset in enumerate(datasets):
-        d = dataset.masked_data
-        sss.append(d)
+            if force_stack:
+                # in
+                if len(set(list(map(len, rcompat)))) != 1:
+                    warn(
+                        "These datasets have not the same shape, so they cannot be stacked. By default they will be "
+                        "concatenated along the first dimension.",
+                        category=SpectroChemPyWarning,
+                    )
+                    axis, dim = datasets[0].get_axis(dim=0)
 
-    sconcat = np.ma.concatenate(sss, axis=axis)
-    data = np.asarray(sconcat)
-    mask = sconcat.mask
+            # now check if data shapes are compatible (all dimension must have the same size
+            # except the one to be concatenated)
+            for i, item in enumerate(zip(*rshapes)):
+                if i != axis and len(set(item)) > 1:
+                    raise DimensionsCompatibilityError(
+                        "Datasets must have the same shape for all dimensions except the one along which the"
+                        " concatenation is performed"
+                    )
 
-    # out = NDDataset(data, coordset=coords, mask=mask, units=units)    # This doesn't keep the order of the
-    # coordinates
-    out = dataset.copy()
-    out._data = data
-    if coords is not None:
-        out._coordset[dim] = coords[dim]
-    out._mask = mask
-    out._units = units
+            # retry
+            sconcat = np.ma.concatenate(sss, axis=axis)
 
-    thist = "Stack" if axis == 0 else "Concatenation"
+        data = np.asarray(sconcat)
+        mask = sconcat.mask
 
-    out.description = "{} of {}  datasets:\n".format(thist, len(datasets))
-    out.description += "( {}".format(datasets[0].name)
-    out.title = datasets[0].title
-    authortuple = (datasets[0].author,)
+        out = dataset.copy()
+        out._data = data
+        if coords is not None:
+            out._coordset[dim] = coords[dim]
+        out._mask = mask
+        out._units = units
 
-    for dataset in datasets[1:]:
+        thist = "Stack" if axis == 0 else "Concatenation"
 
-        if out.title != dataset.title:
-            warn("Different data title => the title is that of the 1st dataset")
+        out.description = "{} of {}  datasets:\n".format(thist, len(datasets))
+        out.description += "( {}".format(datasets[0].name)
+        out.title = datasets[0].title
+        authortuple = (datasets[0].author,)
 
-        if not (dataset.author in authortuple):
-            authortuple = authortuple + (dataset.author,)
-            out.author = out.author + " & " + dataset.author
+        for dataset in datasets[1:]:
 
-        out.description += ", {}".format(dataset.name)
+            if out.title != dataset.title:
+                warn("Different data title => the title is that of the 1st dataset")
 
-    out.description += " )"
-    out._date = out._modified = datetime.datetime.now(datetime.timezone.utc)
-    out._history = [str(out.date) + ": Created by %s" % thist]
+            if not (dataset.author in authortuple):
+                authortuple = authortuple + (dataset.author,)
+                out.author = out.author + " & " + dataset.author
 
-    return out
+            out.description += ", {}".format(dataset.name)
+
+        out.description += " )"
+        out._date = out._modified = datetime.datetime.now(datetime.timezone.utc)
+        out._history = [str(out.date) + ": Created by %s" % thist]
+
+        return out
+
+    except Exception as e:
+        print(f"oups : {e}")
+
+    # except Exception:
+    #     # there has been an error, could be due incompatible units, missing labels...
+    #     # more checks are carried out
+    #
+
+    #     # Check unit compatibility
+    #     # ------------------------------------------------------------------------
+    #     units = datasets[0].units
+    #     for dataset in datasets:
+    #         if not dataset.is_units_compatible(datasets[0]):
+    #             raise ValueError(
+    #                 "units of the datasets to concatenate are not compatible"
+    #             )
+    #         # if needed transform to the same unit
+    #         dataset.ito(units)
+    #     # TODO: make concatenation of heterogeneous data possible by using labels
+    #
+    #     # Check coordinates compatibility
+    #     # ------------------------------------------------------------------------
+    #
+    #     # coordinates units of NDDatasets must be compatible in all dimensions
+    #     # get the coordss
+    #
+    #     coordss = [dataset.coordset for dataset in datasets]
+    #     if set(coordss) == {None}:
+    #         coordss = None
+    #
+    #     # concatenate coords if they exists
+    #     # ------------------------------------------------------------------------
+    #
+    #     if coordss is None or (len(coordss) == 1 and coordss.pop() is None):
+    #         # no coords
+    #         coords = None
+    #     else:
+    #         # we take the coords of the first dataset, and extend the coord along the concatenate axis
+    #         coords = coordss[0].copy()
+    #
+    #         try:
+    #             coords[dim] = Coord(
+    #                 coords[dim], linear=False
+    #             )  # de-linearize the coordinates
+    #             coords[dim]._data = np.concatenate(
+    #                 tuple((c[dim].data for c in coordss))
+    #             )
+    #         except (KeyError, ValueError):
+    #             pass
+    #
+    #     # check labeling
+    #     # concatenation of the labels (first check the presence of at least one labeled coordinates)
+    #
+    #     is_labeled = False
+    #     for i, c in enumerate(coordss):
+    #         if c[dim].implements() in ["Coord", "LinearCoord"]:
+    #             # this is a coord
+    #             if c[dim].is_labeled:
+    #                 # at least one of the coord is labeled
+    #                 is_labeled = True
+    #                 break
+    #         if c[dim].implements("CoordSet"):
+    #             # this is a coordset
+    #             for coord in c[dim]:
+    #                 if coord.is_labeled:
+    #                     # at least one of the coord is labeled
+    #                     is_labeled = True
+    #                     break
+    #
+    #     if is_labeled:
+    #         labels = []
+    #         # be sure that now all the coordinates have a label, or create one
+    #         for i, c in enumerate(coordss):
+    #             if c[dim].implements() in ["Coord", "LinearCoord"]:
+    #                 # this is a coord
+    #                 if c[dim].is_labeled:
+    #                     labels.append(c[dim].labels)
+    #                 else:
+    #                     labels.append(str(i))
+    #             if c[dim].implements("CoordSet"):
+    #                 # this is a coordset
+    #                 for coord in c[dim]:
+    #                     if coord.is_labeled:
+    #                         labels.append(c[dim].labels)
+    #                     else:
+    #                         labels.append(str(i))
+    #
+    #         if isinstance(coords[dim], Coord):
+    #             coords[dim]._labels = np.concatenate(labels)
+    #         if coords[dim].implements("CoordSet"):
+    #             for i, coord in enumerate(coords[dim]):
+    #                 coord._labels = np.concatenate(labels[i :: len(coords[dim])])
+    #
+    #         coords[dim]._labels = np.concatenate(labels)
+    #
 
 
 def stack(*datasets, **kwargs):
@@ -393,6 +369,17 @@ def stack(*datasets, **kwargs):
     """
 
     return concatenate(*datasets, force_stack=True, **kwargs)
+
+
+def _prepend_dim(dataset, coord_value):
+    """prepend a new dimension with coords"""
+    dataset._data = dataset.data[np.newaxis]
+    dataset._mask = dataset.mask[np.newaxis]
+    newcoord = Coord([coord_value], labels=[dataset.name])
+    newcoord.name = (OrderedSet(DEFAULT_DIM_NAME) - dataset._dims).pop()
+    dataset.add_coordset(newcoord)
+    dataset.dims = [newcoord.name] + dataset.dims
+    return dataset
 
 
 if __name__ == "__main__":

--- a/spectrochempy/core/processors/concatenate.py
+++ b/spectrochempy/core/processors/concatenate.py
@@ -77,6 +77,11 @@ def concatenate(*datasets, **kwargs):
     ((55, 5549), (55, 5549), (55, 11098))
     """
 
+    # check uise
+    if "force_stack" in kwargs:
+        warn("force_stack not used anymore, use stack() instead")
+        return stack(datasets)
+
     # get a copy of input datasets in order that input data are not modified
     datasets = _get_copy(datasets)
 

--- a/spectrochempy/core/processors/concatenate.py
+++ b/spectrochempy/core/processors/concatenate.py
@@ -112,7 +112,7 @@ def concatenate(*datasets, **kwargs):
                 ds.ito(units)
 
     # concatenate or stack the data array + mask
-    # ------------------------------------------------------------------------
+    # --------------------------------------------
 
     sss = []
     for i, dataset in enumerate(datasets):

--- a/spectrochempy/core/readers/importer.py
+++ b/spectrochempy/core/readers/importer.py
@@ -248,10 +248,7 @@ class Importer(HasTraits):
         if merged:
             # Try to stack the dataset into a single one
             try:
-                if dim0 == 0:
-                    dataset = self.objtype.stack(datasets)
-                else:
-                    dataset = self.objtype.concatenate(datasets, axis=1)
+                dataset = self.objtype.concatenate(datasets, axis=0)
                 if dataset.coordset is not None and kwargs.pop("sortbydate", True):
                     dataset.sort(dim="y", inplace=True)
                     dataset.history = (

--- a/spectrochempy/core/readers/importer.py
+++ b/spectrochempy/core/readers/importer.py
@@ -248,7 +248,10 @@ class Importer(HasTraits):
         if merged:
             # Try to stack the dataset into a single one
             try:
-                dataset = self.objtype.stack(datasets)
+                if dim0 == 0:
+                    dataset = self.objtype.stack(datasets)
+                else:
+                    dataset = self.objtype.concatenate(datasets, axis=1)
                 if dataset.coordset is not None and kwargs.pop("sortbydate", True):
                     dataset.sort(dim="y", inplace=True)
                     dataset.history = (

--- a/spectrochempy/core/readers/importer.py
+++ b/spectrochempy/core/readers/importer.py
@@ -248,8 +248,7 @@ class Importer(HasTraits):
         if merged:
             # Try to stack the dataset into a single one
             try:
-                homogeneous = kwargs.pop("homogeneous", True)
-                dataset = self.objtype.stack(datasets, homogeneous=homogeneous)
+                dataset = self.objtype.stack(datasets)
                 if dataset.coordset is not None and kwargs.pop("sortbydate", True):
                     dataset.sort(dim="y", inplace=True)
                     dataset.history = (
@@ -313,10 +312,6 @@ def read(*paths, **kwargs):
         Default value is False. If True, and several filenames have been provided as arguments,
         then a single dataset with merged (stacked along the first
         dimension) is returned (default=False).
-    homogeneous : bool, optional, default=False
-        If True, the datasets extracted from each file are assumed to homogeneous: same shapes, same coordinates and
-        labels all dimensions but one (along which the merge will be applied), same units, etc... This avoids many
-        checks and save times when reading hundreds or thousands files.
     sortbydate : bool, optional
         Sort multiple spectra by acquisition date (default=True).
     description : str, optional

--- a/spectrochempy/core/readers/importer.py
+++ b/spectrochempy/core/readers/importer.py
@@ -248,7 +248,8 @@ class Importer(HasTraits):
         if merged:
             # Try to stack the dataset into a single one
             try:
-                dataset = self.objtype.stack(datasets)
+                homogeneous = kwargs.pop("homogeneous", True)
+                dataset = self.objtype.stack(datasets, homogeneous=homogeneous)
                 if dataset.coordset is not None and kwargs.pop("sortbydate", True):
                     dataset.sort(dim="y", inplace=True)
                     dataset.history = (
@@ -312,6 +313,10 @@ def read(*paths, **kwargs):
         Default value is False. If True, and several filenames have been provided as arguments,
         then a single dataset with merged (stacked along the first
         dimension) is returned (default=False).
+    homogeneous : bool, optional, default=False
+        If True, the datasets extracted from each file are assumed to homogeneous: same shapes, same coordinates and
+        labels all dimensions but one (along which the merge will be applied), same units, etc... This avoids many
+        checks and save times when reading hundreds or thousands files.
     sortbydate : bool, optional
         Sort multiple spectra by acquisition date (default=True).
     description : str, optional

--- a/tests/test_core/test_processors/test_concatenate.py
+++ b/tests/test_core/test_processors/test_concatenate.py
@@ -88,7 +88,7 @@ def test_concatenate(IR_dataset_2D):
         s0.concatenate(s1[0].squeeze())
 
     with pytest.raises(DimensionsCompatibilityError):
-        s0.concatenate(s1[:, 50])
+        s0.concatenate(s1[:, :50], axis=0)
 
     # incompatible units
     s0 = scp.NDDataset(np.zeros((10, 100)), units="V")
@@ -112,6 +112,9 @@ def test_concatenate(IR_dataset_2D):
     assert s.y.size == s1.y.size
     assert s.x.size == s1.x.size
 
+    with pytest.warns(UserWarning):
+        concatenate(s1, s2, force_stack=True)
+
     # If one of the dimensions is of size one, then this dimension is NOT removed before stacking
     s0 = dataset[0]
     s1 = dataset[1]
@@ -131,6 +134,7 @@ def test_concatenate(IR_dataset_2D):
     s2 = s1[0:100]
     with pytest.raises(DimensionsCompatibilityError):
         s = stack(s0, s2)
+
 
 def test_bug_243():
     import spectrochempy as scp

--- a/tests/test_core/test_processors/test_concatenate.py
+++ b/tests/test_core/test_processors/test_concatenate.py
@@ -8,7 +8,10 @@ from spectrochempy.core.processors.concatenate import concatenate, stack
 from spectrochempy.core.units import ur
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.utils.testing import assert_dataset_almost_equal
-from spectrochempy.utils.exceptions import DimensionsCompatibilityError
+from spectrochempy.utils.exceptions import (
+    DimensionsCompatibilityError,
+    UnitsCompatibilityError,
+)
 
 import pytest
 
@@ -93,7 +96,7 @@ def test_concatenate(IR_dataset_2D):
     # incompatible units
     s0 = scp.NDDataset(np.zeros((10, 100)), units="V")
     s1 = scp.NDDataset(np.zeros((10, 100)), units="A")
-    with pytest.raises(ValueError):
+    with pytest.raises(UnitsCompatibilityError):
         scp.concatenate(s0, s1)
 
     s1 = scp.NDDataset(np.ones((10, 100)), units="mV")
@@ -112,7 +115,7 @@ def test_concatenate(IR_dataset_2D):
     assert s.y.size == s1.y.size
     assert s.x.size == s1.x.size
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(DeprecationWarning):
         concatenate(s1, s2, force_stack=True)
 
     # If one of the dimensions is of size one, then this dimension is NOT removed before stacking

--- a/tests/test_core/test_processors/test_concatenate.py
+++ b/tests/test_core/test_processors/test_concatenate.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 
-
+from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.processors.concatenate import concatenate, stack
 from spectrochempy.core.units import ur
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.utils.testing import assert_dataset_almost_equal
 from spectrochempy.utils import show
+from spectrochempy.utils.exceptions import DimensionsCompatibilityError
+
+import pytest
 
 
 def test_concatenate(IR_dataset_2D):
@@ -59,7 +62,7 @@ def test_concatenate(IR_dataset_2D):
     assert s.shape[0] == (s1.shape[0] + s2.shape[0])
     assert s.y.size == (s1.y.size + s2.y.size)
 
-    # concatenation in the first dimenson using stack
+    # concatenation in the first dimension using stack
     s = stack(s1, s2)
     assert s.units == s1.units
     assert s.shape[0] == (s1.shape[0] + s2.shape[0])
@@ -77,6 +80,22 @@ def test_concatenate(IR_dataset_2D):
     ss = s0.concatenate(s1, force_stack=True)
     assert s0.shape == (1, 5549)
     assert ss.shape == (2, 5549)
+
+    # if incompatible dimensions
+    s0 = s[0, :1000]
+    s1 = s[1]
+    with pytest.raises(DimensionsCompatibilityError):
+        s0.concatenate(s1, force_stack=True)
+    s0 = s[0]
+    s1 = s[1].squeeze()
+    with pytest.raises(DimensionsCompatibilityError):
+        s0.concatenate(s1, force_stack=True)
+
+    s0 = s[0]
+    s1 = s[1]
+    s0.author = "sdqe65g4rf"
+    s2 = concatenate(s0, s1)
+    assert "sdqe65g4rf" in s2.author and s1.author in s2.author
 
     # stack squeezed nD dataset
     s0 = s[0].copy().squeeze()

--- a/tests/test_core/test_readers/test_read_zip.py
+++ b/tests/test_core/test_readers/test_read_zip.py
@@ -47,4 +47,4 @@ def test_read_zip():
         csv_delimiter=";",
         merge=True,
     )
-    assert C.shape == (2, 10, 2843)
+    assert C.shape == (20, 2843)


### PR DESCRIPTION
Concatenate now scales linearly with the number of datasets

NB 
- `force_stack` keyword in concatenate() amounted to stack(), it is now deprecated. 
- `stack()` method now generates a new dim, even if a dim of size one is present, so that it resembles more to the the stack() methods of numpy or xarray
- `concatenate()` now can only be used on existing dimension


- [X] related to  #408
- [X] Tests have been added, coverage is 100% 
- [X] The docstrings have been tested 
- [X] User-visible changes documented in `CHANGELOG.md` 