### PR TITLE
FIX: publish a draft release

### DIFF
--- a/.github/workflows/publish_new_release.yml
+++ b/.github/workflows/publish_new_release.yml
@@ -1,4 +1,4 @@
-name: "Publish new release"
+name: "Publish new draft release"
 
 on:
 
@@ -36,6 +36,6 @@ jobs:
         with:
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           tag_name: ${{ env.RELEASE_VERSION }}
-          name: ${{ env.RELEASE_VERSION }}
-          draft: false
+          name: SpectrChemPy v.${{ env.RELEASE_VERSION }}
+          draft: true
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # What's new
 
+## Unreleased
+
+
 ## Version 0.4.5 [2022-04-09]
 
 ### NEW FEATURES


### PR DESCRIPTION
Workflow was not publishing correctly on pypi and anaconda due to the fact that  Build_package workflow wasn't trigerred  on publishing release. 
To try fixing this problem, I will try to automatically create a draft release: Publishing the final release will be done manually by clicking on publishing on the release page..
