### PR TITLE
Standardize plugin namespace and deprecation policy

### DIFF
--- a/docs/sources/userguide/plugins.rst
+++ b/docs/sources/userguide/plugins.rst
@@ -45,7 +45,7 @@ SpectroChemPy.
     They are loaded lazily, only when you actually call a plugin function.
     This keeps startup fast and avoids unnecessary imports.
 
-Plugin functions are available from package-level namespaces,
+Plugin functions and classes are available from package-level namespaces,
 and dataset-bound operations are available from dataset accessors:
 
 .. code-block:: python
@@ -58,12 +58,21 @@ and dataset-bound operations are available from dataset accessors:
     # Cantera plugin: access the PFR simulation callable
     PFR = scp.cantera.PFR
 
+    # IRIS plugin: use the modern namespaced analysis class
+    iris = scp.iris.IRIS()
+
     # IRIS plugin: build an IRIS kernel from an existing dataset
     kernel = dataset.iris.kernel_matrix(kernel_type="langmuir")
 
 For backward compatibility, some former top-level APIs remain available as thin
 aliases. For example, ``scp.read_topspin(...)`` delegates to
 ``scp.nmr.read_topspin(...)`` when the NMR plugin is installed.
+
+Some official plugins may also provide explicit root-level compatibility aliases.
+For example, ``scp.IRIS`` delegates to ``scp.iris.IRIS`` and emits a
+``FutureWarning`` when accessed. New code and examples should prefer the
+namespaced API, such as ``scp.iris.IRIS``. Compatibility aliases are intentionally
+limited and may disappear in a future release.
 
 If a plugin is not installed, the corresponding official optional feature gives
 a clear installation hint. For example:

--- a/plugins/spectrochempy-cantera/src/spectrochempy_cantera/__init__.py
+++ b/plugins/spectrochempy-cantera/src/spectrochempy_cantera/__init__.py
@@ -34,6 +34,13 @@ class CanteraPlugin(SpectroChemPyPlugin):
         PluginCapability.SIMULATION,
     ]
     requires = ["cantera"]
+    root_exports = {
+        "PFR": {
+            "target": "PFR",
+            "deprecated": True,
+            "replacement": "scp.cantera.PFR",
+        },
+    }
 
     # ------------------------------------------------------------------
     # Declarative hooks

--- a/plugins/spectrochempy-cantera/tests/test_cantera.py
+++ b/plugins/spectrochempy-cantera/tests/test_cantera.py
@@ -154,6 +154,33 @@ def test_package_namespace_exposes_pfr():
     assert callable(pfr_entry)
 
 
+def test_pfr_root_compatibility_alias_warns_once():
+    """scp.PFR works as a compatibility alias and emits FutureWarning once."""
+    if not HAS_CANTERA:
+        pytest.skip("cantera not installed")
+
+    import warnings
+
+    import spectrochempy as scp  # noqa: PLC0415
+
+    if not scp.plugin_manager.has_plugin("cantera"):
+        scp.plugin_manager.register(CanteraPlugin())
+
+    scp._EMITTED_PLUGIN_ROOT_WARNINGS.discard("PFR")
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", FutureWarning)
+        pfr1 = scp.PFR
+        pfr2 = scp.PFR
+
+    assert callable(pfr1)
+    assert pfr1 is pfr2
+    assert len(captured) == 1
+    assert captured[0].category is FutureWarning
+    assert "scp.PFR is deprecated" in str(captured[0].message)
+    assert "scp.cantera.PFR" in str(captured[0].message)
+
+
 def test_cantera_does_not_register_dataset_accessor():
     """Cantera has no dataset accessor."""
     import spectrochempy as scp  # noqa: PLC0415

--- a/plugins/spectrochempy-cantera/tests/test_cantera.py
+++ b/plugins/spectrochempy-cantera/tests/test_cantera.py
@@ -155,7 +155,7 @@ def test_package_namespace_exposes_pfr():
 
 
 def test_pfr_root_compatibility_alias_warns_once():
-    """scp.PFR works as a compatibility alias and emits FutureWarning once."""
+    """scp.PFR works as a compatibility alias and emits DeprecationWarning once."""
     if not HAS_CANTERA:
         pytest.skip("cantera not installed")
 
@@ -169,15 +169,16 @@ def test_pfr_root_compatibility_alias_warns_once():
     scp._EMITTED_PLUGIN_ROOT_WARNINGS.discard("PFR")
 
     with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always", FutureWarning)
+        warnings.simplefilter("always", DeprecationWarning)
         pfr1 = scp.PFR
         pfr2 = scp.PFR
 
     assert callable(pfr1)
     assert pfr1 is pfr2
     assert len(captured) == 1
-    assert captured[0].category is FutureWarning
-    assert "scp.PFR is deprecated" in str(captured[0].message)
+    assert captured[0].category is DeprecationWarning
+    assert "scp.PFR is deprecated since SpectroChemPy 0.9.0" in str(captured[0].message)
+    assert "will be removed in 0.10.0" in str(captured[0].message)
     assert "scp.cantera.PFR" in str(captured[0].message)
 
 

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
@@ -93,7 +93,27 @@ class IrisPlugin(SpectroChemPyPlugin):
             "target": "IRIS",
             "deprecated": True,
             "replacement": "scp.iris.IRIS",
-        }
+        },
+        "IrisKernel": {
+            "target": "IrisKernel",
+            "deprecated": True,
+            "replacement": "scp.iris.IrisKernel",
+        },
+        "batch_iris": {
+            "target": "batch_iris",
+            "deprecated": True,
+            "replacement": "scp.iris.batch_iris",
+        },
+        "compare_kernels": {
+            "target": "compare_kernels",
+            "deprecated": True,
+            "replacement": "scp.iris.compare_kernels",
+        },
+        "iris_report": {
+            "target": "iris_report",
+            "deprecated": True,
+            "replacement": "scp.iris.iris_report",
+        },
     }
 
     def register_analyses(self) -> list[dict]:

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
@@ -88,6 +88,13 @@ class IrisPlugin(SpectroChemPyPlugin):
         PluginCapability.VISUALIZER,
         PluginCapability.ACCESSOR,
     ]
+    root_exports = {
+        "IRIS": {
+            "target": "IRIS",
+            "deprecated": True,
+            "replacement": "scp.iris.IRIS",
+        }
+    }
 
     def register_analyses(self) -> list[dict]:
         """Declare analysis workflows extending core IRIS."""

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from spectrochempy_iris import IrisPlugin
 from spectrochempy_iris import batch_iris_analysis
 from spectrochempy_iris import compare_kernel_models
@@ -131,6 +132,47 @@ def test_iris_namespace_does_not_shadow_load_iris(monkeypatch):
     assert callable(scp.load_iris)
     assert scp.iris.batch_iris is batch_iris_analysis
     assert not hasattr(scp.iris, "load_iris")
+
+
+def test_iris_namespace_exposes_lazy_module_classes(monkeypatch):
+    """scp.iris delegates unknown attributes to the plugin module lazily."""
+    import sys
+
+    import spectrochempy as scp
+
+    harness = PluginTestHarness()
+    harness.register(IrisPlugin())
+    monkeypatch.setattr(scp, "plugin_manager", harness.manager)
+    monkeypatch.setattr(scp, "registry", harness.registry)
+    monkeypatch.delitem(scp.__dict__, "iris", raising=False)
+    monkeypatch.delitem(sys.modules, "spectrochempy_iris._core", raising=False)
+
+    namespace = scp.iris
+    assert "spectrochempy_iris._core" not in sys.modules
+    assert "IRIS" in dir(namespace)
+    assert "IrisKernel" in dir(namespace)
+    assert "spectrochempy_iris._core" not in sys.modules
+
+    iris_class = namespace.IRIS
+    assert iris_class.__name__ == "IRIS"
+    assert "spectrochempy_iris._core" in sys.modules
+
+    kernel_class = namespace.IrisKernel
+    assert kernel_class.__name__ == "IrisKernel"
+
+
+def test_iris_classes_are_not_exposed_at_scp_root(monkeypatch):
+    """Plugin module attributes stay under scp.iris, not at the scp root."""
+    import spectrochempy as scp
+
+    harness = PluginTestHarness()
+    harness.register(IrisPlugin())
+    monkeypatch.setattr(scp, "plugin_manager", harness.manager)
+    monkeypatch.setattr(scp, "registry", harness.registry)
+    monkeypatch.delitem(scp.__dict__, "IRIS", raising=False)
+
+    with pytest.raises(AttributeError):
+        _ = scp.IRIS
 
 
 # ------------------------------------------------------------------

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -198,7 +198,6 @@ def test_iris_root_compatibility_alias_warns_once(monkeypatch):
 
     assert "spectrochempy_iris._core" not in sys.modules
     with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("default", FutureWarning)
         iris_class = scp.IRIS
         second_access = scp.IRIS
 

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 from spectrochempy_iris import IrisPlugin
@@ -153,16 +155,37 @@ def test_iris_namespace_exposes_lazy_module_classes(monkeypatch):
     assert "IrisKernel" in dir(namespace)
     assert "spectrochempy_iris._core" not in sys.modules
 
-    iris_class = namespace.IRIS
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", FutureWarning)
+        iris_class = namespace.IRIS
     assert iris_class.__name__ == "IRIS"
+    assert captured == []
     assert "spectrochempy_iris._core" in sys.modules
 
     kernel_class = namespace.IrisKernel
     assert kernel_class.__name__ == "IrisKernel"
 
 
-def test_iris_classes_are_not_exposed_at_scp_root(monkeypatch):
-    """Plugin module attributes stay under scp.iris, not at the scp root."""
+def test_from_spectrochempy_import_iris_supports_lazy_classes(monkeypatch):
+    """Importing iris from spectrochempy returns the same lazy namespace API."""
+    import spectrochempy as scp
+
+    harness = PluginTestHarness()
+    harness.register(IrisPlugin())
+    monkeypatch.setattr(scp, "plugin_manager", harness.manager)
+    monkeypatch.setattr(scp, "registry", harness.registry)
+    monkeypatch.delitem(scp.__dict__, "iris", raising=False)
+
+    from spectrochempy import iris
+
+    assert iris.IRIS.__name__ == "IRIS"
+    assert iris.IrisKernel.__name__ == "IrisKernel"
+
+
+def test_iris_root_compatibility_alias_warns_once(monkeypatch):
+    """scp.IRIS works as an explicit compatibility alias and warns once."""
+    import sys
+
     import spectrochempy as scp
 
     harness = PluginTestHarness()
@@ -170,9 +193,36 @@ def test_iris_classes_are_not_exposed_at_scp_root(monkeypatch):
     monkeypatch.setattr(scp, "plugin_manager", harness.manager)
     monkeypatch.setattr(scp, "registry", harness.registry)
     monkeypatch.delitem(scp.__dict__, "IRIS", raising=False)
+    monkeypatch.delitem(sys.modules, "spectrochempy_iris._core", raising=False)
+    scp._EMITTED_PLUGIN_ROOT_WARNINGS.clear()
+
+    assert "spectrochempy_iris._core" not in sys.modules
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("default", FutureWarning)
+        iris_class = scp.IRIS
+        second_access = scp.IRIS
+
+    assert iris_class.__name__ == "IRIS"
+    assert second_access is iris_class
+    assert "spectrochempy_iris._core" in sys.modules
+    assert len(captured) == 1
+    assert captured[0].category is FutureWarning
+    assert "scp.IRIS is deprecated" in str(captured[0].message)
+    assert "scp.iris.IRIS" in str(captured[0].message)
+
+
+def test_iris_kernel_is_not_exposed_at_scp_root(monkeypatch):
+    """Only explicit official compatibility aliases are exposed at the root."""
+    import spectrochempy as scp
+
+    harness = PluginTestHarness()
+    harness.register(IrisPlugin())
+    monkeypatch.setattr(scp, "plugin_manager", harness.manager)
+    monkeypatch.setattr(scp, "registry", harness.registry)
+    monkeypatch.delitem(scp.__dict__, "IrisKernel", raising=False)
 
     with pytest.raises(AttributeError):
-        _ = scp.IRIS
+        _ = scp.IrisKernel
 
 
 # ------------------------------------------------------------------

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -182,8 +182,47 @@ def test_from_spectrochempy_import_iris_supports_lazy_classes(monkeypatch):
     assert iris.IrisKernel.__name__ == "IrisKernel"
 
 
-def test_iris_root_compatibility_alias_warns_once(monkeypatch):
-    """scp.IRIS works as an explicit compatibility alias and warns once."""
+# ------------------------------------------------------------------
+# Root-level compatibility alias tests
+# ------------------------------------------------------------------
+
+
+_IRIS_ROOT_ALIASES = [
+    ("IRIS", "spectrochempy_iris._core"),
+    ("IrisKernel", "spectrochempy_iris._core"),
+    ("batch_iris", None),
+    ("compare_kernels", None),
+    ("iris_report", None),
+]
+
+
+def test_iris_namespaced_api_no_warning(monkeypatch):
+    """scp.iris.* public objects are accessible without FutureWarning."""
+    import spectrochempy as scp
+
+    harness = PluginTestHarness()
+    harness.register(IrisPlugin())
+    monkeypatch.setattr(scp, "plugin_manager", harness.manager)
+    monkeypatch.setattr(scp, "registry", harness.registry)
+    monkeypatch.delitem(scp.__dict__, "iris", raising=False)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", FutureWarning)
+        assert scp.iris.IRIS.__name__ == "IRIS"
+        assert scp.iris.IrisKernel.__name__ == "IrisKernel"
+        assert scp.iris.batch_iris is batch_iris_analysis
+        assert scp.iris.compare_kernels is compare_kernel_models
+        assert scp.iris.iris_report is iris_analysis_report
+
+    future_warnings = [w for w in captured if issubclass(w.category, FutureWarning)]
+    assert (
+        future_warnings == []
+    ), f"Expected no FutureWarning from namespaced API, got: {future_warnings}"
+
+
+@pytest.mark.parametrize("alias,heavy_module", _IRIS_ROOT_ALIASES)
+def test_iris_root_alias_warns_once(monkeypatch, alias, heavy_module):
+    """scp.<alias> works as a compatibility alias and emits FutureWarning once."""
     import sys
 
     import spectrochempy as scp
@@ -192,36 +231,27 @@ def test_iris_root_compatibility_alias_warns_once(monkeypatch):
     harness.register(IrisPlugin())
     monkeypatch.setattr(scp, "plugin_manager", harness.manager)
     monkeypatch.setattr(scp, "registry", harness.registry)
-    monkeypatch.delitem(scp.__dict__, "IRIS", raising=False)
-    monkeypatch.delitem(sys.modules, "spectrochempy_iris._core", raising=False)
-    scp._EMITTED_PLUGIN_ROOT_WARNINGS.clear()
+    monkeypatch.delitem(scp.__dict__, alias, raising=False)
+    if heavy_module:
+        monkeypatch.delitem(sys.modules, heavy_module, raising=False)
+    scp._EMITTED_PLUGIN_ROOT_WARNINGS.discard(alias)
 
-    assert "spectrochempy_iris._core" not in sys.modules
+    if heavy_module:
+        assert heavy_module not in sys.modules
+
     with warnings.catch_warnings(record=True) as captured:
-        iris_class = scp.IRIS
-        second_access = scp.IRIS
+        warnings.simplefilter("always", FutureWarning)
+        val1 = getattr(scp, alias)
+        val2 = getattr(scp, alias)
 
-    assert iris_class.__name__ == "IRIS"
-    assert second_access is iris_class
-    assert "spectrochempy_iris._core" in sys.modules
+    assert val1 is val2
     assert len(captured) == 1
     assert captured[0].category is FutureWarning
-    assert "scp.IRIS is deprecated" in str(captured[0].message)
-    assert "scp.iris.IRIS" in str(captured[0].message)
+    assert f"scp.{alias} is deprecated" in str(captured[0].message)
+    assert f"scp.iris.{alias}" in str(captured[0].message)
 
-
-def test_iris_kernel_is_not_exposed_at_scp_root(monkeypatch):
-    """Only explicit official compatibility aliases are exposed at the root."""
-    import spectrochempy as scp
-
-    harness = PluginTestHarness()
-    harness.register(IrisPlugin())
-    monkeypatch.setattr(scp, "plugin_manager", harness.manager)
-    monkeypatch.setattr(scp, "registry", harness.registry)
-    monkeypatch.delitem(scp.__dict__, "IrisKernel", raising=False)
-
-    with pytest.raises(AttributeError):
-        _ = scp.IrisKernel
+    if heavy_module:
+        assert heavy_module in sys.modules
 
 
 # ------------------------------------------------------------------

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -156,7 +156,7 @@ def test_iris_namespace_exposes_lazy_module_classes(monkeypatch):
     assert "spectrochempy_iris._core" not in sys.modules
 
     with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always", FutureWarning)
+        warnings.simplefilter("always", DeprecationWarning)
         iris_class = namespace.IRIS
     assert iris_class.__name__ == "IRIS"
     assert captured == []
@@ -197,7 +197,7 @@ _IRIS_ROOT_ALIASES = [
 
 
 def test_iris_namespaced_api_no_warning(monkeypatch):
-    """scp.iris.* public objects are accessible without FutureWarning."""
+    """scp.iris.* public objects are accessible without DeprecationWarning."""
     import spectrochempy as scp
 
     harness = PluginTestHarness()
@@ -207,22 +207,24 @@ def test_iris_namespaced_api_no_warning(monkeypatch):
     monkeypatch.delitem(scp.__dict__, "iris", raising=False)
 
     with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always", FutureWarning)
+        warnings.simplefilter("always", DeprecationWarning)
         assert scp.iris.IRIS.__name__ == "IRIS"
         assert scp.iris.IrisKernel.__name__ == "IrisKernel"
         assert scp.iris.batch_iris is batch_iris_analysis
         assert scp.iris.compare_kernels is compare_kernel_models
         assert scp.iris.iris_report is iris_analysis_report
 
-    future_warnings = [w for w in captured if issubclass(w.category, FutureWarning)]
+    deprecation_warnings = [
+        w for w in captured if issubclass(w.category, DeprecationWarning)
+    ]
     assert (
-        future_warnings == []
-    ), f"Expected no FutureWarning from namespaced API, got: {future_warnings}"
+        deprecation_warnings == []
+    ), f"Expected no DeprecationWarning from namespaced API, got: {deprecation_warnings}"
 
 
 @pytest.mark.parametrize("alias,heavy_module", _IRIS_ROOT_ALIASES)
 def test_iris_root_alias_warns_once(monkeypatch, alias, heavy_module):
-    """scp.<alias> works as a compatibility alias and emits FutureWarning once."""
+    """scp.<alias> works as a compatibility alias and emits DeprecationWarning once."""
     import sys
 
     import spectrochempy as scp
@@ -240,29 +242,27 @@ def test_iris_root_alias_warns_once(monkeypatch, alias, heavy_module):
         assert heavy_module not in sys.modules
 
     with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always", FutureWarning)
+        warnings.simplefilter("always", DeprecationWarning)
         val1 = getattr(scp, alias)
         val2 = getattr(scp, alias)
 
     assert val1 is val2
     assert len(captured) == 1
-    assert captured[0].category is FutureWarning
-    assert f"scp.{alias} is deprecated" in str(captured[0].message)
+    assert captured[0].category is DeprecationWarning
+    assert f"scp.{alias} is deprecated since SpectroChemPy 0.9.0" in str(
+        captured[0].message
+    )
+    assert "will be removed in 0.10.0" in str(captured[0].message)
     assert f"scp.iris.{alias}" in str(captured[0].message)
 
     if heavy_module:
         assert heavy_module in sys.modules
 
 
-# ------------------------------------------------------------------
-# IRIS analysis function tests (use synthetic data)
-# ------------------------------------------------------------------
-
-
 def test_iris_analysis_report():
     """iris_analysis_report produces expected summary."""
-    from spectrochempy_iris import IRIS
-    from spectrochempy_iris import IrisKernel
+    from spectrochempy_iris import IRIS  # noqa: PLC0415
+    from spectrochempy_iris import IrisKernel  # noqa: PLC0415
 
     ds = _make_test_dataset()
     kernel = IrisKernel(ds, "langmuir", q=[-8, 1, 10])

--- a/plugins/spectrochempy-nmr/tests/test_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_plugin.py
@@ -175,21 +175,23 @@ def test_core_stub_is_actionable():
     assert "pip install spectrochempy[nmr]" in message
 
 
-def test_read_topspin_no_future_warning():
-    """scp.read_topspin and scp.nmr.read_topspin do not emit FutureWarning."""
+def test_read_topspin_no_deprecation_warning():
+    """scp.read_topspin and scp.nmr.read_topspin do not emit DeprecationWarning."""
     _require_reader_dependencies()
 
     with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always", FutureWarning)
+        warnings.simplefilter("always", DeprecationWarning)
         rt = scp.read_topspin
         rt_ns = scp.nmr.read_topspin
 
     assert callable(rt)
     assert rt is rt_ns
-    future_warnings = [w for w in captured if issubclass(w.category, FutureWarning)]
+    deprecation_warnings = [
+        w for w in captured if issubclass(w.category, DeprecationWarning)
+    ]
     assert (
-        future_warnings == []
-    ), f"Expected no FutureWarning from read_topspin, got: {future_warnings}"
+        deprecation_warnings == []
+    ), f"Expected no DeprecationWarning from read_topspin, got: {deprecation_warnings}"
 
 
 def test_nmr_reader_is_not_dataset_accessor_namespace(monkeypatch):

--- a/plugins/spectrochempy-nmr/tests/test_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_plugin.py
@@ -2,6 +2,8 @@
 
 """Tests for spectrochempy-nmr plugin registration and lifecycle."""
 
+import warnings
+
 import pytest
 from spectrochempy_nmr import NMRPlugin
 
@@ -171,6 +173,23 @@ def test_core_stub_is_actionable():
 
     assert "spectrochempy-nmr" in message
     assert "pip install spectrochempy[nmr]" in message
+
+
+def test_read_topspin_no_future_warning():
+    """scp.read_topspin and scp.nmr.read_topspin do not emit FutureWarning."""
+    _require_reader_dependencies()
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", FutureWarning)
+        rt = scp.read_topspin
+        rt_ns = scp.nmr.read_topspin
+
+    assert callable(rt)
+    assert rt is rt_ns
+    future_warnings = [w for w in captured if issubclass(w.category, FutureWarning)]
+    assert (
+        future_warnings == []
+    ), f"Expected no FutureWarning from read_topspin, got: {future_warnings}"
 
 
 def test_nmr_reader_is_not_dataset_accessor_namespace(monkeypatch):

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -194,6 +194,13 @@ def __getattr__(name):
     if has_namespace(registry, name):
         return PluginNamespace(name, plugin_manager, registry)
 
+    # Check root-level compatibility aliases before extensions so that
+    # deprecated root exports emit FutureWarning (the namespaced API
+    # accessed via PluginNamespace does not warn).
+    root_export = _plugin_root_export(name, PluginNamespace)
+    if root_export is not None:
+        return root_export
+
     # Check plugin readers first (e.g., read_topspin from external plugins)
     if name.startswith("read_"):
         reader_name = name[len("read_") :]
@@ -208,10 +215,6 @@ def __getattr__(name):
         extension_info = registry.extensions.get(category, name)
         if extension_info:
             return extension_info["obj"]
-
-    root_export = _plugin_root_export(name, PluginNamespace)
-    if root_export is not None:
-        return root_export
 
     if name in _LAZY_IMPORTS:
         module_path = _LAZY_IMPORTS[name]

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -51,6 +51,8 @@ This module serves as the main entry point for the SpectroChemPy package, provid
 - Dynamic attribute access to NDDataset methods
 """
 
+import warnings
+
 import lazy_loader as _lazy_loader
 
 # --------------------------------------------------------------------------------------
@@ -80,6 +82,8 @@ from spectrochempy.plugins.features import plugin_reader_missing_stub
 from spectrochempy.plugins.manager import plugin_manager
 from spectrochempy.plugins.registry import registry
 
+_EMITTED_PLUGIN_ROOT_WARNINGS: set[str] = set()
+
 # --------------------------------------------------------------------------------------
 # Plot profile API (lazy loaded)
 # --------------------------------------------------------------------------------------
@@ -101,6 +105,7 @@ def __dir__():
     # without triggering entry-point scanning (dir() should be side-effect free).
     names.update(_reader_names())
     names.update(_extension_names())
+    names.update(_root_export_names())
     return sorted(names)
 
 
@@ -118,6 +123,51 @@ def _extension_names():
         for entry_name in registry.extensions.list_category(category):
             names.add(entry_name)
     return names
+
+
+def _root_export_names():
+    names = set()
+    for plugin in registry.available_plugins.values():
+        names.update(getattr(plugin, "root_exports", {}))
+    return names
+
+
+def _normalise_root_export(plugin, alias, export):
+    if isinstance(export, str):
+        export = {"target": export}
+    if not isinstance(export, dict):
+        return None
+    target = export.get("target", alias)
+    namespace = export.get("namespace", getattr(plugin, "name", None))
+    if not target or not namespace:
+        return None
+    return {
+        "deprecated": bool(export.get("deprecated", False)),
+        "namespace": namespace,
+        "replacement": export.get("replacement", f"scp.{namespace}.{target}"),
+        "target": target,
+    }
+
+
+def _plugin_root_export(name, namespace_cls):
+    for plugin in plugin_manager.list_plugins():
+        root_exports = getattr(plugin, "root_exports", {})
+        if name not in root_exports:
+            continue
+        export = _normalise_root_export(plugin, name, root_exports[name])
+        if export is None:
+            continue
+        if export["deprecated"] and name not in _EMITTED_PLUGIN_ROOT_WARNINGS:
+            warnings.warn(
+                f"scp.{name} is deprecated and may be removed in a future release. "
+                f"Use {export['replacement']} instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            _EMITTED_PLUGIN_ROOT_WARNINGS.add(name)
+        namespace = namespace_cls(export["namespace"], plugin_manager, registry)
+        return getattr(namespace, export["target"])
+    return None
 
 
 # Override __getattr__ to handle both submodules and direct class access
@@ -159,15 +209,14 @@ def __getattr__(name):
         if extension_info:
             return extension_info["obj"]
 
+    root_export = _plugin_root_export(name, PluginNamespace)
+    if root_export is not None:
+        return root_export
+
     if name in _LAZY_IMPORTS:
         module_path = _LAZY_IMPORTS[name]
         module = __import__(module_path, fromlist=[name])
         return getattr(module, name)
-
-    # Check other plugin-provided attributes
-    for plugin in plugin_manager.list_plugins():
-        if hasattr(plugin, name):
-            return getattr(plugin, name)
 
     # Look also NDDataset attribute which can be used as API methods
     if name in _LAZY_DATASETS_IMPORTS:

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -159,9 +159,10 @@ def _plugin_root_export(name, namespace_cls):
             continue
         if export["deprecated"] and name not in _EMITTED_PLUGIN_ROOT_WARNINGS:
             warnings.warn(
-                f"scp.{name} is deprecated and may be removed in a future release. "
+                f"scp.{name} is deprecated since SpectroChemPy 0.9.0 "
+                f"and will be removed in 0.10.0. "
                 f"Use {export['replacement']} instead.",
-                FutureWarning,
+                DeprecationWarning,
                 stacklevel=3,
             )
             _EMITTED_PLUGIN_ROOT_WARNINGS.add(name)

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -231,7 +231,9 @@ def __getattr__(name):
         # Check if this is a known plugin namespace
         hint = plugin_namespace_install_hint(name)
         if hint:
-            raise AttributeError(hint) from err
+            from spectrochempy.plugins.deps import MissingPluginNamespaceError
+
+            raise MissingPluginNamespaceError(hint) from err
         raise AttributeError(
             f"module 'spectrochempy' has no attribute '{name}'"
         ) from err

--- a/src/spectrochempy/api/plugins/base.py
+++ b/src/spectrochempy/api/plugins/base.py
@@ -44,6 +44,14 @@ class SpectroChemPyPlugin:
     If any dependency cannot be imported, the plugin is marked as
     ``FAILED`` with a clear message and skipped.
     """
+    root_exports: dict[str, str | dict[str, Any]] = {}
+    """
+    Explicit root-level compatibility exports.
+
+    Modern plugin APIs should live under the plugin namespace
+    (for example ``scp.iris.IRIS``). Official plugins may use this
+    mapping for selected backward-compatible aliases such as ``scp.IRIS``.
+    """
 
     # ------------------------------------------------------------------
     # Registration API

--- a/src/spectrochempy/application/start.py
+++ b/src/spectrochempy/application/start.py
@@ -29,11 +29,6 @@ def set_warnings() -> None:
     warnings.filterwarnings(action="ignore", module="pykwalify")
     warnings.filterwarnings(action="ignore", module="matplotlib")
     warnings.filterwarnings(action="ignore", category=FutureWarning)
-    warnings.filterwarnings(
-        action="once",
-        category=FutureWarning,
-        message=r"^scp\..* is deprecated.*",
-    )
 
     # from pint import UnitStrippedWarning
 

--- a/src/spectrochempy/application/start.py
+++ b/src/spectrochempy/application/start.py
@@ -29,6 +29,11 @@ def set_warnings() -> None:
     warnings.filterwarnings(action="ignore", module="pykwalify")
     warnings.filterwarnings(action="ignore", module="matplotlib")
     warnings.filterwarnings(action="ignore", category=FutureWarning)
+    warnings.filterwarnings(
+        action="once",
+        category=FutureWarning,
+        message=r"^scp\..* is deprecated.*",
+    )
 
     # from pint import UnitStrippedWarning
 

--- a/src/spectrochempy/examples/plugins/iris/plot_iris_intro.py
+++ b/src/spectrochempy/examples/plugins/iris/plot_iris_intro.py
@@ -27,10 +27,7 @@ if find_spec(OPTIONAL_PLUGIN) is None:
 else:
     # %%
     # The IRIS plugin provides package-level workflows under ``scp.iris`` and
-    # dataset-bound helpers under ``dataset.iris``. The classes remain available
-    # from the plugin package for advanced workflows.
-
-    from spectrochempy_iris import IRIS
+    # dataset-bound helpers under ``dataset.iris``.
 
     # Load CO adsorption data
     ds = scp.read_omnic("irdata/CO@Mo_Al2O3.SPG")[:, 2250.0:1950.0]
@@ -65,7 +62,7 @@ else:
     # Build the IRIS kernel from the dataset accessor, then run the analysis:
 
     K = ds.iris.kernel_matrix(kernel_type="langmuir", q=[-7, -1, 50])
-    iris = IRIS(reg_par=[-10, 1, 12])
+    iris = scp.iris.IRIS(reg_par=[-10, 1, 12])
     iris.fit(ds, K)
 
     _ = iris.f[-7].plot_contour(colorbar=True)

--- a/src/spectrochempy/plugins/deps.py
+++ b/src/spectrochempy/plugins/deps.py
@@ -30,6 +30,20 @@ class MissingPluginError(ImportError):
         return [f"{type(self).__name__}: {self}\n"]
 
 
+class MissingPluginNamespaceError(ImportError):
+    """
+    Error raised for missing official plugin namespaces.
+
+    Using an ``ImportError`` allows ``from spectrochempy import iris`` to
+    surface the actionable installation hint instead of Python's generic
+    ``cannot import name`` message.
+    """
+
+    def _render_traceback_(self) -> list[str]:
+        """Return a compact IPython/Jupyter rendering without the full traceback."""
+        return [f"{type(self).__name__}: {self}\n"]
+
+
 class PluginVersionError(RuntimeError):
     def __init__(self, plugin_name: str, required: str, found: str) -> None:
         super().__init__(

--- a/src/spectrochempy/plugins/features.py
+++ b/src/spectrochempy/plugins/features.py
@@ -22,6 +22,7 @@ KNOWN_PLUGIN_READERS = {
 KNOWN_PLUGIN_NAMESPACES = {
     "nmr": ("spectrochempy-nmr", "spectrochempy[nmr]"),
     "iris": ("spectrochempy-iris", "spectrochempy[iris]"),
+    "cantera": ("spectrochempy-cantera", "spectrochempy[cantera]"),
 }
 
 

--- a/src/spectrochempy/plugins/namespace.py
+++ b/src/spectrochempy/plugins/namespace.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import importlib
 from collections.abc import Callable
+from types import ModuleType
 from typing import Any
 
 
@@ -36,6 +38,9 @@ class PluginNamespace:
         plugin = self._manager.get_plugin(self._namespace)
         if plugin is not None:
             names.update(name for name in dir(plugin) if not name.startswith("_"))
+            module = self._plugin_module(plugin)
+            if module is not None:
+                names.update(name for name in dir(module) if not name.startswith("_"))
         return sorted(names)
 
     def __getattr__(self, name: str) -> Any:
@@ -54,9 +59,24 @@ class PluginNamespace:
         if plugin is not None and hasattr(plugin, name):
             return getattr(plugin, name)
 
+        if plugin is not None:
+            module = self._plugin_module(plugin)
+            if module is not None:
+                try:
+                    return getattr(module, name)
+                except AttributeError:
+                    pass
+
         raise AttributeError(
             f"plugin namespace '{self._namespace}' has no attribute '{name}'"
         )
+
+    @staticmethod
+    def _plugin_module(plugin: Any) -> ModuleType | None:
+        module_name = getattr(plugin.__class__, "__module__", None)
+        if not module_name:
+            return None
+        return importlib.import_module(module_name)
 
     def _reader_names(self) -> set[str]:
         return {

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -20,6 +20,7 @@ import spectrochempy
 from spectrochempy.api.plugins import SpectroChemPyPlugin
 from spectrochempy.api.plugins.validation import check_plugin_contributions
 from spectrochempy.plugins.deps import MissingPluginError
+from spectrochempy.plugins.deps import MissingPluginNamespaceError
 from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 from spectrochempy.plugins.manager import PluginManager
 from spectrochempy.plugins.namespace import PluginNamespace
@@ -369,7 +370,9 @@ class TestMissingPlugin:
         monkeypatch.setattr(spectrochempy, "plugin_manager", pm)
         monkeypatch.setattr(spectrochempy, "registry", registry)
 
-        with pytest.raises(AttributeError, match="requires the optional plugin"):
+        with pytest.raises(
+            MissingPluginNamespaceError, match="requires the optional plugin"
+        ):
             _ = spectrochempy.nmr
 
     def test_missing_iris_namespace_clear_error(self, monkeypatch):
@@ -382,10 +385,42 @@ class TestMissingPlugin:
         monkeypatch.setattr(spectrochempy, "registry", registry)
         monkeypatch.delitem(spectrochempy.__dict__, "iris", raising=False)
 
-        with pytest.raises(AttributeError, match="spectrochempy-iris") as excinfo:
+        with pytest.raises(
+            MissingPluginNamespaceError, match="spectrochempy-iris"
+        ) as excinfo:
             _ = spectrochempy.iris
 
         assert "spectrochempy[iris]" in str(excinfo.value)
+
+    def test_missing_iris_from_import_clear_error(self):
+        """From spectrochempy import iris keeps the missing-plugin hint."""
+        code = """
+import importlib.metadata as im
+import spectrochempy as scp
+from spectrochempy.plugins.manager import PluginManager
+from spectrochempy.plugins.registry import PluginRegistry
+
+registry = PluginRegistry()
+scp.plugin_manager = PluginManager(registry=registry)
+scp.registry = registry
+im.entry_points = lambda group=None: []
+
+try:
+    from spectrochempy import iris
+except ImportError as exc:
+    message = str(exc)
+    assert "spectrochempy-iris" in message
+    assert "spectrochempy[iris]" in message
+else:
+    raise AssertionError("from spectrochempy import iris should fail")
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
 
     def test_unknown_attribute_standard_error(self):
         """Accessing a truly unknown attribute gives a standard error."""


### PR DESCRIPTION
## Summary

Hardening PR for the `plugins` integration branch. Implements consistent plugin compatibility alias behavior and aligns deprecation warnings with the SpectroChemPy core policy.

## Changes

### Compatibility aliases (root-level backward compatibility)

Official plugin public objects are now consistently exposed at root level with a **DeprecationWarning**:

| Root alias | Namespaced API | Deprecated since | Removed in |
|---|---|---|---|
| `scp.IRIS` | `scp.iris.IRIS` | 0.9.0 | 0.10.0 |
| `scp.IrisKernel` | `scp.iris.IrisKernel` | 0.9.0 | 0.10.0 |
| `scp.batch_iris` | `scp.iris.batch_iris` | 0.9.0 | 0.10.0 |
| `scp.compare_kernels` | `scp.iris.compare_kernels` | 0.9.0 | 0.10.0 |
| `scp.iris_report` | `scp.iris.iris_report` | 0.9.0 | 0.10.0 |
| `scp.PFR` | `scp.cantera.PFR` | 0.9.0 | 0.10.0 |

### Exception

`scp.read_topspin` remains accepted without any warning (historical reader-style alias).

### Deprecation alignment with core policy

- Changed from `FutureWarning` to `DeprecationWarning` (consistent with `spectrochempy.utils.decorators.deprecated()`)
- Warning messages now include: "deprecated since SpectroChemPy 0.9.0" and "will be removed in 0.10.0"
- Removed the obsolete `FutureWarning` filter for `scp.*` patterns in `start.py`
- The existing `DeprecationWarning` "once" filter already handles deduplication

### Plugin exports mechanism

- Official plugins now declare all their public root exports via an explicit `root_exports` dict on the plugin class
- Root-export lookup moved before extension-registry lookup so deprecated aliases emit warnings before being silently intercepted by the extension system
- Added `cantera` to `KNOWN_PLUGIN_NAMESPACES` for proper install hints

### Lazy imports preserved

- `import spectrochempy as scp` does not load heavy modules (`_core`, `_pfr`, `read_topspin`, `osqp`, `cantera`, `nmrglue`, `quaternion`)
- Namespace access (`scp.iris`, `scp.cantera`, `scp.nmr`) does not trigger heavy imports
- Only actual object access loads the implementation

### Tests updated

- Parametrized tests for all IRIS root aliases
- Tests verify DeprecationWarning is emitted exactly once per alias
- Tests verify namespaced APIs emit no warnings
- Cantera PFR root alias test added
- NMR read_topspin no-warning test added

## Verification

```
pytest tests/test_plugins -q          # 190 passed
pytest plugins/spectrochempy-iris/tests -q  # 27 passed, 1 skipped
pytest plugins/spectrochempy-cantera/tests -q # 13 passed, 1 skipped
pytest plugins/spectrochempy-nmr/tests -q    # 16 passed
pre-commit run --all-files            # all hooks pass
```