### PR TITLE
fix issue 858

### DIFF
--- a/.github/workflows/install_on_colab.yml
+++ b/.github/workflows/install_on_colab.yml
@@ -10,7 +10,6 @@ on:
       - develop
       - feature/*
       - fix/*
-  # pull_request:
   workflow_dispatch:  # Allows manual trigger from GitHub UI
 
 permissions:

--- a/.github/workflows/install_on_colab.yml
+++ b/.github/workflows/install_on_colab.yml
@@ -10,7 +10,7 @@ on:
       - develop
       - feature/*
       - fix/*
-  pull_request:
+  # pull_request:
   workflow_dispatch:  # Allows manual trigger from GitHub UI
 
 permissions:

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,7 +26,9 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- fixed issue #858 (omnic series reader)
 - fixed issue #856 (osqp dependency, used for IRIS)
+
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -9,6 +9,7 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- fixed issue #858 (omnic series reader)
 - fixed issue #856 (osqp dependency, used for IRIS)
 
 Dependency Updates

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -271,6 +271,11 @@ def read_srs(*paths, **kwargs):
     ----------------
     return_bg : bool, optional
         Default value is False. When set to 'True' returns the series background
+    reverse_x : bool, optional
+        Specifies whether to reverse the x-axis (wavenumber) data. Default is False.
+        In most srs files, the absorbance/intensity data are recorded from high to low
+        wavenumbers. However, in some cases the data maybe stored in low to high order.
+        If your data appear reversed, set 'reverse_x=True'.
     %(Importer.other_parameters)s
 
     See Also
@@ -735,6 +740,7 @@ def _read_srs(*args, **kwargs):
     frombytes = kwargs.get("frombytes", False)
 
     return_bg = kwargs.get("return_bg", False)
+    reverse_x = kwargs.get("reverse_x", False)
 
     # in this case, filename is actually a byte content
     fid = io.BytesIO(filename) if frombytes else open(filename, "rb")  # noqa: SIM115
@@ -1025,7 +1031,8 @@ def _read_srs(*args, **kwargs):
 
     # Create NDDataset Object for the series
     if not return_bg:
-        dataset = NDDataset(data)
+        dataset = NDDataset(data) if not reverse_x else NDDataset(data[:, ::-1])
+
     else:
         dataset = NDDataset(np.expand_dims(data, axis=0))
 
@@ -1038,6 +1045,7 @@ def _read_srs(*args, **kwargs):
     dataset.filename = filename
 
     # now add coordinates
+
     _x = Coord.linspace(
         info["firstx"],
         info["lastx"],


### PR DESCRIPTION
In some srs files, the absorbance/intensity data are recorded from low to high wavenumbers, i.e. in the reverse order as compared to most cases (... all cases know by us until issue #858). We don't know yet how to determine this inversion from the srs file. So the current fix consists in adding an adhoc option  'reverse_x' which reverses the data ordering along the x axis: `data = data[:,::-1]`  

As only one case has been reported for the moment we do not add a specific test

**Checklist**:

<!-- delete unused entries -->
- [x] Close the #858
- [ ] Tests have been added. -> not necvessary for the moment 
- [x] User-visible changes (including notable bug fixes) have been documented in `docs/sources/whatsnew/changelog.rst`.

