### PR TITLE
Use trusted publishing for PyPI uploads

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -68,14 +68,11 @@ jobs:
         if: github.event_name == 'push' && github.repository == 'spectrochempy/spectrochempy'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish package to PyPI
         if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'spectrochempy/spectrochempy'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   build_and_publish_conda_package:
     name: Build and publish conda package to Anaconda.org


### PR DESCRIPTION
## Summary

This PR updates the package publication workflow to use PyPI Trusted Publishing for both TestPyPI and PyPI uploads.

## What changed

- Removed the explicit `TEST_PYPI_API_TOKEN` password from the TestPyPI publishing step.
- Removed the explicit `PYPI_API_TOKEN` password from the PyPI publishing step.
- Kept the existing `id-token: write` permission required for OpenID Connect publishing.
- Kept the TestPyPI repository URL so pushes still publish to TestPyPI.

## Why

The `spectrochempy/spectrochempy` project already has a Trusted Publisher configured on PyPI/TestPyPI for:

- Repository: `spectrochempy/spectrochempy`
- Workflow: `build_package.yml`
- Environment: any / none specified

With this configuration, `pypa/gh-action-pypi-publish` can authenticate via GitHub OIDC and no longer needs long-lived API tokens stored as repository secrets.

## Validation

- `pre-commit run check-yaml --files .github/workflows/build_package.yml`
- `pre-commit run mixed-line-ending --files .github/workflows/build_package.yml`

The change was first validated on a temporary branch where the TestPyPI publish step succeeded with Trusted Publishing.
