### PR TITLE
Feature/docwarnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -554,3 +554,4 @@ def setup(app):
     # # Ignore .ipynb files
     app.registry.source_suffix.pop(".ipynb", None)
     app.registry.source_suffix.pop(".py", None)
+    app.registry.source_suffix.pop(".py.md5", None)

--- a/docs/devguide/codespec_adding_reader.rst
+++ b/docs/devguide/codespec_adding_reader.rst
@@ -146,7 +146,7 @@ be added.
 
 For consistency with existing readers, the following guidelines should be followed as closely as possible:
 
-- The NDDataset should be at least bi-dimensional with a first dimension ```` pertaining to the wavelength/frequency dimension
+- The NDDataset should be at least bi-dimensional with a first dimension pertaining to the wavelength/frequency dimension
   and the second dimension ``y`` pertaining to the acquisition time axis, even if the dataset consists of single 1D spectrum.
   For instance
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,7 +107,7 @@ User's Guide & Tutorials
     userguide/units/units
     userguide/api/api
 
-.. _api_reference:
+.. _reference:
 
 ***********************
 Reference

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -65,6 +65,18 @@ Glossary
         Hence, :math:`\mathbf{T}` and :math:`\mathbf{P}` can then be viewed as collections of :math:`n` and :math:`m`
         vectors in k-dimensional spaces in which each observation/spectrum or feature/wavelength can be located.
 
+    score
+    scores
+        In the context of :term:`PCA`\ , scores are vectors :math:`\mathbf{t}_i` of length :term:`n_observations`
+        which, associated to the corresponding :term:`loading` vectors, are related to the so-called
+        i-th principal component describing the variance of a datastet :math:`X`.
+
+    loading
+    loadings
+        In the context of :term:`PCA`\ , loadings are vectors :math:`\mathbf{p}_i` of length :term:`n_features`
+        which, associated to the corresponding :term:`score` vectors, are related to the so-called
+        i-th principal component describing the variance of a datastet :math:`X`.
+
     PLS
         ``Partial Least Squares`` regression (or Projection on Latent Structures) is a statistical method to
         estimate :math:`n \times l` dependant or predicted variables :math:`Y` from :math:`n \times m`
@@ -73,12 +85,12 @@ Glossary
 
         .. math::  X = S_X L_Y^T + E_X
 
-                   Y = S_Y L_Y^T + E_Y
+        .. math::  Y = S_Y L_Y^T + E_Y
 
-                   S_X, S_y = \textrm{argmax}_{S_X, S_Y}(\textrm{cov}(S_X, S_Y))
+        .. math::  S_X, S_y = \textrm{argmax}_{S_X, S_Y}(\textrm{cov}(S_X, S_Y))
 
-        :math:`S_X` and :math:`S_Y` are :math:`n \times k` matrices often called score matrices, and :math:`L_X^T`
-        and :math:`L_Y^T` are, respectively, :math:`k \times l` and :math:`k \times m` loading matrices.
+        :math:`S_X` and :math:`S_Y` are :math:`n \times k` matrices often called X- and Y-score matrices, and :math:`L_X^T`
+        and :math:`L_Y^T` are, respectively, :math:`k \times l` and :math:`k \times m` X- and Y-loading matrices.
         Matrices :math:`E_X` and :math:`E_Y`  are the error terms or residuals.
         As indicated by the third equation, the decompositions of :math:`X` and :math:`Y` are made to maximise
         the covariance of the score matrices.
@@ -111,7 +123,7 @@ Glossary
         Constraint where the sum of concentrations is fixed to a target value.
 
     unimodality
-        Constraint where the profile has a single maximum ir minimum.
+        Constraint where the profile has a single maximum or minimum.
 
     regularization
         Technique used to reduce the errors of over-fitting a function on given data
@@ -135,7 +147,7 @@ Glossary
 
     n_targets
         Number of ``targets``. A target is a property to predict using cross-decomposition methods such as PLS.
-        Typically a tartget is a composition variable such as a concentration.
+        Typically a target is a composition variable such as a concentration.
 
     rank
         Number of linearly independent number or columns of a matrix

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -83,7 +83,7 @@ Glossary
         explanatory or observed variables :math:`X` by projecting both of them on new spaces spanned by
         :math:`k` latent variables according to the master equations :
 
-        .. math::  X = S_X L_Y^T + E_X
+        .. math::  X = S_X L_X^T + E_X
 
         .. math::  Y = S_Y L_Y^T + E_Y
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,4 +1,4 @@
-.. _api_reference_:
+.. _api_reference:
 
 .. currentmodule:: spectrochempy
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,4 +1,4 @@
-.. _api_reference:
+.. _api_reference_:
 
 .. currentmodule:: spectrochempy
 

--- a/docs/userguide/analysis/pls.py
+++ b/docs/userguide/analysis/pls.py
@@ -36,7 +36,7 @@ import spectrochempy as scp
 # $n \times l$ dependant or predicted variables $Y$ from $n \times m$ explanatory or observed
 # variables $X$ by projecting both of them on new spaces spanned by $k$ latent variables,
 # according to the master equations :
-# $$ X = S_X L_Y^T + E_X $$
+# $$ X = S_X L_X^T + E_X $$
 # $$ Y = S_Y L_Y^T + E_Y $$
 # $$ S_X, S_y = \textrm{argmax}_{S_X, S_Y}(\textrm{cov}(S_X, S_Y)) $$
 # $S_X$ and $S_Y$ are $n \times k$ matrices often called score matrices, and $L_X^T$ and $L_Y^T$ are,

--- a/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -248,12 +248,12 @@ class NDIO(HasTraits):
     @classmethod
     def load(cls, filename, **kwargs):
         """
-        Open data from a '*.scp' (NDDataset) or '.pscp' (Project) file.
+        Open data from a '\*.scp' (NDDataset) or '\*.pscp' (Project) file.
 
         Parameters
         ----------
         filename :  `str` , `pathlib` or `file` objects
-            The name of the file to read (or a file objects.
+            The name of the file to read (or a file objects).
         **kwargs
             Optional keyword parameters (see Other Parameters).
 

--- a/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -2302,23 +2302,24 @@ class NDMath(object):
         Return random floats in the half-open interval [0.0, 1.0).
 
         Results are from the “continuous uniform” distribution over the stated interval.
-        To sample :math:`\\mathrm{Uniform}[a, b), b > a` multiply the output of random
-        by (b-a) and add a:
 
-            (b - a) * random() + a
+        .. note::
+            To sample :math:`\\mathrm{Uniform}[a, b)` with :math:`b > a`, multiply the
+            output of random by (b-a) and
+            add a, i.e.: :math:`(b - a) * \\mathrm{random}() + a`\ .
 
         Parameters
         ----------
         size : int or tuple of ints, optional
             Output shape. If the given shape is, e.g., (m, n, k), then m * n * k samples
-             are drawn.
+            are drawn.
             Default is None, in which case a single value is returned.
         dtype : dtype, optional
             Desired dtype of the result, only float64 and float32 are supported.
             The default value is np.float64.
         **kwargs
             Keywords argument used when creating the returned object, such as units,
-            name, title, ...
+            name, title, etc...
 
         Returns
         -------
@@ -2348,7 +2349,7 @@ class NDMath(object):
             Calculate the standard deviation of these values.
         dim : None or int or dimension name , optional
             Dimension or dimensions along which to operate.  By default, flattened input
-             is used.
+            is used.
         dtype : dtype, optional
             Type to use in computing the standard deviation. For arrays of
             integer type the default is float64, for arrays of float types it is


### PR DESCRIPTION
remove some warnings when building docs. Only remaining warnings are related to the gallery examples (`WARNING: multiple files found for the document ...`)

