### PR TITLE
MAINT: remove pytz dependency

### DIFF
--- a/.ci/templates/dependencies.tmpl
+++ b/.ci/templates/dependencies.tmpl
@@ -26,11 +26,11 @@ be created or updated accordingly
     - numpy
     - numpydoc>=1.2
     - pint>=0.20
-    - pytz
     - requests
     - scipy
     - tqdm
     - traitlets
+    - tzlocal
     - scikit-learn
     - xlrd
     - pyyaml

--- a/.ci/templates/meta.tmpl
+++ b/.ci/templates/meta.tmpl
@@ -25,7 +25,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python >=3.9
     - setuptools
     - setuptools_scm
   run:

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -48,11 +48,11 @@ requirements:
     - numpy
     - numpydoc>=1.2
     - pint>=0.20
-    - pytz
     - requests
     - scipy
     - tqdm
     - traitlets
+    - tzlocal
     - scikit-learn
     - xlrd
     - pyyaml

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -25,7 +25,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python >=3.9
     - setuptools
     - setuptools_scm
   run:

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -42,12 +42,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        pythonVersion: ["3.8", "3.10"]
+        pythonVersion: ["3.9", "3.10"]
         exclude:
           - os: macos-latest
-            pythonVersion: 3.8
+            pythonVersion: 3.9
           - os: windows-latest
-            pythonVersion: 3.8
+            pythonVersion: 3.9
     steps:
       - name: Checkout spectrochempy repository
         uses: actions/checkout@v3

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -78,11 +78,6 @@ jobs:
           python -m pip install --no-deps .
           python -m pip list
 
-      - name: Setup timezone
-        uses: zcong1993/setup-timezone@master
-        with:
-          timezone: Central European Time
-
       - name: Test with coverage
         run: |
           coverage run -m pytest tests --durations=10

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -78,6 +78,11 @@ jobs:
           python -m pip install --no-deps .
           python -m pip list
 
+      - name: Setup timezone
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Central European Time
+
       - name: Test with coverage
         run: |
           coverage run -m pytest tests --durations=10

--- a/.pylintrc
+++ b/.pylintrc
@@ -52,7 +52,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.8
+py-version=3.9
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN sudo apt-get update -y && \
 
 USER $NB_UID
 
-# Choose python 3.8 version
-ARG PY_VERSION=3.8
+# Choose python 3.9 version
+ARG PY_VERSION=3.9
 ARG DEV=''
 ARG DASH=''
 ARG CANTERA=''

--- a/docs/gettingstarted/install/index.rst
+++ b/docs/gettingstarted/install/index.rst
@@ -8,7 +8,7 @@ Prerequisites
 *************
 
 `SpectroChemPy` requires a working `Python <http://www.python.org/>`_ installation
-(version 3.8 to 3.10).
+(version 3.9 to 3.10).
 
 We highly recommend installing
 `Anaconda <https://www.anaconda.com/distribution/>`_ or
@@ -32,7 +32,7 @@ whether you choose Miniconda or Anaconda…
   or `Miniconda download page <https://docs.conda.io/en/latest/miniconda.html>`_
   to get one of these distributions.
 * Choose your platform and download one of the available installers,
-  *e.g.*, the 3.8 or + version (up to now it has been tested upon 3.10).
+  *e.g.*, the 3.9 or + version (up to now it has been tested upon 3.10).
 * Install the version which you just downloaded, following the instructions
   on the download page.
 

--- a/docs/gettingstarted/install/install_sources.rst
+++ b/docs/gettingstarted/install/install_sources.rst
@@ -77,7 +77,6 @@ Create a conda environment
      $ mamba env create -n scpy -f environment.yml
      $ conda activate scpy
 
-  If you prefer to work with ``3.8`` python version, you just change ``-v 3.9`` by ``-v 3.8`` or ``3.7`` .
   Of course, you can also name your environment differently by replacing ``scpy`` by the name of your choice.
 
 Install `SpectroChemPy` in this environment

--- a/environment.yml
+++ b/environment.yml
@@ -37,11 +37,11 @@ dependencies:
     - numpy
     - numpydoc>=1.2
     - pint>=0.20
-    - pytz
     - requests
     - scipy
     - tqdm
     - traitlets
+    - tzlocal
     - scikit-learn
     - xlrd
     - pyyaml

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -37,11 +37,11 @@ dependencies:
     - numpy
     - numpydoc>=1.2
     - pint>=0.20
-    - pytz
     - requests
     - scipy
     - tqdm
     - traitlets
+    - tzlocal
     - scikit-learn
     - xlrd
     - pyyaml

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -37,11 +37,11 @@ dependencies:
     - numpy
     - numpydoc>=1.2
     - pint>=0.20
-    - pytz
     - requests
     - scipy
     - tqdm
     - traitlets
+    - tzlocal
     - scikit-learn
     - xlrd
     - pyyaml

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -21,11 +21,11 @@ numba
 numpy
 numpydoc>=1.2
 pint>=0.20
-pytz
 requests
 scipy
 tqdm
 traitlets
+tzlocal
 scikit-learn
 xlrd
 pyyaml

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -21,11 +21,11 @@ numba
 numpy
 numpydoc>=1.2
 pint>=0.20
-pytz
 requests
 scipy
 tqdm
 traitlets
+tzlocal
 scikit-learn
 xlrd
 pyyaml

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -21,11 +21,11 @@ numba
 numpy
 numpydoc>=1.2
 pint>=0.20
-pytz
 requests
 scipy
 tqdm
 traitlets
+tzlocal
 scikit-learn
 xlrd
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -140,9 +140,8 @@ setup_args = dict(
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development :: Libraries",
         "Intended Audience :: Science/Research",
-        "License :: CeCILL-B Free Software License Agreement (CECILL-B)",
+        "License :: CeCILL-B Free Software License Agreement (CeCILL-B)",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
@@ -151,7 +150,7 @@ setup_args = dict(
     zip_safe=False,
     packages=find_packages() + packages,
     include_package_data=True,  # requirements
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     setup_requires=["setuptools_scm>=6.3.2", "matplotlib>=3.5.1"],
     install_requires=read_requirements(),
     # post-commands

--- a/spectrochempy/application/plot_preferences.py
+++ b/spectrochempy/application/plot_preferences.py
@@ -455,7 +455,7 @@ class PlotPreferences(MetaConfigurable):
     # DATE
     #
     timezone = Unicode(
-        "UTC", help=r"""a pytz timezone string, e.g., US/Central or Europe/Paris"""
+        "UTC", help=r"""a IANA timezone string, e.g., US/Central or Europe/Paris"""
     ).tag(config=True, kind="")
     date_autoformatter_year = Unicode("%Y").tag(config=True, kind="")
     date_autoformatter_month = Unicode("%b %Y").tag(config=True, kind="")

--- a/spectrochempy/processing/transformation/concatenate.py
+++ b/spectrochempy/processing/transformation/concatenate.py
@@ -8,7 +8,6 @@ __all__ = ["concatenate", "stack"]
 
 __dataset_methods__ = __all__
 
-import datetime as datetime
 from warnings import warn
 
 import numpy as np
@@ -16,6 +15,7 @@ import numpy as np
 from spectrochempy.core.dataset.baseobjects.ndarray import DEFAULT_DIM_NAME
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.utils import exceptions
+from spectrochempy.utils.datetimeutils import utcnow
 from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.orderedset import OrderedSet
 
@@ -182,7 +182,7 @@ def concatenate(*datasets, **kwargs):
         out.description += ", {}".format(dataset.name)
 
     out.description += " )"
-    out._date = out._modified = datetime.datetime.now(datetime.timezone.utc)
+    out._date = out._modified = utcnow()
     out.history = ["Created by concatenate"]
 
     return out

--- a/spectrochempy/utils/datetimeutils.py
+++ b/spectrochempy/utils/datetimeutils.py
@@ -9,6 +9,8 @@ Datetime utilities
 """
 
 import re
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import numpy as np
 
@@ -32,6 +34,11 @@ DT64_TO_SCP_UNITS = {
     "fs": "femtosecond",
     "as": "attosecond",
 }
+
+
+def utcnow():
+    """Return the current time in UTC with a timezone."""
+    return datetime.utcnow().replace(microsecond=0, tzinfo=ZoneInfo("UTC"))
 
 
 def from_dt64_units(units):

--- a/spectrochempy/utils/testing.py
+++ b/spectrochempy/utils/testing.py
@@ -573,7 +573,7 @@ class RandomSeedContext(object):
 # ======================================================================================
 # raises and assertions (mostly copied from astropy)
 # ======================================================================================
-def assert_equal_units(unit1, unit2, strict=False):
+def assert_units_equal(unit1, unit2, strict=False):
     """
     Compare units.
 

--- a/tests/test_core/test_dataset/test_coord.py
+++ b/tests/test_core/test_dataset/test_coord.py
@@ -17,7 +17,7 @@ from spectrochempy.core.units import Quantity, ur
 from spectrochempy.utils.testing import (
     assert_approx_equal,
     assert_array_equal,
-    assert_equal_units,
+    assert_units_equal,
 )
 from spectrochempy.utils.warnings import assert_produces_warning
 
@@ -439,7 +439,7 @@ def test_coord_unit_conversion_operators_a(operation, result_units):
 
     combined = operator_km(scalar_in_m)
 
-    assert_equal_units(combined.units, result_units)
+    assert_units_equal(combined.units, result_units)
 
 
 UNARY_MATH = [
@@ -480,7 +480,7 @@ def test_coord_unit_conversion_operators(operation, result_units):
 
     combined = operator_km(scalar)
     debug_(f"{operation}, {combined}")
-    assert_equal_units(combined.units, result_units)
+    assert_units_equal(combined.units, result_units)
 
 
 NOTIMPL = [

--- a/tests/test_core/test_dataset/test_dataset.py
+++ b/tests/test_core/test_dataset/test_dataset.py
@@ -1124,7 +1124,7 @@ def test_nddataset_timezone():
     nd = scp.NDDataset(np.ones((1, 3, 1, 2)), name="value")
     assert nd.timezone is not None
     assert nd.timezone == nd.local_timezone
-    nd.timezone = "UTC"
+    nd.timezone = "Pacific/Honolulu"
     assert nd.timezone != nd.local_timezone
     with pytest.raises(ZoneInfoNotFoundError):
         nd.timezone = "XXX"

--- a/tests/test_core/test_dataset/test_dataset.py
+++ b/tests/test_core/test_dataset/test_dataset.py
@@ -6,6 +6,7 @@
 # ======================================================================================
 # flake8: noqa
 from os import environ
+from zoneinfo import ZoneInfoNotFoundError
 
 import numpy as np
 import pytest
@@ -1122,10 +1123,10 @@ def test_nddataset_init_complex_1D_with_mask():
 def test_nddataset_timezone():
     nd = scp.NDDataset(np.ones((1, 3, 1, 2)), name="value")
     assert nd.timezone is not None
-    assert str(nd.timezone) == nd.local_timezone
+    assert nd.timezone == nd.local_timezone
     nd.timezone = "UTC"
     assert nd.timezone != nd.local_timezone
-    with pytest.raises(UnknownTimeZoneError):
+    with pytest.raises(ZoneInfoNotFoundError):
         nd.timezone = "XXX"
 
 

--- a/tests/test_core/test_dataset/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_ndmath.py
@@ -32,7 +32,7 @@ from spectrochempy.utils.testing import (
     RandomSeedContext,
     assert_array_equal,
     assert_dataset_equal,
-    assert_equal_units,
+    assert_units_equal,
 )
 
 typequaternion = np.dtype(np.quaternion)
@@ -489,7 +489,7 @@ def test_ndmath_unit_conversion_operators(operation, result_units):
     in_m = NDDataset(in_km.data * 1000, units=ur.m)
     operator_km = in_km.__getattribute__(operation)
     combined = operator_km(in_m)
-    assert_equal_units(combined.units, result_units)
+    assert_units_equal(combined.units, result_units)
 
 
 @pytest.mark.parametrize(
@@ -513,7 +513,7 @@ def test_arithmetic_unit_calculation(unit1, unit2, op, result_units):
     try:
         assert result.units == result_units
     except AssertionError:
-        assert_equal_units(ndd1_method(ndd2).units, result_units)
+        assert_units_equal(ndd1_method(ndd2).units, result_units)
 
 
 def test_simple_arithmetic_on_full_dataset():
@@ -1064,7 +1064,7 @@ def test_issue417():
 
     assert_array_equal(X.data, X_r.data)
     assert_dataset_equal(X, X_r)
-    assert_equal_units(X.units, X_r.units)
+    assert_units_equal(X.units, X_r.units)
     assert_dataset_equal(X[-1], X_r[-1])
 
     x_r = X_r - X_r[-1]

--- a/tests/test_utils/test_testing.py
+++ b/tests/test_utils/test_testing.py
@@ -129,9 +129,9 @@ def test_compare_project(simple_project):
 
 def test_compare_units():
 
-    testing.assert_equal_units(ur.km, ur.m)
+    testing.assert_units_equal(ur.km, ur.m)
     with pytest.raises(AssertionError):
-        testing.assert_equal_units(ur.km, ur.m, strict=True)
+        testing.assert_units_equal(ur.km, ur.m, strict=True)
 
     with pytest.raises(AssertionError):
-        testing.assert_equal_units(ur.absorbance, ur.transmittance)
+        testing.assert_units_equal(ur.absorbance, ur.transmittance)


### PR DESCRIPTION
Changes : 
* `pytz` library is replaced by the `zoneinfo` available since py3.9.
   The change is now possible sine collaborators works with 3.10. 
* make testing assert more unifom. 


**Checklist**:

- [ ] Close the #xxxx (optional)
- [ ] Tests have been added (mostly required)
- [x] `.ci/templates/dependencies.tmpl` file has been updated with new dependencies
- [ ] User-visible changes (including notable bug fixes) have been documented in `docs/whatsnew/changelog.rst`.
- [ ] The new API methods have been included in a section of `docs/reference/index.rst`.
- [ ] If you are a new contributor, you have added your name (affiliation and ORCID
      if you have one) in the .zenodo.json in the field contributors field. *Be careful
      not to break the json format (check the content of the file with the
      [JSON Validator](https://jsonformatter.curiousconcept.com/))*
