### PR TITLE
Revert all 6 Copilot autofix commits on plugins branch

### DIFF
--- a/plugins/spectrochempy-cantera/src/spectrochempy_cantera/_pfr.py
+++ b/plugins/spectrochempy-cantera/src/spectrochempy_cantera/_pfr.py
@@ -482,7 +482,7 @@ class PFR:
                                 + np.argmin(pop_sse)
                                 + 1
                             )
-                            if gen == 1 or prev_min_sse is None:
+                            if gen == 1:
                                 logging.info(
                                     f"                      Minimum SSE: {min_sse:.3e} "
                                     f"(Eval # {it_min_sse})",

--- a/plugins/spectrochempy-cantera/src/spectrochempy_cantera/_pfr.py
+++ b/plugins/spectrochempy-cantera/src/spectrochempy_cantera/_pfr.py
@@ -522,6 +522,7 @@ class PFR:
                             + 12 * len(param_to_optimize) * "-"
                             + "--|-----------",
                         )
+                        pop_sse = []
 
                 guess_string = ""
                 for val in guess:

--- a/plugins/spectrochempy-nmr/tests/test_read_topspin.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_topspin.py
@@ -54,4 +54,4 @@ def test_readdir_for_nmr():
 
 @pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
 def test_use_list():
-    scp.read_topspin(nmrdir / "relax" / "100" / "ser", use_list=True)
+    dataset = scp.read_topspin(nmrdir / "relax" / "100" / "ser", use_list=True)

--- a/src/spectrochempy/analysis/psd.py
+++ b/src/spectrochempy/analysis/psd.py
@@ -621,6 +621,7 @@ class PSD(AnalysisConfigurable):
 
         else:
             # Averaged or single cycle: D shape (n_spectra, n_wavenumbers)
+            n_wavenumbers = D.shape[1]
 
             # angle: (n_phi, n_spectra)
             angle = (

--- a/src/spectrochempy/analysis/psd.py
+++ b/src/spectrochempy/analysis/psd.py
@@ -623,6 +623,9 @@ class PSD(AnalysisConfigurable):
             # Averaged or single cycle: D shape (n_spectra, n_wavenumbers)
             n_wavenumbers = D.shape[1]
 
+            # Result array: (n_phi, n_wavenumbers)
+            psd = np.zeros((n_phi, n_wavenumbers))
+
             # angle: (n_phi, n_spectra)
             angle = (
                 harmonic * 2.0 * np.pi * time_data / T_period + phi_rad[:, np.newaxis]

--- a/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
@@ -73,11 +73,6 @@ class NDComplexArray(NDArray):
             The given array can be a list, a tuple, a `~numpy.ndarray` , a ndarray-like,
             a  `NDArray` or any subclass of `NDArray` .
         mask : array of bool or `NOMASK` , optional
-
-    def __eq__(self, other):
-        if not isinstance(other, NDComplexArray):
-            return NotImplemented
-        return super().__eq__(other) and self._dtype == other._dtype
             Mask for the data. The mask array must have the same shape as the data.
             The given array can be a list,
             a tuple, or a `~numpy.ndarray` . Each values in the array must be `False`


### PR DESCRIPTION
The 6 Copilot autofix commits on `plugins` introduced test failures (106 tests failing) including `TypeError: NDComplexArray.__eq__() takes 2 positional arguments but 3 were given`.

Commits reverted:
- `5090cec33` Unused global variable (`_pfr.py`)
- `b5ad8e005` Variable defined multiple times (`psd.py`)
- `42d6f028b` __eq__ in docstring (`ndcomplex.py`)
- `046021426` Unused global variable (`_pfr.py`)
- `64692ef17` Unused local variable (`test_read_topspin.py`)
- `2f43b3c0f` Unused local variable (`psd.py`)

Pre-commit passes cleanly after revert.