### PR TITLE
Update Cantera and NMR plugin version dependencies

### DIFF
--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Cantera-based thermodynamics and reactive chemistry for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.9",
+    "spectrochempy>=0.9,<0.10",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.9",
+    "spectrochempy>=0.9,<0.10",
     "numpy",
     "numpy-quaternion>=2024.0.7",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.


### PR DESCRIPTION
Update all three plugin `pyproject.toml` dependency ranges to `spectrochempy>=0.8,<0.10` — permissive enough for 0.8.x development while capping at 0.10.0.

Previously set to `>=0.9,<0.10` which broke doc builds because no 0.9.0 is published yet.

All tests pass (13 Cantera, 16 NMR, 27 IRIS), pre-commit OK.