### PR TITLE
Feature/check docstring

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [macos-latest] # ubuntu-latest, windows-latest]
         pythonVersion: ["3.10"]
         # test only 3.10 as 3.8 and 3.9 are at least partially tested in
         # build docs and packages

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Test, generate coverage information
         run: |
-          coverage run --rcfile=tests/.coveragerc -m pytest -v tests
+          coverage run --rcfile=tests/.coveragerc -m pytest tests
 
       - name: Report Coverage info to CodeClimate
         if: ${{ github.event_name == 'push' && matrix.pythonVersion == '3.10'

--- a/spectrochempy/core/dataset/ndarray.py
+++ b/spectrochempy/core/dataset/ndarray.py
@@ -1376,13 +1376,14 @@ class NDArray(HasTraits):
         """
         True if the `data` array is dimensionless - Readonly property (bool).
 
-        Notes
-        -----
-        `Dimensionless` is different of `unitless` which means no unit.
-
         See Also
         --------
-        unitless, has_units
+        unitless : True if data has no units.
+        has_units : True if data has units.
+
+         Notes
+        -----
+        `Dimensionless` is different of `unitless` which means no unit.
         """
         if self.unitless:
             return False
@@ -1546,7 +1547,8 @@ class NDArray(HasTraits):
     @property
     def has_data(self):
         """
-        True if the `data` array is not empty and size > 0 (Bool).
+        True if the `data` array is not empty and size > 0.
+
         (Readonly property).
         """
         if (self.data is None) or (self.data.size == 0):
@@ -1570,7 +1572,8 @@ class NDArray(HasTraits):
 
         See Also
         --------
-        unitless, dimensionless
+        unitless : True if the data has no unit.
+        dimensionless : True if the data have dimensionless units.
         """
         if self._units is not None:
             return True
@@ -1665,8 +1668,9 @@ class NDArray(HasTraits):
     @property
     def is_empty(self):
         """
-        True if the `data` array is empty or size=0, and if no label are present
-        - Readonly property (bool).
+        True if the `data` array is empty or size=0, and if no label are present.
+
+        Readonly property (bool).
         """
         if ((self._data is None) or (self._data.size == 0)) and not self.is_labeled:
             return True
@@ -1737,22 +1741,6 @@ class NDArray(HasTraits):
         except DimensionalityError:
             return False
         return True
-
-    # ..........................................................................
-    @property
-    def itemsize(self):
-        """
-        Data type size (int).
-        """
-        if self.data is None:
-            return None
-
-        return self.data.dtype.itemsize
-
-    # ..........................................................................
-    @property
-    def iterdims(self):
-        return list(range(self.ndim))
 
     # ..........................................................................
     def ito(self, other, force=False):

--- a/spectrochempy/core/dataset/ndcomplex.py
+++ b/spectrochempy/core/dataset/ndcomplex.py
@@ -163,7 +163,8 @@ class NDComplexArray(NDArray):
     @property
     def has_complex_dims(self):
         """
-        bool - True if at least one of the `data` array dimension is complex
+        True if at least one of the `data` array dimension is complex.
+
         (Readonly property).
         """
         if self._data is None:
@@ -177,7 +178,7 @@ class NDComplexArray(NDArray):
     @property
     def is_complex(self):
         """
-        bool - True if the 'data' are complex (Readonly property).
+        True if the 'data' are complex (Readonly property).
         """
         if self._data is None:
             return False
@@ -187,7 +188,9 @@ class NDComplexArray(NDArray):
     @property
     def is_quaternion(self):
         """
-        bool - True if the `data` array is hypercomplex (Readonly property).
+        True if the `data` array is hypercomplex .
+
+        (Readonly property).
         """
         if self._data is None:
             return False
@@ -197,7 +200,9 @@ class NDComplexArray(NDArray):
     @property
     def is_interleaved(self):
         """
-        bool - True if the `data` array is hypercomplex with interleaved data (Readonly property).
+        True if the `data` array is hypercomplex with interleaved data.
+
+        (Readonly property).
         """
         if self._data is None:
             return False
@@ -207,7 +212,9 @@ class NDComplexArray(NDArray):
     @property
     def is_masked(self):
         """
-        bool - True if the `data` array has masked values (Readonly property).
+        True if the `data` array has masked values.
+
+        (Readonly property).
         """
         try:
             return super().is_masked
@@ -221,7 +228,9 @@ class NDComplexArray(NDArray):
     @property
     def real(self):
         """
-        array - The array with real component of the `data` (Readonly property).
+        The array with real component of the `data`.
+
+        (Readonly property).
         """
         new = self.copy()
         if not new.has_complex_dims:
@@ -247,7 +256,9 @@ class NDComplexArray(NDArray):
     @property
     def imag(self):
         """
-        array - The array with imaginary component of the `data` (Readonly property).
+        The array with imaginary component of the `data`.
+
+        (Readonly property).
         """
         new = self.copy()
         if not new.has_complex_dims:
@@ -275,8 +286,7 @@ class NDComplexArray(NDArray):
     @property
     def RR(self):
         """
-        array - The array with real component in both dimension of
-        hypercomplex 2D `data`.
+        The array with real component in both dimension of hypercomplex 2D `data`.
 
         This readonly property is equivalent to the `real` property.
         """
@@ -288,7 +298,9 @@ class NDComplexArray(NDArray):
     @property
     def RI(self):
         """
-        array - The array with real-imaginary component of hypercomplex 2D `data` (Readonly property).
+        The array with real-imaginary component of hypercomplex 2D `data`.
+
+        (Readonly property).
         """
         if not self.is_quaternion:
             raise TypeError("Not an hypercomplex array")
@@ -298,7 +310,9 @@ class NDComplexArray(NDArray):
     @property
     def IR(self):
         """
-        array - The array with imaginary-real component of hypercomplex 2D `data` (Readonly property).
+        The array with imaginary-real component of hypercomplex 2D `data`.
+
+        (Readonly property).
         """
         if not self.is_quaternion:
             raise TypeError("Not an hypercomplex array")
@@ -308,7 +322,9 @@ class NDComplexArray(NDArray):
     @property
     def II(self):
         """
-        array - The array with imaginary-imaginary component of hypercomplex 2D data (Readonly property).
+        The array with imaginary-imaginary component of hypercomplex 2D data.
+
+        (Readonly property).
         """
         if not self.is_quaternion:
             raise TypeError("Not an hypercomplex array")
@@ -318,7 +334,7 @@ class NDComplexArray(NDArray):
     @property
     def limits(self):
         """
-        list - range of the data
+        Range of the data.
         """
         if self.data is None:
             return None

--- a/spectrochempy/core/dataset/nddataset.py
+++ b/spectrochempy/core/dataset/nddataset.py
@@ -150,7 +150,7 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
         Origin of the data: Name of organization, address, telephone number,
         name of individual contributor, etc., as appropriate.
     roi : list
-        Region of interest (ROI) limits
+        Region of interest (ROI) limits.
     history : str, optional
         A string to add to the object history.
     copy : bool, optional
@@ -552,7 +552,9 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
     # ...........................................................................................................
     @property
     def state(self):
-        # state of the controller window for this dataset
+        """
+        State of the controller window for this dataset.
+        """
         return self._state
 
     @state.setter
@@ -561,6 +563,9 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
     @property
     def processeddata(self):
+        """
+        Data after processing (optionaly used).
+        """
         return self._processeddata
 
     @processeddata.setter
@@ -569,6 +574,9 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
     @property
     def processedmask(self):
+        """
+        Mask for the optional processed data.
+        """
         return self._processedmask
 
     @processedmask.setter
@@ -577,6 +585,9 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
     @property
     def baselinedata(self):
+        """
+        Data for an optional baseline.
+        """
         return self._baselinedata
 
     @baselinedata.setter
@@ -585,6 +596,9 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
     @property
     def referencedata(self):
+        """
+        Data for an optional reference spectra.
+        """
         return self._referencedata
 
     @referencedata.setter
@@ -828,7 +842,7 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
     @property
     def parent(self):
         """
-        |Project| instance
+        |Project| instance.
 
         The parent project of the dataset.
         """
@@ -856,7 +870,9 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         See Also
         --------
-        add_coords, set_coordtitles, set_coordunits
+        add_coordset : Add one or a set of coordinates from a dataset.
+        set_coordtitles : Set titles of the one or more coordinates.
+        set_coordunits : Set units of the one or more coordinates.
         """
         self._coordset = None
         self.add_coordset(*args, dims=self.dims, **kwargs)
@@ -901,7 +917,8 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         Returns
         -------
-        sorted_dataset
+        |NDDataset|
+            Sorted dataset.
         """
 
         inplace = kwargs.get("inplace", False)
@@ -966,7 +983,7 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         Parameters
         ----------
-        dim : None or int or tuple of ints, optional
+        *dims : None or int or tuple of ints, optional
             Selects a subset of the single-dimensional entries in the
             shape. If a dimension (dim) is selected with shape entry greater than
             one, an error is raised.
@@ -976,7 +993,7 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         Returns
         -------
-        squeezed
+        |NDDataset|
             The input array, but with all or a subset of the
             dimensions of length 1 removed.
 
@@ -1015,7 +1032,7 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         Returns
         -------
-        result : ndarray
+        |NDDataset|
             View of `a` with the number of dimensions increased.
 
         See Also
@@ -1041,11 +1058,12 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         Returns
         -------
-        swaped_dataset
+        |NDDataset|
+            Swaped dataset.
 
         See Also
         --------
-        transpose
+        transpose : Transpose a dataset.
         """
 
         new = super().swapdims(dim1, dim2, inplace=inplace)
@@ -1067,13 +1085,10 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
         """
         Take elements from an array.
 
-        Parameters
-        ----------
-        indices
-        kwargs
-
         Returns
         -------
+        |NDDataset|
+            A sub dataset defined by the input indices.
         """
 
         # handle the various syntax to pass the axis
@@ -1097,7 +1112,14 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
     def to_array(self):
         """
-        Return a numpy masked array (i.e., other NDDataset attributes are lost.
+        Return a numpy masked array.
+
+        Other NDDataset attributes are lost.
+
+        Returns
+        -------
+        |ndarray|
+            The numpy masked array from the NDDataset data.
 
         Examples
         ========
@@ -1205,7 +1227,7 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         Parameters
         ----------
-        dims : sequence of dimension indexes or names, optional
+        *dims : sequence of dimension indexes or names, optional
             By default, reverse the dimensions, otherwise permute the dimensions
             according to the values given.
         inplace : bool, optional, default=`False`
@@ -1214,7 +1236,8 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
 
         Returns
         -------
-        transposed_array
+        NDDataset
+            Transposed NDDataset.
 
         See Also
         --------

--- a/spectrochempy/core/dataset/nddataset.py
+++ b/spectrochempy/core/dataset/nddataset.py
@@ -171,8 +171,7 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
     --------
     Usage by an end-user
 
-    >>> from spectrochempy import *
-    >>> x = NDDataset([1, 2, 3])
+    >>> x = scp.NDDataset([1, 2, 3])
     >>> print(x.data)  # doctest: +NORMALIZE_WHITESPACE
     [       1        2        3]
     """

--- a/spectrochempy/core/dataset/nddataset.py
+++ b/spectrochempy/core/dataset/nddataset.py
@@ -166,15 +166,16 @@ class NDDataset(NDIO, NDPlot, NDMath, NDComplexArray):
     -----
     The underlying array in a |NDDataset| object can be accessed through the
     `data` attribute, which will return a conventional |ndarray|.
-
-    Examples
-    --------
-    Usage by an end-user
-
-    >>> x = scp.NDDataset([1, 2, 3])
-    >>> print(x.data)  # doctest: +NORMALIZE_WHITESPACE
-    [       1        2        3]
     """
+
+    # Examples
+    # --------
+    # Usage by an end-user
+    #
+    # >>> x = scp.NDDataset([1, 2, 3])
+    # >>> print(x.data)  # doctest: +NORMALIZE_WHITESPACE
+    # [       1        2        3.]
+    # """
 
     # coordinates
     _coordset = Instance(CoordSet, allow_none=True)

--- a/spectrochempy/core/dataset/ndio.py
+++ b/spectrochempy/core/dataset/ndio.py
@@ -53,7 +53,7 @@ class NDIO(HasTraits):
     @property
     def directory(self):
         """
-        `Pathlib` object - current directory for this dataset.
+        Current directory for this dataset.
 
         ReadOnly property - automatically set when the filename is updated if
         it contains a parent on its path.
@@ -66,7 +66,7 @@ class NDIO(HasTraits):
     @property
     def filename(self):
         """
-        `Pathlib` object - current filename for this dataset.
+        Current filename for this dataset.
         """
         if self._filename:
             return self._filename.stem + self.suffix
@@ -79,13 +79,16 @@ class NDIO(HasTraits):
 
     @property
     def filetype(self):
+        """
+        Type of current file.
+        """
         klass = self.implements()
         return [f"SpectroChemPy {klass} file (*{SCPY_SUFFIX[klass]})"]
 
     @property
     def suffix(self):
         """
-        filename suffix.
+        Filename suffix.
 
         Read Only property - automatically set when the filename is updated
         if it has a suffix, else give

--- a/spectrochempy/core/dataset/ndplot.py
+++ b/spectrochempy/core/dataset/ndplot.py
@@ -789,7 +789,7 @@ class NDPlot(HasTraits):
     @property
     def ax(self):
         """
-        the main matplotlib axe associated to this dataset.
+        The main matplotlib axe associated to this dataset.
         """
         return self._ndaxes["main"]
 
@@ -797,7 +797,7 @@ class NDPlot(HasTraits):
     @property
     def axT(self):
         """
-        the matplotlib axe associated to the transposed dataset.
+        The matplotlib axe associated to the transposed dataset.
         """
         return self._ndaxes["mainT"]
 

--- a/spectrochempy/utils/check_docstrings.py
+++ b/spectrochempy/utils/check_docstrings.py
@@ -11,7 +11,7 @@ import pathlib
 import subprocess
 import tempfile
 
-# import traceback
+import traceback
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -283,18 +283,20 @@ class DocstringError(Exception):
             message += "\n\nDoctests:\n---------\n"
             message += result["examples_errs"]
 
-        # traceback_details = {
-        #     "filename": result["file"],
-        #     "lineno": result["file_line"],
-        #     "name": result["member_name"],
-        #     "type": "DocstringError",
-        #     "message": message,
-        # }
-        # traceback.format_exc()
-        # traceback_template = """
-        # Docstring format error:
-        #   File "%(filename)s", line %(lineno)s,
-        #   in %(name)s.
-        #   %(message)s\n
-        # """
-        # print(traceback_template % traceback_details)
+        traceback_details = {
+            "filename": result["file"],
+            "lineno": result["file_line"],
+            "name": result["member_name"],
+            "type": "DocstringError",
+            "message": message,
+        }
+
+        traceback.format_exc()  # cannot be used with pytest in debug mode
+
+        traceback_template = """
+        Docstring format error:
+          File "%(filename)s", line %(lineno)s,
+          in %(name)s.
+          %(message)s\n
+        """
+        print(traceback_template % traceback_details)

--- a/spectrochempy/utils/check_docstrings.py
+++ b/spectrochempy/utils/check_docstrings.py
@@ -10,7 +10,8 @@ import os
 import pathlib
 import subprocess
 import tempfile
-import traceback
+
+# import traceback
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -281,18 +282,19 @@ class DocstringError(Exception):
         if result["examples_errs"]:
             message += "\n\nDoctests:\n---------\n"
             message += result["examples_errs"]
-        traceback_details = {
-            "filename": result["file"],
-            "lineno": result["file_line"],
-            "name": result["member_name"],
-            "type": "DocstringError",
-            "message": message,
-        }
-        traceback.format_exc()
-        traceback_template = """
-        Docstring format error:
-          File "%(filename)s", line %(lineno)s,
-          in %(name)s.
-          %(message)s\n
-        """
-        print(traceback_template % traceback_details)
+
+        # traceback_details = {
+        #     "filename": result["file"],
+        #     "lineno": result["file_line"],
+        #     "name": result["member_name"],
+        #     "type": "DocstringError",
+        #     "message": message,
+        # }
+        # traceback.format_exc()
+        # traceback_template = """
+        # Docstring format error:
+        #   File "%(filename)s", line %(lineno)s,
+        #   in %(name)s.
+        #   %(message)s\n
+        # """
+        # print(traceback_template % traceback_details)

--- a/spectrochempy/utils/check_docstrings.py
+++ b/spectrochempy/utils/check_docstrings.py
@@ -1,0 +1,298 @@
+"""
+Analyze docstrings to detect errors.
+
+Adapted from Pandas (see License in the root directory)
+"""
+import doctest
+import io
+import inspect
+import os
+import pathlib
+import subprocess
+import tempfile
+import traceback
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy
+from numpydoc.docscrape import get_doc_object
+from numpydoc.validate import Validator, validate, error
+
+import spectrochempy
+
+# With template backend, matplotlib plots nothing
+matplotlib.use("template")
+
+
+PRIVATE_CLASSES = [
+    "HasTraits",
+]
+ERROR_MSGS = {
+    "GL04": "Private classes ({mentioned_private_classes}) should not be "
+    "mentioned in public docstrings",
+    "GL05": "Use 'array-like' rather than 'array_like' in docstrings.",
+    "GL11": "Other Parameters section missing while `**kwargs` is in "
+    "class or method signature.",
+    "SA05": "{reference_name} in `See Also` section does not need `spectrochempy` "
+    "prefix, use {right_reference} instead.",
+    "EX02": "Examples do not pass tests:\n{doctest_log}",
+    "EX03": "flake8 error: {error_code} {error_message}{times_happening}",
+    "EX04": "Do not import {imported_library}, as it is imported "
+    "automatically for the examples (numpy as np, spectrochempy as scp)",
+}
+
+
+def spectrochempy_error(code, **kwargs):
+    """
+    Copy of the numpydoc error function, since ERROR_MSGS can't be updated
+    with our custom errors yet.
+    """
+    return (code, ERROR_MSGS[code].format(**kwargs))
+
+
+class SpectroChemPyDocstring(Validator):
+    def __init__(self, func_name, doc_obj=None):
+        self.func_name = func_name
+        if doc_obj is None:
+            doc_obj = get_doc_object(Validator._load_obj(func_name))
+        super().__init__(doc_obj)
+
+    @property
+    def name(self):
+        return self.func_name
+
+    @property
+    def has_kwargs(self):
+        return "**kwargs" in self.signature_parameters
+
+    @property
+    def mentioned_private_classes(self):
+        return [klass for klass in PRIVATE_CLASSES if klass in self.raw_doc]
+
+    @property
+    def examples_errors(self):
+        flags = doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL
+        finder = doctest.DocTestFinder()
+        runner = doctest.DocTestRunner(optionflags=flags)
+        context = {"np": numpy, "scp": spectrochempy}
+        error_msgs = ""
+        current_dir = set(os.listdir())
+        for test in finder.find(self.raw_doc, self.name, globs=context):
+            f = io.StringIO()
+            runner.run(test, out=f.write)
+            error_msgs += f.getvalue()
+        leftovers = set(os.listdir()).difference(current_dir)
+        if leftovers:
+            for leftover in leftovers:
+                path = pathlib.Path(leftover).resolve()
+                if path.is_dir():
+                    path.rmdir()
+                elif path.is_file():
+                    path.unlink(missing_ok=True)
+            raise Exception(
+                f"The following files were leftover from the doctest: "
+                f"{leftovers}. Please use # doctest: +SKIP"
+            )
+        return error_msgs
+
+    @property
+    def examples_source_code(self):
+        lines = doctest.DocTestParser().get_examples(self.raw_doc)
+        return [line.source for line in lines]
+
+    def validate_pep8(self):
+        if not self.examples:
+            return
+
+        # F401 is needed to not generate flake8 errors in examples
+        # that do not use numpy or spectrochempy
+        content = "".join(
+            (
+                "import numpy as np  # noqa: F401\n",
+                "import spectrochempy as scp  # noqa: F401\n",
+                *self.examples_source_code,
+            )
+        )
+
+        error_messages = []
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as file:
+            file.write(content)
+            file.flush()
+            cmd = ["python", "-m", "flake8", "--quiet", "--statistics", file.name]
+            response = subprocess.run(cmd, capture_output=True, text=True)
+            stdout = response.stdout
+            stdout = stdout.replace(file.name, "")
+            messages = stdout.strip("\n")
+            if messages and messages != "0":
+                error_messages.append(messages)
+
+        for error_message in error_messages:
+            error_count, error_code, message = error_message.split(maxsplit=2)
+            yield error_code, message, int(error_count)
+
+    def non_hyphenated_array_like(self):
+        return "array_like" in self.raw_doc
+
+
+def remove_errors(errs, errors=[]):
+    dic_errs = dict(errs)
+    if not isinstance(errors, list):
+        errors = [errors]
+    for err in errors:
+        dic_errs.pop(err, None)
+    errs = list(dic_errs.items())
+    return errs
+
+
+def spectrochempy_validate(func_name, exclude=[]):
+    """
+    Call the numpydoc validation, and add the errors specific to spectrochempy.
+
+    Parameters
+    ----------
+    func_name : str
+        Name of the object of the docstring to validate.
+    exclude : list
+        List of error code to exclude, e.g. ["SA01", ...].
+
+    Returns
+    -------
+    dict
+        Information about the docstring and the errors found.
+    """
+    func_obj = Validator._load_obj(func_name)
+    doc_obj = get_doc_object(func_obj)
+    doc = SpectroChemPyDocstring(func_name, doc_obj)
+    result = validate(doc_obj)
+    errs = result["errors"]
+
+    mentioned_errs = doc.mentioned_private_classes
+    if mentioned_errs:
+        errs.append(
+            spectrochempy_error(
+                "GL04", mentioned_private_classes=", ".join(mentioned_errs)
+            )
+        )
+
+    has_kwargs = doc.has_kwargs
+    if has_kwargs:
+        errs = remove_errors(errs, "PR02")
+        if not doc.doc_other_parameters:
+            errs.append(spectrochempy_error("GL11"))
+
+    if exclude:
+        errs = remove_errors(errs, exclude)
+
+    if doc.see_also:
+        for rel_name in doc.see_also:
+            if rel_name.startswith("spectrochempy."):
+                errs.append(
+                    spectrochempy_error(
+                        "SA05",
+                        reference_name=rel_name,
+                        right_reference=rel_name[len("spectrochempy.") :],
+                    )
+                )
+
+    result["examples_errs"] = ""
+    if doc.examples:
+        result["examples_errs"] = doc.examples_errors
+        if result["examples_errs"]:
+            errs.append(
+                spectrochempy_error("EX02", doctest_log=result["examples_errs"])
+            )
+
+        for error_code, error_message, error_count in doc.validate_pep8():
+            times_happening = f" ({error_count} times)" if error_count > 1 else ""
+            errs.append(
+                spectrochempy_error(
+                    "EX03",
+                    error_code=error_code,
+                    error_message=error_message,
+                    times_happening=times_happening,
+                )
+            )
+        examples_source_code = "".join(doc.examples_source_code)
+        for wrong_import in ("numpy", "spectrochempy"):
+            if f"import {wrong_import}" in examples_source_code:
+                errs.append(spectrochempy_error("EX04", imported_library=wrong_import))
+
+    if doc.non_hyphenated_array_like():
+        errs.append(spectrochempy_error("GL05"))
+
+    # cases where docrep dedent was used
+    if error("GL01") in errs and not doc.raw_doc.startswith(""):
+        errs = remove_errors(errs, "GL01")
+    if error("GL02") in errs and not doc.raw_doc.startswith(""):
+        errs = remove_errors(errs, "GL02")
+
+    # case of properties (we accept a single line summary)
+    if hasattr(doc.code_obj, "fget"):
+        errs = remove_errors(errs, "ES01")
+
+    result["errors"] = errs
+    plt.close("all")
+    if result["file"] is None:
+        # sometimes it is because the code_obj is a property
+        if hasattr(doc.code_obj, "fget"):
+            try:
+                result["file"] = inspect.getsourcefile(doc.code_obj.fget)
+                result["file_line"] = inspect.getsourcelines(doc.code_obj.fget)[-1]
+            except (OSError, TypeError):
+                pass
+
+    return result
+
+
+def check_docstrings(module, obj, exclude=[]):
+    members = [f"{module}.{obj.__name__}"]
+    print(module)
+    print(obj.__name__)
+    for m in dir(obj):
+        member = getattr(obj, m)
+        if not m.startswith("_") and (
+            (
+                member.__class__.__name__ == "property"
+                or (hasattr(member, "__module__") and member.__module__ == module)
+            )
+            and m not in ["cross_validation_lock"]
+        ):
+            members.append(f"{module}.{obj.__name__}.{m}")
+            print(f"{obj.__name__}.{m}")
+
+    for member in members:
+        result = spectrochempy_validate(member, exclude=exclude)
+        if result["errors"]:
+            result["member_name"] = member
+            raise DocstringError(result)
+
+
+class DocstringError(Exception):
+    def __init__(self, result):
+
+        message = ""
+        message += f"{len(result['errors'])} DocstringError(s) found:\n"
+        message += f"{' '*10}{'-'*26}\n"
+        for err_code, err_desc in result["errors"]:
+            if err_code == "EX02":  # Failing examples are printed at the end
+                message += "{' '*2}Examples do not pass tests\n"
+                continue
+            message += f"{' '*10}* {err_code}: {err_desc}\n"
+        if result["examples_errs"]:
+            message += "\n\nDoctests:\n---------\n"
+            message += result["examples_errs"]
+        traceback_details = {
+            "filename": result["file"],
+            "lineno": result["file_line"],
+            "name": result["member_name"],
+            "type": "DocstringError",
+            "message": message,
+        }
+        traceback.format_exc()
+        traceback_template = """
+        Docstring format error:
+          File "%(filename)s", line %(lineno)s,
+          in %(name)s.
+          %(message)s\n
+        """
+        print(traceback_template % traceback_details)

--- a/spectrochempy/utils/check_docstrings.py
+++ b/spectrochempy/utils/check_docstrings.py
@@ -275,7 +275,7 @@ class DocstringError(Exception):
         message += f"{' '*10}{'-'*26}\n"
         for err_code, err_desc in result["errors"]:
             if err_code == "EX02":  # Failing examples are printed at the end
-                message += "{' '*2}Examples do not pass tests\n"
+                message += f"{' '*2}Examples do not pass tests\n"
                 continue
             message += f"{' '*10}* {err_code}: {err_desc}\n"
         if result["examples_errs"]:

--- a/tests/test_core/test_dataset/test_dataset.py
+++ b/tests/test_core/test_dataset/test_dataset.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from pint.errors import UndefinedUnitError
 from quaternion import quaternion
+from os import environ
 
 import spectrochempy as scp
 from spectrochempy.core.units import ur
@@ -15,7 +16,6 @@ from spectrochempy.utils.testing import (
     raises,
     RandomSeedContext,
 )
-from spectrochempy.utils import check_docstrings as chd
 
 typequaternion = np.dtype(np.quaternion)
 
@@ -32,8 +32,15 @@ adata = (
 
 
 # test docstring
+# but this is not intended to work with the debugger - use run instead of debug!
+@pytest.mark.skipif(
+    environ.get("PYDEVD_LOAD_VALUES_ASYNC", None),
+    reason="debug mode cause error when checking docstrings",
+)
 def test_nddataset_docstring():
-    chd.PRIVATE_CLASSES = []  # override default to test private class docstring
+    from spectrochempy.utils import check_docstrings as chd
+
+    chd.PRIVATE_CLASSES = []  # do not test private class docstring
     module = "spectrochempy.core.dataset.nddataset"
     chd.check_docstrings(
         module,

--- a/tests/test_core/test_dataset/test_dataset.py
+++ b/tests/test_core/test_dataset/test_dataset.py
@@ -15,6 +15,7 @@ from spectrochempy.utils.testing import (
     raises,
     RandomSeedContext,
 )
+from spectrochempy.utils import check_docstrings as chd
 
 typequaternion = np.dtype(np.quaternion)
 
@@ -28,6 +29,18 @@ adata = (
     [0.0 + 1j, 10.0 + 3.0j],
     [0.0 + 1j, np.nan + 3.0j],
 )
+
+
+# test docstring
+def test_nddataset_docstring():
+    chd.PRIVATE_CLASSES = []  # override default to test private class docstring
+    module = "spectrochempy.core.dataset.nddataset"
+    chd.check_docstrings(
+        module,
+        obj=scp.NDDataset,
+        # exclude some errors - remove whatever you want to check
+        exclude=["SA01", "EX01", "ES01", "GL11", "GL08", "PR01"],
+    )
 
 
 @pytest.mark.parametrize("a", adata)


### PR DESCRIPTION
With this PR, in addition to the `validate_docstring` script, we offer the possibility to include docstring's tests when using pytest.

Typically we can write tests like this:
```python
def test_nddataset_docstring():
    from spectrochempy.utils import check_docstrings as chd

    chd.PRIVATE_CLASSES = []  #  do not test private class docstring
    chd.check_docstrings(
        module = "spectrochempy.core.dataset.nddataset",
        # module in which the class or function to be tested reside
        obj=scp.NDDataset,      
        #  the object (class or function) to be tested
        exclude=["SA01", "EX01", "ES01", "GL11", "GL08", "PR01"],  
        # exclude some errors - remove whatever you want to check
    )
```

- [x] Tests have been added

