### PR TITLE
Harden core plugin system

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -86,6 +86,8 @@ jobs:
         plugin:
           - name: spectrochempy-nmr
             path: plugins/spectrochempy-nmr
+          - name: spectrochempy-iris
+            path: plugins/spectrochempy-iris
 
     defaults:
       run:

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -30,7 +30,6 @@ jobs:
   build-and-publish_pypi:
     name: Build and publish distribution to PyPI
     runs-on: ubuntu-latest
-    if: github.ref_name != 'fix/plugin-testpypi-publish'
 
     defaults:
       run:
@@ -75,65 +74,9 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'spectrochempy/spectrochempy'
         uses: pypa/gh-action-pypi-publish@release/v1
 
-  build-and-publish_plugins_testpypi:
-    name: Build and publish plugin distributions to TestPyPI
-    runs-on: ubuntu-latest
-    if: github.ref_name == 'fix/plugin-testpypi-publish'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        plugin:
-          - name: spectrochempy-nmr
-            path: plugins/spectrochempy-nmr
-          - name: spectrochempy-iris
-            path: plugins/spectrochempy-iris
-
-    defaults:
-      run:
-        shell: bash -l {0}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install pypa/build
-        run: |
-          python -m pip install build --user
-
-      - name: Build plugin source and wheel distributions
-        run: |
-          python -m build --sdist --wheel --outdir dist/${{ matrix.plugin.name }} ${{ matrix.plugin.path }}
-
-      - name: Upload plugin build artifacts
-        if: ${{ !env.ACT }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: pypi-package-${{ matrix.plugin.name }}
-          path: |
-            dist/${{ matrix.plugin.name }}/*.whl
-            dist/${{ matrix.plugin.name }}/*.tar.gz
-          retention-days: 5
-
-      - name: Publish plugin package to TestPyPI
-        if: github.event_name == 'push' && github.repository == 'spectrochempy/spectrochempy'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist/${{ matrix.plugin.name }}
-          skip-existing: true
-
   build_and_publish_conda_package:
     name: Build and publish conda package to Anaconda.org
     runs-on: ubuntu-latest
-    if: github.ref_name != 'fix/plugin-testpypi-publish'
 
     defaults:
       run:

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -30,6 +30,7 @@ jobs:
   build-and-publish_pypi:
     name: Build and publish distribution to PyPI
     runs-on: ubuntu-latest
+    if: github.ref_name != 'fix/plugin-testpypi-publish'
 
     defaults:
       run:
@@ -68,18 +69,73 @@ jobs:
         if: github.event_name == 'push' && github.repository == 'spectrochempy/spectrochempy'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish package to PyPI
         if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'spectrochempy/spectrochempy'
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  build-and-publish_plugins_testpypi:
+    name: Build and publish plugin distributions to TestPyPI
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'fix/plugin-testpypi-publish'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin:
+          - name: spectrochempy-nmr
+            path: plugins/spectrochempy-nmr
+          - name: spectrochempy-iris
+            path: plugins/spectrochempy-iris
+          - name: spectrochempy-cantera
+            path: plugins/spectrochempy-cantera
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
+
+      - name: Build plugin source and wheel distributions
+        run: |
+          python -m build --sdist --wheel --outdir dist/${{ matrix.plugin.name }} ${{ matrix.plugin.path }}
+
+      - name: Upload plugin build artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: pypi-package-${{ matrix.plugin.name }}
+          path: |
+            dist/${{ matrix.plugin.name }}/*.whl
+            dist/${{ matrix.plugin.name }}/*.tar.gz
+          retention-days: 5
+
+      - name: Publish plugin package to TestPyPI
+        if: github.event_name == 'push' && github.repository == 'spectrochempy/spectrochempy'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/${{ matrix.plugin.name }}
+          skip-existing: true
 
   build_and_publish_conda_package:
     name: Build and publish conda package to Anaconda.org
     runs-on: ubuntu-latest
+    if: github.ref_name != 'fix/plugin-testpypi-publish'
 
     defaults:
       run:

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -86,10 +86,6 @@ jobs:
         plugin:
           - name: spectrochempy-nmr
             path: plugins/spectrochempy-nmr
-          - name: spectrochempy-iris
-            path: plugins/spectrochempy-iris
-          - name: spectrochempy-cantera
-            path: plugins/spectrochempy-cantera
 
     defaults:
       run:

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -1,0 +1,111 @@
+# This workflow builds and publishes SpectroChemPy plugin packages to:
+# - TestPyPI on pushes to test branches
+# - PyPI on published releases
+
+name: Publish plugin packages
+
+on:
+  push:
+    branches:
+      - test/plugin-publish-workflow
+    paths:
+      - ".github/workflows/publish_plugins.yml"
+      - "plugins/spectrochempy-nmr/**"
+      - "plugins/spectrochempy-iris/**"
+
+  pull_request:
+    paths:
+      - ".github/workflows/publish_plugins.yml"
+      - "plugins/spectrochempy-nmr/**"
+      - "plugins/spectrochempy-iris/**"
+
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      publish_to:
+        description: "Package index to publish to"
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - none
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish_plugins:
+    name: Build and publish plugin distributions
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin:
+          - name: spectrochempy-nmr
+            path: plugins/spectrochempy-nmr
+          - name: spectrochempy-iris
+            path: plugins/spectrochempy-iris
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
+
+      - name: Build plugin source and wheel distributions
+        run: |
+          python -m build --sdist --wheel --outdir dist/${{ matrix.plugin.name }} ${{ matrix.plugin.path }}
+
+      - name: Upload plugin build artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: pypi-package-${{ matrix.plugin.name }}
+          path: |
+            dist/${{ matrix.plugin.name }}/*.whl
+            dist/${{ matrix.plugin.name }}/*.tar.gz
+          retention-days: 5
+
+      - name: Publish plugin package to TestPyPI
+        if: |
+          github.repository == 'spectrochempy/spectrochempy' &&
+          (
+            github.event_name == 'push' ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish_to == 'testpypi')
+          )
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/${{ matrix.plugin.name }}
+          skip-existing: true
+
+      - name: Publish plugin package to PyPI
+        if: |
+          github.repository == 'spectrochempy/spectrochempy' &&
+          github.event_name == 'release' &&
+          github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/${{ matrix.plugin.name }}

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -142,7 +142,24 @@ Entry point discovery flow
 Distribution (PyPI)
 ===================
 
-To publish on PyPI:
+Official plugins that still live in the SpectroChemPy monorepo are published
+from the root workflow:
+
+.. code-block:: text
+
+    .github/workflows/publish_plugins.yml
+
+GitHub Actions only executes workflows from the repository root, so workflows
+stored inside ``plugins/<plugin>/.github/workflows/`` are templates only while
+the plugin remains in the monorepo.  If a plugin is later moved to its own
+repository, copy the template workflow to that repository's root
+``.github/workflows/`` directory.
+
+The monorepo workflow uses PyPI Trusted Publishing.  Each plugin distribution
+must therefore have its own PyPI/TestPyPI trusted publisher configured with the
+matching project name, for example ``spectrochempy-nmr``.
+
+For a manual local upload:
 
 .. code-block:: bash
 

--- a/plugins/plugin-template/.github/workflows/publish_plugin.yml
+++ b/plugins/plugin-template/.github/workflows/publish_plugin.yml
@@ -1,0 +1,88 @@
+# Template workflow for a plugin moved to its own repository.
+#
+# GitHub Actions only runs workflows from the repository root:
+# .github/workflows/*.yml. This file is therefore documentation while the
+# template lives inside the SpectroChemPy monorepo. Copy it to the repository
+# root when creating a standalone plugin repository.
+
+name: Publish plugin package
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      publish_to:
+        description: "Package index to publish to"
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - none
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish:
+    name: Build and publish plugin distribution
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
+
+      - name: Build source and wheel distributions
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Upload build artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: pypi-package
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+          retention-days: 5
+
+      - name: Publish package to TestPyPI
+        if: |
+          github.event_name == 'workflow_dispatch' &&
+          inputs.publish_to == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+      - name: Publish package to PyPI
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ exclude = ["~*"] # Exclude files and directories. "tests/**"
   "T201", # print statement found.
   "D205", # 1 blank line required between summary line and description.
   "D401", # First line should be in imperative mood; try rephrasing.
+  "PLC0415", # Import should be at the top-level (test isolation requires local imports).
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ doctest_optionflags = [
 ]
 doctest_plus = "enabled"
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+pythonpath = ["."]
 testpaths = ["tests"]
 doctest_norecursedirs = ["tests/test_plotting"]
 

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -56,8 +56,8 @@ import lazy_loader as _lazy_loader
 # --------------------------------------------------------------------------------------
 # Lazy loading of sub-packages
 # --------------------------------------------------------------------------------------
-# Store the original __getattr__ from lazy_loader
-original_getattr, *_ = _lazy_loader.attach_stub(__name__, __file__)
+# Store the original __getattr__ and __dir__ from lazy_loader
+original_getattr, original_dir, *_ = _lazy_loader.attach_stub(__name__, __file__)
 
 # Dictionary mapping top-level objects to their module paths
 
@@ -88,6 +88,54 @@ _PLOT_PROFILE_FUNCTIONS = {
     "save_plot_profile": "spectrochempy.plotting.profile",
     "delete_plot_profile": "spectrochempy.plotting.profile",
 }
+
+# Known plugin readers mapped to their plugin names for helpful error messages.
+_KNOWN_PLUGIN_READERS = {
+    "topspin": ("nmr", "spectrochempy-nmr", "spectrochempy[nmr]"),
+}
+
+_KNOWN_PLUGIN_NAMESPACES = {
+    "nmr": ("spectrochempy-nmr", "spectrochempy[nmr]"),
+    "iris": ("spectrochempy-iris", "spectrochempy[iris]"),
+}
+
+
+def _plugin_reader_install_hint(reader_name: str) -> str | None:
+    """Return an installation hint if *reader_name* belongs to a known optional plugin."""
+    info = _KNOWN_PLUGIN_READERS.get(reader_name)
+    if info is None:
+        return None
+    _ns, plugin_name, extra = info
+    return (
+        f"The 'read_{reader_name}' feature requires the optional plugin "
+        f"'{plugin_name}'. Install it with: pip install {extra}"
+    )
+
+
+def __dir__():
+    names = set(original_dir()) if callable(original_dir) else set()
+    names.update(_PLOT_PROFILE_FUNCTIONS)
+    plugin_manager.discover()
+    names.update(_reader_names())
+    names.update(_namespace_names())
+    names.update(_extension_names())
+    return sorted(names)
+
+
+def _reader_names():
+    return {f"read_{name}" for name in registry.available_readers}
+
+
+def _namespace_names():
+    return set(_KNOWN_PLUGIN_NAMESPACES)
+
+
+def _extension_names():
+    names = set()
+    for category in ("analysis", "simulation"):
+        for entry_name in registry.extensions.list_category(category):
+            names.add(entry_name)
+    return names
 
 
 # Override __getattr__ to handle both submodules and direct class access
@@ -120,6 +168,9 @@ def __getattr__(name):
         reader_info = registry.get_reader(reader_name)
         if reader_info:
             return reader_info["func"]
+        hint = _plugin_reader_install_hint(reader_name)
+        if hint:
+            raise AttributeError(hint)
 
     for category in ("analysis", "simulation", "accessor"):
         extension_info = registry.extensions.get(category, name)
@@ -146,6 +197,13 @@ def __getattr__(name):
     try:
         return original_getattr(name)
     except AttributeError as err:
+        # Check if this is a known plugin namespace
+        if name in _KNOWN_PLUGIN_NAMESPACES:
+            plugin_name, extra = _KNOWN_PLUGIN_NAMESPACES[name]
+            raise AttributeError(
+                f"The '{name}' namespace requires the optional plugin "
+                f"'{plugin_name}'. Install it with: pip install {extra}"
+            ) from err
         raise AttributeError(
             f"module 'spectrochempy' has no attribute '{name}'"
         ) from err

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -74,6 +74,9 @@ application.start.set_warnings()
 # --------------------------------------------------------------------------------------
 # Plugin  manager
 # --------------------------------------------------------------------------------------
+from spectrochempy.plugins.features import KNOWN_PLUGIN_NAMESPACES
+from spectrochempy.plugins.features import plugin_namespace_install_hint
+from spectrochempy.plugins.features import plugin_reader_install_hint
 from spectrochempy.plugins.manager import plugin_manager
 from spectrochempy.plugins.registry import registry
 
@@ -88,31 +91,6 @@ _PLOT_PROFILE_FUNCTIONS = {
     "save_plot_profile": "spectrochempy.plotting.profile",
     "delete_plot_profile": "spectrochempy.plotting.profile",
 }
-
-# Known plugin readers mapped to their plugin names for helpful error messages.
-# These provide clear user-facing errors when a plugin is not installed,
-# before falling through to the lazy-import stub in _LAZY_IMPORTS
-# (e.g., spectrochempy.core.readers.read_topspin which raises MissingPluginError).
-_KNOWN_PLUGIN_READERS = {
-    "topspin": ("nmr", "spectrochempy-nmr", "spectrochempy[nmr]"),
-}
-
-_KNOWN_PLUGIN_NAMESPACES = {
-    "nmr": ("spectrochempy-nmr", "spectrochempy[nmr]"),
-    "iris": ("spectrochempy-iris", "spectrochempy[iris]"),
-}
-
-
-def _plugin_reader_install_hint(reader_name: str) -> str | None:
-    """Return an installation hint if *reader_name* belongs to a known optional plugin."""
-    info = _KNOWN_PLUGIN_READERS.get(reader_name)
-    if info is None:
-        return None
-    _ns, plugin_name, extra = info
-    return (
-        f"The 'read_{reader_name}' feature requires the optional plugin "
-        f"'{plugin_name}'. Install it with: pip install {extra}"
-    )
 
 
 def __dir__():
@@ -131,7 +109,7 @@ def _reader_names():
 
 
 def _namespace_names():
-    return set(_KNOWN_PLUGIN_NAMESPACES)
+    return set(KNOWN_PLUGIN_NAMESPACES)
 
 
 def _extension_names():
@@ -172,7 +150,7 @@ def __getattr__(name):
         reader_info = registry.get_reader(reader_name)
         if reader_info:
             return reader_info["func"]
-        hint = _plugin_reader_install_hint(reader_name)
+        hint = plugin_reader_install_hint(reader_name)
         if hint:
             raise AttributeError(hint)
 
@@ -202,12 +180,9 @@ def __getattr__(name):
         return original_getattr(name)
     except AttributeError as err:
         # Check if this is a known plugin namespace
-        if name in _KNOWN_PLUGIN_NAMESPACES:
-            plugin_name, extra = _KNOWN_PLUGIN_NAMESPACES[name]
-            raise AttributeError(
-                f"The '{name}' namespace requires the optional plugin "
-                f"'{plugin_name}'. Install it with: pip install {extra}"
-            ) from err
+        hint = plugin_namespace_install_hint(name)
+        if hint:
+            raise AttributeError(hint) from err
         raise AttributeError(
             f"module 'spectrochempy' has no attribute '{name}'"
         ) from err

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -76,7 +76,7 @@ application.start.set_warnings()
 # --------------------------------------------------------------------------------------
 from spectrochempy.plugins.features import KNOWN_PLUGIN_NAMESPACES
 from spectrochempy.plugins.features import plugin_namespace_install_hint
-from spectrochempy.plugins.features import plugin_reader_install_hint
+from spectrochempy.plugins.features import plugin_reader_missing_stub
 from spectrochempy.plugins.manager import plugin_manager
 from spectrochempy.plugins.registry import registry
 
@@ -150,9 +150,9 @@ def __getattr__(name):
         reader_info = registry.get_reader(reader_name)
         if reader_info:
             return reader_info["func"]
-        hint = plugin_reader_install_hint(reader_name)
-        if hint:
-            raise AttributeError(hint)
+        stub = plugin_reader_missing_stub(reader_name)
+        if stub:
+            return stub
 
     for category in ("analysis", "simulation", "accessor"):
         extension_info = registry.extensions.get(category, name)

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -90,6 +90,9 @@ _PLOT_PROFILE_FUNCTIONS = {
 }
 
 # Known plugin readers mapped to their plugin names for helpful error messages.
+# These provide clear user-facing errors when a plugin is not installed,
+# before falling through to the lazy-import stub in _LAZY_IMPORTS
+# (e.g., spectrochempy.core.readers.read_topspin which raises MissingPluginError).
 _KNOWN_PLUGIN_READERS = {
     "topspin": ("nmr", "spectrochempy-nmr", "spectrochempy[nmr]"),
 }
@@ -115,9 +118,10 @@ def _plugin_reader_install_hint(reader_name: str) -> str | None:
 def __dir__():
     names = set(original_dir()) if callable(original_dir) else set()
     names.update(_PLOT_PROFILE_FUNCTIONS)
-    plugin_manager.discover()
-    names.update(_reader_names())
     names.update(_namespace_names())
+    # Include already-discovered plugin readers and extensions
+    # without triggering entry-point scanning (dir() should be side-effect free).
+    names.update(_reader_names())
     names.update(_extension_names())
     return sorted(names)
 

--- a/src/spectrochempy/api/plugins/validation.py
+++ b/src/spectrochempy/api/plugins/validation.py
@@ -92,6 +92,16 @@ def check_plugin_contributions(plugin: Any) -> list[str]:
     """
     Check plugin contribution declarations for consistency.
 
+    .. caution::
+
+       This function **calls** the hook methods (``register_readers()``,
+       etc.) to inspect their return values.  If a hook has side effects
+       (e.g. incrementing a counter), those effects will occur during
+       validation.  During normal discovery/registration the plugin
+       manager calls each hook **once** through
+       :meth:`~spectrochempy.plugins.manager.PluginManager._collect_declarative_hooks`;
+       use this function only for ad‑hoc / development checks.
+
     Inspects declarative hooks (``register_readers``,
     ``register_writers``, ``register_processors``,
     ``register_visualizers``, ``register_analyses``,

--- a/src/spectrochempy/api/plugins/validation.py
+++ b/src/spectrochempy/api/plugins/validation.py
@@ -267,14 +267,15 @@ def _get_plugin_metadata(plugin: Any) -> dict[str, Any]:
         except Exception as exc:
             logger.debug("plugin_info() raised %s: %s", type(exc).__name__, exc)
 
+    plugin_api_version = getattr(
+        plugin,
+        "PLUGIN_API_VERSION",
+        getattr(plugin, "api_version", ""),
+    )
     return {
         "name": getattr(plugin, "name", ""),
         "version": getattr(plugin, "version", ""),
-        "plugin_api_version": getattr(
-            plugin,
-            "api_version",
-            getattr(plugin, "PLUGIN_API_VERSION", ""),
-        ),
+        "plugin_api_version": plugin_api_version,
         "spectrochempy_min_version": getattr(plugin, "spectrochempy_min_version", ""),
         "description": getattr(plugin, "description", ""),
     }

--- a/src/spectrochempy/api/plugins/validation.py
+++ b/src/spectrochempy/api/plugins/validation.py
@@ -92,21 +92,11 @@ def check_plugin_contributions(plugin: Any) -> list[str]:
     """
     Check plugin contribution declarations for consistency.
 
-    .. caution::
-
-       This function **calls** the hook methods (``register_readers()``,
-       etc.) to inspect their return values.  If a hook has side effects
-       (e.g. incrementing a counter), those effects will occur during
-       validation.  During normal discovery/registration the plugin
-       manager calls each hook **once** through
-       :meth:`~spectrochempy.plugins.manager.PluginManager._collect_declarative_hooks`;
-       use this function only for ad‑hoc / development checks.
-
     Inspects declarative hooks (``register_readers``,
     ``register_writers``, ``register_processors``,
     ``register_visualizers``, ``register_analyses``,
-    ``register_simulations``, ``register_accessors``) and validates
-    the structure of returned data.
+    ``register_simulations``, ``register_accessors``) without executing
+    them. This intentionally avoids hook side effects during validation.
 
     Parameters
     ----------
@@ -136,37 +126,6 @@ def check_plugin_contributions(plugin: Any) -> list[str]:
         method = getattr(plugin, hook_name)
         if not callable(method):
             issues.append(f"Plugin '{name}': '{hook_name}' is not callable.")
-            continue
-        try:
-            result = method()
-        except Exception as exc:
-            issues.append(
-                f"Plugin '{name}': '{hook_name}()' raised {type(exc).__name__}: {exc}"
-            )
-            continue
-        if result is None:
-            continue
-        if not isinstance(result, list):
-            issues.append(
-                f"Plugin '{name}': '{hook_name}()' returned {type(result).__name__}, "
-                f"expected list[dict]."
-            )
-            continue
-        for i, item in enumerate(result):
-            if not isinstance(item, dict):
-                issues.append(
-                    f"Plugin '{name}': '{hook_name}()' item {i} is "
-                    f"{type(item).__name__}, expected dict."
-                )
-                continue
-            if "name" not in item:
-                issues.append(
-                    f"Plugin '{name}': '{hook_name}()' item {i} is missing 'name'."
-                )
-            if "func" not in item:
-                issues.append(
-                    f"Plugin '{name}': '{hook_name}()' item {i} is missing 'func'."
-                )
 
     return issues
 

--- a/src/spectrochempy/plugins/base.py
+++ b/src/spectrochempy/plugins/base.py
@@ -9,13 +9,13 @@ from typing import runtime_checkable
 
 
 @runtime_checkable
-class SpectroChemPyPlugin(Protocol):
+class SpectroChemPyPluginProtocol(Protocol):
     """
     Structural protocol for duck-type checks (e.g., ``isinstance``).
 
     This is **not** the base class for plugin authors.
     Use ``spectrochempy.api.plugins.SpectroChemPyPlugin`` (the concrete
-    base class) when writing a plugin.
+    base class from ``spectrochempy.api.plugins``) when writing a plugin.
     """
 
     name: str

--- a/src/spectrochempy/plugins/base.py
+++ b/src/spectrochempy/plugins/base.py
@@ -12,7 +12,7 @@ from typing import runtime_checkable
 class SpectroChemPyPlugin(Protocol):
     name: str
     version: str
-    api_version: str = "1.0"
+    PLUGIN_API_VERSION: str = "1.0"
 
     def register(self, registry) -> None:
         ...

--- a/src/spectrochempy/plugins/base.py
+++ b/src/spectrochempy/plugins/base.py
@@ -10,6 +10,14 @@ from typing import runtime_checkable
 
 @runtime_checkable
 class SpectroChemPyPlugin(Protocol):
+    """
+    Structural protocol for duck-type checks (e.g., ``isinstance``).
+
+    This is **not** the base class for plugin authors.
+    Use ``spectrochempy.api.plugins.SpectroChemPyPlugin`` (the concrete
+    base class) when writing a plugin.
+    """
+
     name: str
     version: str
     PLUGIN_API_VERSION: str = "1.0"

--- a/src/spectrochempy/plugins/deps.py
+++ b/src/spectrochempy/plugins/deps.py
@@ -9,16 +9,19 @@ class MissingPluginError(ImportError):
     def __init__(
         self,
         feature: str,
-        plugin_name: str = "spectrochempy-nmr",
+        plugin_name: str = "",
         install_hint: str | None = None,
     ) -> None:
-        msg = f"The '{feature}' feature requires the plugin '{plugin_name}'.\n"
+        if plugin_name:
+            msg = f"The '{feature}' feature requires the plugin '{plugin_name}'.\n"
+        else:
+            msg = f"The '{feature}' feature requires an optional plugin.\n"
         if install_hint:
             msg += install_hint
-        else:
+        elif plugin_name:
             msg += (
-                f"Install it with : pip install {plugin_name}\n"
-                f"Or using spectrochempy extras : pip install spectrochempy[{plugin_name.split('-')[-1]}]"
+                f"Install it with: pip install {plugin_name}\n"
+                f"Or using spectrochempy extras: pip install spectrochempy[{plugin_name.split('-')[-1]}]"
             )
         super().__init__(msg)
 

--- a/src/spectrochempy/plugins/features.py
+++ b/src/spectrochempy/plugins/features.py
@@ -4,7 +4,14 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 
-"""Known optional plugin features used for user-facing installation hints."""
+"""
+Known optional plugin features used for user-facing installation hints.
+
+This registry is intentionally static and limited to official optional
+SpectroChemPy plugins. It is only used to produce clear errors when an optional
+plugin is not installed. Installed plugins must declare their own contributions
+through the plugin system; third-party plugins must not be listed here.
+"""
 
 from __future__ import annotations
 

--- a/src/spectrochempy/plugins/features.py
+++ b/src/spectrochempy/plugins/features.py
@@ -1,0 +1,42 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+"""Known optional plugin features used for user-facing installation hints."""
+
+from __future__ import annotations
+
+KNOWN_PLUGIN_READERS = {
+    "topspin": ("nmr", "spectrochempy-nmr", "spectrochempy[nmr]"),
+}
+
+KNOWN_PLUGIN_NAMESPACES = {
+    "nmr": ("spectrochempy-nmr", "spectrochempy[nmr]"),
+    "iris": ("spectrochempy-iris", "spectrochempy[iris]"),
+}
+
+
+def plugin_reader_install_hint(reader_name: str) -> str | None:
+    """Return an install hint if *reader_name* belongs to an optional plugin."""
+    info = KNOWN_PLUGIN_READERS.get(reader_name)
+    if info is None:
+        return None
+    _ns, plugin_name, extra = info
+    return (
+        f"The 'read_{reader_name}' feature requires the optional plugin "
+        f"'{plugin_name}'. Install it with: pip install {extra}"
+    )
+
+
+def plugin_namespace_install_hint(namespace: str) -> str | None:
+    """Return an install hint if *namespace* belongs to an optional plugin."""
+    info = KNOWN_PLUGIN_NAMESPACES.get(namespace)
+    if info is None:
+        return None
+    plugin_name, extra = info
+    return (
+        f"The '{namespace}' namespace requires the optional plugin "
+        f"'{plugin_name}'. Install it with: pip install {extra}"
+    )

--- a/src/spectrochempy/plugins/features.py
+++ b/src/spectrochempy/plugins/features.py
@@ -37,6 +37,29 @@ def plugin_reader_install_hint(reader_name: str) -> str | None:
     )
 
 
+def plugin_reader_missing_stub(reader_name: str):
+    """Return a callable stub for a missing official optional plugin reader."""
+    info = KNOWN_PLUGIN_READERS.get(reader_name)
+    if info is None:
+        return None
+    _ns, plugin_name, extra = info
+    feature = f"read_{reader_name}"
+
+    def _missing_plugin_reader(*args, **kwargs):
+        from spectrochempy.plugins.deps import MissingPluginError
+
+        raise MissingPluginError(
+            feature,
+            plugin_name=plugin_name,
+            install_hint=f"pip install {extra}",
+        )
+
+    _missing_plugin_reader.__name__ = feature
+    _missing_plugin_reader.__qualname__ = feature
+    _missing_plugin_reader.__doc__ = plugin_reader_install_hint(reader_name)
+    return _missing_plugin_reader
+
+
 def plugin_namespace_install_hint(namespace: str) -> str | None:
     """Return an install hint if *namespace* belongs to an optional plugin."""
     info = KNOWN_PLUGIN_NAMESPACES.get(namespace)

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -17,6 +17,7 @@ from spectrochempy.api.plugins.validation import validate_plugin_compatibility
 from spectrochempy.plugins.hooks import SpectroChemPyHookSpec
 from spectrochempy.plugins.lifecycle import PluginDescriptor
 from spectrochempy.plugins.lifecycle import PluginState
+from spectrochempy.plugins.registry import PluginRegistry
 from spectrochempy.plugins.registry import registry as _default_registry
 
 logger = logging.getLogger(__name__)
@@ -129,12 +130,15 @@ class PluginManager:
             self._plugin_states[name] = PluginState.FAILED
             return
 
-        # --- Imperative registration (backward compatible) ---
-        # Run BEFORE declarative hook collection so that if register()
-        # fails, no orphan contributions leak into the registry.
+        # --- Atomic contribution collection ---
+        # Declarative hooks and imperative register() write into a temporary
+        # registry first. Nothing is merged into the active registry unless the
+        # whole plugin registration succeeds.
+        temp_registry = PluginRegistry()
+        self._collect_declarative_hooks(plugin, temp_registry)
         if hasattr(plugin, "register") and callable(plugin.register):
             try:
-                plugin.register(self.registry)
+                plugin.register(temp_registry)
             except Exception as exc:
                 logger.exception(
                     "Plugin '%s' raised an error during register().\n"
@@ -145,12 +149,8 @@ class PluginManager:
                 self._plugin_errors[name] = exc
                 return
 
-        # --- Declarative hook collection ---
-        # Collected only after imperative register() succeeds so that
-        # a failing register() cannot leave orphan readers/writers etc.
-        self._collect_declarative_hooks(plugin)
-
         # --- Register in pluggy for hook-based communication ---
+        self.registry.merge_from(temp_registry)
         self._pm.register(plugin, name)
         self.registry.register_plugin(name, plugin)
         self._plugin_states[name] = PluginState.ACTIVE
@@ -166,16 +166,19 @@ class PluginManager:
     #   register_visualizers → self.registry.visualization
     # ------------------------------------------------------------------
 
-    def _collect_declarative_hooks(self, plugin: Any) -> dict[str, list[str]]:
+    def _collect_declarative_hooks(
+        self, plugin: Any, registry: PluginRegistry | None = None
+    ) -> dict[str, list[str]]:
         contributions: dict[str, list[str]] = {}
+        registry = registry or self.registry
 
-        self._collect_readers(plugin, contributions)
-        self._collect_writers(plugin, contributions)
-        self._collect_processors(plugin, contributions)
-        self._collect_visualizers(plugin, contributions)
-        self._collect_analyses(plugin, contributions)
-        self._collect_simulations(plugin, contributions)
-        self._collect_accessors(plugin, contributions)
+        self._collect_readers(plugin, contributions, registry)
+        self._collect_writers(plugin, contributions, registry)
+        self._collect_processors(plugin, contributions, registry)
+        self._collect_visualizers(plugin, contributions, registry)
+        self._collect_analyses(plugin, contributions, registry)
+        self._collect_simulations(plugin, contributions, registry)
+        self._collect_accessors(plugin, contributions, registry)
 
         return contributions
 
@@ -216,7 +219,10 @@ class PluginManager:
         return valid
 
     def _collect_readers(
-        self, plugin: Any, contributions: dict[str, list[str]]
+        self,
+        plugin: Any,
+        contributions: dict[str, list[str]],
+        registry: PluginRegistry,
     ) -> None:
         plugin_name = getattr(plugin, "name", "unknown")
         if not (
@@ -231,7 +237,7 @@ class PluginManager:
             for reader in readers:
                 name = reader["name"]
                 func = reader["func"]
-                self.registry.io.register_reader(
+                registry.io.register_reader(
                     name,
                     func,
                     description=reader.get("description", ""),
@@ -247,7 +253,10 @@ class PluginManager:
             )
 
     def _collect_writers(
-        self, plugin: Any, contributions: dict[str, list[str]]
+        self,
+        plugin: Any,
+        contributions: dict[str, list[str]],
+        registry: PluginRegistry,
     ) -> None:
         plugin_name = getattr(plugin, "name", "unknown")
         if not (
@@ -262,7 +271,7 @@ class PluginManager:
             for writer in writers:
                 name = writer["name"]
                 func = writer["func"]
-                self.registry.io.register_writer(
+                registry.io.register_writer(
                     name,
                     func,
                     description=writer.get("description", ""),
@@ -275,7 +284,10 @@ class PluginManager:
             )
 
     def _collect_visualizers(
-        self, plugin: Any, contributions: dict[str, list[str]]
+        self,
+        plugin: Any,
+        contributions: dict[str, list[str]],
+        registry: PluginRegistry,
     ) -> None:
         plugin_name = getattr(plugin, "name", "unknown")
         if not (
@@ -291,7 +303,7 @@ class PluginManager:
             for vis in visualizers:
                 name = vis["name"]
                 func = vis["func"]
-                self.registry.visualization.register_visualizer(
+                registry.visualization.register_visualizer(
                     name,
                     func,
                     description=vis.get("description", ""),
@@ -304,7 +316,10 @@ class PluginManager:
             )
 
     def _collect_analyses(
-        self, plugin: Any, contributions: dict[str, list[str]]
+        self,
+        plugin: Any,
+        contributions: dict[str, list[str]],
+        registry: PluginRegistry,
     ) -> None:
         plugin_name = getattr(plugin, "name", "unknown")
         if not (
@@ -319,7 +334,7 @@ class PluginManager:
             for analysis in analyses:
                 name = analysis["name"]
                 func = analysis["func"]
-                self.registry.extensions.register(
+                registry.extensions.register(
                     "analysis",
                     name,
                     func,
@@ -337,7 +352,10 @@ class PluginManager:
             )
 
     def _collect_simulations(
-        self, plugin: Any, contributions: dict[str, list[str]]
+        self,
+        plugin: Any,
+        contributions: dict[str, list[str]],
+        registry: PluginRegistry,
     ) -> None:
         plugin_name = getattr(plugin, "name", "unknown")
         if not (
@@ -353,7 +371,7 @@ class PluginManager:
             for sim in simulations:
                 name = sim["name"]
                 func = sim["func"]
-                self.registry.extensions.register(
+                registry.extensions.register(
                     "simulation",
                     name,
                     func,
@@ -371,7 +389,10 @@ class PluginManager:
             )
 
     def _collect_accessors(
-        self, plugin: Any, contributions: dict[str, list[str]]
+        self,
+        plugin: Any,
+        contributions: dict[str, list[str]],
+        registry: PluginRegistry,
     ) -> None:
         plugin_name = getattr(plugin, "name", "unknown")
         if not (
@@ -398,7 +419,7 @@ class PluginManager:
                     registered_names.extend(accessor.get("legacy_names", []))
 
                 for registered_name in registered_names:
-                    self.registry.register_accessor(
+                    registry.register_accessor(
                         registered_name,
                         func,
                         description=accessor.get("description", ""),
@@ -412,7 +433,10 @@ class PluginManager:
             )
 
     def _collect_processors(
-        self, plugin: Any, contributions: dict[str, list[str]]
+        self,
+        plugin: Any,
+        contributions: dict[str, list[str]],
+        registry: PluginRegistry,
     ) -> None:
         plugin_name = getattr(plugin, "name", "unknown")
         if not (
@@ -428,7 +452,7 @@ class PluginManager:
             for proc in procs:
                 name = proc["name"]
                 func = proc["func"]
-                self.registry.processing.register_processor(
+                registry.processing.register_processor(
                     name,
                     func,
                     description=proc.get("description", ""),

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -24,6 +24,14 @@ logger = logging.getLogger(__name__)
 ENTRY_POINT_GROUP = "spectrochempy.plugins"
 
 
+class DiscoveryState:
+    """Discovery state machine for PluginManager."""
+
+    NOT_DISCOVERED = "not_discovered"
+    DISCOVERING = "discovering"
+    DISCOVERED = "discovered"
+
+
 class PluginManager:
     """
     Orchestrates plugin discovery, validation, registration, and lifecycle.
@@ -43,7 +51,8 @@ class PluginManager:
     def __init__(self, registry: Any = None) -> None:
         self._pm = pluggy.PluginManager("spectrochempy")
         self._pm.add_hookspecs(SpectroChemPyHookSpec)
-        self._discovered = False
+        self._discovery_state = DiscoveryState.NOT_DISCOVERED
+        self._discovering = False
 
         if registry is None:
             registry = _default_registry
@@ -59,23 +68,32 @@ class PluginManager:
     # ------------------------------------------------------------------
 
     def discover(self) -> None:
-        if self._discovered:
+        if self._discovery_state == DiscoveryState.DISCOVERED:
             return
-        for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP):
-            if self._pm.get_plugin(ep.name) is not None:
-                continue
-            self._plugin_states[ep.name] = PluginState.DISCOVERED
-            self._plugin_entry_points[ep.name] = ep.value
+        if self._discovering:
+            return
+        self._discovering = True
+        self._discovery_state = DiscoveryState.DISCOVERING
+        try:
+            for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP):
+                if self._pm.get_plugin(ep.name) is not None:
+                    continue
+                self._plugin_states[ep.name] = PluginState.DISCOVERED
+                self._plugin_entry_points[ep.name] = ep.value
 
-            try:
-                cls = ep.load()
-                plugin = cls() if isinstance(cls, type) else cls
-                self.register(plugin)
-            except Exception as exc:
-                logger.warning("Plugin '%s' failed during discovery: %s", ep.name, exc)
-                self._plugin_states[ep.name] = PluginState.FAILED
-                self._plugin_errors[ep.name] = exc
-        self._discovered = True
+                try:
+                    cls = ep.load()
+                    plugin = cls() if isinstance(cls, type) else cls
+                    self.register(plugin)
+                except Exception as exc:
+                    logger.warning(
+                        "Plugin '%s' failed during discovery: %s", ep.name, exc
+                    )
+                    self._plugin_states[ep.name] = PluginState.FAILED
+                    self._plugin_errors[ep.name] = exc
+        finally:
+            self._discovery_state = DiscoveryState.DISCOVERED
+            self._discovering = False
 
     # ------------------------------------------------------------------
     # Registration (with lifecycle tracking)
@@ -105,6 +123,10 @@ class PluginManager:
         if not is_compatible:
             logger.warning("Plugin '%s' is incompatible and will be skipped.", name)
             self._plugin_states[name] = PluginState.FAILED
+            return
+
+        if self._pm.get_plugin(name) is not None:
+            logger.debug("Plugin '%s' already registered — skipping.", name)
             return
 
         self._pm.register(plugin, name)

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -129,18 +129,26 @@ class PluginManager:
             self._plugin_states[name] = PluginState.FAILED
             return
 
-        # --- Declarative hook collection ---
-        self._collect_declarative_hooks(plugin)
-
         # --- Imperative registration (backward compatible) ---
+        # Run BEFORE declarative hook collection so that if register()
+        # fails, no orphan contributions leak into the registry.
         if hasattr(plugin, "register") and callable(plugin.register):
             try:
                 plugin.register(self.registry)
             except Exception as exc:
-                logger.exception("Plugin '%s' raised an error during register().", name)
+                logger.exception(
+                    "Plugin '%s' raised an error during register().\n"
+                    "  → No contributions from this plugin will be registered.",
+                    name,
+                )
                 self._plugin_states[name] = PluginState.FAILED
                 self._plugin_errors[name] = exc
                 return
+
+        # --- Declarative hook collection ---
+        # Collected only after imperative register() succeeds so that
+        # a failing register() cannot leave orphan readers/writers etc.
+        self._collect_declarative_hooks(plugin)
 
         # --- Register in pluggy for hook-based communication ---
         self._pm.register(plugin, name)
@@ -437,6 +445,33 @@ class PluginManager:
     # ------------------------------------------------------------------
 
     def load_plugin(self, name: str) -> Any | None:
+        """
+        Load and register a specific plugin by name.
+
+        The method runs a two‑pass lookup:
+
+        1. **Already discovered?**  ``discover()`` is called first
+           (idempotent — entry points are scanned only once).  If the
+           plugin is already registered in the pluggy manager it is
+           returned immediately.
+
+        2. **Explicit fallback.**  If the plugin was *not* found after
+           discovery, the entry points are iterated again.  This handles
+           the edge case where a plugin was installed *after* the initial
+           ``discover()`` call completed (since ``discover`` skips entry
+           points that are already registered).
+
+        Parameters
+        ----------
+        name : str
+            Plugin name (matching ``entry_point.name``).
+
+        Returns
+        -------
+        Any or None
+            The loaded plugin instance, or ``None`` if the plugin was
+            not found or failed to register (``FAILED`` state).
+        """
         self.discover()
         plugin = self._pm.get_plugin(name)
         if plugin is None:

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -134,20 +134,20 @@ class PluginManager:
         # Declarative hooks and imperative register() write into a temporary
         # registry first. Nothing is merged into the active registry unless the
         # whole plugin registration succeeds.
-        temp_registry = PluginRegistry()
-        self._collect_declarative_hooks(plugin, temp_registry)
-        if hasattr(plugin, "register") and callable(plugin.register):
-            try:
+        try:
+            temp_registry = PluginRegistry()
+            self._collect_declarative_hooks(plugin, temp_registry)
+            if hasattr(plugin, "register") and callable(plugin.register):
                 plugin.register(temp_registry)
-            except Exception as exc:
-                logger.exception(
-                    "Plugin '%s' raised an error during register().\n"
-                    "  → No contributions from this plugin will be registered.",
-                    name,
-                )
-                self._plugin_states[name] = PluginState.FAILED
-                self._plugin_errors[name] = exc
-                return
+        except Exception as exc:
+            logger.exception(
+                "Plugin '%s' raised an error during registration.\n"
+                "  → No contributions from this plugin will be registered.",
+                name,
+            )
+            self._plugin_states[name] = PluginState.FAILED
+            self._plugin_errors[name] = exc
+            return
 
         # --- Register in pluggy for hook-based communication ---
         self.registry.merge_from(temp_registry)
@@ -251,6 +251,7 @@ class PluginManager:
                 "Failed to collect readers from plugin '%s'",
                 getattr(plugin, "name", "unknown"),
             )
+            raise
 
     def _collect_writers(
         self,
@@ -282,6 +283,7 @@ class PluginManager:
                 "Failed to collect writers from plugin '%s'",
                 getattr(plugin, "name", "unknown"),
             )
+            raise
 
     def _collect_visualizers(
         self,
@@ -314,6 +316,7 @@ class PluginManager:
                 "Failed to collect visualizers from plugin '%s'",
                 getattr(plugin, "name", "unknown"),
             )
+            raise
 
     def _collect_analyses(
         self,
@@ -350,6 +353,7 @@ class PluginManager:
                 "Failed to collect analyses from plugin '%s'",
                 getattr(plugin, "name", "unknown"),
             )
+            raise
 
     def _collect_simulations(
         self,
@@ -387,6 +391,7 @@ class PluginManager:
                 "Failed to collect simulations from plugin '%s'",
                 getattr(plugin, "name", "unknown"),
             )
+            raise
 
     def _collect_accessors(
         self,
@@ -431,6 +436,7 @@ class PluginManager:
                 "Failed to collect accessors from plugin '%s'",
                 getattr(plugin, "name", "unknown"),
             )
+            raise
 
     def _collect_processors(
         self,
@@ -463,6 +469,7 @@ class PluginManager:
                 "Failed to collect processors from plugin '%s'",
                 getattr(plugin, "name", "unknown"),
             )
+            raise
 
     # ------------------------------------------------------------------
     # Plugin loading
@@ -649,7 +656,13 @@ class PluginManager:
     @property
     def available_plugins(self) -> dict[str, Any]:
         self.discover()
-        return {name: self._pm.get_plugin(name) for name in self._pm.get_plugins()}
+        return {
+            name: plugin
+            for name, plugin in (
+                (self._pm.get_name(plugin), plugin) for plugin in self._pm.get_plugins()
+            )
+            if name is not None
+        }
 
     def list_plugins(self) -> list[Any]:
         self.discover()

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -107,6 +107,10 @@ class PluginManager:
             logger.info("Plugin '%s' is disabled — skipping registration.", name)
             return
 
+        if self._pm.get_plugin(name) is not None:
+            logger.debug("Plugin '%s' already registered — skipping.", name)
+            return
+
         self._plugin_states.setdefault(name, PluginState.LOADED)
 
         # --- Optional dependency check ---
@@ -125,11 +129,8 @@ class PluginManager:
             self._plugin_states[name] = PluginState.FAILED
             return
 
-        if self._pm.get_plugin(name) is not None:
-            logger.debug("Plugin '%s' already registered — skipping.", name)
-            return
-
-        self._pm.register(plugin, name)
+        # --- Declarative hook collection ---
+        self._collect_declarative_hooks(plugin)
 
         # --- Imperative registration (backward compatible) ---
         if hasattr(plugin, "register") and callable(plugin.register):
@@ -141,9 +142,8 @@ class PluginManager:
                 self._plugin_errors[name] = exc
                 return
 
-        # --- Declarative hook collection ---
-        self._collect_declarative_hooks(plugin)
-
+        # --- Register in pluggy for hook-based communication ---
+        self._pm.register(plugin, name)
         self.registry.register_plugin(name, plugin)
         self._plugin_states[name] = PluginState.ACTIVE
 
@@ -171,6 +171,42 @@ class PluginManager:
 
         return contributions
 
+    def _validate_contribution_list(
+        self,
+        plugin_name: str,
+        hook_name: str,
+        items: Any,
+    ) -> list[dict[str, Any]]:
+        valid: list[dict[str, Any]] = []
+        if not isinstance(items, list):
+            logger.warning(
+                "Plugin '%s': '%s()' returned %s, expected list[dict].",
+                plugin_name,
+                hook_name,
+                type(items).__name__,
+            )
+            return valid
+        for i, item in enumerate(items):
+            if not isinstance(item, dict):
+                logger.warning(
+                    "Plugin '%s': '%s()' item %d is %s, expected dict.",
+                    plugin_name,
+                    hook_name,
+                    i,
+                    type(item).__name__,
+                )
+                continue
+            if "name" not in item or "func" not in item:
+                logger.warning(
+                    "Plugin '%s': '%s()' item %d missing required keys 'name'/'func'.",
+                    plugin_name,
+                    hook_name,
+                    i,
+                )
+                continue
+            valid.append(item)
+        return valid
+
     def _collect_readers(
         self, plugin: Any, contributions: dict[str, list[str]]
     ) -> None:
@@ -180,24 +216,22 @@ class PluginManager:
         ):
             return
         try:
-            readers = plugin.register_readers()
-            if not isinstance(readers, list):
-                return
+            raw = plugin.register_readers()
+            readers = self._validate_contribution_list(
+                plugin_name, "register_readers", raw
+            )
             for reader in readers:
-                if not isinstance(reader, dict):
-                    continue
-                name = reader.get("name")
-                func = reader.get("func")
-                if name and func:
-                    self.registry.io.register_reader(
-                        name,
-                        func,
-                        description=reader.get("description", ""),
-                        extensions=reader.get("extensions"),
-                        plugin=plugin_name,
-                        namespace=reader.get("namespace", plugin_name),
-                    )
-                    contributions.setdefault("readers", []).append(name)
+                name = reader["name"]
+                func = reader["func"]
+                self.registry.io.register_reader(
+                    name,
+                    func,
+                    description=reader.get("description", ""),
+                    extensions=reader.get("extensions"),
+                    plugin=plugin_name,
+                    namespace=reader.get("namespace", plugin_name),
+                )
+                contributions.setdefault("readers", []).append(name)
         except Exception:
             logger.exception(
                 "Failed to collect readers from plugin '%s'",
@@ -207,26 +241,25 @@ class PluginManager:
     def _collect_writers(
         self, plugin: Any, contributions: dict[str, list[str]]
     ) -> None:
+        plugin_name = getattr(plugin, "name", "unknown")
         if not (
             hasattr(plugin, "register_writers") and callable(plugin.register_writers)
         ):
             return
         try:
-            writers = plugin.register_writers()
-            if not isinstance(writers, list):
-                return
+            raw = plugin.register_writers()
+            writers = self._validate_contribution_list(
+                plugin_name, "register_writers", raw
+            )
             for writer in writers:
-                if not isinstance(writer, dict):
-                    continue
-                name = writer.get("name")
-                func = writer.get("func")
-                if name and func:
-                    self.registry.io.register_writer(
-                        name,
-                        func,
-                        description=writer.get("description", ""),
-                    )
-                    contributions.setdefault("writers", []).append(name)
+                name = writer["name"]
+                func = writer["func"]
+                self.registry.io.register_writer(
+                    name,
+                    func,
+                    description=writer.get("description", ""),
+                )
+                contributions.setdefault("writers", []).append(name)
         except Exception:
             logger.exception(
                 "Failed to collect writers from plugin '%s'",
@@ -236,27 +269,26 @@ class PluginManager:
     def _collect_visualizers(
         self, plugin: Any, contributions: dict[str, list[str]]
     ) -> None:
+        plugin_name = getattr(plugin, "name", "unknown")
         if not (
             hasattr(plugin, "register_visualizers")
             and callable(plugin.register_visualizers)
         ):
             return
         try:
-            visualizers = plugin.register_visualizers()
-            if not isinstance(visualizers, list):
-                return
+            raw = plugin.register_visualizers()
+            visualizers = self._validate_contribution_list(
+                plugin_name, "register_visualizers", raw
+            )
             for vis in visualizers:
-                if not isinstance(vis, dict):
-                    continue
-                name = vis.get("name")
-                func = vis.get("func")
-                if name and func:
-                    self.registry.visualization.register_visualizer(
-                        name,
-                        func,
-                        description=vis.get("description", ""),
-                    )
-                    contributions.setdefault("visualizers", []).append(name)
+                name = vis["name"]
+                func = vis["func"]
+                self.registry.visualization.register_visualizer(
+                    name,
+                    func,
+                    description=vis.get("description", ""),
+                )
+                contributions.setdefault("visualizers", []).append(name)
         except Exception:
             logger.exception(
                 "Failed to collect visualizers from plugin '%s'",
@@ -272,26 +304,24 @@ class PluginManager:
         ):
             return
         try:
-            analyses = plugin.register_analyses()
-            if not isinstance(analyses, list):
-                return
+            raw = plugin.register_analyses()
+            analyses = self._validate_contribution_list(
+                plugin_name, "register_analyses", raw
+            )
             for analysis in analyses:
-                if not isinstance(analysis, dict):
-                    continue
-                name = analysis.get("name")
-                func = analysis.get("func")
-                if name and func:
-                    self.registry.extensions.register(
-                        "analysis",
-                        name,
-                        func,
-                        description=analysis.get("description", ""),
-                        metadata={
-                            "plugin": plugin_name,
-                            "namespace": analysis.get("namespace", plugin_name),
-                        },
-                    )
-                    contributions.setdefault("analyses", []).append(name)
+                name = analysis["name"]
+                func = analysis["func"]
+                self.registry.extensions.register(
+                    "analysis",
+                    name,
+                    func,
+                    description=analysis.get("description", ""),
+                    metadata={
+                        "plugin": plugin_name,
+                        "namespace": analysis.get("namespace", plugin_name),
+                    },
+                )
+                contributions.setdefault("analyses", []).append(name)
         except Exception:
             logger.exception(
                 "Failed to collect analyses from plugin '%s'",
@@ -308,26 +338,24 @@ class PluginManager:
         ):
             return
         try:
-            simulations = plugin.register_simulations()
-            if not isinstance(simulations, list):
-                return
+            raw = plugin.register_simulations()
+            simulations = self._validate_contribution_list(
+                plugin_name, "register_simulations", raw
+            )
             for sim in simulations:
-                if not isinstance(sim, dict):
-                    continue
-                name = sim.get("name")
-                func = sim.get("func")
-                if name and func:
-                    self.registry.extensions.register(
-                        "simulation",
-                        name,
-                        func,
-                        description=sim.get("description", ""),
-                        metadata={
-                            "plugin": plugin_name,
-                            "namespace": sim.get("namespace", plugin_name),
-                        },
-                    )
-                    contributions.setdefault("simulations", []).append(name)
+                name = sim["name"]
+                func = sim["func"]
+                self.registry.extensions.register(
+                    "simulation",
+                    name,
+                    func,
+                    description=sim.get("description", ""),
+                    metadata={
+                        "plugin": plugin_name,
+                        "namespace": sim.get("namespace", plugin_name),
+                    },
+                )
+                contributions.setdefault("simulations", []).append(name)
         except Exception:
             logger.exception(
                 "Failed to collect simulations from plugin '%s'",
@@ -344,35 +372,31 @@ class PluginManager:
         ):
             return
         try:
-            accessors = plugin.register_accessors()
-            if not isinstance(accessors, list):
-                return
+            raw = plugin.register_accessors()
+            accessors = self._validate_contribution_list(
+                plugin_name, "register_accessors", raw
+            )
             for accessor in accessors:
-                if not isinstance(accessor, dict):
-                    continue
-                name = accessor.get("name")
-                func = accessor.get("func")
-                if name and func:
-                    namespace = accessor.get("namespace")
-                    metadata = {
-                        "plugin": plugin_name,
-                        "namespace": namespace or plugin_name,
-                    }
-                    registered_names = [name]
-                    if namespace:
-                        registered_names = [f"{namespace}.{name}"]
-                        registered_names.extend(accessor.get("legacy_names", []))
+                name = accessor["name"]
+                func = accessor["func"]
+                namespace = accessor.get("namespace")
+                metadata = {
+                    "plugin": plugin_name,
+                    "namespace": namespace or plugin_name,
+                }
+                registered_names = [name]
+                if namespace:
+                    registered_names = [f"{namespace}.{name}"]
+                    registered_names.extend(accessor.get("legacy_names", []))
 
-                    for registered_name in registered_names:
-                        self.registry.register_accessor(
-                            registered_name,
-                            func,
-                            description=accessor.get("description", ""),
-                            metadata=metadata,
-                        )
-                        contributions.setdefault("accessors", []).append(
-                            registered_name
-                        )
+                for registered_name in registered_names:
+                    self.registry.register_accessor(
+                        registered_name,
+                        func,
+                        description=accessor.get("description", ""),
+                        metadata=metadata,
+                    )
+                    contributions.setdefault("accessors", []).append(registered_name)
         except Exception:
             logger.exception(
                 "Failed to collect accessors from plugin '%s'",
@@ -382,27 +406,26 @@ class PluginManager:
     def _collect_processors(
         self, plugin: Any, contributions: dict[str, list[str]]
     ) -> None:
+        plugin_name = getattr(plugin, "name", "unknown")
         if not (
             hasattr(plugin, "register_processors")
             and callable(plugin.register_processors)
         ):
             return
         try:
-            procs = plugin.register_processors()
-            if not isinstance(procs, list):
-                return
+            raw = plugin.register_processors()
+            procs = self._validate_contribution_list(
+                plugin_name, "register_processors", raw
+            )
             for proc in procs:
-                if not isinstance(proc, dict):
-                    continue
-                name = proc.get("name")
-                func = proc.get("func")
-                if name and func:
-                    self.registry.processing.register_processor(
-                        name,
-                        func,
-                        description=proc.get("description", ""),
-                    )
-                    contributions.setdefault("processors", []).append(name)
+                name = proc["name"]
+                func = proc["func"]
+                self.registry.processing.register_processor(
+                    name,
+                    func,
+                    description=proc.get("description", ""),
+                )
+                contributions.setdefault("processors", []).append(name)
         except Exception:
             logger.exception(
                 "Failed to collect processors from plugin '%s'",
@@ -425,10 +448,13 @@ class PluginManager:
                         cls = ep.load()
                         plugin = cls() if isinstance(cls, type) else cls
                         self.register(plugin)
+                        if self._plugin_states.get(name) == PluginState.FAILED:
+                            plugin = None
                     except Exception as exc:
                         logger.warning("Plugin '%s' failed to load: %s", name, exc)
                         self._plugin_states[name] = PluginState.FAILED
                         self._plugin_errors[name] = exc
+                        plugin = None
                     break
         return plugin
 

--- a/src/spectrochempy/plugins/registry.py
+++ b/src/spectrochempy/plugins/registry.py
@@ -58,6 +58,18 @@ class PluginRegistry:
         self.metadata.clear()
         self.extensions.clear()
 
+    def merge_from(self, other: PluginRegistry) -> None:
+        """Merge contributions from another registry into this registry."""
+        self.io._readers.update(other.io._readers)
+        self.io._writers.update(other.io._writers)
+        self.io._filetypes.update(other.io._filetypes)
+        self.processing._processors.update(other.processing._processors)
+        self.processing._unit_contexts.update(other.processing._unit_contexts)
+        self.processing._dtype_handlers.update(other.processing._dtype_handlers)
+        self.visualization._visualizers.update(other.visualization._visualizers)
+        for category, entries in other.extensions._extensions.items():
+            self.extensions._extensions.setdefault(category, {}).update(entries)
+
     # ------------------------------------------------------------------
     # Capability-based query
     # ------------------------------------------------------------------

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -264,6 +264,25 @@ class TestMissingPlugin:
         assert "spectrochempy-nmr" in message
         assert "spectrochempy[nmr]" in message
 
+    def test_unknown_plugin_reader_is_not_stubbed(self, monkeypatch):
+        """Unknown read_* attributes fail normally instead of creating stubs."""
+
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+        monkeypatch.delitem(
+            spectrochempy.__dict__,
+            "read_totally_unknown_format",
+            raising=False,
+        )
+
+        with pytest.raises(AttributeError, match="has no attribute") as excinfo:
+            _ = spectrochempy.read_totally_unknown_format
+
+        assert not isinstance(excinfo.value, MissingPluginError)
+        assert "read_totally_unknown_format" not in spectrochempy.__dict__
+
     def test_missing_namespace_clear_error(self, monkeypatch):
         """Accessing scp.nmr without NMR plugin gives a clear error."""
 

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -8,12 +8,18 @@
 
 from __future__ import annotations
 
+import importlib.metadata as im
+import logging
 from typing import Any
 
 import pytest
 
+import spectrochempy
 from spectrochempy.api.plugins import SpectroChemPyPlugin
+from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 from spectrochempy.plugins.manager import PluginManager
+from spectrochempy.plugins.namespace import PluginNamespace
+from spectrochempy.plugins.namespace import has_namespace
 from spectrochempy.plugins.registry import PluginRegistry
 
 # ------------------------------------------------------------------
@@ -93,28 +99,24 @@ class InvalidPlugin:
 
 class TestCoreImport:
     def test_import_spectrochempy(self):
-        """import spectrochempy works without plugin dependencies."""
-        import spectrochempy
+        """Import spectrochempy works without plugin dependencies."""
 
         assert spectrochempy.__version__ is not None
 
     def test_access_nddataset(self):
         """scp.NDDataset is accessible."""
-        import spectrochempy as scp
 
-        assert scp.NDDataset is not None
+        assert spectrochempy.NDDataset is not None
 
     def test_access_read(self):
         """scp.read is accessible (core IO function)."""
-        import spectrochempy as scp
 
-        assert callable(scp.read)
+        assert callable(spectrochempy.read)
 
     def test_access_read_omnic(self):
         """scp.read_omnic is accessible (built-in reader)."""
-        import spectrochempy as scp
 
-        assert callable(scp.read_omnic)
+        assert callable(spectrochempy.read_omnic)
 
 
 # ------------------------------------------------------------------
@@ -158,7 +160,6 @@ class TestDiscoverIdempotent:
 class TestPluginTopLevelFunction:
     def test_reader_exposed_at_top_level(self, monkeypatch):
         """A registered reader is accessible via scp.read_fake."""
-        import spectrochempy
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
@@ -168,7 +169,7 @@ class TestPluginTopLevelFunction:
         monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
         monkeypatch.setattr(spectrochempy, "registry", registry)
 
-        read_fake = getattr(spectrochempy, "read_fake")
+        read_fake = spectrochempy.read_fake
         assert callable(read_fake)
         assert read_fake("/some/path") == "fake data from /some/path"
 
@@ -192,10 +193,6 @@ class TestPluginTopLevelFunction:
 class TestPluginNamespace:
     def test_namespace_accessible_with_prefix(self, monkeypatch):
         """Plugin namespace 'fakenamespace' is accessible via scp.fakenamespace."""
-        import spectrochempy
-
-        from spectrochempy.plugins.namespace import PluginNamespace
-        from spectrochempy.plugins.namespace import has_namespace
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
@@ -206,12 +203,11 @@ class TestPluginNamespace:
         monkeypatch.setattr(spectrochempy, "registry", registry)
 
         assert has_namespace(registry, "fakenamespace")
-        ns = getattr(spectrochempy, "fakenamespace")
+        ns = spectrochempy.fakenamespace
         assert isinstance(ns, PluginNamespace)
 
     def test_namespace_reader_accessible(self, monkeypatch):
         """Namespace reader 'scp.fakenamespace.read_fakename' works."""
-        import spectrochempy
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
@@ -221,13 +217,12 @@ class TestPluginNamespace:
         monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
         monkeypatch.setattr(spectrochempy, "registry", registry)
 
-        ns = getattr(spectrochempy, "fakenamespace")
+        ns = spectrochempy.fakenamespace
         result = ns.read_fakename("/test")
         assert result == "fake ns data from /test"
 
     def test_namespace_error_clear(self, monkeypatch):
         """Accessing a missing attribute on a namespace gives a clear error."""
-        import spectrochempy
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
@@ -237,9 +232,9 @@ class TestPluginNamespace:
         monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
         monkeypatch.setattr(spectrochempy, "registry", registry)
 
-        ns = getattr(spectrochempy, "fakenamespace")
+        ns = spectrochempy.fakenamespace
         with pytest.raises(AttributeError, match="plugin namespace 'fakenamespace'"):
-            ns.missing_attribute
+            _ = ns.missing_attribute
 
 
 # ------------------------------------------------------------------
@@ -250,7 +245,6 @@ class TestPluginNamespace:
 class TestMissingPlugin:
     def test_missing_reader_clear_error(self, monkeypatch):
         """Accessing scp.read_topspin without NMR plugin gives a clear error."""
-        import spectrochempy
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
@@ -258,11 +252,10 @@ class TestMissingPlugin:
         monkeypatch.setattr(spectrochempy, "registry", registry)
 
         with pytest.raises(AttributeError, match="requires the optional plugin"):
-            getattr(spectrochempy, "read_topspin")
+            _ = spectrochempy.read_topspin
 
     def test_missing_namespace_clear_error(self, monkeypatch):
         """Accessing scp.nmr without NMR plugin gives a clear error."""
-        import spectrochempy
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
@@ -270,19 +263,30 @@ class TestMissingPlugin:
         monkeypatch.setattr(spectrochempy, "registry", registry)
 
         with pytest.raises(AttributeError, match="requires the optional plugin"):
-            getattr(spectrochempy, "nmr")
+            _ = spectrochempy.nmr
 
     def test_unknown_attribute_standard_error(self):
         """Accessing a truly unknown attribute gives a standard error."""
-        import spectrochempy as scp
 
         with pytest.raises(AttributeError, match="has no attribute"):
-            getattr(scp, "nonexistent_attribute_xyz123")
+            _ = spectrochempy.nonexistent_attribute_xyz123
 
 
 # ------------------------------------------------------------------
 # F. Invalid plugin
 # ------------------------------------------------------------------
+
+
+class FailingRegisterPlugin:
+    """Plugin whose imperative register() raises."""
+
+    name = "fail-reg"
+    version = "0.1.0"
+    PLUGIN_API_VERSION = "1.0"
+
+    def register(self, registry):
+        msg = "registration failure"
+        raise RuntimeError(msg)
 
 
 class TestInvalidPlugin:
@@ -310,9 +314,6 @@ class TestInvalidPlugin:
 
     def test_discover_does_not_crash_with_bad_entry_points(self, monkeypatch):
         """An entry point that loads a broken class does not crash discover()."""
-        import importlib.metadata as im
-
-        from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 
         class BrokenEntryPoint:
             name = "broken_ep"
@@ -333,6 +334,55 @@ class TestInvalidPlugin:
         monkeypatch.setattr(im, "entry_points", mock_entry_points)
         pm = PluginManager()
         pm.discover()  # must not raise
+
+    def test_failed_plugin_not_available_via_get_plugin(self):
+        """A FAILED plugin must not appear in get_plugin()."""
+        pm = PluginManager()
+        pm.register(FailingRegisterPlugin())
+        assert pm.get_plugin("fail-reg") is None
+
+    def test_failed_plugin_not_available_via_has_plugin(self):
+        """A FAILED plugin must not appear in has_plugin()."""
+        pm = PluginManager()
+        pm.register(FailingRegisterPlugin())
+        assert pm.has_plugin("fail-reg") is False
+
+    def test_failed_plugin_not_in_list_plugins(self):
+        """A FAILED plugin must not appear in list_plugins()."""
+        pm = PluginManager()
+        pm.register(FailingRegisterPlugin())
+        assert "fail-reg" not in [
+            p.name for p in pm.list_plugins() if hasattr(p, "name")
+        ]
+
+    def test_failed_plugin_not_active(self):
+        """A FAILED plugin must not appear in get_active_plugins()."""
+        pm = PluginManager()
+        pm.register(FailingRegisterPlugin())
+        assert "fail-reg" not in pm.get_active_plugins()
+
+    def test_failed_plugin_reported_in_get_failed(self):
+        """A FAILED plugin is still tracked via get_failed_plugins()."""
+        pm = PluginManager()
+        pm.register(FailingRegisterPlugin())
+        failed = pm.get_failed_plugins()
+        assert "fail-reg" in failed
+
+    def test_load_plugin_returns_none_for_failed(self):
+        """load_plugin returns None when the plugin fails to register."""
+        pm = PluginManager()
+
+        class AlwaysFails:
+            name = "always-fails"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register(self, registry):
+                msg = "always fails"
+                raise RuntimeError(msg)
+
+        result = pm.load_plugin("always-fails")
+        assert result is None
 
 
 # ------------------------------------------------------------------
@@ -364,6 +414,211 @@ class TestDatasetAccessors:
 # ------------------------------------------------------------------
 # H. Discovery state machine
 # ------------------------------------------------------------------
+
+
+# ------------------------------------------------------------------
+# I. __dir__ without side effects
+# ------------------------------------------------------------------
+
+
+class TestDirNoSideEffect:
+    def test_dir_does_not_trigger_discovery(self, monkeypatch):
+        """dir(scp) must not trigger plugin_manager.discover()."""
+
+        discover_called = False
+        original_discover = spectrochempy.plugin_manager.discover
+
+        def tracking_discover():
+            nonlocal discover_called
+            discover_called = True
+            original_discover()
+
+        monkeypatch.setattr(spectrochempy.plugin_manager, "discover", tracking_discover)
+        dir(spectrochempy)
+        assert not discover_called, "dir(scp) triggered plugin_manager.discover()"
+
+
+# ------------------------------------------------------------------
+# J. Warnings for invalid contributions
+# ------------------------------------------------------------------
+
+
+class TestInvalidContributionWarnings:
+    def test_warning_on_non_list_return(self, caplog):
+        """register_readers returning a non-list logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadReturnPlugin:
+            name = "bad-return"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_readers(self):
+                return "not a list"
+
+        pm = PluginManager()
+        pm.register(BadReturnPlugin())
+        assert any(
+            "bad-return" in msg and "register_readers" in msg for msg in caplog.messages
+        )
+
+    def test_warning_on_non_dict_item(self, caplog):
+        """register_readers returning a non-dict item logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadItemPlugin:
+            name = "bad-item"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_readers(self):
+                return ["not a dict"]
+
+        pm = PluginManager()
+        pm.register(BadItemPlugin())
+        assert any("bad-item" in msg and "is str" in msg for msg in caplog.messages)
+
+    def test_warning_on_missing_keys(self, caplog):
+        """register_readers with missing 'name'/'func' keys logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class MissingKeysPlugin:
+            name = "missing-keys"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_readers(self):
+                return [{"description": "no name or func"}]
+
+        pm = PluginManager()
+        pm.register(MissingKeysPlugin())
+        assert any(
+            "missing-keys" in msg and "missing required keys" in msg
+            for msg in caplog.messages
+        )
+
+    def test_warning_on_writers_non_list(self, caplog):
+        """register_writers returning a non-list logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadWritersPlugin:
+            name = "bad-writers"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_writers(self):
+                return 42
+
+        pm = PluginManager()
+        pm.register(BadWritersPlugin())
+        assert any(
+            "bad-writers" in msg and "register_writers" in msg
+            for msg in caplog.messages
+        )
+
+    def test_warning_on_analyses_non_list(self, caplog):
+        """register_analyses returning a non-list logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadAnalysesPlugin:
+            name = "bad-analyses"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_analyses(self):
+                return None
+
+        pm = PluginManager()
+        pm.register(BadAnalysesPlugin())
+        assert any(
+            "bad-analyses" in msg and "register_analyses" in msg
+            for msg in caplog.messages
+        )
+
+    def test_warning_on_simulations_non_list(self, caplog):
+        """register_simulations returning a non-list logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadSimPlugin:
+            name = "bad-sim"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_simulations(self):
+                return "invalid"
+
+        pm = PluginManager()
+        pm.register(BadSimPlugin())
+        assert any(
+            "bad-sim" in msg and "register_simulations" in msg
+            for msg in caplog.messages
+        )
+
+    def test_warning_on_accessors_non_list(self, caplog):
+        """register_accessors returning a non-list logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadAccessorPlugin:
+            name = "bad-accessor"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_accessors(self):
+                return [42]
+
+        pm = PluginManager()
+        pm.register(BadAccessorPlugin())
+        assert any(
+            "bad-accessor" in msg and "register_accessors" in msg
+            for msg in caplog.messages
+        )
+
+    def test_warning_on_processors_non_list(self, caplog):
+        """register_processors returning a non-list logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadProcPlugin:
+            name = "bad-proc"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_processors(self):
+                return (1, 2)
+
+        pm = PluginManager()
+        pm.register(BadProcPlugin())
+        assert any(
+            "bad-proc" in msg and "register_processors" in msg
+            for msg in caplog.messages
+        )
+
+    def test_warning_on_visualizers_non_list(self, caplog):
+        """register_visualizers returning a non-list logs a warning."""
+
+        caplog.set_level(logging.WARNING)
+
+        class BadVizPlugin:
+            name = "bad-viz"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_visualizers(self):
+                return [{"name": "foo"}]  # missing func
+
+        pm = PluginManager()
+        pm.register(BadVizPlugin())
+        assert any(
+            "bad-viz" in msg and "missing required keys" in msg
+            for msg in caplog.messages
+        )
 
 
 class TestDiscoveryStateMachine:
@@ -398,8 +653,6 @@ class TestDiscoveryStateMachine:
 
     def test_registration_does_not_trigger_discovery(self):
         """Registering a plugin directly does not trigger entry point discovery."""
-        import importlib.metadata as im
-        from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 
         original = im.entry_points
         call_count = 0

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -665,3 +665,203 @@ class TestDiscoveryStateMachine:
         pm = PluginManager()
         pm.register(FakeReaderPlugin())
         assert call_count == 0
+
+
+# ------------------------------------------------------------------
+# K. Orphan contributions when register() fails
+# ------------------------------------------------------------------
+
+
+class TestOrphanContributions:
+    """
+    A plugin whose imperative register() fails must not leave
+    declarative contributions (readers, writers, …) in the registry.
+    """
+
+    def test_reader_not_registered_when_register_fails(self):
+        """register_readers() works but register() raises → no reader in registry."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+
+        class DeclareThenFailPlugin:
+            name = "declare-then-fail"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_readers(self):
+                return [{"name": "orphan-reader", "func": lambda p: p}]
+
+            def register(self, registry):
+                msg = "intentional failure"
+                raise RuntimeError(msg)
+
+        pm.register(DeclareThenFailPlugin())
+        assert pm.get_plugin_state("declare-then-fail").value == "failed"
+        # The reader must NOT be available
+        assert registry.get_reader("orphan-reader") is None
+
+    def test_writer_not_registered_when_register_fails(self):
+        """register_writers() works but register() raises → no writer in registry."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+
+        class DeclareWriterThenFailPlugin:
+            name = "writer-fail"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_writers(self):
+                return [{"name": "orphan-writer", "func": lambda p: p}]
+
+            def register(self, registry):
+                msg = "intentional failure"
+                raise RuntimeError(msg)
+
+        pm.register(DeclareWriterThenFailPlugin())
+        assert pm.get_plugin_state("writer-fail").value == "failed"
+        assert registry.get_writer("orphan-writer") is None
+
+    def test_accessor_not_registered_when_register_fails(self):
+        """register_accessors() works but register() raises → no accessor in registry."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+
+        class DeclareAccessorThenFailPlugin:
+            name = "accessor-fail"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_accessors(self):
+                return [{"name": "orphan-accessor", "func": lambda p: p}]
+
+            def register(self, registry):
+                msg = "intentional failure"
+                raise RuntimeError(msg)
+
+        pm.register(DeclareAccessorThenFailPlugin())
+        assert pm.get_plugin_state("accessor-fail").value == "failed"
+        assert registry.get_accessor("accessor-fail.orphan-accessor") is None
+
+
+# ------------------------------------------------------------------
+# L. check_plugin_contributions does not double-execute hooks
+# ------------------------------------------------------------------
+
+
+class TestCheckPluginContributionsNoSideEffect:
+    """
+    check_plugin_contributions() validates structure only —
+    it must not be called during normal register flow, and when called
+    explicitly it *does* invoke hooks (by design), but we verify that
+    the normal register flow calls each hook exactly once.
+    """
+
+    def test_register_calls_declarative_hooks_once(self):
+        """Registering a plugin calls each declarative hook exactly once."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+
+        class CountingPlugin:
+            call_count = 0
+            name = "counter"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_readers(self):
+                self.call_count += 1
+                return [{"name": "cnt", "func": lambda p: p}]
+
+        plugin = CountingPlugin()
+        pm.register(plugin)
+        assert plugin.call_count == 1, "register_readers should be called exactly once"
+        assert registry.get_reader("cnt") is not None
+
+
+# ------------------------------------------------------------------
+# M. load_plugin behaviour
+# ------------------------------------------------------------------
+
+
+class TestLoadPlugin:
+    def test_load_plugin_returns_none_for_missing(self):
+        """load_plugin('nonexistent') returns None."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        result = pm.load_plugin("nonexistent-plugin-name")
+        assert result is None
+
+    def test_load_plugin_failed_state(self):
+        """load_plugin returns None when the plugin is in FAILED state."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+
+        class AlwaysFails:
+            name = "always-fails"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register(self, registry):
+                msg = "always fails"
+                raise RuntimeError(msg)
+
+        # Register directly (load only works with entry points)
+        pm.register(AlwaysFails())
+        assert pm.get_plugin_state("always-fails").value == "failed"
+
+        # load_plugin on a FAILED plugin returns None
+        result = pm.load_plugin("always-fails")
+        assert result is None
+
+
+# ------------------------------------------------------------------
+# N. __getattr__ / hasattr side effects
+# ------------------------------------------------------------------
+
+
+class TestGetAttrSideEffects:
+    """
+    Verify that attribute access does not leave corrupted state or
+    trigger repeated expensive discovery.
+    """
+
+    def test_multiple_access_same_reader(self):
+        """Accessing the same reader multiple times does not re-discover."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeReaderPlugin()
+        pm.register(plugin)
+
+        # Access via __getattr__ (mimics scp.read_fake)
+        reader1 = registry.get_reader("fake")
+        reader2 = registry.get_reader("fake")
+        assert reader1 is reader2
+
+    def test_hasattr_on_unknown_does_not_crash(self):
+        """Hasattr on a truly unknown attribute does not leave corrupted state."""
+        import spectrochempy as scp
+
+        # Accessing an unknown attribute should not crash hasattr
+        # (hasattr internally calls __getattr__ and catches AttributeError)
+        result = hasattr(scp, "this_attribute_does_not_exist_xyz")
+        assert result is False
+
+    def test_hasattr_on_known_reader(self):
+        """Hasattr returns True for a registered reader name."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+
+        class SimpleReaderPlugin:
+            name = "simple-reader"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_readers(self):
+                return [
+                    {
+                        "name": "simplereader",
+                        "func": lambda p: p,
+                    }
+                ]
+
+        pm.register(SimpleReaderPlugin())
+        assert registry.get_reader("simplereader") is not None

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -17,6 +17,7 @@ import pytest
 import spectrochempy
 from spectrochempy.api.plugins import SpectroChemPyPlugin
 from spectrochempy.api.plugins.validation import check_plugin_contributions
+from spectrochempy.plugins.deps import MissingPluginError
 from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 from spectrochempy.plugins.manager import PluginManager
 from spectrochempy.plugins.namespace import PluginNamespace
@@ -257,8 +258,8 @@ class TestMissingPlugin:
             "spectrochempy.missing.lazy_import_entry",
         )
 
-        with pytest.raises(AttributeError) as excinfo:
-            _ = spectrochempy.read_topspin
+        with pytest.raises(MissingPluginError) as excinfo:
+            spectrochempy.read_topspin("missing")
         message = str(excinfo.value)
         assert "spectrochempy-nmr" in message
         assert "spectrochempy[nmr]" in message

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -1,0 +1,414 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+"""Integration tests for the plugin system (lazy loading, discovery, user-facing errors)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from spectrochempy.api.plugins import SpectroChemPyPlugin
+from spectrochempy.plugins.manager import PluginManager
+from spectrochempy.plugins.registry import PluginRegistry
+
+# ------------------------------------------------------------------
+# Fake plugins for integration testing
+# ------------------------------------------------------------------
+
+
+class FakeReaderPlugin(SpectroChemPyPlugin):
+    name = "fake_reader"
+    version = "0.1.0"
+    PLUGIN_API_VERSION = "1.0"
+
+    def register_readers(self) -> list[dict]:
+        def read_fake(path: str) -> str:
+            return f"fake data from {path}"
+
+        return [
+            {
+                "name": "fake",
+                "func": read_fake,
+                "description": "Read fake format",
+                "extensions": [".fake"],
+            }
+        ]
+
+
+class FakeNamespacePlugin(SpectroChemPyPlugin):
+    name = "fakenamespace"
+    version = "0.1.0"
+    PLUGIN_API_VERSION = "1.0"
+
+    def register_readers(self) -> list[dict]:
+        def read_fake_ns(path: str) -> str:
+            return f"fake ns data from {path}"
+
+        return [
+            {
+                "name": "fakename",
+                "func": read_fake_ns,
+                "description": "Read fake ns format",
+                "namespace": "fakenamespace",
+                "extensions": [".fns"],
+            }
+        ]
+
+
+class FakeAccessorPlugin(SpectroChemPyPlugin):
+    name = "fakeaccessor"
+    version = "0.1.0"
+    PLUGIN_API_VERSION = "1.0"
+
+    def register_accessors(self) -> list[dict]:
+        def my_accessor(dataset: Any, factor: float = 2.0) -> str:
+            return f"accessor applied with factor {factor}"
+
+        return [
+            {
+                "namespace": "fakeaccessor",
+                "name": "transform",
+                "func": my_accessor,
+                "description": "Fake accessor transform",
+            }
+        ]
+
+
+class InvalidPlugin:
+    """Plugin without name/version/api_version — malformed."""
+
+    def register(self, registry: Any) -> None:
+        registry.register_reader("bad", lambda x: x)
+
+
+# ------------------------------------------------------------------
+# A. Import core
+# ------------------------------------------------------------------
+
+
+class TestCoreImport:
+    def test_import_spectrochempy(self):
+        """import spectrochempy works without plugin dependencies."""
+        import spectrochempy
+
+        assert spectrochempy.__version__ is not None
+
+    def test_access_nddataset(self):
+        """scp.NDDataset is accessible."""
+        import spectrochempy as scp
+
+        assert scp.NDDataset is not None
+
+    def test_access_read(self):
+        """scp.read is accessible (core IO function)."""
+        import spectrochempy as scp
+
+        assert callable(scp.read)
+
+    def test_access_read_omnic(self):
+        """scp.read_omnic is accessible (built-in reader)."""
+        import spectrochempy as scp
+
+        assert callable(scp.read_omnic)
+
+
+# ------------------------------------------------------------------
+# B. Discover idempotent
+# ------------------------------------------------------------------
+
+
+class TestDiscoverIdempotent:
+    def test_discover_idempotent(self):
+        """Two discover() calls do not duplicate readers."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeReaderPlugin()
+        pm.register(plugin)
+
+        pm.discover()
+        before = len(registry.available_readers)
+        pm.discover()
+        assert len(registry.available_readers) == before
+
+    def test_discover_does_not_duplicate_plugins(self):
+        """Calling discover() twice does not register plugins twice."""
+        pm = PluginManager()
+        pm.register(FakeReaderPlugin())
+        active_before = pm.get_active_plugins()
+        pm.discover()
+        active_after = pm.get_active_plugins()
+        assert active_before == active_after
+
+    def test_discover_not_discovered_initial_state(self):
+        """Fresh PluginManager starts as not_discovered."""
+        pm = PluginManager()
+        assert pm._discovery_state == "not_discovered"
+
+
+# ------------------------------------------------------------------
+# C. Plugin top-level function via __getattr__
+# ------------------------------------------------------------------
+
+
+class TestPluginTopLevelFunction:
+    def test_reader_exposed_at_top_level(self, monkeypatch):
+        """A registered reader is accessible via scp.read_fake."""
+        import spectrochempy
+
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeReaderPlugin()
+        pm.register(plugin)
+
+        monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+
+        read_fake = getattr(spectrochempy, "read_fake")
+        assert callable(read_fake)
+        assert read_fake("/some/path") == "fake data from /some/path"
+
+    def test_reader_callable(self):
+        """A registered reader function works when called."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeReaderPlugin()
+        pm.register(plugin)
+
+        reader = registry.get_reader("fake")
+        assert reader is not None
+        assert reader["func"]("/test") == "fake data from /test"
+
+
+# ------------------------------------------------------------------
+# D. Plugin namespace
+# ------------------------------------------------------------------
+
+
+class TestPluginNamespace:
+    def test_namespace_accessible_with_prefix(self, monkeypatch):
+        """Plugin namespace 'fakenamespace' is accessible via scp.fakenamespace."""
+        import spectrochempy
+
+        from spectrochempy.plugins.namespace import PluginNamespace
+        from spectrochempy.plugins.namespace import has_namespace
+
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeNamespacePlugin()
+        pm.register(plugin)
+
+        monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+
+        assert has_namespace(registry, "fakenamespace")
+        ns = getattr(spectrochempy, "fakenamespace")
+        assert isinstance(ns, PluginNamespace)
+
+    def test_namespace_reader_accessible(self, monkeypatch):
+        """Namespace reader 'scp.fakenamespace.read_fakename' works."""
+        import spectrochempy
+
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeNamespacePlugin()
+        pm.register(plugin)
+
+        monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+
+        ns = getattr(spectrochempy, "fakenamespace")
+        result = ns.read_fakename("/test")
+        assert result == "fake ns data from /test"
+
+    def test_namespace_error_clear(self, monkeypatch):
+        """Accessing a missing attribute on a namespace gives a clear error."""
+        import spectrochempy
+
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeNamespacePlugin()
+        pm.register(plugin)
+
+        monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+
+        ns = getattr(spectrochempy, "fakenamespace")
+        with pytest.raises(AttributeError, match="plugin namespace 'fakenamespace'"):
+            ns.missing_attribute
+
+
+# ------------------------------------------------------------------
+# E. Missing plugin / stub
+# ------------------------------------------------------------------
+
+
+class TestMissingPlugin:
+    def test_missing_reader_clear_error(self, monkeypatch):
+        """Accessing scp.read_topspin without NMR plugin gives a clear error."""
+        import spectrochempy
+
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+
+        with pytest.raises(AttributeError, match="requires the optional plugin"):
+            getattr(spectrochempy, "read_topspin")
+
+    def test_missing_namespace_clear_error(self, monkeypatch):
+        """Accessing scp.nmr without NMR plugin gives a clear error."""
+        import spectrochempy
+
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+
+        with pytest.raises(AttributeError, match="requires the optional plugin"):
+            getattr(spectrochempy, "nmr")
+
+    def test_unknown_attribute_standard_error(self):
+        """Accessing a truly unknown attribute gives a standard error."""
+        import spectrochempy as scp
+
+        with pytest.raises(AttributeError, match="has no attribute"):
+            getattr(scp, "nonexistent_attribute_xyz123")
+
+
+# ------------------------------------------------------------------
+# F. Invalid plugin
+# ------------------------------------------------------------------
+
+
+class TestInvalidPlugin:
+    def test_invalid_plugin_does_not_crash(self):
+        """A malformed plugin does not crash the manager."""
+        pm = PluginManager()
+        plugin = InvalidPlugin()
+        pm.register(plugin)
+
+    def test_invalid_plugin_fails_gracefully(self):
+        """A malformed plugin is tracked as FAILED."""
+        pm = PluginManager()
+        plugin = InvalidPlugin()
+        pm.register(plugin)
+        state = pm.get_plugin_state("invalidplugin")
+        assert state is not None
+        assert state.value == "failed"
+
+    def test_valid_plugin_works_after_invalid(self):
+        """A valid plugin can still register after an invalid one."""
+        pm = PluginManager()
+        pm.register(InvalidPlugin())
+        pm.register(FakeReaderPlugin())
+        assert pm.get_plugin_state("fake_reader").value == "active"
+
+    def test_discover_does_not_crash_with_bad_entry_points(self, monkeypatch):
+        """An entry point that loads a broken class does not crash discover()."""
+        import importlib.metadata as im
+
+        from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
+
+        class BrokenEntryPoint:
+            name = "broken_ep"
+            value = "broken_module:BrokenPlugin"
+
+            @staticmethod
+            def load():
+                msg = "broken module"
+                raise ImportError(msg)
+
+        original = im.entry_points
+
+        def mock_entry_points(group=None):
+            if group == ENTRY_POINT_GROUP:
+                return [BrokenEntryPoint()]
+            return original(group=group)
+
+        monkeypatch.setattr(im, "entry_points", mock_entry_points)
+        pm = PluginManager()
+        pm.discover()  # must not raise
+
+
+# ------------------------------------------------------------------
+# G. Dataset accessors
+# ------------------------------------------------------------------
+
+
+class TestDatasetAccessors:
+    def test_accessor_not_duplicated_on_repeated_register(self):
+        """Calling register() twice with the same plugin does not add duplicate accessors."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeAccessorPlugin()
+        pm.register(plugin)
+        assert len(registry.available_accessors) == 1
+        pm.register(plugin)
+        assert len(registry.available_accessors) == 1
+
+    def test_accessor_does_not_become_reader(self):
+        """An accessor is not accidentally exposed as a reader."""
+        registry = PluginRegistry()
+        pm = PluginManager(registry=registry)
+        plugin = FakeAccessorPlugin()
+        pm.register(plugin)
+        assert registry.get_reader("transform") is None
+        assert registry.get_accessor("fakeaccessor.transform") is not None
+
+
+# ------------------------------------------------------------------
+# H. Discovery state machine
+# ------------------------------------------------------------------
+
+
+class TestDiscoveryStateMachine:
+    def test_discovery_state_transition(self):
+        """Discovery goes NOT_DISCOVERED -> DISCOVERING -> DISCOVERED."""
+        pm = PluginManager()
+        assert pm._discovery_state == "not_discovered"
+        pm.discover()
+        assert pm._discovery_state == "discovered"
+
+    def test_reentrant_discovery_safe(self):
+        """Calling discover() during discover() is safe (no infinite loop)."""
+        pm = PluginManager()
+
+        class ReentrantPlugin:
+            name = "reentrant"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register(self, registry):
+                pm.discover()
+
+        pm.register(ReentrantPlugin())
+        assert pm._discovery_state == "discovered"
+
+    def test_discovery_skipped_when_already_discovering(self):
+        """Calling discover() while already discovering returns immediately."""
+        pm = PluginManager()
+        pm._discovering = True
+        pm.discover()
+        assert pm._discovery_state == "not_discovered"
+
+    def test_registration_does_not_trigger_discovery(self):
+        """Registering a plugin directly does not trigger entry point discovery."""
+        import importlib.metadata as im
+        from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
+
+        original = im.entry_points
+        call_count = 0
+
+        def counting_mock(group=None):
+            nonlocal call_count
+            call_count += 1
+            return original(group=group) if group != ENTRY_POINT_GROUP else []
+
+        pm = PluginManager()
+        pm.register(FakeReaderPlugin())
+        assert call_count == 0

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -16,6 +16,7 @@ import pytest
 
 import spectrochempy
 from spectrochempy.api.plugins import SpectroChemPyPlugin
+from spectrochempy.api.plugins.validation import check_plugin_contributions
 from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 from spectrochempy.plugins.manager import PluginManager
 from spectrochempy.plugins.namespace import PluginNamespace
@@ -750,11 +751,28 @@ class TestOrphanContributions:
 
 class TestCheckPluginContributionsNoSideEffect:
     """
-    check_plugin_contributions() validates structure only —
-    it must not be called during normal register flow, and when called
-    explicitly it *does* invoke hooks (by design), but we verify that
-    the normal register flow calls each hook exactly once.
+    check_plugin_contributions() validates hook presence only and must not
+    execute declarative hooks.
     """
+
+    def test_check_plugin_contributions_does_not_call_hooks(self):
+        """Validation must not execute declarative hook methods."""
+
+        class CountingPlugin:
+            call_count = 0
+            name = "counter-validation"
+            version = "0.1.0"
+            PLUGIN_API_VERSION = "1.0"
+
+            def register_readers(self):
+                self.call_count += 1
+                return [{"name": "cnt", "func": lambda p: p}]
+
+        plugin = CountingPlugin()
+        issues = check_plugin_contributions(plugin)
+
+        assert issues == []
+        assert plugin.call_count == 0
 
     def test_register_calls_declarative_hooks_once(self):
         """Registering a plugin calls each declarative hook exactly once."""

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -251,9 +251,17 @@ class TestMissingPlugin:
         pm = PluginManager(registry=registry)
         monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
         monkeypatch.setattr(spectrochempy, "registry", registry)
+        monkeypatch.setitem(
+            spectrochempy._LAZY_IMPORTS,
+            "read_topspin",
+            "spectrochempy.missing.lazy_import_entry",
+        )
 
-        with pytest.raises(AttributeError, match="requires the optional plugin"):
+        with pytest.raises(AttributeError) as excinfo:
             _ = spectrochempy.read_topspin
+        message = str(excinfo.value)
+        assert "spectrochempy-nmr" in message
+        assert "spectrochempy[nmr]" in message
 
     def test_missing_namespace_clear_error(self, monkeypatch):
         """Accessing scp.nmr without NMR plugin gives a clear error."""

--- a/tests/test_plugins/test_manager.py
+++ b/tests/test_plugins/test_manager.py
@@ -11,7 +11,7 @@ from operator import attrgetter
 
 import pytest
 
-from spectrochempy.plugins.base import SpectroChemPyPlugin
+from spectrochempy.plugins.base import SpectroChemPyPluginProtocol
 from spectrochempy.plugins.deps import MissingPluginError
 from spectrochempy.plugins.lifecycle import PluginState
 from spectrochempy.plugins.manager import PluginManager
@@ -455,13 +455,13 @@ def test_registry_not_leaked_across_registrations():
 
 class TestPluginProtocol:
     def test_protocol_check(self):
-        assert isinstance(DummyPlugin(), SpectroChemPyPlugin)
+        assert isinstance(DummyPlugin(), SpectroChemPyPluginProtocol)
 
-    def test_protocol_without_name(self):
+        # An InvalidPlugin without name/version/api_version is NOT a protocol match
         class InvalidPlugin:
             pass
 
-        assert not isinstance(InvalidPlugin(), SpectroChemPyPlugin)
+        assert not isinstance(InvalidPlugin(), SpectroChemPyPluginProtocol)
 
 
 # ------------------------------------------------------------------

--- a/tests/test_plugins/test_manager.py
+++ b/tests/test_plugins/test_manager.py
@@ -27,7 +27,7 @@ from spectrochempy.plugins.registry import PluginRegistry
 class DummyPlugin:
     name = "dummy"
     version = "0.1.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register(self, registry):
         registry.register_reader("dummy", lambda x: x)
@@ -36,7 +36,7 @@ class DummyPlugin:
 class DeclarativeReaderPlugin:
     name = "decl-reader"
     version = "0.2.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register_readers(self) -> list[dict]:
         return [
@@ -52,7 +52,7 @@ class DeclarativeReaderPlugin:
 class DeclarativeWriterPlugin:
     name = "decl-writer"
     version = "0.2.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register_writers(self) -> list[dict]:
         return [
@@ -67,7 +67,7 @@ class DeclarativeWriterPlugin:
 class DeclarativeVisualizerPlugin:
     name = "decl-viz"
     version = "0.2.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register_visualizers(self) -> list[dict]:
         return [
@@ -82,7 +82,7 @@ class DeclarativeVisualizerPlugin:
 class DeclarativeProcessorPlugin:
     name = "decl-proc"
     version = "0.2.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register_processors(self) -> list[dict]:
         return [
@@ -97,7 +97,7 @@ class DeclarativeProcessorPlugin:
 class DeclarativeAccessorPlugin:
     name = "decl-accessor"
     version = "0.2.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register_accessors(self) -> list[dict]:
         return [
@@ -112,7 +112,7 @@ class DeclarativeAccessorPlugin:
 class NamespacedAccessorPlugin:
     name = "domain"
     version = "0.2.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register_accessors(self) -> list[dict]:
         return [
@@ -131,7 +131,7 @@ class HybridPlugin:
 
     name = "hybrid"
     version = "0.3.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register(self, registry):
         registry.register_reader("legacy_reader", lambda x: x)
@@ -151,7 +151,7 @@ class BrokenDeclarativePlugin:
 
     name = "broken"
     version = "0.1.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register_readers(self) -> list[dict]:
         msg = "Internal error"
@@ -166,7 +166,7 @@ class BrokenDeclarativePlugin:
 def test_plugin_manager_creation():
     pm = PluginManager()
     assert pm is not None
-    assert pm._discovered is False
+    assert pm._discovery_state == "not_discovered"
 
 
 def test_plugin_manager_injected_registry():
@@ -190,7 +190,7 @@ def test_plugin_manager_fallback_registry():
 def test_discover_plugins():
     pm = PluginManager()
     pm.discover()
-    assert pm._discovered is True
+    assert pm._discovery_state == "discovered"
     assert isinstance(pm.list_plugins(), list)
 
 
@@ -470,11 +470,17 @@ class TestPluginProtocol:
 
 
 class TestMissingPluginError:
-    def test_default_message(self):
-        err = MissingPluginError("topspin reader")
+    def test_default_message_with_plugin_name(self):
+        err = MissingPluginError("topspin reader", plugin_name="spectrochempy-nmr")
         msg = str(err)
         assert "topspin reader" in msg
         assert "spectrochempy-nmr" in msg
+
+    def test_default_message_without_plugin_name(self):
+        err = MissingPluginError("topspin reader")
+        msg = str(err)
+        assert "topspin reader" in msg
+        assert "optional plugin" in msg
 
     def test_custom_hint(self):
         err = MissingPluginError(
@@ -501,7 +507,7 @@ class FailingConstructorPlugin:
 
     name = "fail-ctor"
     version = "0.1.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def __init__(self):
         msg = "optional dependency not found"
@@ -516,7 +522,7 @@ class FailingRegisterPlugin:
 
     name = "fail-reg"
     version = "0.1.0"
-    api_version = "1.0"
+    PLUGIN_API_VERSION = "1.0"
 
     def register(self, registry):
         msg = "registration failure"

--- a/tests/test_plugins/test_manager.py
+++ b/tests/test_plugins/test_manager.py
@@ -200,6 +200,16 @@ def test_available_plugins_empty():
     assert pm.has_plugin("nonexistent") is False
 
 
+def test_available_plugins_uses_registered_plugin_names():
+    pm = PluginManager()
+    plugin = DummyPlugin()
+
+    pm.register(plugin)
+
+    assert pm.available_plugins["dummy"] is plugin
+    assert all(isinstance(name, str) for name in pm.available_plugins)
+
+
 # ------------------------------------------------------------------
 # Imperative registration (backward compatible)
 # ------------------------------------------------------------------
@@ -399,7 +409,8 @@ def test_broken_declarative_hook_does_not_crash():
     plugin = BrokenDeclarativePlugin()
     # Must not raise despite the RuntimeError in register_readers
     pm.register(plugin)
-    assert pm.has_plugin("broken")
+    assert pm.get_plugin_state("broken") is PluginState.FAILED
+    assert registry.available_readers == {}
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary

This PR hardens the core SpectroChemPy plugin system before continuing with the NMR, IRIS, and Cantera plugin work.

The main goal is to make plugin registration safer, keep optional official plugin hints explicit, and clarify the boundary between core knowledge and dynamically installed plugin contributions.

## Main changes

- Makes plugin registration transactional for declarative contributions:
  - reader/writer/accessor/namespace contributions are collected into a temporary registry first;
  - they are merged into the active registry only after registration succeeds;
  - if registration fails, the plugin is marked as failed and no partial contribution remains active.

- Treats errors in declarative plugin hooks as plugin registration failures:
  - failing hooks such as register_readers() no longer leave orphaned contributions behind;
  - failed plugins are reported consistently through the plugin manager state.

- Adjusts plugin contribution validation:
  - check_plugin_contributions() now checks that declarative hooks exist and are callable;
  - it no longer executes hooks during validation, avoiding side effects.

- Renames the internal plugin protocol:
  - SpectroChemPyPlugin protocol is renamed to SpectroChemPyPluginProtocol;
  - this avoids confusion with the public API class spectrochempy.api.plugins.SpectroChemPyPlugin.

- Fixes available_plugins:
  - pluggy returns plugin objects, not names;
  - the plugin manager now resolves the registered pluggy name correctly.

- Moves official optional plugin feature hints out of spectrochempy/__init__.py:
  - new module: spectrochempy.plugins.features;
  - contains static hints for official optional plugins only;
  - third-party plugins are not listed in the core;
  - installed plugins still declare their contributions dynamically through the plugin system.

- Clarifies read_topspin behavior:
  - _LAZY_IMPORTS is not treated as the source of truth for externalized plugin readers;
  - missing scp.read_topspin now relies on the official optional plugin hint and gives an actionable message mentioning spectrochempy-nmr / spectrochempy[nmr].

- Adds pytest configuration:
  - pythonpath = ["."] ensures local pytest plugins such as tests.test_plotting.plotting_fixtures are importable when running pytest directly from the conda environment.

## Tests

Run locally in the scpy conda environment:

    pytest tests/test_plugins/ -q

Result:

    184 passed

Also checked ruff/ruff-format on the modified files during the incremental commits.

## Notes for reviewers

This PR intentionally does not redesign the plugin system. It keeps the current architecture and focuses on making the existing registration and optional-plugin error paths safer and easier to reason about.

It also does not touch the NMR, IRIS, or Cantera plugin implementation directly. Those remain for follow-up PRs based on this hardened core plugin branch.
