### PR TITLE
fix numpy compatibility

### DIFF
--- a/.ci/templates/dependencies.tmpl
+++ b/.ci/templates/dependencies.tmpl
@@ -22,7 +22,7 @@ be created or updated accordingly
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy
+    - numpy<=2.0.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/.ci/templates/dependencies.tmpl
+++ b/.ci/templates/dependencies.tmpl
@@ -22,7 +22,7 @@ be created or updated accordingly
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy<=2.0.0
+    - numpy<2.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy<=2.0.0
+    - numpy<2.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy
+    - numpy<=2.0.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy
+    - numpy<=2.0.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy<=2.0.0
+    - numpy<2.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -33,7 +33,7 @@ dependencies:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy
+    - numpy<=2.0.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -33,7 +33,7 @@ dependencies:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy<=2.0.0
+    - numpy<2.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -33,7 +33,7 @@ dependencies:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy
+    - numpy<=2.0.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -33,7 +33,7 @@ dependencies:
     - jinja2
     - matplotlib>=3.8
     - numba
-    - numpy<=2.0.0
+    - numpy<2.0
     - numpydoc>=1.2
     - osqp
     - packaging

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ ipython
 jinja2
 matplotlib>=3.8
 numba
-numpy<=2.0.0
+numpy<2.0
 numpydoc>=1.2
 osqp
 packaging

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ ipython
 jinja2
 matplotlib>=3.8
 numba
-numpy
+numpy<=2.0.0
 numpydoc>=1.2
 osqp
 packaging

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -17,7 +17,7 @@ ipython
 jinja2
 matplotlib>=3.8
 numba
-numpy<=2.0.0
+numpy<2.0
 numpydoc>=1.2
 osqp
 packaging

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -17,7 +17,7 @@ ipython
 jinja2
 matplotlib>=3.8
 numba
-numpy
+numpy<=2.0.0
 numpydoc>=1.2
 osqp
 packaging

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -17,7 +17,7 @@ ipython
 jinja2
 matplotlib>=3.8
 numba
-numpy<=2.0.0
+numpy<2.0
 numpydoc>=1.2
 osqp
 packaging

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -17,7 +17,7 @@ ipython
 jinja2
 matplotlib>=3.8
 numba
-numpy
+numpy<=2.0.0
 numpydoc>=1.2
 osqp
 packaging

--- a/spectrochempy/__init__.py
+++ b/spectrochempy/__init__.py
@@ -57,9 +57,16 @@ warnings.filterwarnings(
     action="once", module="spectrochempy", category=DeprecationWarning
 )
 
-warnings.filterwarnings(
-    action="error", module="spectrochempy", category=np.VisibleDeprecationWarning
-)
+if np.version.version[0] == "1":
+    warnings.filterwarnings(
+        action="error", module="spectrochempy", category=np.VisibleDeprecationWarning
+    )
+else:
+    warnings.filterwarnings(
+        action="error",
+        module="spectrochempy",
+        category=np.exceptions.VisibleDeprecationWarning,
+    )
 
 warnings.filterwarnings(action="ignore", module="jupyter")  # , category=UserWarning)
 warnings.filterwarnings(action="ignore", module="pykwalify")  # , category=UserWarning)


### PR DESCRIPTION

Ssome incompatibilities with NumPy 2.0 (relaeased June 16thj 2024), e.g.: 
- visibleDeprecationWarning now in exceptions.VisibleDeprecationWarning (not from base name)
- pint not compatible yetr 
- ...

numpy version is temporarily pinned to <=2.0.0


**Checklist**:

- [ ] Close the #xxxx (optional)
- [ ] Tests have been added (mostly required)
- [ ] `.ci/templates/dependencies.tmpl` file has been updated with new dependencies
- [ ] User-visible changes (including notable bug fixes) have been documented in `docs/whatsnew/changelog.rst`.
- [ ] The new API methods have been included in a section of `docs/reference/index.rst`.
- [ ] If you are a new contributor, you have added your name (affiliation and ORCID
      if you have one) in the .zenodo.json in the field contributors field. *Be careful
      not to break the json format (check the content of the file with the
      [JSON Validator](https://jsonformatter.curiousconcept.com/))*
