### PR TITLE
Hotfix/account for changes in spectrochempy data

### DIFF
--- a/.ci/env_template.yml
+++ b/.ci/env_template.yml
@@ -56,8 +56,8 @@ dependencies:
     - ipywidgets
     - ipympl
 
-    # example and test data
-    - spectrochempy_data
+    # examples and test data
+    - spectrochempy_data=1.3
 
     # mainly for install and a bit more...
     - setuptools

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -45,8 +45,7 @@ jobs:
       - name: Install Data
         shell: bash
         run: |
-          git clone https://github.com/spectrochempy/spectrochempy_data
-          git checkout tags/1.3 -b master
+          git clone -b 1.3 https://github.com/spectrochempy/spectrochempy_data .
           mkdir -p $HOME/.spectrochempy
           mv -v ./spectrochempy_data/testdata $HOME/.spectrochempy/testdata
           echo $HOME

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Data
         shell: bash
         run: |
-          git clone -b 1.3 https://github.com/spectrochempy/spectrochempy_data .
+          git clone -b 1.3 https://github.com/spectrochempy/spectrochempy_data
           mkdir -p $HOME/.spectrochempy
           mv -v ./spectrochempy_data/testdata $HOME/.spectrochempy/testdata
           echo $HOME

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -46,6 +46,7 @@ jobs:
         shell: bash
         run: |
           git clone https://github.com/spectrochempy/spectrochempy_data
+          git checkout tags/1.3 -b master
           mkdir -p $HOME/.spectrochempy
           mv -v ./spectrochempy_data/testdata $HOME/.spectrochempy/testdata
           echo $HOME

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
     - ipympl
 
     # example and test data
-    - spectrochempy_data
+    - spectrochempy_data=1.3
 
     # mainly for install and a bit more...
     - setuptools

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -50,14 +50,14 @@ dependencies:
     - ipympl
 
     # example and test data
-    - spectrochempy_data
+    - spectrochempy_data=1.3
 
     # mainly for install and a bit more...
     - setuptools
     - setuptools_scm
     - git
 
-
+  
 
     # Jupyter lab
     - jupyterlab>=2.2.10
@@ -103,7 +103,7 @@ dependencies:
     # - xarray
     # - datashader
     # - scikit-learn
-
+    
     - pip
     - pip:
 


### PR DESCRIPTION
Spectrochempy_data has been changed in version 1.4 to have only names without spaces. 

This may introduce a problem when testing the current master derived version, which does not yet take these changes into account. 
Pinning to version 1.3 should fix the problem.