### PR TITLE
FIX: pin sphinx to 5.3 and sphinx_rtd_theme to 1.1

### DIFF
--- a/.ci/templates/dependencies.tmpl
+++ b/.ci/templates/dependencies.tmpl
@@ -64,8 +64,8 @@ or updated accordingly
     - mamba
     - docrep
     - jupytext
-    - sphinx
-    - sphinx_rtd_theme
+    - sphinx=5.3
+    - sphinx_rtd_theme=1.1
     - autodocsumm
     - sphinx-gallery
     - nbsphinx


### PR DESCRIPTION
Sphinx6 remove logo and favicon for html doc build with sphinx_rtd_theme theme.
