### PR TITLE
FIX: datadir as Path whenever it is read form a json config file.

### DIFF
--- a/spectrochempy/application.py
+++ b/spectrochempy/application.py
@@ -43,6 +43,7 @@ from traitlets import (
     Instance,
     default,
     observe,
+    validate,
 )
 from traitlets.config.manager import BaseJSONConfigManager
 import matplotlib as mpl
@@ -612,17 +613,25 @@ class GeneralPreferences(MetaConfigurable):
     @default("databases_directory")
     def _get_databases_directory_default(self):
         # the spectra path in package data
-        return Path(get_pkg_path("databases", "scp_data"))
+        return pathclean(get_pkg_path("databases", "scp_data"))
 
     # ..........................................................................
     @default("datadir")
     def _get_default_datadir(self):
-        return self.parent.datadir.path
+        return pathclean(self.parent.datadir.path)
 
     # ..........................................................................
     @observe("datadir")
     def _datadir_changed(self, change):
         self.parent.datadir.path = pathclean(change["new"])
+
+    @validate("datadir")
+    def _data_validate(self, proposal):
+        # validation of the datadir attribute
+        datadir = proposal["value"]
+        if isinstance(datadir, str):
+            datadir = pathclean(datadir)
+        return datadir
 
     # ..........................................................................
     @property


### PR DESCRIPTION
Fixed an issue when a custom datadir path is set. It is stored in a .spectrochempy/config/GeneralPreferences.json file to replace the default setting.However, when it is read at the initialization of a new session, it is read as a string, which has to be converted to a Path to use for example the read_remote method. That's what this fix does automatically.