### PR TITLE
Complete IRIS plugin compatibility migration

### DIFF
--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "IRIS analysis extension for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.9",
+    "spectrochempy>=0.9,<0.10",
     "scipy",
     "osqp",
 ]

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
@@ -215,6 +215,25 @@ def batch_iris_analysis(
     q: list | None = None,
     reg_par: list | None = None,
 ) -> list[dict]:
+    """
+    Run IRIS analysis on multiple datasets or conditions.
+
+    Parameters
+    ----------
+    datasets : list[NDDataset] or dict[str, NDDataset]
+        Datasets to analyse. If a dict, keys are used as condition labels.
+    kernel_type : str, optional
+        Kernel type name or callable. Default is ``"langmuir"``.
+    q : list, optional
+        Internal variable parameter vector or ``[start, stop, num]``.
+    reg_par : list, optional
+        Regularisation parameters (``[min, max]`` or ``[start, stop, num]``).
+
+    Returns
+    -------
+    list[dict]
+        Each dict contains ``label``, ``iris``, ``f``, ``RSS``, ``SM``.
+    """
     from ._core import IRIS as _IRIS  # noqa: PLC0415
     from ._core import IrisKernel as _IrisKernel  # noqa: PLC0415
 
@@ -255,6 +274,25 @@ def compare_kernel_models(
     q: list | None = None,
     reg_par: list | None = None,
 ) -> list[dict]:
+    """
+    Compare multiple IRIS kernel models on the same dataset.
+
+    Parameters
+    ----------
+    dataset : NDDataset
+        Dataset to fit.
+    kernels : list[str], optional
+        Kernel names to compare. Defaults to ``["langmuir", "ca", "freundlich"]``.
+    q : list, optional
+        Internal variable parameter vector or ``[start, stop, num]``.
+    reg_par : list, optional
+        Regularisation parameters (``[min, max]`` or ``[start, stop, num]``).
+
+    Returns
+    -------
+    list[dict]
+        Each dict contains ``kernel``, ``iris``, ``RSS``, ``SM``, ``n_components``.
+    """
     from ._core import IRIS as _IRIS  # noqa: PLC0415
     from ._core import IrisKernel as _IrisKernel  # noqa: PLC0415
 
@@ -288,6 +326,20 @@ def compare_kernel_models(
 
 
 def iris_analysis_report(iris_object: object) -> dict:
+    """
+    Generate a summary report of an IRIS analysis.
+
+    Parameters
+    ----------
+    iris_object : IRIS
+        A fitted IRIS object.
+
+    Returns
+    -------
+    dict
+        Report containing ``kernel_type``, ``n_lambdas``, ``lambda_values``,
+        ``RSS_range``, ``SM_range``, ``q_range``, ``n_channels``.
+    """
     import numpy as np  # noqa: PLC0415
 
     return {
@@ -305,6 +357,21 @@ def plot_kernel_comparison(
     comparison_results: list[dict],
     **kwargs,
 ) -> tuple:
+    """
+    Plot a side-by-side comparison of multiple kernel fits.
+
+    Parameters
+    ----------
+    comparison_results : list[dict]
+        Output from :func:`compare_kernel_models`.
+    **kwargs
+        Additional keyword arguments (reserved for future use).
+
+    Returns
+    -------
+    tuple of (matplotlib.figure.Figure, numpy.ndarray of Axes)
+        The figure and axes array.
+    """
     import matplotlib.pyplot as plt  # noqa: PLC0415
     import numpy as np  # noqa: PLC0415
 
@@ -341,6 +408,21 @@ def plot_distribution_grid(
     batch_results: list[dict],
     **kwargs,
 ) -> tuple:
+    """
+    Plot a grid of distribution functions across conditions and lambdas.
+
+    Parameters
+    ----------
+    batch_results : list[dict]
+        Output from :func:`batch_iris_analysis`.
+    **kwargs
+        Additional keyword arguments (reserved for future use).
+
+    Returns
+    -------
+    tuple of (matplotlib.figure.Figure, numpy.ndarray of Axes)
+        The figure and axes array.
+    """
     import matplotlib.pyplot as plt  # noqa: PLC0415
 
     n_conditions = len(batch_results)

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -196,7 +196,7 @@ def __getattr__(name):
         return PluginNamespace(name, plugin_manager, registry)
 
     # Check root-level compatibility aliases before extensions so that
-    # deprecated root exports emit FutureWarning (the namespaced API
+    # deprecated root exports emit DeprecationWarning (the namespaced API
     # accessed via PluginNamespace does not warn).
     root_export = _plugin_root_export(name, PluginNamespace)
     if root_export is not None:

--- a/src/spectrochempy/analysis/decomposition/__init__.pyi
+++ b/src/spectrochempy/analysis/decomposition/__init__.pyi
@@ -10,6 +10,7 @@ __all__ = [
     "cp",
     "efa",
     "fast_ica",
+    "iris",
     "mcrals",
     "nmf",
     "pca",
@@ -20,6 +21,7 @@ __all__ = [
 from . import cp
 from . import efa
 from . import fast_ica
+from . import iris
 from . import mcrals
 from . import nmf
 from . import pca

--- a/src/spectrochempy/analysis/decomposition/iris.py
+++ b/src/spectrochempy/analysis/decomposition/iris.py
@@ -1,0 +1,54 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+Deprecated import path for IRIS analysis.
+
+IRIS and IrisKernel have been moved to the ``spectrochempy-iris`` plugin.
+Use ``scp.iris.IRIS`` and ``scp.iris.IrisKernel`` instead.
+
+.. deprecated:: 0.9.0
+    Importing from ``spectrochempy.analysis.decomposition.iris`` is deprecated.
+    Use the ``spectrochempy-iris`` plugin API (``scp.iris.*``).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+__all__ = ["IrisKernel", "IRIS"]
+__configurables__ = ["IRIS"]
+
+_IRIS_DEPRECATION_MSG = (
+    "Importing {name!r} from spectrochempy.analysis.decomposition.iris "
+    "is deprecated since SpectroChemPy 0.9.0 and will be removed in 0.10.0. "
+    "Use scp.iris.{name} instead."
+)
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        warnings.warn(
+            _IRIS_DEPRECATION_MSG.format(name=name),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        try:
+            from spectrochempy_iris import IRIS as _IRIS
+            from spectrochempy_iris import IrisKernel as _IrisKernel
+        except ImportError:
+            raise ImportError(
+                "The IRIS plugin (spectrochempy-iris) is required. "
+                "Install it with: pip install spectrochempy[iris]"
+            ) from None
+
+        return _IRIS if name == "IRIS" else _IrisKernel
+
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/src/spectrochempy/plotting/composite/__init__.pyi
+++ b/src/spectrochempy/plotting/composite/__init__.pyi
@@ -3,12 +3,14 @@
 # ruff: noqa
 
 __all__ = [
+    "iris",
     "plotbaseline",
     "plotmerit",
     "plotscore",
     "plotscree",
 ]
 
+from . import iris
 from . import plotbaseline
 from . import plotmerit
 from . import plotscore

--- a/src/spectrochempy/plotting/composite/iris.py
+++ b/src/spectrochempy/plotting/composite/iris.py
@@ -1,0 +1,55 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+Deprecated import path for IRIS plotting functions.
+
+IRIS plotting functions have been moved to the ``spectrochempy-iris`` plugin.
+Use ``scp.iris.plot_iris_lcurve``, ``scp.iris.plot_iris_distribution``, etc. instead.
+
+.. deprecated:: 0.9.0
+    Importing from ``spectrochempy.plotting.composite.iris`` is deprecated.
+    Use the ``spectrochempy-iris`` plugin API (``scp.iris.*``).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+__all__ = ["plot_iris_lcurve", "plot_iris_distribution", "plot_iris_merit"]
+
+_IRIS_DEPRECATION_MSG = (
+    "Importing {name!r} from spectrochempy.plotting.composite.iris "
+    "is deprecated since SpectroChemPy 0.9.0 and will be removed in 0.10.0. "
+    "Use scp.iris.{name} instead."
+)
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        warnings.warn(
+            _IRIS_DEPRECATION_MSG.format(name=name),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from spectrochempy_iris._plotting import (  # noqa: PLC0415
+            plot_iris_distribution as _f1,
+        )
+        from spectrochempy_iris._plotting import plot_iris_lcurve as _f2  # noqa: PLC0415
+        from spectrochempy_iris._plotting import plot_iris_merit as _f3  # noqa: PLC0415
+
+        _mapping = {
+            "plot_iris_distribution": _f1,
+            "plot_iris_lcurve": _f2,
+            "plot_iris_merit": _f3,
+        }
+        return _mapping[name]
+
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+def __dir__() -> list[str]:
+    return __all__


### PR DESCRIPTION
## Summary

Finalise and harden the IRIS plugin migration by restoring backward-compatible import paths, adding deprecation shims, fixing metadata, and improving documentation.

## Changes

### New files (deprecation shims)
- **src/spectrochempy/analysis/decomposition/iris.py** — shim that emits `DeprecationWarning` when importing `IRIS` or `IrisKernel` from the old core path, and lazily loads from `spectrochempy-iris` plugin.
- **src/spectrochempy/plotting/composite/iris.py** — shim for old plotting import path (`plot_iris_lcurve`, `plot_iris_distribution`, `plot_iris_merit`), same lazy-load deprecation pattern.

### Modified files
- **src/spectrochempy/analysis/decomposition/__init__.pyi** — restored `"iris"` to `__all__` so the module appears in `dir()` and is importable from the subpackage.
- **src/spectrochempy/plotting/composite/__init__.pyi** — same restoration for the IRIS plotting module.
- **src/spectrochempy/__init__.py** — fixed obsolete comment still referencing `FutureWarning`.
- **plugins/spectrochempy-iris/pyproject.toml** — updated dependency range to `spectrochempy>=0.9,<0.10`.
- **plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py** — added NumPy-style docstrings to all public functions (`batch_iris_analysis`, `compare_kernel_models`, `iris_analysis_report`, `plot_kernel_comparison`, `plot_distribution_grid`).

### Historical imports preserved with deprecation
| Old import | Replacement |
|---|---|
| `from spectrochempy.analysis.decomposition.iris import IRIS, IrisKernel` | `scp.iris.IRIS`, `scp.iris.IrisKernel` |
| `from spectrochempy.plotting.composite.iris import plot_iris_lcurve, plot_iris_distribution` | `scp.iris.plot_iris_lcurve`, `scp.iris.plot_iris_distribution` |

### Validation
- All 27 IRIS plugin tests pass
- All 8 compatibility-import smoke tests pass
- `pre-commit run --all-files` passes

### Related
Closes the remaining migration items from PR #921.