### PR TITLE
FIX: sphinx related problems with python version > 3.10

### DIFF
--- a/.ci/env_template.yml
+++ b/.ci/env_template.yml
@@ -87,11 +87,11 @@ dependencies:
     # DEV: code and docs
     - mamba
     - jupytext
-    - sphinx<4.0
+    - sphinx
     - sphinx_rtd_theme
     - autodocsumm
-    - sphinx-gallery<=0.7.0
-    - nbsphinx=0.8.1
+    - sphinx-gallery
+    - nbsphinx
     - jupyter_sphinx
     - json5
     - sphinx-copybutton

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ essai.py
 project_1.pscp
 X.scp
 NMR.pscp
+.ci/scpy3.10.yml
+.ci/scpy3.7.yml
+.ci/scpy3.9.yml


### PR DESCRIPTION
For exemple Docstring tests were not working with 3.10.4.

In this commit I remove pinning of sphinx version and other sphinx related package (nbspinx, and sphinx-gallery). 

