### PR TITLE
fix #856

### DIFF
--- a/docs/sources/userguide/processing/smoothing.py
+++ b/docs/sources/userguide/processing/smoothing.py
@@ -63,7 +63,7 @@ X.plot()
 # %%
 # select a region by slicing (note the original shape is (1, 1024)
 Xs = X[:, 0.0:400.0]
-info_("shape: ", X.shape)
+info_(f"shape: {X.shape}")
 Xs.plot()
 
 # %%

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,8 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- fixed issue #856 (osqp dependency, used for IRIS)
+
 
 .. section
 
@@ -33,6 +35,7 @@ Dependency Updates
 ~~~~~~~~~~~~~~~~~~
 .. Add here new dependency updates (do not delete this comment)
 
+- osqp > 1.0 now allowed (#856). A warning has been added, osqp < 1.0 will not be supported in the future.
 
 .. section
 

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.8
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.8.1
     v0.8.0
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -1,18 +1,17 @@
 :orphan:
 
-What's New in Revision 0.8.1
+What's New in Revision 0.8.2.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.8.1.
+These are the changes in SpectroChemPy-0.8.2.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
-
-New Features
-~~~~~~~~~~~~
-
-* `read_spc()` now supports reading SPC files with multiple spectra
-* `read_spc()` now supports reading SPC files in old format (Spectra Calc® and Lab Calc®)
 
 Bug Fixes
 ~~~~~~~~~
 
-* New features listed above fix issues #849 and #771.
+- fixed issue #856 (osqp dependency, used for IRIS)
+
+Dependency Updates
+~~~~~~~~~~~~~~~~~~
+
+- osqp > 1.0 now allowed (#856). A warning has been added, osqp < 1.0 will not be supported in the future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "numpy",
   "numpydoc",
   "numpy-quaternion >= 2024.0.7",
-  "osqp <= 0.7",
+  "osqp",
   "pint",
   "pyyaml",
   "requests",

--- a/src/spectrochempy/analysis/decomposition/iris.py
+++ b/src/spectrochempy/analysis/decomposition/iris.py
@@ -592,7 +592,8 @@ class IRIS(DecompositionAnalysis):
                             )
 
                         fi[:, j] = qprob.solve().x
-                else:
+
+                else:  # quadprog solver
                     for j, channel in enumerate(channels.data):
                         try:
                             P = P0 + 2 * lamda * S

--- a/src/spectrochempy/analysis/decomposition/iris.py
+++ b/src/spectrochempy/analysis/decomposition/iris.py
@@ -538,6 +538,7 @@ class IRIS(DecompositionAnalysis):
                 q = -2 * np.dot(X.T, K)
                 A = sparse.csc_matrix(np.eye(M))
                 lo = np.zeros(M)
+                up = np.ones(M) * np.inf
             else:
                 # The standard form used by quadprog() was
                 # minimize (1/2) xT P x - qT x ; subject to: A.T x >= b
@@ -576,7 +577,20 @@ class IRIS(DecompositionAnalysis):
                     for j in range(len(channels.data)):
                         P = sparse.csc_matrix(P0 + 2 * lamda * S)
                         qprob = osqp.OSQP()
-                        qprob.setup(P, q[j].squeeze(), A, lo, alpha=1.0, verbose=False)
+                        if osqp.__version__ < "1.0.0":
+                            qprob.setup(
+                                P, q[j].squeeze(), A, lo, alpha=1.0, verbose=False
+                            )
+                            warning_(
+                                f"The version of 'osqp' is outdated ({osqp.__version__}). "
+                                f"Please update osqp to version '1.0.1' or later. Spectrochempy "
+                                f"will not support this version in the future (scpy > 0.9)"
+                            )
+                        else:
+                            qprob.setup(
+                                P, q[j].squeeze(), A, lo, up, alpha=1.0, verbose=False
+                            )
+
                         fi[:, j] = qprob.solve().x
                 else:
                     for j, channel in enumerate(channels.data):

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_iris.py
@@ -128,27 +128,29 @@ iris2 = scp.IRIS(reg_par=[-10, 1, 12])
 # %%
 # We keep the same kernel object as previously - performs the fit.
 iris2.fit(X_, K)
-
 iris2.plotlcurve(title="L curve, manual search")
-iris2.plotdistribution(-7)
-iris2.plotmerit(-7)
+# %%
+# Visually, the best regularization parameter is at index ~ -6, corresponding to lambda = 1e-4
+
+iris2.plotdistribution(-6)
+iris2.plotmerit(-6)
 # %%
 # Automatic search
 # ----------------
 # %%
-# Now try an automatic search of the regularization parameter:
+# Now try an automatic search of the regularization parameter around the best value found manually:
 
-iris3 = scp.IRIS(reg_par=[-10, 1])
+iris3 = scp.IRIS(log_level="INFO", reg_par=[-6, -2])
 iris3.fit(X_, K)
 iris3.plotlcurve(title="L curve, automated search")
 # %%
 # The data corresponding to the largest curvature of the L-curve
-# are at the second last position of output data.
+# are at index 5 of the output data.
 
 # sphinx_gallery_thumbnail_number = 11
 
-iris3.plotdistribution(-2)
-iris3.plotmerit(-2)
+iris3.plotdistribution(5)
+iris3.plotmerit(5)
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when


### PR DESCRIPTION
fix IRIS for osqp >= 1.0. Backward compatibility is maintained. 

**Checklist**:

<!-- delete unused entries -->
- [x] Close the #856
- [x] Tests now passing
- [x] `pyproject.toml` file has been updated 
- [x] User-visible changes (including notable bug fixes) have been documented in `docs/sources/whatsnew/changelog.rst`.
