### PR TITLE
adapt html colors to dark  mode

### DIFF
--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -122,7 +122,7 @@ def convert_to_html(obj):
     out = re.sub(regex, subst, out, count=0, flags=re.MULTILINE)
 
     regex = r"^(\W{0,12}\w+\W?\w+)(:\W{1}.*$)"  # r"^(\W*\w+\W?\w+)(:.*$)"
-    subst = r"<font color='green'>\1</font> \2"
+    subst = r"<font color='#28A745'>\1</font> \2"  # accent-green (attribute names)
     out = re.sub(regex, subst, out, count=0, flags=re.MULTILINE)
 
     regex = r"^(.*(DIMENSION|DATA).*)$"
@@ -135,7 +135,7 @@ def convert_to_html(obj):
 
     regex = r"\0{2}[\w\W]*?\0{2}"
 
-    def subst(match):
+    def subst(match):  # (labels)
         return "<div><font color='darkcyan'>{}</font></div>".format(
             match.group(0).replace("\n", "<br/>").replace("\0", ""),
         )
@@ -144,8 +144,8 @@ def convert_to_html(obj):
 
     regex = r"\0{1}[\w\W]*?\0{1}"
 
-    def subst(match):
-        return "<div><font color='blue'>{}</font></div>".format(
+    def subst(match):  # accent-blue (numeric data)
+        return "<div><font color='#2D7FF9'>{}</font></div>".format(
             match.group(0).replace("\n", "<br/>").replace("\0", ""),
         )
 

--- a/tests/test_core/test_dataset/test_coord.py
+++ b/tests/test_core/test_dataset/test_coord.py
@@ -402,7 +402,7 @@ def test_coord():
     assert "<div><font color='darkcyan'>[  a   b ..." in s
 
     c = Coord()
-    assert "<div><font color='blue'>Undefined</font></div>" in c._repr_html_()
+    assert "<div><font color='#2D7FF9'>Undefined</font></div>" in c._repr_html_()
 
     # several row of label
     coord0.labels = list("klmnopqrst")

--- a/tests/test_processing/test_fft/test_nmr.py
+++ b/tests/test_processing/test_fft/test_nmr.py
@@ -38,9 +38,9 @@ def test_nmr_reader_1D():
     ndd.read_topspin(path, expno=1, remove_digital_filter=True)
     assert ndd.__str__() == "NDDataset: [complex128] unitless (size: 12411)"
     assert (
-        "<tr><td style='padding-right:5px; padding-bottom:0px; padding-top:0px; width:124px'><font color='green'> "
+        "<tr><td style='padding-right:5px; padding-bottom:0px; padding-top:0px; width:124px'><font color='#28A745'> "
         " coordinates</font> </td><td style='text-align:left; padding-bottom:0px; padding-top:0px; border:.5px "
-        "solid lightgray;  '> <div><font color='blue'>[       0        4 ... 4.964e+04 4.964e+04] us</font></div>"
+        "solid lightgray;  '> <div><font color='#2D7FF9'>[       0        4 ... 4.964e+04 4.964e+04] us</font></div>"
         "</td><tr>" in ndd._repr_html_()
     )
 


### PR DESCRIPTION
html 'blue' has very low contrast with dark mode (and green, but in a lesser extent). This PR replaces these colors by blue and green that are compatible with both light and dark modes. 
  
