### PR TITLE
FIX: accelerate tests when testdata have already been downloaded.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,12 @@ from spectrochempy.utils.testing import RandomSeedContext
 # first download missing data
 datadir = pathclean(prefs.datadir)
 print("DATADIR: ", datadir)
-scp.read_remote(datadir, download_only=True)
+
+# this process is relatively long, so we do not want to do it several time:
+downloaded = datadir / "__downloaded__"
+if not downloaded.exists():
+    scp.read_remote(datadir, download_only=True)
+    downloaded.write_text("")
 
 # ======================================================================================================================
 # FIXTURES


### PR DESCRIPTION
When running test, conftest was downloading data. But even if the data were already downloaded, the fact of checking online, was taking too much time. 
