### PR TITLE
FIX: ANACONDA upload

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Publish package for release
         if: (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'spectrochempy/spectrochempy')
         env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_UPLOAD_TOKEN }}
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |
           conda install anaconda-client
           anaconda upload --force out/*/*.tar.bz2
@@ -132,7 +132,7 @@ jobs:
       - name: Publish development package
         if: (github.event_name == 'push' && github.repository == 'spectrochempy/spectrochempy')
         env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_UPLOAD_TOKEN }}
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |
           conda install anaconda-client
           anaconda upload -l dev --force out/*/*.tar.bz2


### PR DESCRIPTION
For some reason, the previous ANACONDA_UPLOAD_TOKEN pointed to Anaconda.org ATravert account (???). So, I created a new token ANACONDA_API_TOKEN (user Spectrocat) and updated the GitHub setting and the workflow accordingly. 