### PR TITLE
Fix __eq__ placement in NDComplexArray (was inside __init__ docstring)

### DIFF
--- a/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
@@ -73,11 +73,6 @@ class NDComplexArray(NDArray):
             The given array can be a list, a tuple, a `~numpy.ndarray` , a ndarray-like,
             a  `NDArray` or any subclass of `NDArray` .
         mask : array of bool or `NOMASK` , optional
-
-    def __eq__(self, other):
-        if not isinstance(other, NDComplexArray):
-            return NotImplemented
-        return super().__eq__(other) and self._dtype == other._dtype
             Mask for the data. The mask array must have the same shape as the data.
             The given array can be a list,
             a tuple, or a `~numpy.ndarray` . Each values in the array must be `False`
@@ -126,6 +121,14 @@ class NDComplexArray(NDArray):
 
         """
         super().__init__(data=data, **kwargs)
+
+    # ----------------------------------------------------------------------------------
+    # __eq__
+    # ----------------------------------------------------------------------------------
+    def __eq__(self, other):
+        if not isinstance(other, NDComplexArray):
+            return NotImplemented
+        return super().__eq__(other) and self._dtype == other._dtype
 
     # ----------------------------------------------------------------------------------
     # validators


### PR DESCRIPTION
Commit `42d6f028b` ("Potential fix for pull request finding '`__eq__` not overridden when adding attributes'") incorrectly placed `def __eq__` inside the `__init__` docstring of `NDComplexArray`, making the method definition a string literal rather than actual code. This caused ruff pre-commit failures.

Fix:
- Removed `def __eq__` from inside the `__init__` docstring (restoring the mask parameter description)
- Added `def __eq__` as a proper class method after `__init__` and before the validators section

Pre-commit now passes cleanly.