### PR TITLE
full interpolation feature for NDDataset (fixes #673)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -21,6 +21,8 @@ New Features
 
 - The welcome message display functionality has been removed.
 - Implemented lazy matplotlib initialization: SpectroChemPy now loads matplotlib only when plotting is actually used, reducing import-time overhead for non-plotting workflows.
+- Full interpolation feature for NDDataset (issue #673)
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,6 +11,7 @@ New Features
 
 - The welcome message display functionality has been removed.
 - Implemented lazy matplotlib initialization: SpectroChemPy now loads matplotlib only when plotting is actually used, reducing import-time overhead for non-plotting workflows.
+- Full interpolation feature for NDDataset (issue #673)
 
 Bug Fixes
 ~~~~~~~~~

--- a/src/spectrochempy/processing/alignement/align.py
+++ b/src/spectrochempy/processing/alignement/align.py
@@ -250,75 +250,91 @@ def align(dataset, *others, **kwargs):
             else:
                 raise NotImplementedError(f"The method {method} is unknown!")
 
+        # For interpolate method, use reference coordinate as target
+        # instead of the union
+        if method == "interpolate":
+            target_coord = ref_coord.copy()
+            target_coord._labels = None
+        else:
+            target_coord = new_coord
+
         # Now perform alignment of all objects on the new coordinates
         for index, object in _objects.items():
             obj = object["obj"]
 
-            # get the dim index for the given object
-            dim_index = obj.dims.index(dim)
-
-            # prepare slicing keys ; set slice(None) for the untouched
-            # dimensions preceding the dimension of interest
-            prepend_keys = [slice(None)] * dim_index
-
-            # New objects for obj must be created with the new coordinates
-
-            # change the data shape
-            new_obj_shape = list(obj.shape)
-            new_obj_shape[dim_index] = len(new_coord)
-            new_obj_data = np.full(new_obj_shape, np.nan)
-
-            # create new dataset for obj and ref_objects
-            new_obj = obj.copy() if copy else obj
-
-            # update the data and mask
-            coord = obj.coordset[dim]
-            coord_data = set(np.around(coord.data, ndec))
-
-            dim_loc = new_coord._loc2index(sorted(coord_data))
-            loc = tuple(prepend_keys + [dim_loc])
-
-            new_obj._data = new_obj_data
-
-            # mask all the data then unmask later the relevant data in
-            # the next step
-
-            if not new_obj.is_masked:
-                new_obj.mask = MASKED
-                new_obj.mask[loc] = False
-            else:
-                mask = new_obj.mask.copy()
-                new_obj.mask = MASKED
-                new_obj.mask[loc] = mask
-
-            # set the data for the loc
-            new_obj._data[loc] = obj.data
-
-            # update the coordinates
-            new_coordset = obj.coordset.copy()
-            if coord.is_labeled:
-                label_shape = list(coord.labels.shape)
-                label_shape[0] = new_coord.size
-                new_coord._labels = np.zeros(tuple(label_shape)).astype(
-                    coord.labels.dtype,
+            if method == "interpolate":
+                # Perform actual interpolation onto reference coordinates
+                interpolate_method = kwargs.get("interpolate_method", "linear")
+                obj = obj.interpolate(
+                    dim=dim,
+                    coord=target_coord,
+                    method=interpolate_method,
+                    fill_value=np.nan,
+                    inplace=False,
                 )
-                new_coord._labels[:] = "--"
-                new_coord._labels[dim_loc] = coord.labels
-            setattr(new_coordset, dim, new_coord)
-            new_obj._coordset = new_coordset
+            else:
+                # get the dim index for the given object
+                dim_index = obj.dims.index(dim)
 
-            # reversed?
-            if reversed:
-                # we must reverse the given coordinates
-                new_obj.sort(descend=reversed, dim=dim, inplace=True)
+                # prepare slicing keys ; set slice(None) for the untouched
+                # dimensions preceding the dimension of interest
+                prepend_keys = [slice(None)] * dim_index
+
+                # New objects for obj must be created with the new coordinates
+
+                # change the data shape
+                new_obj_shape = list(obj.shape)
+                new_obj_shape[dim_index] = len(new_coord)
+                new_obj_data = np.full(new_obj_shape, np.nan)
+
+                # create new dataset for obj and ref_objects
+                new_obj = obj.copy() if copy else obj
+
+                # update the data and mask
+                coord = obj.coordset[dim]
+                coord_data = set(np.around(coord.data, ndec))
+
+                dim_loc = new_coord._loc2index(sorted(coord_data))
+                loc = tuple(prepend_keys + [dim_loc])
+
+                new_obj._data = new_obj_data
+
+                # mask all the data then unmask later the relevant data in
+                # the next step
+
+                if not new_obj.is_masked:
+                    new_obj.mask = MASKED
+                    new_obj.mask[loc] = False
+                else:
+                    mask = new_obj.mask.copy()
+                    new_obj.mask = MASKED
+                    new_obj.mask[loc] = mask
+
+                # set the data for the loc
+                new_obj._data[loc] = obj.data
+
+                # update the coordinates
+                new_coordset = obj.coordset.copy()
+                if coord.is_labeled:
+                    label_shape = list(coord.labels.shape)
+                    label_shape[0] = new_coord.size
+                    new_coord._labels = np.zeros(tuple(label_shape)).astype(
+                        coord.labels.dtype,
+                    )
+                    new_coord._labels[:] = "--"
+                    new_coord._labels[dim_loc] = coord.labels
+                setattr(new_coordset, dim, new_coord)
+                new_obj._coordset = new_coordset
+
+                # reversed?
+                if reversed:
+                    # we must reverse the given coordinates
+                    new_obj.sort(descend=reversed, dim=dim, inplace=True)
+
+                obj = new_obj
 
             # update the _objects
-            _objects[index]["obj"] = new_obj
-
-            if method == "interpolate":
-                warning_(
-                    "Interpolation not yet implemented - for now equivalent to `outer`",
-                )
+            _objects[index]["obj"] = obj
 
         # the new transformed object must be in the same order as the passed
         # objects
@@ -340,37 +356,3 @@ def align(dataset, *others, **kwargs):
     # Now return
 
     return tuple(objects)
-
-    # if method == 'interpolate':  #  #     # reorders dataset and reference  # in ascending order  #     is_sorted
-    # = False  #     if  # dataset.coordset(axis).reversed:  #         datasetordered =  # dataset.sort(axis,
-    # descend=False)  #         refordered = ref.sort(  # refaxis, descend=False)  #         is_sorted = True  #
-    # else:  #  # datasetordered = dataset.copy()  #         refordered = ref.copy()  #  #     try:  #
-    # datasetordered.coordset(axis).to(  #     refordered.coordset(refaxis).units)  #     except:  #  #     raise
-    # ValueError(  #             'units of the dataset and  #     reference axes on which interpolate are not
-    # compatible')  #  #  #     oldaxisdata = datasetordered.coordset(axis).data  #  #     refaxisdata =
-    # refordered.coordset(refaxis).data  # TODO: at the  #      end restore the original order  #  #     method =
-    #  kwargs.pop(  #      'method', 'linear')  #     fill_value = kwargs.pop('fill_value',  #      np.NaN)  #  #
-    #  if method == 'linear':  #         interpolator  #      = lambda data, ax=0: scipy.interpolate.interp1d(  #  #
-    #  oldaxisdata, data, axis=ax, kind=method, bounds_error=False,  #             fill_value=fill_value,
-    #  assume_sorted=True)  #  #     elif  #             method == 'pchip':  #         interpolator = lambda data,
-    #             ax=0: scipy.interpolate.PchipInterpolator(  #  #             oldaxisdata, data, axis=ax,
-    #             extrapolate=False)  #  #             else:  #         raise AttributeError(f'{method} is not a  #
-    #             recognised option method for `align`')  #  #  #             interpolate_data = interpolator(
-    #             datasetordered.data,  #             axis)  #     newdata = interpolate_data(refaxisdata)  #  #  #
-    #             if datasetordered.is_masked:  #         interpolate_mask =  #             interpolator(
-    #             datasetordered.mask, axis)  #         newmask  #             = interpolate_mask(refaxisdata)  #
-    #             else:  #  #             newmask = NOMASK  #  #     # interpolate_axis =  #
-    #             interpolator(datasetordered.coordset(axis).data)  #     #  #             newaxisdata =
-    #             interpolate_axis(refaxisdata)  #  #             newaxisdata = refaxisdata.copy()  #  #     if
-    #             method ==  #             'pchip' and not np.isnan(fill_value):  #         index =  #
-    #             np.any(np.isnan(newdata))  #         newdata[index] =  #             fill_value  #  #
-    #             index = np.any(np.isnan(  #             newaxisdata))  #         newaxisdata[index] = fill_value
-    #  #     # create the new axis  #     newaxes = dataset.coords.copy()  #  #  newaxes[axis]._data = newaxisdata
-    #     newaxes[axis]._labels =  #  np.array([''] * newaxisdata.size)  #  #     # transform the dataset  #
-    #     inplace = kwargs.pop('inplace', False)  #  #     if inplace:  #  #     out = dataset  #     else:  #
-    #     out = dataset.copy()  #  #  #     out._data = newdata  #     out._coords = newaxes  #     out._mask  #
-    #     = newmask  #  #     out.name = dataset.name  #     out.title =  #     dataset.title  #  #     out.history
-    #     = '{}: Aligned along dim {}  #     with respect to dataset {} using coords {} \n'.format(  #  #     str(
-    #     dataset.modified), axis, ref.name, ref.coords[refaxis].title)  #  #     if is_sorted and out.coordset(
-    #     axis).reversed:  #  #  out.sort(axis, descend=True, inplace=True)  #         ref.sort(  #  refaxis,
-    #     descend=True, inplace=True)  #  # return out

--- a/src/spectrochempy/processing/interpolation/interpolate.py
+++ b/src/spectrochempy/processing/interpolation/interpolate.py
@@ -3,22 +3,350 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-"""Module defines functions related to interpolations."""
+"""Module implementing interpolation for NDDataset."""
 
 __all__ = ["interpolate"]
-
 __dataset_methods__ = __all__
 
+import numpy as np
+from scipy.interpolate import PchipInterpolator
+from scipy.interpolate import interp1d
 
-# import scipy.interpolate
-# import numpy as np
-
-# from ...utils import NOMASK, MASKED, UnitsCompatibilityError
-# from spectrochempy.extern.orderedset import OrderedSet
-# from spectrochempy.application.application import warning_, error_
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
 
 
-def interpolate(dataset, axis=0, size=None):
-    # TODO: a simple interpolator of the data (either to reduce
-    #      or increase number of points in every dimension)
-    raise NotImplementedError("Not yet implemented")
+def _interp_along_axis(values, old_x, new_x, axis, method, fill_value):
+    """
+    Interpolate values along a single axis.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        Data to interpolate.
+    old_x : np.ndarray
+        Original coordinates (1D).
+    new_x : np.ndarray
+        Target coordinates (1D).
+    axis : int
+        Axis along which to interpolate.
+    method : str
+        'linear' or 'pchip'.
+    fill_value : any
+        Value for extrapolation.
+
+    Returns
+    -------
+    np.ndarray
+        Interpolated data with same shape as input along other dimensions.
+    """
+    if method == "linear":
+        interpolator = interp1d(
+            old_x,
+            values,
+            axis=axis,
+            kind="linear",
+            bounds_error=False,
+            fill_value=fill_value,
+            assume_sorted=True,
+        )
+    elif method == "pchip":
+        if values.shape[axis] < 2:
+            raise ValueError(
+                f"PCHIP interpolation requires at least 2 points, got {values.shape[axis]}"
+            )
+        interpolator = PchipInterpolator(
+            old_x,
+            values,
+            axis=axis,
+            extrapolate=fill_value is not np.nan,
+        )
+    else:
+        raise ValueError(f"Unknown interpolation method: {method}")
+
+    return interpolator(new_x)
+
+
+def _validate_monotonic(coord, assume_sorted, tol=1e-12):
+    """
+    Validate coordinate monotonicity with tolerance for floating point noise.
+
+    Parameters
+    ----------
+    coord : Coord
+        Coordinate to validate.
+    assume_sorted : bool
+        If True, skip validation.
+    tol : float, optional
+        Tolerance for duplicate detection. Default is 1e-12.
+
+    Returns
+    -------
+    tuple: (sorted_data, sorted_indices, was_reversed)
+    """
+    data = coord.data
+
+    if assume_sorted:
+        return data, np.arange(len(data)), False
+
+    diffs = np.diff(data)
+
+    if np.any(np.abs(diffs) <= tol):
+        raise ValueError(
+            "Duplicate or near-duplicate coordinate values detected. "
+            "Interpolation requires strictly monotonic coordinates. "
+            "Use `assume_sorted=True` only if data is known to be strictly monotonic."
+        )
+
+    strictly_increasing = np.all(diffs > tol)
+    strictly_decreasing = np.all(diffs < -tol)
+
+    if strictly_increasing:
+        return data, np.arange(len(data)), False
+    if strictly_decreasing:
+        return data[::-1], np.arange(len(data) - 1, -1, -1), True
+
+    sorted_data = np.sort(data)
+    sort_idx = np.argsort(data)
+    return sorted_data, sort_idx, False
+
+
+def _get_coord_data(coord):
+    """Extract numeric data from coord."""
+    if coord.has_data:
+        return coord.data
+    return None
+
+
+def interpolate(
+    dataset,
+    dim=None,
+    dims=None,
+    coord=None,
+    method="linear",
+    fill_value=np.nan,
+    assume_sorted=False,
+    inplace=False,
+):
+    """
+    Interpolate dataset onto new coordinates.
+
+    Parameters
+    ----------
+    dataset : NDDataset
+        Dataset to interpolate.
+    dim : str or int, optional
+        Single dimension name or index.
+    dims : list of str or int, optional
+        List of dimensions to interpolate. Higher priority than dim.
+    coord : Coord, np.ndarray, NDDataset, or dict, optional
+        Target coordinates. If dict, maps dim -> coord.
+        For single dim: can be Coord, ndarray, or NDDataset.
+        For multiple dims: dict {dim: coord} or sequential application.
+    method : str, optional, default='linear'
+        Interpolation method: 'linear' or 'pchip'.
+    fill_value : any, optional, default=np.nan
+        Value for points outside the original range.
+    assume_sorted : bool, optional, default=False
+        If True, skip monotonicity checks.
+    inplace : bool, optional, default=False
+        If True, modify the dataset in place.
+
+    Returns
+    -------
+    NDDataset
+        Dataset with interpolated data and updated coordinates.
+
+    Raises
+    ------
+    TypeError
+        If coordinate is not numeric.
+    ValueError
+        If coordinates are not strictly monotonic.
+
+    Notes
+    -----
+    - Labels are NOT interpolated and are reset after interpolation.
+    - For multiple coordinates per dimension, all are interpolated consistently.
+    - Secondary coordinates are interpolated numerically. If they represent
+      analytical transformations of the primary coordinate (e.g., wavelength = 1/wavenumber),
+      the result may be approximate - consider recomputing them analytically after interpolation.
+    - Unit conversion is performed if needed before interpolation.
+    - Sequential interpolation is applied for multiple dimensions (not true N-D).
+    """
+    new = dataset if inplace else dataset.copy()
+
+    axis_list, dim_list = new.get_axis(only_first=False, dim=dim, dims=dims)
+
+    coord_map = {}
+    if coord is not None:
+        if isinstance(coord, dict):
+            coord_map = coord
+        elif len(axis_list) == 1:
+            coord_map[dim_list[0]] = coord
+
+    for ax, dim in zip(axis_list, dim_list, strict=False):
+        target_coord = coord_map.get(dim)
+
+        if target_coord is None:
+            raise ValueError(f"No target coordinate provided for dimension '{dim}'")
+
+        # Handle different target coordinate types
+        from spectrochempy.core.dataset.nddataset import NDDataset
+
+        if isinstance(target_coord, NDDataset):
+            target_coord = target_coord.coord(dim)
+        elif isinstance(target_coord, np.ndarray):
+            target_coord = Coord(target_coord)
+        elif not isinstance(target_coord, Coord):
+            raise TypeError(
+                f"coord must be Coord, np.ndarray, or NDDataset, got {type(target_coord)}"
+            )
+
+        old_coord = new.coord(dim)
+
+        is_coordset = isinstance(old_coord, CoordSet)
+
+        primary_old_coord = old_coord.default if is_coordset else old_coord
+
+        if primary_old_coord is None or not primary_old_coord.has_data:
+            raise ValueError(f"Dimension '{dim}' has no coordinate data to interpolate")
+
+        old_data = _get_coord_data(primary_old_coord)
+        if old_data is None:
+            raise TypeError(f"Cannot interpolate on non-numeric coordinate '{dim}'")
+
+        new_data = _get_coord_data(target_coord)
+        if new_data is None:
+            raise TypeError("Cannot interpolate to non-numeric coordinate")
+
+        if primary_old_coord.has_units and target_coord.has_units:
+            if not primary_old_coord.is_units_compatible(target_coord):
+                raise ValueError(
+                    f"Incompatible units: {primary_old_coord.units} vs {target_coord.units}"
+                )
+            if primary_old_coord.units != target_coord.units:
+                target_coord = target_coord.copy()
+                target_coord.ito(primary_old_coord.units)
+                new_data = _get_coord_data(target_coord)
+
+        sorted_old_x, sort_idx, was_reversed = _validate_monotonic(
+            primary_old_coord, assume_sorted
+        )
+
+        if sort_idx is not None and len(sort_idx) > 0:
+            sorted_data = new._data[
+                tuple(sort_idx if i == ax else slice(None) for i in range(new.ndim))
+            ].copy()
+        else:
+            sorted_data = new._data
+
+        if method == "linear":
+            interpolator = interp1d(
+                sorted_old_x,
+                sorted_data,
+                axis=ax,
+                kind="linear",
+                bounds_error=False,
+                fill_value=fill_value,
+                assume_sorted=True,
+            )
+        elif method == "pchip":
+            if sorted_data.shape[ax] < 2:
+                raise ValueError(
+                    f"PCHIP interpolation requires at least 2 points, "
+                    f"got {sorted_data.shape[ax]}"
+                )
+            interpolator = PchipInterpolator(
+                sorted_old_x,
+                sorted_data,
+                axis=ax,
+                extrapolate=False,
+            )
+        else:
+            raise ValueError(f"Unknown method: {method}")
+
+        interpolated_data = interpolator(new_data)
+
+        if sort_idx is not None and len(sort_idx) > 0:
+            new._data = interpolated_data
+        else:
+            new._data = interpolated_data
+
+        if new.is_masked:
+            mask_interpolator = interp1d(
+                sorted_old_x,
+                new._mask.astype(float),
+                axis=ax,
+                kind="linear",
+                bounds_error=False,
+                fill_value=True,
+                assume_sorted=True,
+            )
+            new_mask = mask_interpolator(new_data) > 0.5
+            new._mask = new_mask
+
+        coordset = new._coordset
+        if coordset is None:
+            coordset = CoordSet()
+            new._coordset = coordset
+
+        names = coordset.names if coordset else []
+
+        new_coord = target_coord.copy()
+        new_coord._labels = None
+        new_coord.name = dim
+
+        if dim in names:
+            coord_idx = names.index(dim)
+            old_coord_container = coordset._coords[coord_idx]
+
+            if isinstance(old_coord_container, CoordSet):
+                all_coords = list(old_coord_container._coords)
+                new_coords_list = []
+
+                for old_sec_coord in all_coords:
+                    if old_sec_coord.has_data:
+                        old_sec_data = _get_coord_data(old_sec_coord)
+                        if old_sec_data is not None and len(old_sec_data) == len(
+                            sorted_old_x
+                        ):
+                            sec_interpolator = interp1d(
+                                sorted_old_x,
+                                old_sec_data,
+                                axis=0,
+                                kind="linear",
+                                bounds_error=False,
+                                fill_value=np.nan,
+                                assume_sorted=True,
+                            )
+                            new_sec_data = sec_interpolator(new_data)
+                            new_sec_coord = old_sec_coord.copy()
+                            new_sec_coord._data = new_sec_data
+                            new_sec_coord._labels = None
+                        else:
+                            new_sec_coord = old_sec_coord.copy()
+                            new_sec_coord._labels = None
+                    else:
+                        new_sec_coord = old_sec_coord.copy()
+                        new_sec_coord._labels = None
+                    new_coords_list.append(new_sec_coord)
+
+                new_coordset = CoordSet(*new_coords_list[::-1], name=dim)
+                new_coordset._default = old_coord_container._default
+                new_coordset._is_same_dim = True
+                coordset._coords[coord_idx] = new_coordset
+            else:
+                coordset._coords[coord_idx] = new_coord
+        else:
+            coordset._coords.append(new_coord)
+
+        if was_reversed:
+            new.sort(descend=True, dim=dim, inplace=True)
+
+    new.history = (
+        f"Interpolated along dims {dim_list} to {len(new_data)} points "
+        f"using {method} method"
+    )
+
+    return new

--- a/tests/test_processing/test_interpolation/test_interpolate.py
+++ b/tests/test_processing/test_interpolation/test_interpolate.py
@@ -3,16 +3,423 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-# ruff: noqa
+"""Tests for the NDDataset.interpolate method."""
 
-"""Tests for the interpolate module"""
-
+import numpy as np
 import pytest
 
-# align
-# -------
+from spectrochempy import Coord
+from spectrochempy import NDDataset
 
 
-@pytest.mark.skip
-def test_interpolate(ds1, ds2):
-    pass
+class TestInterpolateBasic:
+    """Basic interpolation tests."""
+
+    def test_interpolate_linear_basic(self):
+        """Test basic linear interpolation on 1D data."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.shape == (4,)
+        np.testing.assert_allclose(result.data, [1.0, 3.0, 5.0, 7.0], rtol=1e-5)
+
+    def test_interpolate_pchip_basic(self):
+        """Test PCHIP interpolation on 1D data."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 1.0, 4.0, 9.0, 16.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x, method="pchip")
+
+        assert result.shape == (4,)
+
+    def test_interpolate_coord_input(self):
+        """Test interpolation with Coord as target."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_coord = Coord(np.array([0.5, 1.5, 2.5, 3.5]), title="x")
+        result = ds.interpolate(dim="x", coord=new_coord)
+
+        assert result.shape == (4,)
+        np.testing.assert_allclose(result.data, [1.0, 3.0, 5.0, 7.0], rtol=1e-5)
+
+    def test_interpolate_nddataset_input(self):
+        """Test interpolation with NDDataset as target coordinate."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        target_ds = NDDataset(
+            np.array([0.5, 1.5, 2.5, 3.5]),
+            coordset=[Coord(np.array([0.5, 1.5, 2.5, 3.5]), title="x")],
+        )
+        result = ds.interpolate(dim="x", coord=target_ds)
+
+        assert result.shape == (4,)
+
+    def test_interpolate_unsorted_coordinates(self):
+        """Test interpolation handles unsorted coordinates."""
+        x = np.array([4.0, 2.0, 0.0, 1.0, 3.0])
+        y = np.array([8.0, 4.0, 0.0, 2.0, 6.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.shape == (4,)
+        np.testing.assert_allclose(result.data, [1.0, 3.0, 5.0, 7.0], rtol=1e-5)
+
+    def test_interpolate_assume_sorted(self):
+        """Test assume_sorted parameter."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x, assume_sorted=True)
+
+        assert result.shape == (4,)
+
+
+class TestInterpolateMultidimensional:
+    """Multi-dimensional interpolation tests."""
+
+    def test_interpolate_2d(self):
+        """Test interpolation on 2D data along first dimension."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 10.0, 20.0])
+        data = np.arange(15).reshape(3, 5).astype(float)
+        ds = NDDataset(data, coordset=[Coord(y, title="y"), Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.shape == (3, 4)
+        np.testing.assert_allclose(result.data[0], [0.5, 1.5, 2.5, 3.5], rtol=1e-5)
+
+    def test_interpolate_multiple_dims(self):
+        """Test interpolation along multiple dimensions."""
+        x = np.array([0.0, 1.0, 2.0, 3.0])
+        y = np.array([0.0, 10.0, 20.0])
+        data = np.arange(12).reshape(3, 4).astype(float)
+        ds = NDDataset(data, coordset=[Coord(y, title="y"), Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5])
+        new_y = np.array([5.0, 15.0])
+        result = ds.interpolate(dims=["x", "y"], coord={"x": new_x, "y": new_y})
+
+        assert result.shape == (2, 3)
+
+
+class TestInterpolateErrorCases:
+    """Error handling tests."""
+
+    def test_duplicate_coordinates_error(self):
+        """Test that duplicate coordinates raise error."""
+        x = np.array([0.0, 1.0, 1.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        with pytest.raises(ValueError, match="Duplicate"):
+            ds.interpolate(dim="x", coord=new_x, assume_sorted=False)
+
+    def test_non_numeric_coordinate_error(self):
+        """Test that non-numeric coordinates raise TypeError."""
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y)
+        ds.set_coordset(x=None)
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        with pytest.raises(ValueError):
+            ds.interpolate(dim="x", coord=new_x)
+
+
+class TestInterpolateUnits:
+    """Unit handling tests."""
+
+    def test_interpolate_with_units(self):
+        """Test interpolation with unit conversion."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", units="m")])
+
+        new_coord = Coord(np.array([0.5, 1.5, 2.5, 3.5]), title="x", units="m")
+        result = ds.interpolate(dim="x", coord=new_coord)
+
+        assert result.shape == (4,)
+        assert str(result.coord("x").units) == "m"
+
+    def test_interpolate_unit_conversion(self):
+        """Test interpolation with automatic unit conversion."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", units="m")])
+
+        new_coord = Coord(np.array([50.0, 150.0, 250.0, 350.0]), title="x", units="cm")
+        result = ds.interpolate(dim="x", coord=new_coord)
+
+        assert result.shape == (4,)
+
+
+class TestInterpolateLabels:
+    """Label handling tests."""
+
+    def test_interpolate_removes_labels(self):
+        """Test that labels are removed after interpolation."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        labels = ["a", "b", "c", "d", "e"]
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", labels=labels)])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        assert coord._labels is None
+
+
+class TestInterpolateMask:
+    """Mask handling tests."""
+
+    def test_interpolate_masked_data(self):
+        """Test interpolation of masked data."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        mask = np.array([False, False, False, False, False])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")], mask=mask)
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.shape == (4,)
+        assert not result.is_masked
+
+
+class TestInterpolateMultipleCoords:
+    """Multiple coordinates per dimension tests."""
+
+    def test_interpolate_multiple_coords(self):
+        """Test interpolation with multiple coordinates per dimension."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 10.0, 20.0])
+        data = np.arange(15).reshape(3, 5).astype(float)
+
+        coord_x = Coord(x, title="x")
+        coord_y = Coord(y, title="y")
+
+        ds = NDDataset(data, coordset=[coord_y, coord_x])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.shape == (3, 4)
+
+
+class TestInterpolateInplace:
+    """Inplace modification tests."""
+
+    def test_interpolate_inplace(self):
+        """Test inplace interpolation."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x, inplace=True)
+
+        assert result is ds
+        assert result.shape == (4,)
+
+
+class TestInterpolateMetadata:
+    """Metadata preservation tests."""
+
+    def test_interpolate_preserves_name_title(self):
+        """Test that name and title are preserved."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(
+            y, coordset=[Coord(x, title="x")], title="test title", name="test_name"
+        )
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.name == "test_name"
+        assert result.title == "test title"
+
+    def test_interpolate_updates_history(self):
+        """Test that history is updated."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert len(result.history) > 0
+
+
+class TestInterpolateTolerance:
+    """Monotonicity tolerance tests."""
+
+    def test_interpolate_noisy_increasing(self):
+        """Test that slightly noisy increasing coordinates pass."""
+        x = np.array([0.0, 1.0 + 1e-13, 2.0 - 1e-13, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.shape == (4,)
+        np.testing.assert_allclose(result.data, [1.0, 3.0, 5.0, 7.0], rtol=1e-5)
+
+    def test_interpolate_near_duplicate_fails(self):
+        """Test that near-duplicate coordinates (within tolerance) fail."""
+        x = np.array([0.0, 1.0, 1.0 + 1e-13, 2.0, 3.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5])
+        with pytest.raises(ValueError, match="Duplicate or near-duplicate"):
+            ds.interpolate(dim="x", coord=new_x)
+
+    def test_interpolate_true_duplicate_fails(self):
+        """Test that true duplicate coordinates fail."""
+        x = np.array([0.0, 1.0, 1.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x")])
+
+        new_x = np.array([0.5, 1.5, 2.5, 3.5])
+        with pytest.raises(ValueError, match="Duplicate"):
+            ds.interpolate(dim="x", coord=new_x, assume_sorted=False)
+
+
+class TestAlignInterpolate:
+    """Tests for align with interpolate method."""
+
+    def test_align_interpolate_basic(self):
+        """Test basic align with interpolate method."""
+        coord0 = Coord(
+            data=np.linspace(4000.0, 1000.0, 10), units="cm^-1", title="wavenumber"
+        )
+        coord1 = Coord(data=np.linspace(0.0, 60.0, 100), units="s", title="time")
+
+        ds1 = NDDataset(
+            np.random.rand(100, 10),
+            coordset=[coord1, coord0],
+            title="test",
+            units="absorbance",
+        )
+
+        coord0_2 = Coord(
+            data=np.linspace(4000.0, 1000.0, 9), units="cm^-1", title="wavenumber"
+        )
+        coord1_2 = Coord(data=np.linspace(0.0, 60.0, 50), units="s", title="time")
+
+        ds2 = NDDataset(
+            np.random.rand(50, 9),
+            coordset=[coord1_2, coord0_2],
+            title="test",
+            units="absorbance",
+        )
+
+        ds1_aligned, ds2_aligned = ds1.align(ds2, dim="x", method="interpolate")
+
+        assert ds1_aligned.shape[1] == 10
+        assert ds2_aligned.shape[1] == 10
+        assert len(ds2_aligned.coord("x").data) == 10
+
+    def test_align_interpolate_pchip(self):
+        """Test align with interpolate and pchip method."""
+        coord0 = Coord(
+            data=np.linspace(4000.0, 1000.0, 10), units="cm^-1", title="wavenumber"
+        )
+        coord1 = Coord(data=np.linspace(0.0, 60.0, 100), units="s", title="time")
+
+        ds1 = NDDataset(
+            np.random.rand(100, 10),
+            coordset=[coord1, coord0],
+            title="test",
+            units="absorbance",
+        )
+
+        coord0_2 = Coord(
+            data=np.linspace(4000.0, 1000.0, 9), units="cm^-1", title="wavenumber"
+        )
+        coord1_2 = Coord(data=np.linspace(0.0, 60.0, 50), units="s", title="time")
+
+        ds2 = NDDataset(
+            np.random.rand(50, 9),
+            coordset=[coord1_2, coord0_2],
+            title="test",
+            units="absorbance",
+        )
+
+        ds1_aligned, ds2_aligned = ds1.align(
+            ds2, dim="x", method="interpolate", interpolate_method="pchip"
+        )
+
+        assert ds1_aligned.shape[1] == 10
+        assert ds2_aligned.shape[1] == 10
+
+    def test_align_interpolate_multiple_datasets(self):
+        """Test align with interpolate method for 3 datasets."""
+        coord0 = Coord(
+            data=np.linspace(4000.0, 1000.0, 10), units="cm^-1", title="wavenumber"
+        )
+        coord1 = Coord(data=np.linspace(0.0, 60.0, 100), units="s", title="time")
+
+        ds1 = NDDataset(
+            np.random.rand(100, 10),
+            coordset=[coord1, coord0],
+            title="test",
+            units="absorbance",
+        )
+
+        coord0_2 = Coord(
+            data=np.linspace(4000.0, 1000.0, 9), units="cm^-1", title="wavenumber"
+        )
+        coord1_2 = Coord(data=np.linspace(0.0, 60.0, 50), units="s", title="time")
+        ds2 = NDDataset(
+            np.random.rand(50, 9),
+            coordset=[coord1_2, coord0_2],
+            title="test",
+            units="absorbance",
+        )
+
+        coord0_3 = Coord(
+            data=np.linspace(4000.0, 1000.0, 8), units="cm^-1", title="wavenumber"
+        )
+        coord1_3 = Coord(data=np.linspace(0.0, 60.0, 40), units="s", title="time")
+        ds3 = NDDataset(
+            np.random.rand(40, 8),
+            coordset=[coord1_3, coord0_3],
+            title="test",
+            units="absorbance",
+        )
+
+        ds1_aligned, ds2_aligned, ds3_aligned = ds1.align(
+            ds2, ds3, dim="x", method="interpolate"
+        )
+
+        assert ds1_aligned.shape[1] == 10
+        assert ds2_aligned.shape[1] == 10
+        assert ds3_aligned.shape[1] == 10
+
+        np.testing.assert_array_equal(
+            ds1_aligned.coord("x").data, ds2_aligned.coord("x").data
+        )
+        np.testing.assert_array_equal(
+            ds1_aligned.coord("x").data, ds3_aligned.coord("x").data
+        )
+        assert len(ds2_aligned.coord("x").data) == 10


### PR DESCRIPTION
This PR introduces a full interpolation feature for NDDataset and refactors its implementation to align with SpectroChemPy’s architecture and method registration patterns.

✨ Features

- Add interpolate() for NDDataset
- Supports linear and pchip interpolation
- Works with Coord, ndarray, or NDDataset as target
- Supports multi-dimensional interpolation (sequential)
- Handles unit conversion
- Handles masked data
- Removes labels after interpolation (by design)

Integrate interpolation into:
`align(..., method="interpolate")`

The implementation follows the standard SCP processing pattern:

interpolate is implemented as a standalone function

registered via:

`__dataset_methods__ = __all__`

exposed as a dataset method via lazy loading (NDDataset.__getattr__)


🔬 Key Design Choices

- Secondary coordinates
- Interpolated consistently using the primary coordinate as reference
- Ensures coordinate alignment is preserved
- Labels
- Removed after interpolation (not propagated)
- Users can redefine them if needed
- Monotonicity
- Enforced with tolerance to handle floating-point noise
- duplicate coordinates raise an error
- Mask handling
- Mask is interpolated separately (linear) and reconstructed via thresholding
 
 🧪 Tests

~25 tests added/updated
Covers:

- linear & pchip interpolation
- multiple input types
- multi-dimensional cases
- unit conversion
- masked data
- label removal
- secondary coordinates
- align(method="interpolate")



