### PR TITLE
compatibility error with pint 0.24+

### DIFF
--- a/.ci/templates/dependencies.tmpl
+++ b/.ci/templates/dependencies.tmpl
@@ -26,7 +26,7 @@ be created or updated accordingly
     - numpydoc>=1.2
     - osqp
     - packaging
-    - pint>=0.20
+    - pint>=0.20,<=0.23
     - requests
     - scipy
     - tqdm

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - numpydoc>=1.2
     - osqp
     - packaging
-    - pint>=0.20
+    - pint>=0.20,<=0.23
     - requests
     - scipy
     - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
     - numpydoc>=1.2
     - osqp
     - packaging
-    - pint>=0.20
+    - pint>=0.20,<=0.23
     - requests
     - scipy
     - tqdm

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -37,7 +37,7 @@ dependencies:
     - numpydoc>=1.2
     - osqp
     - packaging
-    - pint>=0.20
+    - pint>=0.20,<=0.23
     - requests
     - scipy
     - tqdm

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -37,7 +37,7 @@ dependencies:
     - numpydoc>=1.2
     - osqp
     - packaging
-    - pint>=0.20
+    - pint>=0.20,<=0.23
     - requests
     - scipy
     - tqdm

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -21,7 +21,7 @@ numpy
 numpydoc>=1.2
 osqp
 packaging
-pint>=0.20
+pint>=0.20,<=0.23
 requests
 scipy
 tqdm

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -21,7 +21,7 @@ numpy
 numpydoc>=1.2
 osqp
 packaging
-pint>=0.20
+pint>=0.20,<=0.23
 requests
 scipy
 tqdm

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -21,7 +21,7 @@ numpy
 numpydoc>=1.2
 osqp
 packaging
-pint>=0.20
+pint>=0.20,<=0.23
 requests
 scipy
 tqdm


### PR DESCRIPTION
in pint 0.24, "old formatting codeé has been removec (sse https://github.com/hgrecco/pint/commit/9dff7c853ed5c12b136c8c883e3864417a05aba2), whuch raises an error in core/units: formatting._FORMATTERS does not exist anymore.

in this temporary fix we pin the pint version to >=0.20, <=0.23 



