### PR TITLE
FIX nonnegative spectra in MCRALS

### DIFF
--- a/spectrochempy/analysis/decomposition/mcrals.py
+++ b/spectrochempy/analysis/decomposition/mcrals.py
@@ -959,13 +959,18 @@ and `St`.
             # ------------------------------------------
             C_constrained = C.copy()
 
-            # Compute St taking into account non-negativity
-            # --------------------------------------------
+            # Compute St
+            # -----------
             St = self._solve_St(C)
 
             # stores St in St_unconstrained
             # ------------------------------------------
             St_unconstrained = St.copy()
+
+            # Force non-negative spectra
+            # ------------------------------------------
+            if np.any(self.nonnegSpec):
+                St[self.nonnegSpec, :] = St[self.nonnegSpec, :].clip(min=0)
 
             # Force unimodal spectra
             # ------------------------------------------


### PR DESCRIPTION
the correction for nonnegative spectra was missing 
**Checklist**:

- [ ] Close the #xxxx (optional)
- [ ] Tests have been added (mostly required)
- [ ] `.ci/templates/dependencies.tmpl` file has been updated with new dependencies
- [ ] User-visible changes (including notable bug fixes) have been documented in `docs/whatsnew/changelog.rst`.
- [ ] The new API methods have been included in a section of `docs/reference/index.rst`.
- [ ] If you are a new contributor, you have added your name (affiliation and ORCID
      if you have one) in the .zenodo.json in the field contributors field. *Be careful
      not to break the json format (check the content of the file with the
      [JSON Validator](https://jsonformatter.curiousconcept.com/))*
