### PR TITLE
FIX: docs problem with the `@_docstring.get_docstring` decorator.

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -350,7 +350,7 @@ Clipping and rounding
 
 
 Algebra
-========
+=======
 
 .. autosummary::
     :nosignatures:
@@ -435,7 +435,7 @@ Units manipulation
     set_nmr_context
 
 
-mathematical operations
+Mathematical operations
 =======================
 
 .. autosummary::
@@ -444,6 +444,7 @@ mathematical operations
 
     mc
     ps
+
 
 Statistical operations
 =======================
@@ -473,7 +474,6 @@ Baseline correction
     abc
     basc
     detrend
-    dc
 
 
 Fourier transform
@@ -489,29 +489,6 @@ Fourier transform
     fsh
     fsh2
 
-Zero-filling
-============
-
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    zf
-    zf_auto
-    zf_double
-    zf_size
-
-Rolling
-=======
-
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    cs
-    ls
-    roll
-    rs
 
 Phasing
 =======
@@ -524,15 +501,52 @@ Phasing
     pk_exp
 
 
-Smoothing, apodization
-=======================
+Time-domain processing
+======================
+
+Offset correction
+-----------------
 
 .. autosummary::
     :nosignatures:
     :toctree: generated/
 
-    savgol_filter
-    smooth
+    dc
+
+
+Zero-filling
+------------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    zf
+    zf_auto
+    zf_double
+    zf_size
+
+
+Rolling
+-------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    cs
+    ls
+    roll
+    rs
+
+
+Apodization
+-----------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
     bartlett
     blackmanharris
     hamming
@@ -545,6 +559,17 @@ Smoothing, apodization
     sine
     qsin
     sinm
+
+
+Smoothing, filtering
+====================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    savgol_filter
+    smooth
 
 
 Alignment, interpolation

--- a/docs/whatsnew/changelog.rst
+++ b/docs/whatsnew/changelog.rst
@@ -29,6 +29,7 @@ Bug fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+* #687 fixed.
 
 .. section
 
@@ -42,3 +43,5 @@ Breaking changes
 Deprecations
 ~~~~~~~~~~~~
 .. Add here new deprecations (do not delete this comment)
+
+* `parameters` method of Analysis configurables is now deprecated in favor of `params`.

--- a/docs/whatsnew/latest.rst
+++ b/docs/whatsnew/latest.rst
@@ -11,3 +11,13 @@ New features
 
 * `plot_multiple` method now accept keyword arguments to change the default
   plot style of the different spectra. See :ref:`plot_multiple` for details.
+
+Bug fixes
+~~~~~~~~~
+
+* #687 fixed.
+
+Deprecations
+~~~~~~~~~~~~
+
+* `parameters` method of Analysis configurables is now deprecated in favor of `params`.

--- a/spectrochempy/core/__init__.py
+++ b/spectrochempy/core/__init__.py
@@ -95,7 +95,6 @@ with timeit("application"):
 # constants
 # ---------
 with timeit("constants"):
-
     from spectrochempy.utils.plots import show
     from spectrochempy.utils.constants import (
         MASKED,

--- a/spectrochempy/core/dataset/baseobjects/ndarray.py
+++ b/spectrochempy/core/dataset/baseobjects/ndarray.py
@@ -1204,7 +1204,6 @@ class NDArray(HasTraits):
 
     @property
     @_docstring.get_docstring(base="data")
-    @_docstring.dedent
     def data(self):
         """
         Data array (`~numpy.ndarray`).
@@ -1977,7 +1976,7 @@ class NDArray(HasTraits):
     @property
     def title(self):
         """
-        An user friendly title (str).
+        An user-friendly title (str).
 
         When the title is provided, it can be used for labeling the object,
         e.g., axe title in a matplotlib plot.
@@ -1992,8 +1991,6 @@ class NDArray(HasTraits):
         if title:
             self._title = title
 
-    @_docstring.get_docstring(base="to")
-    @_docstring.dedent
     def to(self, other, inplace=False, force=False):
         """
         Return the object with data rescaled to different units.
@@ -2168,6 +2165,8 @@ class NDArray(HasTraits):
 
         else:
             return new
+
+    _docstring.get_docstring(to.__doc__, base="to")
 
     def to_base_units(self, inplace=False):
         """

--- a/spectrochempy/processing/baseline/baseline.py
+++ b/spectrochempy/processing/baseline/baseline.py
@@ -7,9 +7,9 @@
 """
 This module implements the `BaselineCorrection` class for baseline corrections.
 """
-__all__ = ["BaselineCorrection", "ab", "abc", "dc", "basc"]
+__all__ = ["BaselineCorrection", "ab", "abc", "basc"]
 
-__dataset_methods__ = ["ab", "abc", "dc", "basc"]
+__dataset_methods__ = ["ab", "abc", "basc"]
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -21,10 +21,7 @@ from spectrochempy.core import debug_, warning_
 from spectrochempy.core.plotters.multiplot import multiplot
 from spectrochempy.processing.filter.smooth import smooth
 from spectrochempy.utils.coordrange import trim_ranges
-from spectrochempy.utils.decorators import (
-    _units_agnostic_method,
-    signature_has_configurable_traits,
-)
+from spectrochempy.utils.decorators import signature_has_configurable_traits
 from spectrochempy.utils.misc import TYPE_FLOAT, TYPE_INTEGER
 from spectrochempy.utils.traits import NDDatasetType
 
@@ -78,7 +75,6 @@ class BaselineCorrection(HasTraits):
     sps = List()
 
     def __init__(self, dataset, **kwargs):
-
         super().__init__(**kwargs)
 
         self.dataset = dataset
@@ -116,7 +112,6 @@ class BaselineCorrection(HasTraits):
             self.ranges.append(item)
 
     def _setup(self, **kwargs):
-
         self.method = kwargs.get("method", self.method)
         self.interpolation = kwargs.get("interpolation", self.interpolation)
         if self.interpolation == "polynomial":
@@ -127,7 +122,6 @@ class BaselineCorrection(HasTraits):
         self.figsize = kwargs.get("figsize", self.figsize)
 
     def __call__(self, *ranges, **kwargs):
-
         return self.compute(*ranges, **kwargs)
 
     def compute(self, *ranges, **kwargs):
@@ -215,7 +209,6 @@ class BaselineCorrection(HasTraits):
         xbase = sbase.coordset(dim)
 
         if self.method == "sequential":
-
             if self.interpolation == "polynomial":
                 # # bad fit when NaN values => are replaced by 0      # NO reason we have Nan -> suppressed
                 # if np.any(np.isnan(sbase)):
@@ -234,7 +227,6 @@ class BaselineCorrection(HasTraits):
                     baseline[i] = interp(x)
 
         elif self.method == "multivariate":
-
             # SVD of Sbase
             U, s, Vt = np.linalg.svd(sbase.data, full_matrices=False, compute_uv=True)
 
@@ -364,7 +356,6 @@ class BaselineCorrection(HasTraits):
         self.show_regions(ax1)
 
         def show_basecor(ax2):
-
             corrected = self.compute(*ranges, **kwargs)
 
             ax2.clear()
@@ -591,36 +582,6 @@ def ab(dataset, dim=-1, **kwargs):
     Alias of `abc` .
     """
     return abs(dataset, dim, **kwargs)
-
-
-@_units_agnostic_method
-def dc(dataset, **kwargs):
-    """
-    Time domain baseline correction.
-
-    Parameters
-    ----------
-    dataset : nddataset
-        The time domain daatset to be corrected.
-    kwargs : dict, optional
-        Additional parameters.
-
-    Returns
-    -------
-    dc
-        DC corrected array.
-
-    Other Parameters
-    ----------------
-    len : float, optional
-        Proportion in percent of the data at the end of the dataset to take into account. By default, 25%.
-    """
-
-    len = int(kwargs.pop("len", 0.25) * dataset.shape[-1])
-    dc = np.mean(np.atleast_2d(dataset)[..., -len:])
-    dataset -= dc
-
-    return dataset
 
 
 # ======================================================================================

--- a/spectrochempy/processing/fft/shift.py
+++ b/spectrochempy/processing/fft/shift.py
@@ -11,7 +11,7 @@ dimension (1) of 2D arrays.
 Adapted from NMRGLUE proc_base (New BSD License)
 """
 
-__all__ = ["rs", "ls", "roll", "cs", "fsh", "fsh2"]
+__all__ = ["rs", "ls", "roll", "cs", "fsh", "fsh2", "dc"]
 __dataset_methods__ = __all__
 
 import numpy as np
@@ -266,3 +266,33 @@ def fsh2(dataset, pts, **kwargs):
     data = _fft_positive(data)
 
     return data
+
+
+@_units_agnostic_method
+def dc(dataset, **kwargs):
+    """
+    Time domain baseline correction.
+
+    Parameters
+    ----------
+    dataset : nddataset
+        The time domain daatset to be corrected.
+    kwargs : dict, optional
+        Additional parameters.
+
+    Returns
+    -------
+    dc
+        DC corrected array.
+
+    Other Parameters
+    ----------------
+    len : float, optional
+        Proportion in percent of the data at the end of the dataset to take into account. By default, 25%.
+    """
+
+    len = int(kwargs.pop("len", 0.25) * dataset.shape[-1])
+    dc = np.mean(np.atleast_2d(dataset)[..., -len:])
+    dataset -= dc
+
+    return dataset

--- a/spectrochempy/utils/baseconfigurable.py
+++ b/spectrochempy/utils/baseconfigurable.py
@@ -108,7 +108,7 @@ class BaseConfigurable(MetaConfigurable):
         # Initial configuration
         # ---------------------
         # Reset all config parameters to default, if not warm_start
-        defaults = self.parameters(default=True)
+        defaults = self.params(default=True)
         configkw = {} if self._warm_start else defaults
 
         # Eventually take parameters from kwargs
@@ -350,19 +350,3 @@ class BaseConfigurable(MetaConfigurable):
         from spectrochempy.application import app
 
         return app.log.handlers[1].stream.getvalue().rstrip()
-
-    @property
-    def X(self):
-        """
-        Return the X input dataset (eventually modified by the model).
-        """
-        # We use X property only to show this information to the end user. Internally
-        # we use _X attribute to refer to the input data
-        X = self._X.copy()
-        if np.any(self._X_mask):
-            # restore masked row and column if necessary
-            X = self._restore_masked_data(X, axis="both")
-        if self._is_dataset or self._output_type == "NDDataset":
-            return X
-        else:
-            return np.asarray(X)

--- a/spectrochempy/utils/metaconfigurable.py
+++ b/spectrochempy/utils/metaconfigurable.py
@@ -23,6 +23,7 @@ from traitlets.config import Config
 from traitlets.config.configurable import Configurable
 from traitlets.config.loader import LazyConfigValue
 
+from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.docstrings import _docstring
 from spectrochempy.utils.objects import Adict
 
@@ -81,9 +82,7 @@ class MetaConfigurable(Configurable):
             defaults.update(config)
         return defaults
 
-    @_docstring.get_docstring(base="MetaConfigurable.parameters_doc")
-    @_docstring.dedent
-    def parameters(self, default=False):
+    def params(self, default=False):
         """
         Current or default configuration values.
 
@@ -105,6 +104,15 @@ class MetaConfigurable(Configurable):
             d.update(self.trait_defaults(config=True))
         return d
 
+    _docstring.get_docstring(params.__doc__, base="MetaConfigurable.parameters_doc")
+
+    @deprecated(replace="params", removed="0.7.1")
+    def parameters(self, default=False):
+        """
+        Alias for `params` method.
+        """
+        return self.params(default=default)
+
     def reset(self):
         """
         Reset configuration parameters to their default values
@@ -119,7 +127,7 @@ class MetaConfigurable(Configurable):
             f.unlink(missing_ok=True)
 
         # then set the default parameters
-        for k, v in self.parameters(default=True).items():
+        for k, v in self.params(default=True).items():
             if getattr(self, k) != v:
                 setattr(self, k, v)
 
@@ -132,7 +140,6 @@ class MetaConfigurable(Configurable):
             return
 
         if change.name in self.trait_names(config=True):
-
             value = change.new
 
             # Serialization of callable functions

--- a/tests/test_analysis/test_decomposition/test_mcrals.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals.py
@@ -153,13 +153,13 @@ def test_MCRALS(model, data):
     assert mcr.transform(D) == mcr.C
 
     # test current parameters
-    params = mcr.parameters()
+    params = mcr.params()
     assert len(params) == 31
     assert np.all(params.closureTarget == [1] * 10)
     assert params.tol == 30.0
 
     # test display of default
-    params = mcr.parameters(default=True)
+    params = mcr.params(default=True)
     assert params.tol == 0.1
 
     # full process


### PR DESCRIPTION
When used as a decorator the signature of the function was wrongly changed.

This PR also deprecates `parameters` method of configurable in favor of `params` (in order to avoid conflict with other usage of this keyword)


