### PR TITLE
Add conservative targeted CI test selection

### DIFF
--- a/.github/workflows/scripts/select_test_targets.py
+++ b/.github/workflows/scripts/select_test_targets.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Select conservative pytest targets for CI runs."""
+
+# ruff: noqa: S603, S607, T201
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+FULL_TARGETS = ["tests"]
+DOC_TARGETS = ["tests/test_docs"]
+PLUGIN_TESTS = {
+    "spectrochempy-cantera": "plugins/spectrochempy-cantera/tests",
+    "spectrochempy-iris": "plugins/spectrochempy-iris/tests",
+    "spectrochempy-nmr": "plugins/spectrochempy-nmr/tests",
+}
+ALL_PLUGIN_TARGETS = ["tests/test_plugins", *PLUGIN_TESTS.values()]
+PROTECTED_REFS = {"master", "develop"}
+FULL_TEST_FILES = {
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "tox.ini",
+    "noxfile.py",
+    "tests/conftest.py",
+}
+FULL_TEST_PREFIXES = (
+    ".github/workflows/",
+    ".github/actions/",
+    "src/spectrochempy/",
+)
+PLUGIN_CORE_PREFIXES = (
+    "src/spectrochempy/plugins/",
+    "tests/test_plugins/",
+    "plugins/plugin-template/",
+)
+DOC_PREFIXES = (
+    "docs/",
+    "examples/",
+)
+
+
+def _run_git(args: list[str]) -> list[str]:
+    result = subprocess.run(  # noqa: S603
+        ["git", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _is_zero_sha(value: str) -> bool:
+    return bool(value) and set(value) == {"0"}
+
+
+def changed_files(base: str | None, head: str | None) -> list[str]:
+    """Return changed files between two refs, using conservative fallbacks."""
+    if not head:
+        head = "HEAD"
+
+    if base and not _is_zero_sha(base):
+        for separator in ("...", ".."):
+            try:
+                return _run_git(["diff", "--name-only", f"{base}{separator}{head}"])
+            except subprocess.CalledProcessError:
+                continue
+
+    try:
+        return _run_git(["diff", "--name-only", "HEAD~1..HEAD"])
+    except subprocess.CalledProcessError:
+        return []
+
+
+def _add_existing(targets: list[str], target: str) -> None:
+    if target not in targets and Path(target).exists():
+        targets.append(target)
+
+
+def _plugin_targets(path: str, targets: list[str]) -> bool:
+    for plugin_name, test_path in PLUGIN_TESTS.items():
+        if path.startswith(f"plugins/{plugin_name}/"):
+            _add_existing(targets, test_path)
+            _add_existing(targets, "tests/test_plugins")
+            return True
+    return False
+
+
+def select_targets(
+    files: list[str],
+    *,
+    event_name: str = "",
+    ref_name: str = "",
+    base_ref: str = "",
+) -> tuple[str, list[str], str]:
+    """
+    Select pytest targets.
+
+    The selector only narrows tests for low-risk categories. Shared core,
+    packaging, and workflow changes keep the full test suite.
+    """
+    if event_name in {"schedule", "workflow_dispatch"}:
+        return "full", FULL_TARGETS, "scheduled or manually dispatched run"
+
+    if ref_name in PROTECTED_REFS or base_ref in PROTECTED_REFS:
+        return "full", FULL_TARGETS, "protected branch run"
+
+    if not files:
+        return "full", FULL_TARGETS, "no changed files detected"
+
+    targets: list[str] = []
+    docs_only = True
+
+    for path in sorted(set(files)):
+        if path in FULL_TEST_FILES:
+            return "full", FULL_TARGETS, f"{path} requires full tests"
+
+        if any(path.startswith(prefix) for prefix in PLUGIN_CORE_PREFIXES):
+            docs_only = False
+            for target in ALL_PLUGIN_TARGETS:
+                _add_existing(targets, target)
+            continue
+
+        if _plugin_targets(path, targets):
+            docs_only = False
+            continue
+
+        if path.startswith("tests/"):
+            docs_only = False
+            if path.endswith(".py") and Path(path).exists():
+                _add_existing(targets, path)
+            else:
+                return "full", FULL_TARGETS, f"{path} requires full tests"
+            continue
+
+        if any(path.startswith(prefix) for prefix in DOC_PREFIXES):
+            for target in DOC_TARGETS:
+                _add_existing(targets, target)
+            continue
+
+        if any(path.startswith(prefix) for prefix in FULL_TEST_PREFIXES):
+            return "full", FULL_TARGETS, f"{path} requires full tests"
+
+        docs_only = False
+
+    if targets:
+        return "targeted", targets, "low-risk plugin, test, or documentation changes"
+
+    if docs_only:
+        return "targeted", DOC_TARGETS, "documentation-only changes"
+
+    return "full", FULL_TARGETS, "changed files are outside targeted rules"
+
+
+def write_github_env(mode: str, targets: list[str], reason: str) -> None:
+    env_file = os.environ.get("GITHUB_ENV")
+    if not env_file:
+        return
+
+    with Path(env_file).open("a", encoding="utf-8") as stream:
+        stream.write(f"SCPY_TEST_SELECTION={mode}\n")
+        stream.write(f"SCPY_TEST_TARGETS={' '.join(targets)}\n")
+        stream.write(f"SCPY_TEST_SELECTION_REASON={reason}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", ""))
+    parser.add_argument("--ref-name", default=os.environ.get("GITHUB_REF_NAME", ""))
+    parser.add_argument("--base-ref", default=os.environ.get("GITHUB_BASE_REF", ""))
+    parser.add_argument("--files", nargs="*", help="Explicit changed files for testing.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    files = args.files if args.files is not None else changed_files(args.base, args.head)
+    mode, targets, reason = select_targets(
+        files,
+        event_name=args.event_name,
+        ref_name=args.ref_name,
+        base_ref=args.base_ref,
+    )
+
+    print("Changed files:")
+    for path in files:
+        print(f"  - {path}")
+    if not files:
+        print("  none")
+    print(f"Test selection: {mode}")
+    print(f"Reason: {reason}")
+    print(f"Pytest targets: {' '.join(targets)}")
+
+    if not args.dry_run:
+        write_github_env(mode, targets, reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -164,12 +164,25 @@ jobs:
         run: |
           python .github/workflows/scripts/ci_diagnostics.py environment
 
+      - name: Select pytest targets
+        if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
+        run: |
+          python .github/workflows/scripts/select_test_targets.py \
+            --base "${{ github.event.pull_request.base.sha || github.event.before || '' }}" \
+            --head "${{ github.sha }}" \
+            --event-name "${{ github.event_name }}" \
+            --ref-name "${{ github.ref_name }}" \
+            --base-ref "${{ github.base_ref }}"
+
       - name: Test with coverage
         if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
         run: |
           set -o pipefail
           start=$SECONDS
-          coverage run --source=spectrochempy -m pytest tests -s -ra --durations=10 | tee pytest.log
+          echo "pytest selection: ${SCPY_TEST_SELECTION:-full}"
+          echo "pytest selection reason: ${SCPY_TEST_SELECTION_REASON:-not provided}"
+          echo "pytest targets: ${SCPY_TEST_TARGETS:-tests}"
+          coverage run --source=spectrochempy -m pytest ${SCPY_TEST_TARGETS:-tests} -s -ra --durations=10 | tee pytest.log
           status=${PIPESTATUS[0]}
           duration=$((SECONDS - start))
           echo "pytest execution: ${duration}s" | tee -a "$CI_TIMING_FILE"

--- a/tests/test_analysis/test_crossdecomposition/test_pls.py
+++ b/tests/test_analysis/test_crossdecomposition/test_pls.py
@@ -50,8 +50,8 @@ def test_pls():
 
     try:
         datasets = read("http://www.eigenvector.com/data/Corn/corn.mat", merge=False)
-    except requests.exceptions.RequestException:
-        pytest.skip("eigenvector.com not reachable")
+    except (FileNotFoundError, requests.exceptions.RequestException):
+        pytest.skip("eigenvector.com corn dataset not reachable")
     # information: [20x59 char ]    Information about the data
     # m5spec: [80x700 dataset] Spectra on instrument m5
     # mp5spec: [80x700 dataset] Spectra on instrument mp5


### PR DESCRIPTION
## Summary

This PR adds a conservative pytest target selector for the package test workflow.

The goal is to reduce CI time for low-risk PRs without changing the safety behavior for broad changes:

- plugin-only changes run the relevant plugin tests plus core plugin tests;
- docs/example-only changes run documentation tests;
- direct test-file changes run the affected test file, except shared fixtures;
- shared core, packaging, workflow, scheduled, manual, `master`, and `develop` runs still use the full `tests` suite.

Because this PR changes the workflow itself, its own test workflow is expected to stay on the full test suite. The speedup should become visible on later PRs touching only plugin/docs/test files covered by the targeted rules.

## Validation

Local lightweight validation only, no full pytest suite:

- `ruff check .github/workflows/scripts/select_test_targets.py`
- `python -m py_compile .github/workflows/scripts/select_test_targets.py`
- YAML parse of `.github/workflows/test_package.yml`
- Dry-run selector scenarios for plugin, core, docs, and test-file changes

## Notes

This remains intentionally incremental. It does not alter the test matrix or remove platforms; it only changes the pytest target list when the changed files are clearly narrow enough.