### PR TITLE
SOC reader, simplisma, fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### NEW FEATURES
 * Documentation improvement.
-* Add spectra unimodality constraint on MCRALS
-  unimodMod and unimodTol now deprectated 
-* Add `plotmerit()` method
+* MCRALS: add spectra unimodality constraint on MCRALS, `unimodMod` and `unimodTol now deprectated 
+* PCA: add `plotmerit()` method in PCA
+* Readers: add Surface Optics Corp. reader
+* SIMPLISMA: `verbose` now deprecated
 
 ### BUG FIXED
 * Compatibility with pint=0.19

--- a/docs/userguide/reference/api.rst
+++ b/docs/userguide/reference/api.rst
@@ -349,7 +349,9 @@
     NDDataset.read
     NDDataset.read_carroucell
     NDDataset.read_csv
+    NDDataset.read_ddr
     NDDataset.read_dir
+    NDDataset.read_hdr
     NDDataset.read_jcamp
     NDDataset.read_labspec
     NDDataset.read_mat
@@ -358,6 +360,8 @@
     NDDataset.read_opus
     NDDataset.read_quadera
     NDDataset.read_remote
+    NDDataset.read_sdr
+    NDDataset.read_soc
     NDDataset.read_spa
     NDDataset.read_spc
     NDDataset.read_spg

--- a/spectrochempy/analysis/simplisma.py
+++ b/spectrochempy/analysis/simplisma.py
@@ -60,8 +60,6 @@ class SIMPLISMA(HasTraits):
     noise : float or int, optional, default=5
         A correction factor (%) for low intensity variables (0 - no offset,
         15 - large offset).
-    verbose : bool, optional, default=True
-        If True some information is given during the analysis.
     """
 
     _St = Instance(NDDataset)
@@ -117,8 +115,11 @@ class SIMPLISMA(HasTraits):
             warnings.warn("SIMPLISMA does not handle easily negative values.")
             # TODO: check whether negative values should be set to zero or not.
 
-        verbose = kwargs.get("verbose", True)
-        if verbose:
+        if "verbose" in kwargs.keys():
+            warnings.warn(
+                "verbose deprecated. Instead, use set_loglevel(INFO) before launching MCRALS",
+                DeprecationWarning,
+            )
             set_loglevel(INFO)
 
         interactive = kwargs.get("interactive", False)
@@ -222,7 +223,7 @@ class SIMPLISMA(HasTraits):
                 )
                 logs += llog + "\n"
 
-                if verbose or interactive:
+                if interactive:
                     print(llog)
 
                 if interactive:
@@ -303,7 +304,7 @@ class SIMPLISMA(HasTraits):
                 )
                 logs += llog + "\n"
 
-                if verbose or interactive:
+                if interactive:
                     info_(llog)
 
                 if (

--- a/spectrochempy/core/readers/importer.py
+++ b/spectrochempy/core/readers/importer.py
@@ -26,6 +26,7 @@ from spectrochempy.core import warning_
 FILETYPES = [
     ("scp", "SpectroChemPy files (*.scp)"),
     ("omnic", "Nicolet OMNIC files and series (*.spa *.spg *.srs)"),
+    ("soc", "Surface Optics Corp. (*.ddr *.hdr *.srs)"),
     ("labspec", "LABSPEC exported files (*.txt)"),
     ("opus", "Bruker OPUS files (*.[0-9]*)"),
     (
@@ -46,6 +47,9 @@ FILETYPES = [
 ALIAS = [
     ("spg", "omnic"),
     ("spa", "omnic"),
+    ("ddr", "soc"),
+    ("hdr", "soc"),
+    ("sdr", "soc"),
     ("spc", "galactic"),
     ("srs", "omnic"),
     ("mat", "matlab"),

--- a/spectrochempy/core/readers/importer.py
+++ b/spectrochempy/core/readers/importer.py
@@ -26,7 +26,7 @@ from spectrochempy.core import warning_
 FILETYPES = [
     ("scp", "SpectroChemPy files (*.scp)"),
     ("omnic", "Nicolet OMNIC files and series (*.spa *.spg *.srs)"),
-    ("soc", "Surface Optics Corp. (*.ddr *.hdr *.srs)"),
+    ("soc", "Surface Optics Corp. (*.ddr *.hdr *.sdr)"),
     ("labspec", "LABSPEC exported files (*.txt)"),
     ("opus", "Bruker OPUS files (*.[0-9]*)"),
     (

--- a/spectrochempy/core/readers/read_omnic.py
+++ b/spectrochempy/core/readers/read_omnic.py
@@ -1286,6 +1286,9 @@ def _read_header(fid, pos):
     elif key == 20:  # pragma: no cover
         out["units"] = "Kubelka_Munk"
         out["title"] = "Kubelka-Munk"
+    elif key == 21:
+        out["units"] = None
+        out["title"] = "reflectance"
     elif key == 22:
         out["units"] = "V"
         out["title"] = "detector signal"

--- a/spectrochempy/core/readers/read_soc.py
+++ b/spectrochempy/core/readers/read_soc.py
@@ -1,0 +1,390 @@
+#  -*- coding: utf-8 -*-
+#
+#  =====================================================================================================================
+#  Copyright (©) 2015-2022 LCS - Laboratoire Catalyse et Spectrochimie,
+#  Caen, France.
+#  CeCILL-B FREE SOFTWARE LICENSE AGREEMENT - See full LICENSE agreement in
+#  the root directory
+#  =====================================================================================================================
+#
+"""
+This module extend NDDataset with the import method for Thermo galactic (spc) data files.
+"""
+__all__ = ["read_soc", "read_ddr", "read_sdr", "read_hdr"]
+__dataset_methods__ = __all__
+
+from datetime import datetime, timezone
+
+from spectrochempy.core.readers.importer import (
+    _importer_method,
+    Importer,
+)
+from spectrochempy.core.readers.read_omnic import _read_spa
+
+# ======================================================================================================================
+# Public function
+# ======================================================================================================================
+
+
+def read_soc(*paths, **kwargs):
+    """
+    Open a Surface Optics Corps. file or a list of files with extension ``.ddr``, ``.hdr`` or ``.sdr``.
+
+    Parameters
+    -----------
+    *paths : str, pathlib.Path object, list of str, or list of pathlib.Path objects, optional
+        The data source(s) can be specified by the name or a list of name
+        for the file(s) to be loaded:
+
+        *e.g.,( file1, file2, ...,  **kwargs )*
+
+        If the list of filenames are enclosed into brackets:
+
+        *e.g.,* ( **[** *file1, file2, ...* **]**, **kwargs *)*
+
+        The returned datasets are merged to form a single dataset,
+        except if `merge` is set to False. If a source is not provided (i.e.
+        no `filename`, nor `content`),
+        a dialog box will be opened to select files.
+    **kwargs
+        Optional keyword parameters (see Other Parameters).
+
+    Returns
+    --------
+    read_soc
+        The dataset or a list of dataset corresponding to a (set of) file(s).
+
+    Other Parameters
+    -----------------
+    directory : str, optional
+        From where to read the specified `filename`. If not specified,
+        read in the default ``datadir`` specified in
+        SpectroChemPy Preferences.
+    merge : bool, optional
+        Default value is False. If True, and several filenames have been
+        provided as arguments,
+        then a single dataset with merged (stacked along the first
+        dimension) is returned (default=False).
+    sortbydate : bool, optional
+        Sort multiple spectra by acquisition date (default=True).
+    description: str, optional
+        A Custom description.
+    content : bytes object, optional
+        Instead of passing a filename for further reading, a bytes content
+        can be directly provided as bytes objects.
+        The most convenient way is to use a dictionary. This feature is
+        particularly useful for a GUI Dash application
+        to handle drag and drop of files into a Browser.
+        For examples on how to use this feature, one can look in the
+        ``tests/tests_readers`` directory.
+    listdir : bool, optional
+        If True and filename is None, all files present in the provided
+        `directory` are returned (and merged if `merge`
+        is True. It is assumed that all the files correspond to current
+        reading protocol (default=True).
+    recursive : bool, optional
+        Read also in subfolders. (default=False).
+
+    See Also
+    --------
+    read : Generic read method.
+    read_topspin : Read TopSpin Bruker NMR spectra.
+    read_omnic : Read Omnic spectra.
+    read_opus : Read OPUS spectra.
+    read_labspec : Read Raman LABSPEC spectra.
+    read_spa : Read Omnic *.spa spectra.
+    read_spg : Read Omnic *.spg grouped spectra.
+    read_srs : Read Omnic series.
+    read_csv : Read CSV files.
+    read_zip : Read Zip files.
+    read_matlab : Read Matlab files.
+
+    Examples
+    ---------
+
+    """
+
+    kwargs["filetypes"] = ["Surface Optics Corp. (*.ddr *.hdr *.sdr)"]
+    kwargs["protocol"] = ["soc", "ddr", "hdr", "sdr"]
+    importer = Importer()
+    return importer(*paths, **kwargs)
+
+
+# ..............................................................................
+def read_ddr(*paths, **kwargs):
+    """
+    Open a Surface Optics Corps. file or a list of files with extension ``.ddr``.
+
+    Open Surface Optics Corps. file or a list of files with extension ``.ddr`` and set
+    data/metadata in the current dataset.
+
+    Parameters
+    -----------
+    *paths : str, pathlib.Path object, list of str, or list of pathlib.Path objects, optional
+        The data source(s) can be specified by the name or a list of name
+        for the file(s) to be loaded:
+
+        *e.g.,( file1, file2, ...,  **kwargs )*
+
+        If the list of filenames are enclosed into brackets:
+
+        *e.g.,* ( **[** *file1, file2, ...* **]**, **kwargs *)*
+
+        The returned datasets are merged to form a single dataset,
+        except if `merge` is set to False. If a source is not provided (i.e.
+        no `filename`, nor `content`),
+        a dialog box will be opened to select files.
+    **kwargs
+        Optional keyword parameters (see Other Parameters).
+
+    Returns
+    --------
+    read_ddr
+        The dataset or a list of dataset corresponding to the (set of)
+        file(s).
+
+    Other Parameters
+    -----------------
+    return_ifg : str or None, optional
+        Default value is None. When set to 'sample' returns the sample interferogram
+        of the spa file if present or None if absent. When set to 'background' returns
+        the backgroung interferogram of the spa file if present or None if absent.
+    directory : str, optional
+        From where to read the specified `filename`. If not specified,
+        read in the default ``datadir`` specified in
+        SpectroChemPy Preferences.
+    merge : bool, optional
+        Default value is False. If True, and several filenames have been
+        provided as arguments,
+        then a single dataset with merged (stacked along the first
+        dimension) is returned (default=False).
+    sortbydate : bool, optional
+        Sort multiple spectra by acquisition date (default=True).
+    description: str, optional
+        A Custom description.
+    content : bytes object, optional
+        Instead of passing a filename for further reading, a bytes content
+        can be directly provided as bytes objects.
+        The most convenient way is to use a dictionary. This feature is
+        particularly useful for a GUI Dash application
+        to handle drag and drop of files into a Browser.
+        For examples on how to use this feature, one can look in the
+        ``tests/tests_readers`` directory.
+    listdir : bool, optional
+        If True and filename is None, all files present in the provided
+        `directory` are returned (and merged if `merge`
+        is True. It is assumed that all the files correspond to current
+        reading protocol (default=True).
+    recursive : bool, optional
+        Read also in subfolders. (default=False).
+
+    See Also
+    --------
+    read : Generic read method.
+
+    Examples
+    ---------
+
+    """
+
+    kwargs["filetypes"] = ["Surface Optics Corp. (*.ddr)"]
+    kwargs["protocol"] = ["ddr"]
+    importer = Importer()
+    return importer(*paths, **kwargs)
+
+
+# ..............................................................................
+def read_hdr(*paths, **kwargs):
+    """
+    Open a Surface Optics Corps. file or a list of files with extension ``.hdr``.
+
+    Open Surface Optics Corps. file or a list of files with extension ``.hdr`` and set
+    data/metadata in the current dataset.
+
+    Parameters
+    -----------
+    *paths : str, pathlib.Path object, list of str, or list of pathlib.Path objects, optional
+        The data source(s) can be specified by the name or a list of name
+        for the file(s) to be loaded:
+
+        *e.g.,( file1, file2, ...,  **kwargs )*
+
+        If the list of filenames are enclosed into brackets:
+
+        *e.g.,* ( **[** *file1, file2, ...* **]**, **kwargs *)*
+
+        The returned datasets are merged to form a single dataset,
+        except if `merge` is set to False. If a source is not provided (i.e.
+        no `filename`, nor `content`),
+        a dialog box will be opened to select files.
+    **kwargs
+        Optional keyword parameters (see Other Parameters).
+
+    Returns
+    --------
+    read_ddr
+        The dataset or a list of dataset corresponding to the (set of)
+        file(s).
+
+    Other Parameters
+    -----------------
+    return_ifg : str or None, optional
+        Default value is None. When set to 'sample' returns the sample interferogram
+        of the spa file if present or None if absent. When set to 'background' returns
+        the backgroung interferogram of the spa file if present or None if absent.
+    directory : str, optional
+        From where to read the specified `filename`. If not specified,
+        read in the default ``datadir`` specified in
+        SpectroChemPy Preferences.
+    merge : bool, optional
+        Default value is False. If True, and several filenames have been
+        provided as arguments,
+        then a single dataset with merged (stacked along the first
+        dimension) is returned (default=False).
+    sortbydate : bool, optional
+        Sort multiple spectra by acquisition date (default=True).
+    description: str, optional
+        A Custom description.
+    content : bytes object, optional
+        Instead of passing a filename for further reading, a bytes content
+        can be directly provided as bytes objects.
+        The most convenient way is to use a dictionary. This feature is
+        particularly useful for a GUI Dash application
+        to handle drag and drop of files into a Browser.
+        For examples on how to use this feature, one can look in the
+        ``tests/tests_readers`` directory.
+    listdir : bool, optional
+        If True and filename is None, all files present in the provided
+        `directory` are returned (and merged if `merge`
+        is True. It is assumed that all the files correspond to current
+        reading protocol (default=True).
+    recursive : bool, optional
+        Read also in subfolders. (default=False).
+
+    See Also
+    --------
+    read : Generic read method.
+
+    Examples
+    ---------
+
+    """
+
+    kwargs["filetypes"] = ["Surface Optics Corp. (*.hdr)"]
+    kwargs["protocol"] = ["hdr"]
+    importer = Importer()
+    return importer(*paths, **kwargs)
+
+
+# ..............................................................................
+def read_sdr(*paths, **kwargs):
+    """
+    Open a Surface Optics Corps. file or a list of files with extension ``.sdr``.
+
+    Open Surface Optics Corps. file or a list of files with extension ``.sdr`` and set
+    data/metadata in the current dataset.
+
+    Parameters
+    -----------
+    *paths : str, pathlib.Path object, list of str, or list of pathlib.Path objects, optional
+        The data source(s) can be specified by the name or a list of name
+        for the file(s) to be loaded:
+
+        *e.g.,( file1, file2, ...,  **kwargs )*
+
+        If the list of filenames are enclosed into brackets:
+
+        *e.g.,* ( **[** *file1, file2, ...* **]**, **kwargs *)*
+
+        The returned datasets are merged to form a single dataset,
+        except if `merge` is set to False. If a source is not provided (i.e.
+        no `filename`, nor `content`),
+        a dialog box will be opened to select files.
+    **kwargs
+        Optional keyword parameters (see Other Parameters).
+
+    Returns
+    --------
+    read_ddr
+        The dataset or a list of dataset corresponding to the (set of)
+        file(s).
+
+    Other Parameters
+    -----------------
+    return_ifg : str or None, optional
+        Default value is None. When set to 'sample' returns the sample interferogram
+        of the spa file if present or None if absent. When set to 'background' returns
+        the backgroung interferogram of the spa file if present or None if absent.
+    directory : str, optional
+        From where to read the specified `filename`. If not specified,
+        read in the default ``datadir`` specified in
+        SpectroChemPy Preferences.
+    merge : bool, optional
+        Default value is False. If True, and several filenames have been
+        provided as arguments,
+        then a single dataset with merged (stacked along the first
+        dimension) is returned (default=False).
+    sortbydate : bool, optional
+        Sort multiple spectra by acquisition date (default=True).
+    description: str, optional
+        A Custom description.
+    content : bytes object, optional
+        Instead of passing a filename for further reading, a bytes content
+        can be directly provided as bytes objects.
+        The most convenient way is to use a dictionary. This feature is
+        particularly useful for a GUI Dash application
+        to handle drag and drop of files into a Browser.
+        For examples on how to use this feature, one can look in the
+        ``tests/tests_readers`` directory.
+    listdir : bool, optional
+        If True and filename is None, all files present in the provided
+        `directory` are returned (and merged if `merge`
+        is True. It is assumed that all the files correspond to current
+        reading protocol (default=True).
+    recursive : bool, optional
+        Read also in subfolders. (default=False).
+
+    See Also
+    --------
+    read : Generic read method.
+
+    Examples
+    ---------
+
+    """
+
+    kwargs["filetypes"] = ["Surface Optics Corp. (*.sdr)"]
+    kwargs["protocol"] = ["sdr"]
+    importer = Importer()
+    return importer(*paths, **kwargs)
+
+
+# ======================================================================================================================
+# Private functions
+# ======================================================================================================================
+
+# ..............................................................................
+@_importer_method
+def _read_ddr(*args, **kwargs):
+    ds = _read_spa(*args, **kwargs)
+    ds.history[-1] = str(datetime.now(timezone.utc)) + ":imported from ddr file(s)"
+    return ds
+
+
+@_importer_method
+def _read_hdr(*args, **kwargs):
+    ds = _read_spa(*args, **kwargs)
+    ds.history[-1] = str(datetime.now(timezone.utc)) + ":imported from hdr file(s)"
+    return ds
+
+
+@_importer_method
+def _read_sdr(*args, **kwargs):
+    ds = _read_spa(*args, **kwargs)
+    ds.history[-1] = str(datetime.now(timezone.utc)) + ":imported from sdr file(s)"
+    return ds
+
+
+# ------------------------------------------------------------------
+if __name__ == "__main__":
+    pass

--- a/tests/test_core/test_readers/test_read_soc.py
+++ b/tests/test_core/test_readers/test_read_soc.py
@@ -1,0 +1,32 @@
+import requests
+from pathlib import Path
+import spectrochempy as scp
+
+
+def test_read_SOC():
+    """upload and read surface oftics exemple"""
+
+    # the following does not work
+    baseurl = "https://github.com/chet-j-ski/SOC100_example_data/raw/main/"
+    fnames = [
+        "Fused%20Silica0004.DDR",
+        "Fused%20Silica0004.HDR",
+        "Fused%20Silica0004.SDR",
+    ]
+
+    for i, fname in enumerate(fnames):
+        response = requests.get(baseurl + fname)
+        if response.status_code == 200:
+            with open(fname, "wb") as f:
+                f.write(response.content)
+            ds = scp.read_soc(fname)
+            assert str(ds) == "NDDataset: [float64] unitless (shape: (y:1, x:599))"
+            assert ds.title == "reflectance"
+            if i == 0:
+                ds_ = scp.read_ddr(fname)
+            elif i == 1:
+                ds_ = scp.read_hdr(fname)
+            else:
+                ds_ = scp.read_sdr(fname)
+            assert ds_.name == ds.name
+            Path(fname).unlink(missing_ok=True)

--- a/tests/test_core/test_readers/test_read_soc.py
+++ b/tests/test_core/test_readers/test_read_soc.py
@@ -1,5 +1,8 @@
 import requests
 from pathlib import Path
+import platform
+
+
 import spectrochempy as scp
 
 
@@ -29,4 +32,7 @@ def test_read_SOC():
             else:
                 ds_ = scp.read_sdr(fname)
             assert ds_.name == ds.name
-            Path(fname).unlink(missing_ok=True)
+            if int(platform.python_version_tuple()[1]) > 7:
+                Path(fname).unlink(missing_ok=True)
+            else:
+                Path(fname).unlink()


### PR DESCRIPTION
Add Surface optics reader
- [x] related to #455 
- [x] Tests have been added (mostly required)
- [x] User-visible changes  documented in `CHANGELOG.md` 
- [x] The new methods have been listed in `docs/userguide/reference/api.rst`.
- [ ] Sample files and Examples to be added after authorization of file owner  !

Deprecate verbose option in simplisma for consistency with mcarls
- [x] User-visible changes  documented in `CHANGELOG.md` 

Put back `__init__.py` in test_readers (caused an error on my fork for tests with py 3.9)