### PR TITLE
Update Cantera and NMR plugin version dependencies

### DIFF
--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Cantera-based thermodynamics and reactive chemistry for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.9",
+    "spectrochempy>=0.9,<0.10",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.9",
+    "spectrochempy>=0.9,<0.10",
     "numpy",
     "numpy-quaternion>=2024.0.7",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.


### PR DESCRIPTION
## Summary

Update version constraints for the Cantera and NMR plugins to align with the SpectroChemPy 0.9.0 release.

## Changes

- **plugins/spectrochempy-cantera/pyproject.toml**: `spectrochempy>=0.8,<0.9` → `spectrochempy>=0.9,<0.10`
- **plugins/spectrochempy-nmr/pyproject.toml**: `spectrochempy>=0.8,<0.9` → `spectrochempy>=0.9,<0.10`

## Validation

- All 13 Cantera tests pass
- All 16 NMR tests pass
- `pre-commit run --all-files` passes

## Context

Both plugins were already migrated to the plugin system — no historical import shims or additional changes are needed (Cantera's `PFR` old import path is already handled via delegation in `kineticutilities.py`, NMR's `read_topspin` old import path is already handled via the core stub).