### PR TITLE
Stabilize NMR plugin registration

### DIFF
--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "spectrochempy>=0.8,<0.9",
     "numpy",
     "numpy-quaternion>=2024.0.7",
+    # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.
 ]
 
 [project.entry-points."spectrochempy.plugins"]

--- a/plugins/spectrochempy-nmr/tests/test_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_plugin.py
@@ -5,18 +5,34 @@
 import pytest
 from spectrochempy_nmr import NMRPlugin
 
+import spectrochempy as scp
 import spectrochempy.plugins.manager as manager_module
 from spectrochempy.api.plugins import PluginCapability
 from spectrochempy.api.plugins import PluginState
 from spectrochempy.api.plugins import check_plugin_compatibility
+from spectrochempy.core.readers.read_topspin import read_topspin as core_read_topspin
 from spectrochempy.plugins.deps import MissingPluginError
 from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 from spectrochempy.plugins.manager import PluginManager
+from spectrochempy.plugins.registry import PluginRegistry
 from spectrochempy.testing.plugins import PluginTestHarness
 
 
 def _require_reader_dependencies() -> None:
     pytest.importorskip("quaternion")
+
+
+def _isolate_scp_plugins(monkeypatch, scp):
+    registry = PluginRegistry()
+    pm = PluginManager(registry=registry)
+    monkeypatch.setattr(
+        manager_module.importlib.metadata,
+        "entry_points",
+        lambda group=None: [],
+    )
+    monkeypatch.setattr(scp, "plugin_manager", pm)
+    monkeypatch.setattr(scp, "registry", registry)
+    return pm, registry
 
 
 def test_plugin_metadata():
@@ -44,6 +60,8 @@ def test_registration():
     reader = harness.get_reader("topspin")
     assert reader is not None
     assert reader["description"]
+    assert reader["plugin"] == "nmr"
+    assert reader["namespace"] == "nmr"
 
 
 def test_registration_is_idempotent():
@@ -115,23 +133,37 @@ def test_isolated_harness():
     assert h2.registry.metadata.get_plugin("nmr") is None
 
 
-def test_package_namespace_exposes_topspin_reader():
+def test_package_namespace_exposes_topspin_reader(monkeypatch):
     """scp.nmr.read_topspin exposes the reader while preserving legacy alias."""
     _require_reader_dependencies()
-    import spectrochempy as scp
 
-    if not scp.plugin_manager.has_plugin("nmr"):
-        scp.plugin_manager.register(NMRPlugin())
+    pm, registry = _isolate_scp_plugins(monkeypatch, scp)
+    pm.register(NMRPlugin())
 
     assert scp.nmr.read_topspin is scp.read_topspin
+    assert registry.get_reader("topspin")["namespace"] == "nmr"
+    assert scp.read_topspin.__module__ == "spectrochempy_nmr.read_topspin"
+    assert scp.nmr.read_topspin.__module__ == "spectrochempy_nmr.read_topspin"
 
 
-def test_missing_topspin_reader_stub_is_actionable():
-    """The core compatibility stub explains how to install the NMR plugin."""
-    from spectrochempy.core.readers.read_topspin import read_topspin
+def test_top_level_stub_is_actionable_without_registered_nmr(monkeypatch):
+    """scp.read_topspin is a callable MissingPluginError stub without NMR."""
+    _isolate_scp_plugins(monkeypatch, scp)
 
-    try:
+    read_topspin = scp.read_topspin
+    assert callable(read_topspin)
+    with pytest.raises(MissingPluginError) as excinfo:
         read_topspin("missing")
+
+    message = str(excinfo.value)
+    assert "spectrochempy-nmr" in message
+    assert "pip install spectrochempy[nmr]" in message
+
+
+def test_core_stub_is_actionable():
+    """The core compatibility stub explains how to install the NMR plugin."""
+    try:
+        core_read_topspin("missing")
     except MissingPluginError as err:
         message = str(err)
     else:  # pragma: no cover
@@ -141,13 +173,12 @@ def test_missing_topspin_reader_stub_is_actionable():
     assert "pip install spectrochempy[nmr]" in message
 
 
-def test_nmr_reader_is_not_dataset_accessor_namespace():
+def test_nmr_reader_is_not_dataset_accessor_namespace(monkeypatch):
     """Readers are package-level APIs, not dataset accessor methods."""
     _require_reader_dependencies()
-    import spectrochempy as scp
 
-    if not scp.plugin_manager.has_plugin("nmr"):
-        scp.plugin_manager.register(NMRPlugin())
+    pm, _registry = _isolate_scp_plugins(monkeypatch, scp)
+    pm.register(NMRPlugin())
 
     dataset = scp.NDDataset([1, 2, 3])
     assert not hasattr(dataset, "nmr")

--- a/plugins/spectrochempy-nmr/tests/test_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_plugin.py
@@ -2,13 +2,21 @@
 
 """Tests for spectrochempy-nmr plugin registration and lifecycle."""
 
+import pytest
 from spectrochempy_nmr import NMRPlugin
 
+import spectrochempy.plugins.manager as manager_module
 from spectrochempy.api.plugins import PluginCapability
 from spectrochempy.api.plugins import PluginState
 from spectrochempy.api.plugins import check_plugin_compatibility
 from spectrochempy.plugins.deps import MissingPluginError
+from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
+from spectrochempy.plugins.manager import PluginManager
 from spectrochempy.testing.plugins import PluginTestHarness
+
+
+def _require_reader_dependencies() -> None:
+    pytest.importorskip("quaternion")
 
 
 def test_plugin_metadata():
@@ -29,6 +37,7 @@ def test_plugin_compatibility():
 
 def test_registration():
     """Plugin registers the topspin reader via declarative hook."""
+    _require_reader_dependencies()
     harness = PluginTestHarness()
     harness.register(NMRPlugin())
 
@@ -37,8 +46,59 @@ def test_registration():
     assert reader["description"]
 
 
+def test_registration_is_idempotent():
+    """Registering the same NMR plugin twice does not duplicate contributions."""
+    _require_reader_dependencies()
+    harness = PluginTestHarness()
+    plugin = NMRPlugin()
+
+    harness.register(plugin)
+    first_reader = harness.get_reader("topspin")
+    harness.register(plugin)
+    second_reader = harness.get_reader("topspin")
+
+    assert harness.get_plugin_state("nmr") == PluginState.ACTIVE
+    assert list(harness.available_readers).count("topspin") == 1
+    assert second_reader is not None
+    assert first_reader is not None
+    assert second_reader["func"] is first_reader["func"]
+
+
+def test_discovery_is_idempotent(monkeypatch):
+    """Repeated discovery keeps a single active NMR reader and namespace."""
+    _require_reader_dependencies()
+
+    class NMREntryPoint:
+        name = "nmr"
+        value = "spectrochempy_nmr:NMRPlugin"
+
+        @staticmethod
+        def load():
+            return NMRPlugin
+
+    def mock_entry_points(group=None):
+        if group == ENTRY_POINT_GROUP:
+            return [NMREntryPoint()]
+        return []
+
+    monkeypatch.setattr(
+        manager_module.importlib.metadata,
+        "entry_points",
+        mock_entry_points,
+    )
+
+    pm = PluginManager()
+    pm.discover()
+    pm.discover()
+
+    assert pm.get_plugin_state("nmr") == PluginState.ACTIVE
+    assert list(pm.registry.available_readers).count("topspin") == 1
+    assert pm.registry.get_reader("topspin")["namespace"] == "nmr"
+
+
 def test_lifecycle_state():
     """Plugin transitions to ACTIVE after registration."""
+    _require_reader_dependencies()
     harness = PluginTestHarness()
     harness.register(NMRPlugin())
     assert harness.get_plugin_state("nmr") == PluginState.ACTIVE
@@ -46,6 +106,7 @@ def test_lifecycle_state():
 
 def test_isolated_harness():
     """Each PluginTestHarness is independent."""
+    _require_reader_dependencies()
     h1 = PluginTestHarness()
     h2 = PluginTestHarness()
 
@@ -56,6 +117,7 @@ def test_isolated_harness():
 
 def test_package_namespace_exposes_topspin_reader():
     """scp.nmr.read_topspin exposes the reader while preserving legacy alias."""
+    _require_reader_dependencies()
     import spectrochempy as scp
 
     if not scp.plugin_manager.has_plugin("nmr"):
@@ -81,6 +143,7 @@ def test_missing_topspin_reader_stub_is_actionable():
 
 def test_nmr_reader_is_not_dataset_accessor_namespace():
     """Readers are package-level APIs, not dataset accessor methods."""
+    _require_reader_dependencies()
     import spectrochempy as scp
 
     if not scp.plugin_manager.has_plugin("nmr"):

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -583,28 +583,6 @@ def _read_(*args, **kwargs):
         return Importer._read_dir(*args, **kwargs)
     raise FileNotFoundError
 
-    # protocol = kwargs.get("protocol", None)
-    # if protocol and ".scp" in protocol:
-    #     return dataset.load(filename, **kwargs)
-    #
-    # elif filename and filename.name in ("fid", "ser", "1r", "2rr", "3rrr"):
-    #     # probably a TopSpin NMR file
-    #     return read_topspin(filename, **kwargs)
-    # elif filename:
-    #     # try scp format
-    #     try:
-    #         return dataset.load(filename, **kwargs)
-    #     except Exception:
-    #         # lets try some common format
-    #         for key in ["omnic", "opus", "topspin", "labspec", "matlab", "jdx"]:
-    #             try:
-    #                 _read = getattr(scp, f"read_{key}")
-    #                 f = f"{filename}.{key}"
-    #                 return _read(f, **kwargs)
-    #             except Exception:
-    #                 pass
-    #         raise NotImplementedError
-
 
 # ======================================================================================
 # Private functions

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -170,7 +170,8 @@ class PluginManager:
         self, plugin: Any, registry: PluginRegistry | None = None
     ) -> dict[str, list[str]]:
         contributions: dict[str, list[str]] = {}
-        registry = registry or self.registry
+        if registry is None:
+            registry = self.registry
 
         self._collect_readers(plugin, contributions, registry)
         self._collect_writers(plugin, contributions, registry)

--- a/tests/test_core/test_dataset/test_reader_api_policy.py
+++ b/tests/test_core/test_dataset/test_reader_api_policy.py
@@ -2,11 +2,15 @@
 
 """Reader API exposure policy tests."""
 
+import importlib.metadata
+import sys
+
 import pytest
 
 import spectrochempy as scp
 from spectrochempy.plugins.deps import MissingPluginError
-from spectrochempy.plugins.registry import registry
+from spectrochempy.plugins.manager import PluginManager
+from spectrochempy.plugins.registry import PluginRegistry
 
 
 def test_core_readers_are_package_level_not_dataset_methods():
@@ -45,19 +49,25 @@ def test_core_readers_are_package_level_not_dataset_methods():
 
 def test_missing_topspin_top_level_alias_is_actionable(monkeypatch):
     """Without the NMR plugin reader, scp.read_topspin points to a clear stub."""
-    scp.plugin_manager.discover()
+    isolated_registry = PluginRegistry()
+    isolated_manager = PluginManager(registry=isolated_registry)
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(scp, "plugin_manager", isolated_manager)
+    monkeypatch.setattr(scp, "registry", isolated_registry)
     monkeypatch.delitem(scp.__dict__, "read_topspin", raising=False)
-    monkeypatch.setattr(
-        registry.io,
-        "_readers",
-        {
-            name: info
-            for name, info in registry.io.available_readers.items()
-            if name != "topspin"
-        },
-    )
+    for module_name in list(sys.modules):
+        if module_name == "spectrochempy_nmr" or module_name.startswith(
+            "spectrochempy_nmr."
+        ):
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    assert not any(name.startswith("spectrochempy_nmr") for name in sys.modules)
+    read_topspin = scp.read_topspin
+    assert callable(read_topspin)
+    assert not any(name.startswith("spectrochempy_nmr") for name in sys.modules)
 
     with pytest.raises(MissingPluginError, match="spectrochempy-nmr") as excinfo:
-        scp.read_topspin("missing")
+        read_topspin("missing")
 
     assert "pip install spectrochempy[nmr]" in str(excinfo.value)
+    assert not any(name.startswith("spectrochempy_nmr") for name in sys.modules)

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -250,6 +250,7 @@ class TestMissingPlugin:
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
+        monkeypatch.setattr(im, "entry_points", lambda group=None: [])
         monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
         monkeypatch.setattr(spectrochempy, "registry", registry)
         monkeypatch.setitem(
@@ -288,6 +289,7 @@ class TestMissingPlugin:
 
         registry = PluginRegistry()
         pm = PluginManager(registry=registry)
+        monkeypatch.setattr(im, "entry_points", lambda group=None: [])
         monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
         monkeypatch.setattr(spectrochempy, "registry", registry)
 

--- a/tests/test_plugins/test_manager.py
+++ b/tests/test_plugins/test_manager.py
@@ -410,7 +410,9 @@ def test_broken_declarative_hook_does_not_crash():
     # Must not raise despite the RuntimeError in register_readers
     pm.register(plugin)
     assert pm.get_plugin_state("broken") is PluginState.FAILED
-    assert registry.available_readers == {}
+    assert all(
+        info.get("plugin") != "broken" for info in registry.available_readers.values()
+    )
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
﻿## Summary

This PR stabilizes the NMR plugin as the first real optional plugin on top of the `plugins` integration branch.

The goal is intentionally narrow: verify and harden NMR plugin registration/discovery behavior without touching IRIS, Cantera, broad documentation, or global examples.

## What changed

- Added stronger NMR plugin tests for:
  - plugin metadata and compatibility;
  - TopSpin reader registration;
  - direct registration idempotence;
  - entry-point discovery idempotence;
  - absence of duplicate `topspin` reader registration;
  - namespace behavior: `scp.nmr.read_topspin is scp.read_topspin`;
  - reader API policy: no `nd.read_topspin` and no `nd.nmr` accessor for reader-only functionality.

- Made NMR plugin tests skip cleanly when the reader dependency `quaternion` is unavailable.

- Made missing-plugin tests robust when `spectrochempy-nmr` is installed in the local environment:
  - tests that simulate missing NMR now mock entry-point discovery to return no plugins;
  - this keeps the expected `MissingPluginError` / missing namespace behavior independent of the developer environment.

- Fixed a small registry handling edge case in `PluginManager._collect_declarative_hooks()`:
  - an explicitly passed temporary registry is now preserved unless it is actually `None`;
  - this keeps registration rollback behavior reliable.

- Adjusted one rollback test so it checks that the broken plugin did not contribute anything, without assuming the environment has no other installed plugins.

## Behavior verified

### Core without NMR

Verified in the `scpy` environment before installing the plugin:

- `import spectrochempy as scp` does not import `spectrochempy_nmr`.
- `scp.read_topspin` is a callable compatibility stub.
- Calling `scp.read_topspin(...)` raises `MissingPluginError` with an actionable message mentioning:
  - `spectrochempy-nmr`
  - `pip install spectrochempy[nmr]`

### With NMR installed

Installed locally for testing with:

    python -m pip install -e plugins/spectrochempy-nmr --no-deps

Verified:

- `scp.read_topspin(...)` resolves to the registered NMR reader.
- `scp.nmr.read_topspin(...)` resolves to the same callable.
- Repeated discovery does not duplicate the reader.
- The `topspin` reader namespace remains `nmr`.

## Packaging audit

Checked the NMR plugin packaging:

- distribution name: `spectrochempy-nmr`
- import package: `spectrochempy_nmr`
- entry point: `nmr = spectrochempy_nmr:NMRPlugin`
- plugin API version: `PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION`
- NMR-specific dependency remains isolated in the plugin: `numpy-quaternion`

## Tests

Run locally in the `scpy` conda environment:

    pytest plugins/spectrochempy-nmr/tests/test_plugin.py -q
    pytest tests/test_plugins/ -q
    pytest tests -q

Results:

    10 passed
    185 passed
    1366 passed, 34 skipped, 2 xpassed

Also run on modified files:

    ruff
    ruff-format

Both passed.

## Notes for reviewers

This PR does not move notebooks/examples and does not reorganize documentation. It only stabilizes the NMR plugin registration/discovery surface and a small core registry handling edge case needed for reliable plugin tests.
