### PR TITLE
fix to issue #696 coordset subtraction

### DIFF
--- a/docs/sources/userguide/objects/dataset/dataset.py
+++ b/docs/sources/userguide/objects/dataset/dataset.py
@@ -541,6 +541,56 @@ d3D
 d3D.v_1
 
 # %% [markdown]
+# ## Math operations on coordinates
+# arithmetic operations can be performed on single coordinates:
+
+# %%
+d3D.u = d3D.u * 2
+d3D.u
+
+# %% [markdown]
+# ufunc numpy functions can also be applied, and will affect both the magnitude and
+# the units of the coordinates:
+
+# %%
+d3D.u = 1.5 + np.sqrt(d3D.u)
+d3D.u
+
+# %% [markdown]
+# A particularly frequent use case is to subtract the initial value from a coordinate. This can be done
+# directly with the `-` operator:
+
+# %%
+d3D.u = d3D.u - d3D.u[0]
+d3D.u
+
+# %% [markdown]
+# The operations above will generally *not* work on multiple coordinates, and
+# will raise an error if attempted:
+
+# %%
+try:
+    d3D.v = d3D.v - 1.5
+except NotImplementedError as e:
+    scp.error_(NotImplementedError, e)
+
+# %% [markdown]
+# Only subtraction between multiple coordinates, and will return a new `CoordSet` where each coordinate
+# has been subtracted::
+
+# %%
+d3D.v = d3D.v - d3D.v[0]
+d3D.v
+
+# %% [markdown]
+# Of course, it is always possible to carry out operations on a coordinate
+# has been subtracted by the reference values:
+
+# %%
+d3D.v_2 = d3D.v_2 + 5.0
+d3D.v
+
+# %% [markdown]
 # ## Summary of the coordinate setting syntax
 # Some additional information about coordinate setting syntax
 

--- a/docs/sources/userguide/objects/dataset/dataset.py
+++ b/docs/sources/userguide/objects/dataset/dataset.py
@@ -542,14 +542,14 @@ d3D.v_1
 
 # %% [markdown]
 # ## Math operations on coordinates
-# arithmetic operations can be performed on single coordinates:
+# Arithmetic operations can be performed on single coordinates:
 
 # %%
 d3D.u = d3D.u * 2
 d3D.u
 
 # %% [markdown]
-# ufunc numpy functions can also be applied, and will affect both the magnitude and
+# The ufunc numpy functions can also be applied, and will affect both the magnitude and
 # the units of the coordinates:
 
 # %%
@@ -575,7 +575,7 @@ except NotImplementedError as e:
     scp.error_(NotImplementedError, e)
 
 # %% [markdown]
-# Only subtraction between multiple coordinates, and will return a new `CoordSet` where each coordinate
+# Only subtraction between multiple coordinates is allowed, and will return a new `CoordSet` where each coordinate
 # has been subtracted::
 
 # %%

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -25,7 +25,7 @@ New features
 
 Bug fixes
 ~~~~~~~~~
-.. Add here new bug fixes (do not delete this comment)
+* Bug #696. Now subtraction od multicoordinates works transparently
 
 
 .. section

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,7 +26,7 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-* Bug #696. Now subtraction of multicoordinates works transparently
+* Bug #696. Subtraction/Addition of multicoordinates works transparently
 
 
 .. section

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -25,6 +25,7 @@ New features
 
 Bug fixes
 ~~~~~~~~~
+
 * Bug #696. Now subtraction od multicoordinates works transparently
 
 

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -283,17 +283,17 @@ class CoordSet(HasTraits):
 
     def __sub__(self, other):
         """
-        Subtraction of coordinates.
+        Subtraction of Coordsets.
 
         Parameters
         ----------
         other : CoordSet
-            The coordinates to subtract.
+            The Coordset to subtract to self.
 
         Returns
         -------
         sub : CoordSet
-            The difference of the coordinates.
+            The difference of the Coordsets.
 
         """
         out = []
@@ -309,17 +309,17 @@ class CoordSet(HasTraits):
 
     def __add__(self, other):
         """
-        Subtraction of coordinates.
+        Addition of Coordsets.
 
         Parameters
         ----------
         other : CoordSet,
-            The coordinates to subtract.
+            The Coordset to add to self.
 
         Returns
         -------
         add : CoordSet
-            The sum of the coordinates.
+            The sum of the Coordsets.
 
         """
         out = []

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -278,6 +278,63 @@ class CoordSet(HasTraits):
         return name == "CoordSet"
 
     # ----------------------------------------------------------------------------------
+    # Special methods
+    # ----------------------------------------------------------------------------------
+
+    def __sub__(self, other):
+        """
+        Subtraction of coordinates.
+
+        Parameters
+        ----------
+        other : CoordSet
+            The coordinates to subtract.
+
+        Returns
+        -------
+        sub : CoordSet
+            The difference of the coordinates.
+
+        """
+        out = []
+        if isinstance(other, CoordSet):
+            for coord1, coord2 in zip(self.coords, other.coords, strict=False):
+                out.append(coord1 - coord2)
+        else:
+            raise NotImplementedError(
+                f"Subtraction f a CoordSet with an object of type {type(other)} is not implemented yet"
+            )
+
+        return CoordSet(list(out))
+
+    def __add__(self, other):
+        """
+        Subtraction of coordinates.
+
+        Parameters
+        ----------
+        other : CoordSet,
+            The coordinates to subtract.
+
+        Returns
+        -------
+        add : CoordSet
+            The sum of the coordinates.
+
+        """
+        out = []
+        if isinstance(other, CoordSet):
+            for coord1, coord2 in zip(self.coords, other.coords, strict=False):
+                out.append(coord1 + coord2)
+
+        else:
+            raise NotImplementedError(
+                f"Addition of a CoordSet with an object of type {type(other)} is not implemented yet"
+            )
+
+        return CoordSet(list(out))
+
+    # ----------------------------------------------------------------------------------
     # Validation methods
     # ----------------------------------------------------------------------------------
     @validate("_coords")

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -457,15 +457,15 @@ def test_coordset_arithmetics():
     # typical use case
     ds = NDDataset([0.0, 1.0, 2.0])
     x2 = Coord(np.array([0.5, 0.8, 9.0]))
-    x1 = Coord(np.array([0.5, 0.8, 9.0]))
+    x1 = Coord(np.array([1.5, 5.8, -9.0]))
     ds.x = CoordSet(Coord(x2), Coord(x1))
 
     diff = ds.x - ds.x[0]
 
     assert_coord_almost_equal(diff["_1"], x1 - x1[0])
-    assert_coord_almost_equal(diff["_1"], x2 - x2[0])
+    assert_coord_almost_equal(diff["_2"], x2 - x2[0])
 
-    # in the following case, the coordinates are not considered
+    # in the following, the coordinates are not considered by default
     # as multi coordinates, so the slicing returns a Coord, not a
     # slices Coorset:
     x = CoordSet(Coord(x2), Coord(x1))
@@ -478,4 +478,4 @@ def test_coordset_arithmetics():
     x._is_same_dim = True
     diff = x - x[0]
     assert_coord_almost_equal(diff["_1"], x1 - x1[0])
-    assert_coord_almost_equal(diff["_1"], x2 - x2[0])
+    assert_coord_almost_equal(diff["_2"], x2 - x2[0])


### PR DESCRIPTION
fix to issue #696.

Now the subtraction on multicoordinates works transparently. 

Note  that all coordinates (not only the default) are subtracted;  which I think has the advantage to be consistent with the slicing. If `ds.y` is a multicoordinate,  `ds.y[0]` returns a multiocoordinate, and one would expect that `ds.y - ds.y[0]`  subtracts all the coordinates ?

In practice, I agree that the user would certainly prefer to make the subtraction on one of the coordinates, but in this case it is probably better that he makes it explicitely ?, i.e. `ds.y_1 - ds.y_1[0]` 

maybe it would be worthwhile adding something about this in the user guide ?

  
**Checklist**:

- [x] Close the #696 (optional)
- [x] Tests have been added (mostly required)
- [ ] `pyproject.toml` file has been updated with new dependencies
- [x] User-visible changes (including notable bug fixes) have been documented in `docs/whatsnew/changelog.rst`.
- [ ] The new API methods have been included in a section of `docs/reference/index.rst`.
- [ ] If you are a new contributor, you have added your name (affiliation and ORCID
      if you have one) in the zenodo.json in the field contributors field. _Be careful
      not to break the json format (check the content of the file with the
      [JSON Validator](https://jsonformatter.curiousconcept.com/))_
