### PR TITLE
Cache reusable docs and test CI artifacts

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -165,6 +165,20 @@ jobs:
             echo "build_subdir=build/branch_preview" >> "$GITHUB_OUTPUT"
           fi
 
+      # ---------- restore reusable Sphinx/Sphinx-Gallery outputs for previews ----------
+      - name: Restore documentation build cache
+        if: steps.preview.outputs.is_preview == 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/branch_preview/~doctrees
+            docs/sources/gettingstarted/examples/gallery
+          key: >-
+            ${{ runner.os }}-docs-${{ steps.preview.outputs.preview_path }}-${{ hashFiles('pyproject.toml', 'docs/conf.py', 'docs/make.py', 'docs/sources/**/*.rst', 'docs/sources/**/*.py', 'docs/sources/**/*.ipynb', 'src/spectrochempy/examples/**/*.py', 'plugins/**/examples/**/*.py', 'plugins/**/examples/gallery.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-${{ steps.preview.outputs.preview_path }}-
+            ${{ runner.os }}-docs-
+
       # ---------- clone gh-pages (preserve existing content) ----------
       - name: Clone gh-pages branch
         run: |

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -123,6 +123,20 @@ jobs:
           echo "PYTHONIOENCODING=utf-8" >> $GITHUB_ENV
           echo "PYTHONUTF8=1" >> $GITHUB_ENV
 
+      - name: Restore test data and runtime caches
+        if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.spectrochempy/testdata
+            ~/.cache/matplotlib
+            .pytest_cache
+          key: >-
+            ${{ runner.os }}-py${{ matrix.pythonVersion }}-test-runtime-${{ hashFiles('src/spectrochempy/application/testdata.py', 'tests/conftest.py', 'pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.pythonVersion }}-test-runtime-
+            ${{ runner.os }}-test-runtime-
+
       - name: Install spectrochempy
         if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
         run: |


### PR DESCRIPTION
## Summary

Experimental CI caching pass on top of `plugins`.

The goal is to test whether we can reduce repeated work across pushes without changing test coverage or doc build behavior.

## Changes

### Docs workflow

- Restores a preview-only documentation cache before the docs build.
- Caches:
  - `build/branch_preview/~doctrees`
  - `docs/sources/gettingstarted/examples/gallery`
- Uses a branch-preview-specific key plus restore keys so Sphinx/Sphinx-Gallery can reuse generated files when safe.
- Does not cache or publish `build/html`; the preview output is still rebuilt and copied normally.

### Test workflow

- Restores runtime caches before install/test steps.
- Caches:
  - `~/.spectrochempy/testdata`
  - `~/.cache/matplotlib`
  - `.pytest_cache`
- Does not change the pytest command or selected test coverage.

## Notes

- This is intentionally conservative: no test selection, no skipped suites, no change to merge requirements.
- `test_package.yml` is normalized to LF line endings in this branch, which accounts for much of the diff.

## Validation

Local validation only:

```bash
python - <<'PY'
import yaml
for path in ['.github/workflows/build_docs.yml', '.github/workflows/test_package.yml']:
    with open(path, encoding='utf-8') as f:
        yaml.safe_load(f)
    print(path, 'ok')
PY

git diff --check -- .github/workflows/build_docs.yml .github/workflows/test_package.yml
```

No full docs build or test suite was run locally; the point of this branch is to evaluate the workflow behavior in GitHub Actions.