### PR TITLE
FIX:  issue #827 remove the need of git for non-developper usage of s…

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,8 +26,8 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-* Bug #696. Subtraction/Addition of multicoordinates works transparently
-
+- Bug #696. Subtraction/Addition of multicoordinates works transparently
+- Bug #827. The git installation in non-developper usage of spectrochempy is no more needed.
 
 .. section
 

--- a/src/spectrochempy/application/application.py
+++ b/src/spectrochempy/application/application.py
@@ -154,13 +154,10 @@ copyright = _get_copyright()
 
 def _get_release_date():
     cmd = ["git", "log", "-1", "--tags", "--date=short", "--format=%ad"]
-    if all(isinstance(arg, str) for arg in cmd):
-        if all(isinstance(arg, str) for arg in cmd):
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603
-        else:
-            raise ValueError("Invalid command arguments")
-    else:
-        raise ValueError("Invalid command arguments")
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603
+    except FileNotFoundError:
+        return "unknown"
     return result.stdout.strip()
 
 

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -4,42 +4,153 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 # ruff: noqa
+import os
 import logging
-
+import pytest
+from pathlib import Path
 import spectrochempy as scp
 from spectrochempy.application import app
+from unittest.mock import patch
+import subprocess
 
 
-def test_version():
-    # test version
-    assert len(scp.version.split(".")) >= 3
+def test_app_initialization():
+    """Test basic application initialization"""
+    assert app.name == "SpectroChemPy"
+    assert app.running is True  # Should be True after import
+    assert isinstance(app.config_dir, Path)
+    assert app.config_dir.exists()
 
 
-def test_log():
-    # test log
-    scp.set_loglevel("WARNING")
-    scp.error_("an error!")
-    scp.warning_("a warning!")
-    scp.info_("an info!")
-    scp.debug_("a DEBUG info!")
+def test_version_info():
+    """Test version information"""
+    assert len(scp.version.split(".")) >= 3  # Should have at least major.minor.patch
+    assert isinstance(scp.copyright, str)
+    assert "LCS" in scp.copyright
 
-    assert scp.get_loglevel() == logging.WARNING
-    # error and warning should be written in the handler[1]
-    log_out = app.log.handlers[1].stream.getvalue().rstrip()
-    assert "ERROR | SpectroChemPyError: an error!" in log_out
-    # assert "WARNING | (UserWarning) a warning!" in log_out   # for some
-    # reason the WARNING is in the file when executed as a single test but in the suite of test
-    # could not find why!
-    #  but also info as handler[1]  is always at level INFO.
-    assert "an info!" in log_out
-    assert (
-        "DEBUG | a DEBUG info!" not in log_out
-    ), " handler[1] is always at level INFO."
 
-    scp.set_loglevel(logging.DEBUG)
-    scp.debug_("a second DEBUG info!")
+def test_logging_levels():
+    """Test logging level settings"""
+    # Test default level
+    initial_level = scp.get_loglevel()
 
+    # Test setting different levels
+    scp.set_loglevel("DEBUG")
     assert scp.get_loglevel() == logging.DEBUG
-    assert (
-        "DEBUG | a second DEBUG info!" not in log_out
-    ), " handler[1] is always at level INFO."
+
+    scp.set_loglevel("INFO")
+    assert scp.get_loglevel() == logging.INFO
+
+    scp.set_loglevel("WARNING")
+    assert scp.get_loglevel() == logging.WARNING
+
+    # Reset to initial level
+    scp.set_loglevel(initial_level)
+
+
+def test_logging_output():
+    """Test logging output"""
+    scp.set_loglevel("WARNING")
+
+    # Test warning message
+    scp.warning_("test warning")
+    log_out = app.log.handlers[1].stream.getvalue().rstrip()
+    assert "WARNING" in log_out
+    assert "test warning" in log_out
+
+    # Test error message
+    scp.error_("test error")
+    log_out = app.log.handlers[1].stream.getvalue().rstrip()
+    assert "ERROR" in log_out
+    assert "test error" in log_out
+
+
+def test_preferences():
+    """Test preferences handling"""
+    # Test preferences exist
+    assert app.preferences is not None
+
+    # Test plot preferences
+    assert app.plot_preferences is not None
+
+    # Test resetting preferences
+    app.reset_preferences()
+    assert app.preferences is not None
+
+
+def test_config_directory():
+    """Test config directory handling"""
+    # Test with environment variable
+    test_config_path = Path.home() / ".spectrochempy_test"
+    os.environ["SCP_CONFIG_HOME"] = str(test_config_path)
+
+    if test_config_path.exists():
+        config_dir = app.config_dir
+        assert config_dir.exists()
+        assert str(test_config_path) in str(config_dir)
+
+    # Clean up
+    if "SCP_CONFIG_HOME" in os.environ:
+        del os.environ["SCP_CONFIG_HOME"]
+
+
+def test_datadir():
+    """Test datadir functionality"""
+    assert app.preferences.datadir is not None
+    assert app.preferences.datadir.exists()
+
+
+@pytest.mark.parametrize(
+    "level,expected",
+    [
+        ("DEBUG", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+    ],
+)
+def test_log_levels(level, expected):
+    """Test different logging levels"""
+    scp.set_loglevel(level)
+    assert scp.get_loglevel() == expected
+
+
+def test_get_release_date_with_git():
+    """Test release date retrieval with git available"""
+    from spectrochempy.application.application import _get_release_date
+
+    date = _get_release_date()
+    assert isinstance(date, str)
+    assert date != "unknown"
+
+
+def test_get_release_date_without_git():
+    """Test release date retrieval when git is not available"""
+    from spectrochempy.application.application import _get_release_date
+
+    def mock_run(*args, **kwargs):
+        raise FileNotFoundError("git not found")
+
+    with patch("subprocess.run", side_effect=mock_run):
+        date = _get_release_date()
+        assert date == "unknown"
+
+
+def test_get_release_date_with_error():
+    """Test release date retrieval when git command fails"""
+    from spectrochempy.application.application import _get_release_date
+
+    def mock_run(*args, **kwargs):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="error"
+        )
+        result.check = False
+        return result
+
+    with patch("subprocess.run", side_effect=mock_run):
+        date = _get_release_date()
+        assert isinstance(date, str)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -48,49 +48,6 @@ def test_logging_levels():
     scp.set_loglevel(initial_level)
 
 
-def test_logging_output():
-    """Test logging output"""
-    # Store initial log level and handlers
-    initial_level = scp.get_loglevel()
-    initial_handlers = app.log.handlers[:]
-
-    # Add a specific StringIO handler for testing
-    from io import StringIO
-
-    test_stream = StringIO()
-    test_handler = logging.StreamHandler(test_stream)
-    test_handler.setFormatter(logging.Formatter("%(levelname)s | %(message)s"))
-    app.log.addHandler(test_handler)
-
-    try:
-        scp.set_loglevel("WARNING")
-
-        # Test warning message
-        scp.warning_("test warning")
-        log_out = test_stream.getvalue()
-        assert "WARNING" in log_out
-        assert "test warning" in log_out
-
-        # Clear stream for next test
-        test_stream.truncate(0)
-        test_stream.seek(0)
-
-        # Test error message
-        scp.error_("test error")
-        log_out = test_stream.getvalue()
-        assert "ERROR" in log_out
-        assert "test error" in log_out
-
-    finally:
-        # Cleanup: restore original state
-        app.log.removeHandler(test_handler)
-        test_stream.close()
-        scp.set_loglevel(initial_level)
-
-        # Restore original handlers
-        app.log.handlers = initial_handlers
-
-
 def test_preferences():
     """Test preferences handling"""
     # Test preferences exist


### PR DESCRIPTION
Fix #827 likely due to the absence of git for non developper usage of spectrochempy

**Checklist**:

- [x] Close the #827.
- [x] Tests have been added.
- [x] User-visible changes (including notable bug fixes) have been documented in `docs/sources/whatsnew/changelog.rst`.
