### PR TITLE
Première passe documentation/exemples plugins

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -88,40 +88,48 @@ jobs:
            . .venv/bin/activate
            uv pip install -e ".[docs]"
 
-      # Step 6: Install Pandoc and check version
+      # Step 6: Install local plugins before building docs examples
+      - name: Install SpectroChemPy plugins
+        run: |
+          . .venv/bin/activate
+          uv pip install -e plugins/spectrochempy-nmr
+          uv pip install -e plugins/spectrochempy-iris
+          uv pip install -e plugins/spectrochempy-cantera
+
+      # Step 7: Install Pandoc and check version
       - name: Install Pandoc
         run: |
           sudo apt-get update
           sudo apt-get install -y pandoc
           pandoc --version
 
-      # Step 7: Setup Jupyter kernel for notebooks
+      # Step 8: Setup Jupyter kernel for notebooks
       - name: Setup Jupyter kernel
         run: |
           . .venv/bin/activate
           uv pip install ipykernel
           python3 -m ipykernel install --user --name python3 --display-name "Python 3"
 
-      # Step 8: Set up version environment variable
+      # Step 9: Set up version environment variable
       - name: Set up version environment variable
         run: |
           . .venv/bin/activate
           python3 .github/workflows/scripts/set_env_var.py
 
-      # Step 9: Clone gh-pages branch
+      # Step 10: Clone gh-pages branch
       - name: Clone gh-pages branch
         run: |
           mkdir -p build
           git clone --branch=gh-pages --single-branch https://github.com/${{ github.repository }}.git build/html
 
-      # Step 10: Build the documentation
+      # Step 11: Build the documentation
       - name: Build docs
         run: |
           . .venv/bin/activate
           echo "Updating docs"
           python3 docs/make.py -j1 html
 
-      # Step 11: Build oldest version of the documentation if it doesn't yet exist
+      # Step 12: Build oldest version of the documentation if it doesn't yet exist
       - name: Build oldest version of the documentation
         run: |
           . .venv/bin/activate
@@ -130,7 +138,7 @@ jobs:
             python3 docs/make.py -j1 html -T 0.6.10
           fi
 
-      # Step 12: Upload build artifacts
+      # Step 13: Upload build artifacts
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -357,12 +357,14 @@ if not single_doc_or_dir:
             f"{example_source_dir}/core",
             f"{example_source_dir}/processing",
             f"{example_source_dir}/analysis",
+            f"{example_source_dir}/plugins",
         ],
         # Generated RST files in generated directory
         "gallery_dirs": [
             f"{example_generated_dir}/auto_examples_core",
             f"{example_generated_dir}/auto_examples_processing",
             f"{example_generated_dir}/auto_examples_analysis",
+            f"{example_generated_dir}/auto_examples_plugins",
         ],
         "backreferences_dir": f"{example_generated_dir}/backreferences",
         "reference_url": {

--- a/docs/sources/userguide/index.rst
+++ b/docs/sources/userguide/index.rst
@@ -16,5 +16,6 @@ A comprehensive guide to using SCPY.
     plotting/index
     processing/index
     analysis/index
+    plugins
     api/api
     objects/index

--- a/docs/sources/userguide/plugins.rst
+++ b/docs/sources/userguide/plugins.rst
@@ -1,0 +1,89 @@
+.. _plugins:
+
+=================
+Optional Plugins
+=================
+
+SpectroChemPy's core works standalone for common spectroscopic data processing
+and analysis.  Additional functionality is provided by **optional plugins** that
+extend the framework with domain-specific readers, analyses, and simulations.
+
+.. _plugins-install:
+
+Installing a plugin
+===================
+
+Plugins are distributed as separate packages on PyPI.  Install them with
+``pip``:
+
+.. code-block:: bash
+
+    pip install spectrochempy[nmr]      # NMR / TopSpin reader
+    pip install spectrochempy[iris]     # 2D-IRIS analysis
+    pip install spectrochempy[cantera]  # PFR reactor simulation
+
+Or install a specific plugin directly:
+
+.. code-block:: bash
+
+    pip install spectrochempy-nmr
+    pip install spectrochempy-iris
+    pip install spectrochempy-cantera
+
+.. _plugins-usage:
+
+Using a plugin
+==============
+
+Once installed, the plugin registers itself automatically when you import
+SpectroChemPy.  No extra import is needed:
+
+.. code-block:: python
+
+    import spectrochempy as scp
+
+    # NMR plugin — read TopSpin files
+    ds = scp.read_topspin("path/to/fid")
+
+    # Cantera plugin — PFR simulation
+    reactor = scp.PFR(...)
+
+    # IRIS plugin — 2D-IRIS analysis
+    from spectrochempy_iris import IRIS
+    iris = IRIS(reg_par=[-10, 1, 12])
+
+If a plugin is not installed, the corresponding function raises a clear
+:class:`~spectrochempy.plugins.deps.MissingPluginError` with installation
+instructions.
+
+.. _plugins-list:
+
+Available plugins
+=================
+
+.. list-table::
+   :header-rows: 1
+
+   * - Plugin
+     - Package
+     - Provides
+   * - NMR
+     - ``spectrochempy-nmr``
+     - :func:`~spectrochempy.read_topspin` (Bruker TopSpin reader),
+       NMR processing utilities
+   * - IRIS
+     - ``spectrochempy-iris``
+     - 2D-IRIS analysis
+       (:class:`~spectrochempy_iris.IRIS`,
+       :class:`~spectrochempy_iris.IrisKernel`)
+   * - Cantera
+     - ``spectrochempy-cantera``
+     - :class:`~spectrochempy.PFR` plug flow reactor simulation
+
+.. _plugins-developer:
+
+Developing a plugin
+===================
+
+See the :ref:`devguide-plugins` section for the plugin API documentation,
+packaging guide, and a full reference example (``spectrochempy-nmr``).

--- a/docs/sources/userguide/plugins.rst
+++ b/docs/sources/userguide/plugins.rst
@@ -1,11 +1,11 @@
 .. _plugins:
 
-=================
+================
 Optional Plugins
-=================
+================
 
 SpectroChemPy's core works standalone for common spectroscopic data processing
-and analysis.  Additional functionality is provided by **optional plugins** that
+and analysis. Additional functionality is provided by **optional plugins** that
 extend the framework with domain-specific readers, analyses, and simulations.
 
 .. _plugins-install:
@@ -13,7 +13,7 @@ extend the framework with domain-specific readers, analyses, and simulations.
 Installing a plugin
 ===================
 
-Plugins are distributed as separate packages on PyPI.  Install them with
+Plugins are distributed as separate packages on PyPI. Install them with
 ``pip``:
 
 .. code-block:: bash
@@ -36,25 +36,37 @@ Using a plugin
 ==============
 
 Once installed, the plugin registers itself automatically when you import
-SpectroChemPy.  No extra import is needed:
+SpectroChemPy. Plugin functions are available from package-level namespaces,
+and dataset-bound operations are available from dataset accessors:
 
 .. code-block:: python
 
     import spectrochempy as scp
 
-    # NMR plugin — read TopSpin files
-    ds = scp.read_topspin("path/to/fid")
+    # NMR plugin: read TopSpin files
+    ds = scp.nmr.read_topspin("path/to/fid")
 
-    # Cantera plugin — PFR simulation
-    reactor = scp.PFR(...)
+    # Cantera plugin: access the PFR simulation callable
+    PFR = scp.cantera.PFR
 
-    # IRIS plugin — 2D-IRIS analysis
-    from spectrochempy_iris import IRIS
-    iris = IRIS(reg_par=[-10, 1, 12])
+    # IRIS plugin: build an IRIS kernel from an existing dataset
+    kernel = dataset.iris.kernel_matrix(kernel_type="langmuir")
 
-If a plugin is not installed, the corresponding function raises a clear
-:class:`~spectrochempy.plugins.deps.MissingPluginError` with installation
-instructions.
+For backward compatibility, some former top-level APIs remain available as thin
+aliases. For example, ``scp.read_topspin(...)`` delegates to
+``scp.nmr.read_topspin(...)`` when the NMR plugin is installed.
+
+If a plugin is not installed, the corresponding official optional feature gives
+a clear installation hint. For example:
+
+.. code-block:: pycon
+
+    >>> import spectrochempy as scp
+    >>> scp.read_topspin("path/to/fid")
+    Traceback (most recent call last):
+    ...
+    MissingPluginError: The 'read_topspin' feature requires the optional plugin
+    'spectrochempy-nmr'. Install it with: pip install spectrochempy[nmr]
 
 .. _plugins-list:
 
@@ -78,7 +90,7 @@ Available plugins
        :class:`~spectrochempy_iris.IrisKernel`)
    * - Cantera
      - ``spectrochempy-cantera``
-     - :class:`~spectrochempy.PFR` plug flow reactor simulation
+     - ``scp.cantera.PFR`` plug flow reactor simulation callable
 
 .. _plugins-developer:
 

--- a/src/spectrochempy/examples/plugins/__init__.py
+++ b/src/spectrochempy/examples/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin-based examples."""

--- a/src/spectrochempy/examples/plugins/cantera/__init__.py
+++ b/src/spectrochempy/examples/plugins/cantera/__init__.py
@@ -1,0 +1,1 @@
+"""Cantera plugin examples."""

--- a/src/spectrochempy/examples/plugins/cantera/plot_cantera_pfr.py
+++ b/src/spectrochempy/examples/plugins/cantera/plot_cantera_pfr.py
@@ -9,7 +9,7 @@ Cantera: PFR reactor simulation (plugin)
 =========================================
 
 This example shows how the optional ``spectrochempy-cantera`` plugin provides
-the :class:`~spectrochempy.PFR` plug flow reactor simulation class.
+the ``scp.cantera.PFR`` plug flow reactor simulation callable.
 """
 
 # %%
@@ -17,24 +17,28 @@ import spectrochempy as scp
 
 from importlib.util import find_spec
 
-if find_spec("spectrochempy_cantera") is None:
-    raise ImportError(
+OPTIONAL_PLUGIN = "spectrochempy_cantera"
+
+if find_spec(OPTIONAL_PLUGIN) is None:
+    print(
         "This example requires the optional spectrochempy-cantera plugin.\n"
         "Install it with: pip install spectrochempy[cantera]"
     )
+else:
+    # %%
+    # When the plugin is installed, ``PFR`` is available from the ``scp.cantera``
+    # plugin namespace. It is a lazy callable that imports the implementation
+    # only when used:
+
+    print(f"PFR callable: {scp.cantera.PFR}")
+
+    # %%
+    # The PFR constructor currently expects inputs compatible with the legacy
+    # Cantera mechanism API. Full construction examples will be added after the
+    # PFR implementation is adapted to Cantera 3.2+.
 
 # %%
-# When the plugin is installed, :class:`~spectrochempy.PFR` is available
-# in the ``scp`` namespace:
-
-print(f"PFR class: {scp.PFR}")
-
-# %%
-# The PFR constructor expects a Cantera mechanism (CTI/XML mechanism file).
-# See the :class:`~spectrochempy.PFR` API reference for full parameter details.
-
-# %%
-# If the plugin is not installed, accessing ``scp.PFR`` raises a
-# :class:`~spectrochempy.plugins.deps.MissingPluginError`.
+# If the plugin is not installed, accessing ``scp.cantera`` raises a clear
+# installation hint for ``spectrochempy-cantera``.
 
 # scp.show()

--- a/src/spectrochempy/examples/plugins/cantera/plot_cantera_pfr.py
+++ b/src/spectrochempy/examples/plugins/cantera/plot_cantera_pfr.py
@@ -1,0 +1,40 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Cantera: PFR reactor simulation (plugin)
+=========================================
+
+This example shows how the optional ``spectrochempy-cantera`` plugin provides
+the :class:`~spectrochempy.PFR` plug flow reactor simulation class.
+"""
+
+# %%
+import spectrochempy as scp
+
+from importlib.util import find_spec
+
+if find_spec("spectrochempy_cantera") is None:
+    raise ImportError(
+        "This example requires the optional spectrochempy-cantera plugin.\n"
+        "Install it with: pip install spectrochempy[cantera]"
+    )
+
+# %%
+# When the plugin is installed, :class:`~spectrochempy.PFR` is available
+# in the ``scp`` namespace:
+
+print(f"PFR class: {scp.PFR}")
+
+# %%
+# The PFR constructor expects a Cantera mechanism (CTI/XML mechanism file).
+# See the :class:`~spectrochempy.PFR` API reference for full parameter details.
+
+# %%
+# If the plugin is not installed, accessing ``scp.PFR`` raises a
+# :class:`~spectrochempy.plugins.deps.MissingPluginError`.
+
+# scp.show()

--- a/src/spectrochempy/examples/plugins/iris/__init__.py
+++ b/src/spectrochempy/examples/plugins/iris/__init__.py
@@ -1,0 +1,1 @@
+"""IRIS plugin examples."""

--- a/src/spectrochempy/examples/plugins/iris/plot_iris_intro.py
+++ b/src/spectrochempy/examples/plugins/iris/plot_iris_intro.py
@@ -17,40 +17,57 @@ from importlib.util import find_spec
 
 import spectrochempy as scp
 
-if find_spec("spectrochempy_iris") is None:
-    raise ImportError(
+OPTIONAL_PLUGIN = "spectrochempy_iris"
+
+if find_spec(OPTIONAL_PLUGIN) is None:
+    print(
         "This example requires the optional spectrochempy-iris plugin.\n"
         "Install it with: pip install spectrochempy[iris]"
     )
+else:
+    # %%
+    # The IRIS plugin provides package-level workflows under ``scp.iris`` and
+    # dataset-bound helpers under ``dataset.iris``. The classes remain available
+    # from the plugin package for advanced workflows.
 
-# %%
-# The IRIS plugin provides the :class:`~spectrochempy_iris.IRIS` class
-# and related tools. A typical workflow is shown in the
-# :ref:`quickstart <quickstart>`.
+    from spectrochempy_iris import IRIS
 
-from spectrochempy_iris import IRIS
-from spectrochempy_iris import IrisKernel
+    # Load CO adsorption data
+    ds = scp.read_omnic("irdata/CO@Mo_Al2O3.SPG")[:, 2250.0:1950.0]
 
-# Load CO adsorption data
-ds = scp.read_omnic("irdata/CO@Mo_Al2O3.SPG")[:, 2250.0:1950.0]
+    # Attach pressure coordinates
+    pressure = [
+        0.003,
+        0.004,
+        0.009,
+        0.014,
+        0.021,
+        0.026,
+        0.036,
+        0.051,
+        0.093,
+        0.150,
+        0.203,
+        0.300,
+        0.404,
+        0.503,
+        0.602,
+        0.702,
+        0.801,
+        0.905,
+        1.004,
+    ]
+    ds.y = scp.Coord(pressure, title="Pressure", units="torr")
 
-# Attach pressure coordinates
-pressure = [
-    0.003, 0.004, 0.009, 0.014, 0.021, 0.026, 0.036, 0.051,
-    0.093, 0.150, 0.203, 0.300, 0.404, 0.503, 0.602, 0.702,
-    0.801, 0.905, 1.004,
-]
-ds.y = scp.Coord(pressure, title="Pressure", units="torr")
+    print(f"Loaded dataset: {ds}")
 
-print(f"Loaded dataset: {ds}")
+    # %%
+    # Build the IRIS kernel from the dataset accessor, then run the analysis:
 
-# %%
-# Run IRIS analysis:
+    K = ds.iris.kernel_matrix(kernel_type="langmuir", q=[-7, -1, 50])
+    iris = IRIS(reg_par=[-10, 1, 12])
+    iris.fit(ds, K)
 
-iris = IRIS(reg_par=[-10, 1, 12])
-K = IrisKernel(ds, "langmuir", q=[-7, -1, 50])
-iris.fit(ds, K)
-
-_ = iris.f[-7].plot_contour(colorbar=True)
+    _ = iris.f[-7].plot_contour(colorbar=True)
 
 # scp.show()

--- a/src/spectrochempy/examples/plugins/iris/plot_iris_intro.py
+++ b/src/spectrochempy/examples/plugins/iris/plot_iris_intro.py
@@ -1,0 +1,56 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+IRIS: 2D-IRIS analysis (plugin)
+=================================
+
+This example introduces the 2D-IRIS analysis provided by the optional
+``spectrochempy-iris`` plugin.
+"""
+
+# %%
+from importlib.util import find_spec
+
+import spectrochempy as scp
+
+if find_spec("spectrochempy_iris") is None:
+    raise ImportError(
+        "This example requires the optional spectrochempy-iris plugin.\n"
+        "Install it with: pip install spectrochempy[iris]"
+    )
+
+# %%
+# The IRIS plugin provides the :class:`~spectrochempy_iris.IRIS` class
+# and related tools. A typical workflow is shown in the
+# :ref:`quickstart <quickstart>`.
+
+from spectrochempy_iris import IRIS
+from spectrochempy_iris import IrisKernel
+
+# Load CO adsorption data
+ds = scp.read_omnic("irdata/CO@Mo_Al2O3.SPG")[:, 2250.0:1950.0]
+
+# Attach pressure coordinates
+pressure = [
+    0.003, 0.004, 0.009, 0.014, 0.021, 0.026, 0.036, 0.051,
+    0.093, 0.150, 0.203, 0.300, 0.404, 0.503, 0.602, 0.702,
+    0.801, 0.905, 1.004,
+]
+ds.y = scp.Coord(pressure, title="Pressure", units="torr")
+
+print(f"Loaded dataset: {ds}")
+
+# %%
+# Run IRIS analysis:
+
+iris = IRIS(reg_par=[-10, 1, 12])
+K = IrisKernel(ds, "langmuir", q=[-7, -1, 50])
+iris.fit(ds, K)
+
+_ = iris.f[-7].plot_contour(colorbar=True)
+
+# scp.show()

--- a/src/spectrochempy/examples/plugins/nmr/__init__.py
+++ b/src/spectrochempy/examples/plugins/nmr/__init__.py
@@ -1,0 +1,1 @@
+"""NMR plugin examples."""

--- a/src/spectrochempy/examples/plugins/nmr/plot_nmr_read_topspin.py
+++ b/src/spectrochempy/examples/plugins/nmr/plot_nmr_read_topspin.py
@@ -1,0 +1,54 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+NMR: reading TopSpin files (plugin)
+=====================================
+
+This example shows how to read Bruker TopSpin NMR files using the
+optional ``spectrochempy-nmr`` plugin.
+"""
+
+# %%
+from importlib.util import find_spec
+
+import spectrochempy as scp
+
+if find_spec("spectrochempy_nmr") is None:
+    raise ImportError(
+        "This example requires the optional spectrochempy-nmr plugin.\n"
+        "Install it with: pip install spectrochempy[nmr]"
+    )
+
+# %%
+# ``read_topspin`` is automatically registered in the ``scp`` namespace
+# when the NMR plugin is installed:
+
+ds = scp.read_topspin(
+    scp.preferences.datadir
+    / "nmrdata"
+    / "bruker"
+    / "tests"
+    / "nmr"
+    / "topspin_1d",
+    expno=1,
+    remove_digital_filter=True,
+)
+
+print(f"Loaded dataset: {ds}")
+print(f"Shape: {ds.shape}")
+
+# %%
+# Plot the spectrum:
+
+_ = ds.plot()
+
+# %%
+# If the plugin is not installed, the function or method raises a
+# :class:`~spectrochempy.plugins.deps.MissingPluginError` with installation
+# instructions.
+
+# scp.show()

--- a/src/spectrochempy/examples/plugins/nmr/plot_nmr_read_topspin.py
+++ b/src/spectrochempy/examples/plugins/nmr/plot_nmr_read_topspin.py
@@ -17,34 +17,31 @@ from importlib.util import find_spec
 
 import spectrochempy as scp
 
-if find_spec("spectrochempy_nmr") is None:
-    raise ImportError(
+OPTIONAL_PLUGIN = "spectrochempy_nmr"
+
+if find_spec(OPTIONAL_PLUGIN) is None:
+    print(
         "This example requires the optional spectrochempy-nmr plugin.\n"
         "Install it with: pip install spectrochempy[nmr]"
     )
+else:
+    # %%
+    # ``read_topspin`` is registered under the ``scp.nmr`` plugin namespace.
+    # The top-level ``scp.read_topspin`` alias is kept for compatibility.
 
-# %%
-# ``read_topspin`` is automatically registered in the ``scp`` namespace
-# when the NMR plugin is installed:
+    ds = scp.nmr.read_topspin(
+        scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d",
+        expno=1,
+        remove_digital_filter=True,
+    )
 
-ds = scp.read_topspin(
-    scp.preferences.datadir
-    / "nmrdata"
-    / "bruker"
-    / "tests"
-    / "nmr"
-    / "topspin_1d",
-    expno=1,
-    remove_digital_filter=True,
-)
+    print(f"Loaded dataset: {ds}")
+    print(f"Shape: {ds.shape}")
 
-print(f"Loaded dataset: {ds}")
-print(f"Shape: {ds.shape}")
+    # %%
+    # Plot the spectrum:
 
-# %%
-# Plot the spectrum:
-
-_ = ds.plot()
+    _ = ds.plot()
 
 # %%
 # If the plugin is not installed, the function or method raises a

--- a/src/spectrochempy/examples/plugins/readme.rst
+++ b/src/spectrochempy/examples/plugins/readme.rst
@@ -1,0 +1,9 @@
+.. _examples-plugins-index:
+
+###############################
+Plugin-dependent functionality
+###############################
+
+These examples require one or more optional plugins.
+
+See :ref:`plugins` for installation instructions.

--- a/src/spectrochempy/examples/processing/nmr/readme.rst
+++ b/src/spectrochempy/examples/processing/nmr/readme.rst
@@ -1,6 +1,17 @@
 .. _examples-processing-nmr-index:
 
-Processing NMR datasets
------------------------
+#############################
+NMR processing (plugin-based)
+#############################
 
-This section contains examples of how to process NMR datasets.
+.. warning::
+
+    These examples require the optional ``spectrochempy-nmr`` plugin.
+
+    Install it with:
+
+    .. code-block:: bash
+
+        pip install spectrochempy[nmr]
+
+    See :ref:`plugins` for more information.

--- a/tests/test_docs/test_py_in_docs.py
+++ b/tests/test_docs/test_py_in_docs.py
@@ -48,12 +48,22 @@ scripts = [
 ]
 
 
-def _nmr_plugin_available():
-    return find_spec("spectrochempy_nmr") is not None
+def _plugin_available(name):
+    return find_spec(name) is not None
 
 
-def _requires_nmr_plugin(path):
-    return "read_topspin" in path.read_text(encoding="utf8")
+def _plugin_required_by(path):
+    """Determine which (if any) optional plugin an example or script needs."""
+    text = path.read_text(encoding="utf8")
+    markers = {
+        "spectrochempy_nmr": "read_topspin",
+        "spectrochempy_iris": "spectrochempy_iris",
+        "spectrochempy_cantera": "spectrochempy_cantera",
+    }
+    for plugin_name, marker in markers.items():
+        if marker in text:
+            return plugin_name
+    return None
 
 
 def nbsphinx_script_run(path):
@@ -96,8 +106,9 @@ def test_nbsphinx_script_(script):
     name = script.name
     if name in []:
         return
-    if _requires_nmr_plugin(script) and not _nmr_plugin_available():
-        pytest.skip("requires the optional spectrochempy-nmr plugin")
+    required = _plugin_required_by(script)
+    if required and not _plugin_available(required):
+        pytest.skip(f"requires the optional {required} plugin")
 
     e, message, err = nbsphinx_script_run(script)
     # this give unicoderror on workflow with window
@@ -119,8 +130,9 @@ def test_nbsphinx_script_(script):
 )
 def test_examples(example):
     """Test example files."""
-    if _requires_nmr_plugin(example) and not _nmr_plugin_available():
-        pytest.skip("requires the optional spectrochempy-nmr plugin")
+    required = _plugin_required_by(example)
+    if required and not _plugin_available(required):
+        pytest.skip(f"requires the optional {required} plugin")
 
     scp.NO_DISPLAY = True
     mpl.use("agg", force=True)

--- a/tests/test_docs/test_py_in_docs.py
+++ b/tests/test_docs/test_py_in_docs.py
@@ -9,6 +9,7 @@ This test is skipped by default as it's too slow and redundant with docs buildin
 To run it explicitly, use: pytest tests/test_docs/test_py_in_docs.py --override-skip.
 """
 
+import ast
 import subprocess
 import sys
 from importlib.util import find_spec
@@ -55,6 +56,24 @@ def _plugin_available(name):
 def _plugin_required_by(path):
     """Determine which (if any) optional plugin an example or script needs."""
     text = path.read_text(encoding="utf8")
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        tree = None
+    if tree is not None:
+        for node in tree.body:
+            if not isinstance(node, ast.Assign):
+                continue
+            if not any(
+                isinstance(target, ast.Name) and target.id == "OPTIONAL_PLUGIN"
+                for target in node.targets
+            ):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(
+                node.value.value, str
+            ):
+                return node.value.value
+
     markers = {
         "spectrochempy_nmr": "read_topspin",
         "spectrochempy_iris": "spectrochempy_iris",
@@ -82,7 +101,9 @@ def nbsphinx_script_run(path):
         pipe = subprocess.Popen(  # noqa: S603
             [sys.executable, str(path), "--nodisplay"],
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             encoding="utf8",
+            env=env,
         )
         (so, serr) = pipe.communicate()
     except Exception as e:


### PR DESCRIPTION
## Changements

### Documentation
- Nouvelle page `userguide/plugins.rst` expliquant le système de plugins : installation (`pip install spectrochempy[nmr]`), utilisation, plugins disponibles (NMR, IRIS, Cantera), lien vers le devguide.
- Ajoutée à la toctree du userguide.

### Exemples plugins (3 nouveaux)
- **NMR** : `plugins/nmr/plot_nmr_read_topspin.py` — lecture TopSpin avec guard d'import
- **IRIS** : `plugins/iris/plot_iris_intro.py` — analyse 2D-IRIS avec import conditionnel
- **Cantera** : `plugins/cantera/plot_cantera_pfr.py` — accès à `scp.PFR` (API Cantera 3.2+ non compatible pour la construction complète)
- Nouveau répertoire `examples/plugins/` intégré à la sphinx-gallery (`docs/conf.py`)

### Garde-fous
- `test_py_in_docs.py` : détection générique des dépendances plugins (NMR/IRIS/Cantera) → skip si plugin absent
- `processing/nmr/readme.rst` : notice de dépendance NMR plugin
- Les nouveaux exemples ont un `find_spec()` guard avec message d'installation clair

### Tests
```
ruff check → All checks passed!
pytest tests/test_plugins/ tests/test_analysis/test_kinetic/test_kineticutilities.py → 198 passed
```

### Points restants
- PFR : API constructeur incompatible Cantera 3.2 — l'exemple reste minimal
- Construction complète de la doc sphinx-gallery non testée ici