### PR TITLE
Hotfix/for colab

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -29,7 +29,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest] # , , macos-latest, windows-latest
-        pythonVersion: ["3.10", "3.9"]  # no support for 3.8 and 3.7
+        pythonVersion: ["3.10", "3.9", "3.7"]
 
     steps:
       - name: Checkout code

--- a/tests/test_core/test_readers/test_read_spc.py
+++ b/tests/test_core/test_readers/test_read_spc.py
@@ -63,7 +63,7 @@ def test_read_spc():
     N = scp.read_spc("galacticdata/KKSAM.SPC")
     assert N.shape == (1, 751)
 
-    O = scp.read_spc("galacticdata/LC_DIODE ARRAY.SPC")
+    O = scp.read_spc("galacticdata/LC_DIODE_ARRAY.SPC")
     # "The version b'M' is not yet supported"
     assert O is None
 


### PR DESCRIPTION
As Colab requires python 3.7, I have make a compatible version of read_remote (actually replaced some functions from pathlib).