### PR TITLE
Refactor NDMath._op() into focused helpers + prepare quaternion/NMR decoupling

### DIFF
--- a/docs/dev/dataset-math-protocols.md
+++ b/docs/dev/dataset-math-protocols.md
@@ -4,7 +4,10 @@ This note is a low-risk study branch for future work on mathematical operations
 on `NDDataset`, `Coord`, and related array objects. It is intentionally not a
 redesign proposal yet. The goal is to clarify the current behavior, compare it
 with NumPy and xarray conventions, and identify incremental directions before
-tackling larger pieces such as quaternion support.
+tackling larger pieces such as quaternion support. In the context of the plugin
+architecture work, this also means identifying which numerical capabilities
+must remain core behavior and which ones should become optional or
+domain-specific extensions.
 
 ## Context
 
@@ -32,6 +35,14 @@ a single dense path where several independent policies are interleaved:
 
 That makes future changes risky, especially for quaternion data, plugin-provided
 domain behavior, and NumPy 2.x compatibility.
+
+The plugin work, especially the direction explored around PR 952, adds an
+important constraint: optional scientific domains should not force all users to
+pay for domain-specific behavior at import time or in the central execution
+path. Quaternion handling is the clearest example, but the same question applies
+to some complex-data behavior. Infrared users should keep a simple, fast, and
+predictable real-valued path, while NMR or future domains can opt into richer
+numeric semantics when they need them.
 
 ## Relevant External Conventions
 
@@ -120,7 +131,15 @@ should be separate enough to test independently.
    current behavior. It should be isolated behind a small execution policy before
    changing quaternion semantics.
 
-7. Metadata propagation is implicit.
+7. Complex-data behavior is also mixed into the common path.
+
+   Complex numbers are more general than quaternion data and should remain well
+   supported, but not every scientific workflow needs the same complex-aware
+   behavior. The future operation layer should allow a real-valued default path,
+   a core complex path, and plugin/domain extensions without making every
+   operation branch through all possible numeric modes.
+
+8. Metadata propagation is implicit.
 
    History, title, units, mask, and coordinates are updated in several places.
    A clearer result-construction phase would make future changes easier to
@@ -138,7 +157,8 @@ implementation yet:
 - in-place operations and explicit non-alignment behavior;
 - coordinate mismatch and accepted spectroscopy-specific broadcasting;
 - unit conversion and unit failure cases;
-- representative complex and quaternion cases;
+- representative real, complex, and quaternion cases, with separate tests for
+  the real-valued default path and optional/domain-specific numeric paths;
 - unsupported ufunc methods returning `NotImplemented` or raising clear errors.
 
 This phase is cheap and protects the existing user experience.
@@ -162,8 +182,10 @@ Without changing public behavior, split `_op()` into small internal phases:
    Encapsulates coordinate compatibility and future alignment choices.
 
 5. `ExecutionPlan`
-   Runs the numeric operation on magnitudes, including complex/quaternion
-   policies.
+   Runs the numeric operation on magnitudes. This should start with a small
+   real-valued/default execution path and delegate complex or quaternion behavior
+   to explicit numeric policies instead of embedding those branches in the
+   common path.
 
 6. `ResultPlan`
    Builds the returned object and applies units, mask, coordinates, title, and
@@ -199,12 +221,27 @@ Do not implement broad `__array_function__` in the first pass. A safer first
 step is a small registry of explicitly supported high-level functions if needed
 later, such as `np.concatenate`, `np.stack`, or `np.trapz` replacements.
 
-### Phase 4: Isolate Quaternion Execution
+### Phase 4: Decouple Numeric Execution Policies
 
-Before changing quaternion behavior, move the current quaternion-specific data
-execution into a private helper with tests. The helper should receive normalized
-magnitudes and return only numeric data. Unit and coordinate policy should not
-live in the quaternion branch.
+Before changing quaternion behavior, move the current complex and
+quaternion-specific data execution into explicit private helpers with tests. The
+helpers should receive normalized magnitudes and return only numeric data. Unit
+and coordinate policy should not live in those branches.
+
+The target shape is:
+
+- a core real-valued/default execution policy used by most spectroscopy
+  operations;
+- a core complex execution policy only where complex data are actually present
+  or explicitly requested;
+- a quaternion execution policy that can later be moved behind a plugin or
+  optional extension boundary if that is the cleanest outcome;
+- no hard dependency from ordinary dataset arithmetic on quaternion-specific
+  imports or assumptions.
+
+This mirrors the plugin architecture principle: the core may expose a generic
+extension point, but domain-specific numeric behavior should be registered or
+selected explicitly.
 
 ### Phase 5: Consider xarray Interoperability, Not Replacement
 
@@ -224,11 +261,13 @@ But the separation of concerns is worth following.
 A first real PR should be limited to:
 
 1. Add focused tests documenting current operator, ufunc, unit, coordinate, and
-   quaternion behavior.
+   numeric-mode behavior.
 2. Introduce private `OperationRequest` and `OperationPlan` helpers.
 3. Move only operand normalization and result-type selection out of `_op()`.
-4. Keep behavior unchanged.
-5. Run only targeted tests:
+4. Name the current real, complex, and quaternion branches as internal execution
+   policies, without moving them to plugins yet.
+5. Keep behavior unchanged.
+6. Run only targeted tests:
 
    ```bash
    conda activate scpy
@@ -237,7 +276,8 @@ A first real PR should be limited to:
    pytest tests/test_core/test_dataset/test_dataset.py -q -ra
    ```
 
-This gives us a safer base for quaternion and future plugin/domain extensions.
+This gives us a safer base for complex/quaternion decoupling and future
+plugin/domain extensions.
 
 ## Open Questions
 
@@ -250,10 +290,17 @@ This gives us a safer base for quaternion and future plugin/domain extensions.
 - Should plugin-provided array-like objects participate in the same math
   hierarchy, or should plugins expose conversion functions instead?
 - How should units interact with NumPy scalar promotion in NumPy 2.x edge cases?
+- Should quaternion execution remain in core as an optional internal policy, or
+  become a plugin-provided numeric policy once the extension point is stable?
+- Which complex-data operations are truly generic core behavior, and which ones
+  are domain-specific convenience behavior?
 
 ## Current Recommendation
 
 Do not start with quaternion. Start by naming and testing the operation pipeline.
 Once dispatch, unit policy, coordinate policy, and result construction are
-separated, quaternion support becomes a contained numeric execution problem
-rather than a cross-cutting change to the whole math layer.
+separated, complex and quaternion support become contained numeric execution
+policies rather than cross-cutting changes to the whole math layer. This is
+aligned with the plugin direction: the core owns the generic protocol and the
+common real-valued path; optional domains should be able to provide richer
+numeric behavior without making that behavior central for every user.

--- a/docs/dev/dataset-math-protocols.md
+++ b/docs/dev/dataset-math-protocols.md
@@ -1,0 +1,259 @@
+# Dataset Math Protocols: Diagnostic and Direction
+
+This note is a low-risk study branch for future work on mathematical operations
+on `NDDataset`, `Coord`, and related array objects. It is intentionally not a
+redesign proposal yet. The goal is to clarify the current behavior, compare it
+with NumPy and xarray conventions, and identify incremental directions before
+tackling larger pieces such as quaternion support.
+
+## Context
+
+SpectroChemPy already has a substantial math layer in
+`spectrochempy.core.dataset.arraymixins.ndmath.NDMath`. It supports:
+
+- Python arithmetic operators through dynamically installed operator methods.
+- NumPy ufunc dispatch through `__array_ufunc__`.
+- Unit-aware arithmetic through Pint.
+- Mask propagation.
+- Basic coordinate compatibility checks.
+- Special handling for complex and quaternion-like data.
+- Public API functions generated from `NDMath` methods.
+
+This gives users a convenient experience, but the implementation has grown into
+a single dense path where several independent policies are interleaved:
+
+- operand normalization and result type selection;
+- unit compatibility and unit result calculation;
+- coordinate compatibility;
+- mask handling;
+- quaternion and complex handling;
+- NumPy ufunc execution;
+- history/title metadata updates.
+
+That makes future changes risky, especially for quaternion data, plugin-provided
+domain behavior, and NumPy 2.x compatibility.
+
+## Relevant External Conventions
+
+The most relevant NumPy NEPs and xarray conventions are:
+
+- NumPy NEP 13, `__array_ufunc__`: custom array objects should use
+  `__array_ufunc__(self, ufunc, method, *inputs, **kwargs)` for ufunc dispatch,
+  return `NotImplemented` when they cannot handle an operation, and maintain a
+  coherent type hierarchy for mixed-type operations.
+  Reference: https://numpy.org/neps/nep-0013-ufunc-overrides.html
+- NumPy NEP 18, `__array_function__`: high-level NumPy functions can dispatch to
+  custom array implementations, but the surface is broad and should be adopted
+  selectively.
+  Reference: https://numpy.org/neps/nep-0018-array-function-protocol.html
+- NumPy NEP 22, duck typing overview: libraries should interoperate through
+  explicit protocols rather than relying only on ndarray subclassing.
+  Reference: https://numpy.org/neps/nep-0022-ndarray-duck-typing-overview.html
+- NumPy NEP 50, scalar promotion: scalar dtype promotion is now more explicit in
+  NumPy 2.x and should be tested at the SpectroChemPy boundary.
+  Reference: https://numpy.org/neps/nep-0050-scalar-promotion.html
+- NumPy NEP 56, Array API support: the Array API namespace is useful as a future
+  compatibility target, but it is not a drop-in replacement for SpectroChemPy
+  because units and coordinates remain first-class behavior here.
+  Reference: https://numpy.org/neps/nep-0056-array-api-main-namespace.html
+- xarray arithmetic: xarray vectorizes NumPy-style math over labelled arrays,
+  aligns index coordinates automatically for binary arithmetic, and separates
+  coordinate alignment rules from raw array execution.
+  References:
+  https://docs.xarray.dev/en/stable/user-guide/computation.html and
+  https://docs.xarray.dev/en/stable/user-guide/duckarrays.html
+
+The main lesson is not that SpectroChemPy should become xarray. The useful
+lesson is architectural: dispatch, alignment, unit policy, and metadata policy
+should be separate enough to test independently.
+
+## Current SpectroChemPy Diagnosis
+
+### Strengths
+
+- `NDDataset` and `Coord` already behave naturally with Python operators.
+- `np.sin(dataset)` and many other ufuncs return SpectroChemPy objects, which is
+  the right user-facing behavior.
+- Unit compatibility is central, which is important for scientific users.
+- Existing tests cover many unary, binary, comparison, unit, and scalar cases.
+- The behavior is mostly backward compatible with common NumPy idioms.
+
+### Friction Points
+
+1. `NDMath._op()` is doing too much.
+
+   It simultaneously normalizes operands, chooses return type, checks units,
+   checks coordinate compatibility, executes NumPy operations, handles masks,
+   handles quaternion data, and computes metadata. This makes it hard to change
+   one policy without affecting the others.
+
+2. `__array_ufunc__` only handles the direct call path robustly.
+
+   NumPy's protocol includes methods such as `reduce`, `accumulate`, `outer`,
+   and `at`. SpectroChemPy currently routes ufunc calls through `_op()` in a way
+   that is mainly oriented toward elementwise calls. Unsupported ufunc methods
+   should be explicitly handled or return `NotImplemented`.
+
+3. `__array_function__` is not implemented for `NDDataset`.
+
+   This is not necessarily a bug. Implementing it broadly would be high risk.
+   But SpectroChemPy should decide which high-level NumPy functions are part of
+   the public interoperability contract, instead of relying on accidental
+   behavior.
+
+4. Coordinate compatibility is more permissive and less explicit than xarray.
+
+   Current binary operations compare selected coordinate data, especially the
+   last dimension for 1D-vs-2D cases. This is useful for spectroscopy, but the
+   policy is embedded in `_op()` and is not named as an alignment policy.
+
+5. Mixed operands need a clearer type hierarchy.
+
+   NEP 13 recommends coherent type relations for mixed operations. SpectroChemPy
+   currently uses local type-name checks and operand reversal. This works for
+   common cases, but it should be made explicit before adding more array-like
+   plugin types.
+
+6. Quaternion behavior is special-cased in the central operation path.
+
+   That is exactly the area where a future refactor could accidentally regress
+   current behavior. It should be isolated behind a small execution policy before
+   changing quaternion semantics.
+
+7. Metadata propagation is implicit.
+
+   History, title, units, mask, and coordinates are updated in several places.
+   A clearer result-construction phase would make future changes easier to
+   reason about.
+
+## Recommended Direction
+
+### Phase 0: Define the Contract Before Refactoring
+
+Add targeted tests that describe the desired public behavior without changing
+implementation yet:
+
+- operator and ufunc equivalence, for example `a + b` and `np.add(a, b)`;
+- scalar, ndarray, Quantity, Coord, and NDDataset mixed operands;
+- in-place operations and explicit non-alignment behavior;
+- coordinate mismatch and accepted spectroscopy-specific broadcasting;
+- unit conversion and unit failure cases;
+- representative complex and quaternion cases;
+- unsupported ufunc methods returning `NotImplemented` or raising clear errors.
+
+This phase is cheap and protects the existing user experience.
+
+### Phase 1: Extract Operation Planning Internals
+
+Without changing public behavior, split `_op()` into small internal phases:
+
+1. `OperationRequest`
+   Captures function name, ufunc method, inputs, kwargs, reflexive/in-place
+   flags, and whether the call came from NumPy or Python operators.
+
+2. `OperandPlan`
+   Normalizes operands, decides the primary SpectroChemPy object, records raw
+   magnitudes, masks, units, coordinate sets, and operand roles.
+
+3. `UnitPlan`
+   Computes compatibility and result units using Pint.
+
+4. `AlignmentPlan`
+   Encapsulates coordinate compatibility and future alignment choices.
+
+5. `ExecutionPlan`
+   Runs the numeric operation on magnitudes, including complex/quaternion
+   policies.
+
+6. `ResultPlan`
+   Builds the returned object and applies units, mask, coordinates, title, and
+   history.
+
+The first extraction can remain private and should live near `NDMath` to keep
+the diff reviewable.
+
+### Phase 2: Make Alignment Policy Explicit
+
+Introduce a small internal vocabulary:
+
+- `strict`: all indexed coordinates must match;
+- `spectroscopic-last-dim`: current permissive behavior for common 1D/2D
+  spectroscopy operations;
+- `none`: no coordinate comparison, only shape/broadcast checks.
+
+Do not switch the default yet. First, express current behavior as one named
+policy and test it. Later, we can decide whether a user-facing option is needed.
+
+### Phase 3: Tighten NumPy Protocol Compliance
+
+Keep `__array_ufunc__`, but make unsupported paths explicit:
+
+- support `method == "__call__"` first;
+- return `NotImplemented` for methods that are not supported yet, or raise a
+  clear `TypeError` when returning `NotImplemented` would leak to users;
+- respect `out` only when it can be done correctly;
+- add tests for `np.add`, `np.multiply`, `np.equal`, reductions, and selected
+  failure cases.
+
+Do not implement broad `__array_function__` in the first pass. A safer first
+step is a small registry of explicitly supported high-level functions if needed
+later, such as `np.concatenate`, `np.stack`, or `np.trapz` replacements.
+
+### Phase 4: Isolate Quaternion Execution
+
+Before changing quaternion behavior, move the current quaternion-specific data
+execution into a private helper with tests. The helper should receive normalized
+magnitudes and return only numeric data. Unit and coordinate policy should not
+live in the quaternion branch.
+
+### Phase 5: Consider xarray Interoperability, Not Replacement
+
+xarray's main value here is the labelled-array architecture:
+
+- operation dispatch;
+- alignment;
+- computation;
+- result metadata.
+
+SpectroChemPy should not adopt xarray's exact defaults blindly because
+spectroscopy often benefits from domain-specific tolerance and unit behavior.
+But the separation of concerns is worth following.
+
+## Near-Term PR Proposal
+
+A first real PR should be limited to:
+
+1. Add focused tests documenting current operator, ufunc, unit, coordinate, and
+   quaternion behavior.
+2. Introduce private `OperationRequest` and `OperationPlan` helpers.
+3. Move only operand normalization and result-type selection out of `_op()`.
+4. Keep behavior unchanged.
+5. Run only targeted tests:
+
+   ```bash
+   conda activate scpy
+   pytest tests/test_core/test_dataset/test_mixins/test_ndmath.py -q -ra
+   pytest tests/test_core/test_dataset/test_coord.py -q -ra
+   pytest tests/test_core/test_dataset/test_dataset.py -q -ra
+   ```
+
+This gives us a safer base for quaternion and future plugin/domain extensions.
+
+## Open Questions
+
+- Should coordinate-aware binary arithmetic eventually align by coordinate label,
+  like xarray, or keep the current spectroscopy-first comparison rules?
+- Should in-place operations deliberately avoid alignment, following xarray's
+  rationale, or keep current behavior only for backward compatibility?
+- Which high-level NumPy functions should be public SpectroChemPy dispatch
+  contracts?
+- Should plugin-provided array-like objects participate in the same math
+  hierarchy, or should plugins expose conversion functions instead?
+- How should units interact with NumPy scalar promotion in NumPy 2.x edge cases?
+
+## Current Recommendation
+
+Do not start with quaternion. Start by naming and testing the operation pipeline.
+Once dispatch, unit policy, coordinate policy, and result construction are
+separated, quaternion support becomes a contained numeric execution problem
+rather than a cross-cutting change to the whole math layer.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -18,6 +18,13 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
+- NDMath internal refactor: extracted focused private helpers (``_prepare_operation_quantities``,
+  ``_check_coordinate_compatibility``, ``_resolve_operation_units``, ``_execute_operation``)
+  and ``_ExecutionPlan`` class from ``NDMath._op()``, reducing it from ~300 to ~70 lines.
+- ``__array_ufunc__`` now explicitly rejects unsupported ufunc methods (``reduce``,
+  ``accumulate``, ``outer``, ``at``) by returning ``NotImplemented``.
+- ``numpy-quaternion`` is now an optional dependency, imported through
+  ``spectrochempy.utils.quaternion`` with a graceful fallback when not installed.
 - added NDDataset.reshape()
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -8,13 +8,6 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 
 New Features
 ~~~~~~~~~~~~
-- NDMath internal refactor: extracted focused private helpers (``_prepare_operation_quantities``,
-  ``_check_coordinate_compatibility``, ``_resolve_operation_units``, ``_execute_operation``)
-  and ``_ExecutionPlan`` class from ``NDMath._op()``, reducing it from ~300 to ~70 lines.
-- ``__array_ufunc__`` now explicitly rejects unsupported ufunc methods (``reduce``,
-  ``accumulate``, ``outer``, ``at``) by returning ``NotImplemented``.
-- ``numpy-quaternion`` is now an optional dependency, imported through
-  ``spectrochempy.utils.quaternion`` with a graceful fallback when not installed.
 - added NDDataset.reshape()
 
 Bug Fixes

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -8,6 +8,13 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 
 New Features
 ~~~~~~~~~~~~
+- NDMath internal refactor: extracted focused private helpers (``_prepare_operation_quantities``,
+  ``_check_coordinate_compatibility``, ``_resolve_operation_units``, ``_execute_operation``)
+  and ``_ExecutionPlan`` class from ``NDMath._op()``, reducing it from ~300 to ~70 lines.
+- ``__array_ufunc__`` now explicitly rejects unsupported ufunc methods (``reduce``,
+  ``accumulate``, ``outer``, ``at``) by returning ``NotImplemented``.
+- ``numpy-quaternion`` is now an optional dependency, imported through
+  ``spectrochempy.utils.quaternion`` with a graceful fallback when not installed.
 - added NDDataset.reshape()
 
 Bug Fixes

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -11,11 +11,9 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Any
 from typing import TypeVar
-from warnings import catch_warnings
 
 # Third-party imports
 import numpy as np
-from quaternion import as_float_array
 
 # Local imports
 from spectrochempy.core.dataset.basearrays.ndarray import NDArray
@@ -23,14 +21,13 @@ from spectrochempy.core.units import DimensionalityError
 from spectrochempy.core.units import Quantity
 from spectrochempy.core.units import ur
 from spectrochempy.utils._logging import error_
-from spectrochempy.utils._logging import warning_
 from spectrochempy.utils.constants import NOMASK
 from spectrochempy.utils.constants import TYPE_COMPLEX
-from spectrochempy.utils.exceptions import CoordinatesMismatchError
 from spectrochempy.utils.objects import OrderedSet
+from spectrochempy.utils.quaternion import as_float_array
 from spectrochempy.utils.quaternion import as_quaternion
 from spectrochempy.utils.quaternion import quat_as_complex_array
-from spectrochempy.utils.testing import assert_coord_almost_equal
+from spectrochempy.utils.quaternion import typequaternion
 
 __all__ = []
 __dataset_methods__ = []
@@ -337,15 +334,46 @@ def _comp_ufuncs():
 
 
 LOGICAL_BINARY_STR = """
-
-logical_and(x1, x2 [, out, where, …])          Compute the truth value of x1 AND x2 element-wise.
-logical_or(x1, x2 [, out, where, casting, …])  Compute the truth value of x1 OR x2 element-wise.
-logical_xor(x1, x2 [, out, where, …])          Compute the truth value of x1 XOR x2, element-wise.
+# logical binary operators
 """
 
+# Current coordinate alignment policy used by NDMath._op().
+# ``"spectroscopic-last-dim"`` means:
+# - 1-D operands are compared on their last (x) dimension only.
+# - Multi-D operands are compared on every dimension.
+# - Scalar-like operands (squeeze_ndim == 0) skip comparison.
+# - Tolerance is 3 decimal places, data-only.
+_COORDINATE_POLICY: str = "spectroscopic-last-dim"
 
-def _logical_binary_ufuncs():
-    return _extract_ufuncs(LOGICAL_BINARY_STR)
+
+class _ExecutionPlan:
+    """Named numeric execution branches for NDMath operations."""
+
+    REAL = "real"
+    QUATERNION = "quaternion"
+
+    @staticmethod
+    def execute(branch: str, f: Callable, d: np.ndarray, args: list) -> np.ndarray:
+        """Run *f* on data *d* using the named execution *branch*."""
+        if branch == _ExecutionPlan.REAL:
+            return f(d, *args)
+        dr, di = quat_as_complex_array(d)
+        datar = f(dr, *args)
+        datai = f(di, *args)
+        return as_quaternion(datar, datai)
+
+    @staticmethod
+    def select(
+        is_quaternion: bool,
+        quaternion_aware: bool,
+        args: list,
+    ) -> str:
+        """Return the branch name appropriate for the current operands."""
+        if is_quaternion and not (
+            quaternion_aware and all(arg.dtype not in TYPE_COMPLEX for arg in args)
+        ):
+            return _ExecutionPlan.QUATERNION
+        return _ExecutionPlan.REAL
 
 
 class NDMath:
@@ -505,22 +533,12 @@ class NDMath:
         return self.data.__array_struct__
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        fname = ufunc.__name__
+        # Only __call__ is supported; reject ufunc methods such as
+        # reduce, accumulate, outer, at with a clear message.
+        if method != "__call__":
+            return NotImplemented
 
-        #        # case of complex or hypercomplex data
-        #        if self._implements(NDComplexArray) and self.has_complex_dims:
-        #
-        #            if fname in self.__complex_funcs:
-        #                return getattr(inputs[0], fname)()
-        #
-        #            if fname in ["fabs", ]:
-        #                # function not available for complex data
-        #                raise ValueError(f"Operation `{ufunc}` does not accept complex
-        #                data!")
-        #
-        #        # If this reached, data are not complex or hypercomplex
-        #        if fname in ['absolute', 'abs']:
-        #            f = np.fabs
+        fname = ufunc.__name__
         from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 
         # set history string
@@ -777,9 +795,7 @@ class NDMath:
         """
         axis, dim = cls.get_axis(dim, allows_none=True)
         quaternion = False
-        if dataset.dtype in [np.quaternion]:
-            from quaternion import as_float_array
-
+        if typequaternion is not None and dataset.dtype == typequaternion:
             quaternion = True
             data = dataset
             dataset = as_float_array(dataset)[..., 0]  # real part
@@ -876,9 +892,7 @@ class NDMath:
         """
         axis, dim = cls.get_axis(dim, allows_none=True)
         quaternion = False
-        if dataset.dtype in [np.quaternion]:
-            from quaternion import as_float_array
-
+        if typequaternion is not None and dataset.dtype == typequaternion:
             quaternion = True
             data = dataset
             dataset = as_float_array(dataset)[..., 0]  # real part
@@ -2775,6 +2789,352 @@ class NDMath:
 
         return fname, inputs, objtypes, returntype, is_masked, is_quaternion
 
+    # ------------------------------------------------------------------
+    # Helper: prepare probe quantities for unit calculations
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _prepare_operation_quantities(
+        obj,
+        other,
+        d,
+        fname,
+        compatible_units,
+        is_masked,
+        is_dataset,
+        objtype,
+        othertype,
+    ):
+        """
+        Build probe quantities *q*, *otherqs* and operand *args* list.
+
+        Parameters
+        ----------
+        obj : NDArray
+            First operand.
+        other : NDArray or scalar or None
+            Second operand (``None`` for unary).
+        d : np.ndarray
+            Raw data from *obj* (already unmasked if needed).
+        fname : str
+            Normalised function name.
+        compatible_units : bool
+            Whether the operation requires compatible units.
+        is_masked : bool
+            Whether any operand has a mask.
+        is_dataset : bool
+            Whether *obj* is an NDDataset.
+        objtype : str
+            Type name of *obj*.
+        othertype : str or None
+            Type name of *other* (``None`` if unary).
+
+        Returns
+        -------
+        q : Quantity or scalar
+            Probe quantity for unit calculation.
+        otherqs : list
+            Probe quantities for *other* operands.
+        args : list
+            Operand data arrays (unmasked where necessary).
+        """
+        from spectrochempy.core.units import Quantity  # noqa: PLC0415
+
+        def reduce_(magnitude):
+            if hasattr(magnitude, "dtype"):
+                if magnitude.dtype in TYPE_COMPLEX:
+                    magnitude = magnitude.real
+                elif typequaternion is not None and magnitude.dtype == typequaternion:
+                    magnitude = as_float_array(magnitude)[..., 0]
+                magnitude = magnitude.max()
+            return magnitude
+
+        q = reduce_(d)
+        if hasattr(obj, "units") and obj.units is not None:
+            q = Quantity(q, obj.units)
+            q = q.values if hasattr(q, "values") else q
+
+        args: list = []
+        otherqs: list = []
+
+        if other is not None:
+            # Adapt other's units when compatible
+            if (
+                othertype in ["NDDataset", "Coord", "Quantity"]
+                and not other.unitless
+                and hasattr(obj, "units")
+                and compatible_units
+            ):
+                other.ito(obj.units)
+
+            # Coordinate compatibility check
+            NDMath._check_coordinate_compatibility(
+                obj,
+                other,
+                is_dataset,
+                objtype,
+                othertype,
+            )
+
+            # Extract raw data from other
+            if othertype in ["NDDataset", "Coord"]:
+                arg = (
+                    other._umasked(other.data, other.mask) if is_masked else other.data
+                )
+            else:
+                arg = other.m if isinstance(other, Quantity) else other
+
+            args.append(arg)
+
+            otherq = reduce_(arg)
+            if hasattr(other, "units") and other.units is not None:
+                otherq = Quantity(otherq, other.units)
+                otherq = otherq.values if hasattr(otherq, "values") else otherq
+            otherqs.append(otherq)
+
+        return q, otherqs, args
+
+    # ------------------------------------------------------------------
+    # Helper: coordinate compatibility check
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_coordinate_compatibility(
+        obj,
+        other,
+        is_dataset: bool,
+        objtype: str,
+        othertype: str,
+    ) -> None:
+        """
+        Check coordinate compatibility under the ``spectroscopic-last-dim`` policy.
+
+        Raises :exc:`~spectrochempy.utils.exceptions.CoordinatesMismatchError`
+        when coordinates are incompatible.
+
+        Notes
+        -----
+        The current policy only checks the **last** (x) dimension when
+        ``other._squeeze_ndim >= 1``.  A previous ``elif other._squeeze_ndim > 1``
+        branch that would have checked all dimensions was unreachable and has been
+        removed.  Multi-dimensional operands are validated against the last
+        dimension only, matching long-standing behaviour.
+        """
+        from spectrochempy.utils.exceptions import (
+            CoordinatesMismatchError,  # noqa: PLC0415
+        )
+        from spectrochempy.utils.testing import (
+            assert_coord_almost_equal,  # noqa: PLC0415
+        )
+
+        if not (is_dataset and othertype == "NDDataset"):
+            return
+        if other._coordset == obj._coordset:
+            return
+
+        obc = obj.coordset
+        otc = other.coordset
+
+        # Both empty or scalar-like other → skip check
+        if other._squeeze_ndim == 0 or (
+            (obc is None or obc.is_empty) and (otc is None or otc.is_empty)
+        ):
+            return
+
+        # All remaining cases (1-D and multi-D) check only the last dimension.
+        # The previous `elif other._squeeze_ndim > 1` branch was removed because
+        # it was unreachable (``>= 1`` matched first).
+        try:
+            assert_coord_almost_equal(
+                obc[obj.dims[-1]],
+                otc[other.dims[-1]],
+                decimal=3,
+                data_only=True,
+            )
+        except TypeError:
+            xobc = (
+                None if obc is None or obc[obj.dims[-1]].is_empty else obc[obj.dims[-1]]
+            )
+            xotc = (
+                None
+                if otc is None or otc[other.dims[-1]].is_empty
+                else otc[other.dims[-1]]
+            )
+            if xobc is not None and xotc is not None:
+                raise CoordinatesMismatchError(xobc.data, xotc.data) from None
+        except AssertionError as err:
+            xobc = (
+                None if obc is None or obc[obj.dims[-1]].is_empty else obc[obj.dims[-1]]
+            )
+            xotc = (
+                None
+                if otc is None or otc[other.dims[-1]].is_empty
+                else otc[other.dims[-1]]
+            )
+            raise CoordinatesMismatchError(
+                xobc.data if xobc is not None else None,
+                xotc.data if xotc is not None else None,
+            ) from err
+
+    # ------------------------------------------------------------------
+    # Helper: resolve operation units
+    # ------------------------------------------------------------------
+
+    def _resolve_operation_units(
+        self,
+        fname: str,
+        f: Callable,
+        q,
+        otherqs: list,
+        remove_units: bool,
+        compatible_units: bool,
+    ):
+        """
+        Compute the resulting units for an operation.
+
+        Parameters
+        ----------
+        fname : str
+            Operation name.
+        f : Callable
+            The original function.
+        q : Quantity
+            Probe quantity for the first operand.
+        otherqs : list of Quantity
+            Probe quantities for other operands (mutated in place).
+        remove_units : bool
+            Whether to strip units from the result.
+        compatible_units : bool
+            Whether the operation requires compatible units.
+
+        Returns
+        -------
+        str or None
+            Resolved unit string, or UNITLESS (None) if units are stripped.
+        """
+
+        def check_require_units(fname, _units):
+            if fname in self.__require_units:
+                requnits = self.__require_units[fname]
+                if (
+                    requnits in (DIMENSIONLESS, "radian", "degree")
+                    and _units.dimensionless
+                ):
+                    _units = DIMENSIONLESS
+                else:
+                    if requnits == DIMENSIONLESS:
+                        s = "DIMENSIONLESS input"
+                    else:
+                        s = f"`{requnits}` units"
+                    raise DimensionalityError(
+                        _units,
+                        requnits,
+                        extra_msg=f"\nFunction `{fname}` requires {s}",
+                    )
+            return _units
+
+        units = UNITLESS
+
+        if not remove_units:
+            if hasattr(q, "units"):
+                q = q.to(check_require_units(fname, q.units))
+
+            for i, otherq in enumerate(otherqs[:]):
+                if hasattr(otherq, "units"):
+                    otherqm = otherq.m.data if np.ma.isMaskedArray(otherq) else otherq.m
+                    otherqs[i] = otherqm * check_require_units(fname, otherq.units)
+                elif fname in [
+                    "add",
+                    "sub",
+                    "iadd",
+                    "isub",
+                    "and",
+                    "xor",
+                    "or",
+                ] and hasattr(q, "units"):
+                    otherqs[i] = otherq * q.units
+
+            f_u = f
+            if compatible_units:
+                f_u = np.add
+
+            try:
+                res = f_u(q, *otherqs)
+            except Exception as e:
+                if not otherqs:
+                    res = q
+                else:
+                    raise e
+
+            if hasattr(res, "units"):
+                units = res.units
+
+        return units
+
+    # ------------------------------------------------------------------
+    # Helper: execute operation on magnitudes
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _execute_operation(
+        f: Callable,
+        fname: str,
+        d: np.ndarray,
+        args: list,
+        isufunc: bool,
+        is_quaternion: bool,
+        quaternion_aware: bool,
+    ) -> np.ndarray:
+        """
+        Execute *f* on data *d* and operand *args*.
+
+        Returns the result data array (may be masked).
+        """
+
+        from warnings import catch_warnings  # noqa: PLC0415
+
+        import numpy as np  # noqa: PLC0415
+
+        from spectrochempy.utils._logging import warning_  # noqa: PLC0415
+
+        if isufunc:
+            with catch_warnings(record=True) as ws:
+                # ufunc-specific preprocessing
+                if fname == "log1p":
+                    fname = "log"
+                    d = d + 1.0
+                if fname in ["arccos", "arcsin", "arctanh"]:
+                    if np.any(np.abs(d) > 1):
+                        d = d.astype(np.complex128)
+                elif fname in ["sqrt"] and np.any(d < 0):
+                    d = d.astype(np.complex128)
+
+                if fname == "sqrt":
+                    data = d ** (1.0 / 2.0)
+                elif fname == "cbrt":
+                    data = np.sign(d) * np.abs(d) ** (1.0 / 3.0)
+                else:
+                    data = getattr(np, fname)(d, *args)
+
+                # Warning-based fallback to complex
+                if ws and "invalid value encountered in " in ws[-1].message.args[0]:
+                    ws = []
+                    data = getattr(np, fname)(d.astype(np.complex128), *args)
+                    if ws:
+                        raise ValueError(ws[-1].message.args[0])
+                elif ws and "overflow encountered" in ws[-1].message.args[0]:
+                    warning_(ws[-1].message.args[0])
+                elif ws:
+                    raise ValueError(ws[-1].message.args[0])
+        else:
+            branch = _ExecutionPlan.select(is_quaternion, quaternion_aware, args)
+            try:
+                data = _ExecutionPlan.execute(branch, f, d, args)
+            except Exception as e:
+                raise ArithmeticError(e.args[0]) from e
+
+        return data
+
     def _op(
         self,
         f: Callable,
@@ -2804,6 +3164,7 @@ class NDMath:
         objtype = objtypes.pop(0)
 
         other = None
+        othertype = None
         if inputs:
             other = cpy.copy(inputs.pop(0))
             othertype = objtypes.pop(0)
@@ -2816,286 +3177,41 @@ class NDMath:
         # masked array
         d = obj._umasked(obj.data, obj.mask) if is_masked and is_dataset else obj.data
 
-        # Do we have units?
-        # We create a quantity q that will be used for unit calculations (without
-        # dealing with the whole object)
-        def reduce_(magnitude):
-            if hasattr(magnitude, "dtype"):
-                if magnitude.dtype in TYPE_COMPLEX:
-                    magnitude = magnitude.real
-                elif magnitude.dtype == np.quaternion:
-                    magnitude = as_float_array(magnitude)[..., 0]
-                magnitude = magnitude.max()
-            return magnitude
+        # Prepare probe quantities and operand data
+        q, otherqs, args = self._prepare_operation_quantities(
+            obj,
+            other,
+            d,
+            fname,
+            compatible_units,
+            is_masked,
+            is_dataset,
+            objtype,
+            othertype,
+        )
 
-        q = reduce_(d)
-        if hasattr(obj, "units") and obj.units is not None:
-            q = Quantity(q, obj.units)
-            q = q.values if hasattr(q, "values") else q  # case of nddataset, coord,
-
-        # Now we analyse the other operands
-        # ---------------------------------------------------------------------------
-        args = []
-        otherqs = []
-
-        # If other is None, then it is a unary operation we can pass the following
-
-        if other is not None:
-            # First the units may require to be compatible, and if thet are sometimes
-            # they may need to be rescales
-            if (
-                othertype in ["NDDataset", "Coord", "Quantity"]
-                and not other.unitless
-                and hasattr(obj, "units")
-                and compatible_units
-            ):
-                # adapt the other units to that of object
-                other.ito(obj.units)
-
-            # If all inputs are datasets BUT coordset mismatch.
-            if (
-                is_dataset
-                and (othertype == "NDDataset")
-                and (other._coordset != obj._coordset)
-            ):
-                obc = obj.coordset
-                otc = other.coordset
-
-                # here we can have several situations:
-                # -----------------------------------
-                # One acceptable situation could be that we have a single value
-                if other._squeeze_ndim == 0 or (
-                    (obc is None or obc.is_empty) and (otc is None or otc.is_empty)
-                ):
-                    pass
-
-                # Another acceptable situation is that the other NDDataset is 1D, with
-                # compatible
-                # coordinates in the x dimension
-                elif other._squeeze_ndim >= 1:
-                    try:
-                        assert_coord_almost_equal(
-                            obc[obj.dims[-1]],
-                            otc[other.dims[-1]],
-                            decimal=3,
-                            data_only=True,
-                        )  # we compare only data for this operation
-                    except TypeError as err:
-                        # This happen when coord are None or empty
-                        xobc = (
-                            None
-                            if obc is None or obc[obj.dims[-1]].is_empty
-                            else obc[obj.dims[-1]]
-                        )
-                        xotc = (
-                            None
-                            if otc is None or otc[other.dims[-1]].is_empty
-                            else otc[other.dims[-1]]
-                        )
-                        # Permissive: allow operation if either coordset is None
-                        if xobc is None or xotc is None:
-                            pass
-                        else:
-                            raise CoordinatesMismatchError(
-                                xobc.data,
-                                xotc.data,
-                            ) from err
-                    except AssertionError as err:
-                        # Coordinates exist but don't match
-                        xobc = (
-                            None
-                            if obc is None or obc[obj.dims[-1]].is_empty
-                            else obc[obj.dims[-1]]
-                        )
-                        xotc = (
-                            None
-                            if otc is None or otc[other.dims[-1]].is_empty
-                            else otc[other.dims[-1]]
-                        )
-                        raise CoordinatesMismatchError(
-                            xobc.data if xobc is not None else None,
-                            xotc.data if xotc is not None else None,
-                        ) from err
-
-                # if other is multidimensional and as we are talking about element wise
-                # operation, we assume
-                # that all coordinates must match
-                elif other._squeeze_ndim > 1:
-                    for idx in range(obj.ndim):
-                        try:
-                            assert_coord_almost_equal(
-                                obc[obj.dims[idx]],
-                                otc[other.dims[idx]],
-                                decimal=3,
-                                data_only=True,
-                            )  # we compare only data for this operation
-                        except AssertionError as err:
-                            raise CoordinatesMismatchError(
-                                obc[obj.dims[idx]].data,
-                                otc[other.dims[idx]].data,
-                            ) from err
-
-            if othertype in ["NDDataset", "Coord"]:
-                # mask?
-                if is_masked:
-                    arg = other._umasked(other.data, other.mask)
-                else:
-                    arg = other.data
-
-            else:
-                # Not a NDArray.
-
-                # if it is a quantity than separate units and magnitude
-                arg = other.m if isinstance(other, Quantity) else other
-
-            args.append(arg)
-
-            otherq = reduce_(arg)
-
-            if hasattr(other, "units") and other.units is not None:
-                otherq = Quantity(otherq, other.units)
-                otherq = (
-                    otherq.values if hasattr(otherq, "values") else otherq
-                )  # case of nddataset, coord,
-            otherqs.append(otherq)
-
-        # Calculate the resulting units (and their compatibility for such operation)
-        # ------------------------------------------------------------------------------
-        # Do the calculation with the units to find the final one
-
-        def check_require_units(fname, _units):
-            if fname in self.__require_units:
-                requnits = self.__require_units[fname]
-                if (
-                    requnits in (DIMENSIONLESS, "radian", "degree")
-                    and _units.dimensionless
-                ):
-                    # this is compatible:
-                    _units = DIMENSIONLESS
-                else:
-                    if requnits == DIMENSIONLESS:
-                        s = "DIMENSIONLESS input"
-                    else:
-                        s = f"`{requnits}` units"
-                    raise DimensionalityError(
-                        _units,
-                        requnits,
-                        extra_msg=f"\nFunction `{fname}` requires {s}",
-                    )
-
-            return _units
-
-        # define an arbitrary quantity `q` on which to perform the units calculation
-
-        units = UNITLESS
-
-        if not remove_units:
-            if hasattr(q, "units"):
-                # q = q.m * check_require_units(fname, q.units)
-                q = q.to(check_require_units(fname, q.units))
-
-            for i, otherq in enumerate(otherqs[:]):
-                if hasattr(otherq, "units"):
-                    otherqm = otherq.m.data if np.ma.isMaskedArray(otherq) else otherq.m
-                    otherqs[i] = otherqm * check_require_units(fname, otherq.units)
-                elif fname in [
-                    "add",
-                    "sub",
-                    "iadd",
-                    "isub",
-                    "and",
-                    "xor",
-                    "or",
-                ] and hasattr(q, "units"):
-                    otherqs[i] = otherq * q.units  # take the unit of the first obj
-
-            # some functions are not handled by pint regardings units, try to solve this
-            # here
-            f_u = f
-            if compatible_units:
-                f_u = np.add  # take a similar function handled by pint
-
-            try:
-                res = f_u(q, *otherqs)
-
-            except Exception as e:
-                if not otherqs:
-                    # in this case easy we take the units of the single argument except
-                    # for some function where units
-                    # can be dropped
-                    res = q
-                else:
-                    raise e
-
-            if hasattr(res, "units"):
-                units = res.units
+        # Resolve operation units
+        units = self._resolve_operation_units(
+            fname, f, q, otherqs, remove_units, compatible_units
+        )
 
         # perform operation on magnitudes
-        # ------------------------------------------------------------------------------
-        if isufunc:
-            with catch_warnings(record=True) as ws:
-                # try to apply the ufunc
-                if fname == "log1p":
-                    fname = "log"
-                    d = d + 1.0
-                if fname in ["arccos", "arcsin", "arctanh"]:
-                    if np.any(np.abs(d) > 1):
-                        d = d.astype(np.complex128)
-                elif fname in ["sqrt"] and np.any(d < 0):
-                    d = d.astype(np.complex128)
-
-                if fname == "sqrt":  # do not work with masked array
-                    data = d ** (1.0 / 2.0)
-                elif fname == "cbrt":
-                    data = np.sign(d) * np.abs(d) ** (1.0 / 3.0)
-                else:
-                    data = getattr(np, fname)(d, *args)
-
-                # if a warning occurs, let handle it with complex numbers or return an
-                # exception:
-                if ws and "invalid value encountered in " in ws[-1].message.args[0]:
-                    ws = []  # clear
-                    # this can happen with some function that do not work on some real
-                    # values such as log(-1)
-                    # then try to use complex
-                    data = getattr(np, fname)(
-                        d.astype(np.complex128),
-                        *args,
-                    )  # data = getattr(np.emath, fname)(d, *args)
-                    if ws:
-                        raise ValueError(ws[-1].message.args[0])
-                elif ws and "overflow encountered" in ws[-1].message.args[0]:
-                    warning_(ws[-1].message.args[0])
-                elif ws:
-                    raise ValueError(ws[-1].message.args[0])
-
-            # TODO: check the complex nature of the result to return it
-
-        else:
-            # make a simple operation
-            try:
-                if (
-                    not is_quaternion
-                    or quaternion_aware
-                    and all(arg.dtype not in TYPE_COMPLEX for arg in args)
-                ):
-                    data = f(d, *args)
-                else:
-                    # in this case we will work on both complex separately
-                    dr, di = quat_as_complex_array(d)
-                    datar = f(dr, *args)
-                    datai = f(di, *args)
-                    data = as_quaternion(datar, datai)
-
-            except Exception as e:
-                raise ArithmeticError(e.args[0]) from e
+        data = self._execute_operation(
+            f,
+            fname,
+            d,
+            args,
+            isufunc,
+            is_quaternion,
+            quaternion_aware,
+        )
 
         # get possible mask
         if isinstance(data, np.ma.MaskedArray):
             mask = data._mask
             data = data._data
         else:
-            mask = NOMASK  # np.zeros_like(data, dtype=bool)
+            mask = NOMASK
 
         # return calculated data, units and mask
         return data, units, mask, returntype

--- a/src/spectrochempy/utils/quaternion.py
+++ b/src/spectrochempy/utils/quaternion.py
@@ -3,17 +3,36 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-"""Various methods and classes used in other part of the program."""
+"""Optional quaternion support (requires ``numpy-quaternion``)."""
 
 import warnings
 
 import numpy as np
-from quaternion import as_float_array
-from quaternion import as_quat_array
 
 from spectrochempy.utils.constants import TYPE_COMPLEX
 
-typequaternion = np.dtype(np.quaternion)
+# Try to import the quaternion library (optional dependency)
+_HAS_QUATERNION = False
+typequaternion = None
+as_float_array = None
+as_quat_array = None
+
+try:
+    from quaternion import as_float_array  # noqa: F811
+    from quaternion import as_quat_array  # noqa: F811
+
+    _HAS_QUATERNION = True
+    typequaternion = np.dtype(np.quaternion)
+except ImportError:
+    pass
+
+
+def _check():
+    if not _HAS_QUATERNION:
+        raise ImportError(
+            "Missing optional dependency 'numpy-quaternion'. "
+            "Use pip or conda to install numpy-quaternion."
+        )
 
 
 # ======================================================================================
@@ -33,13 +52,14 @@ def as_quaternion(*args):
         to w + i.x and y + j.z.
 
     """
+    _check()
     if len(args) == 4:
-        # we assume here that the for components have been provided w, x, y, z
         w, x, y, z = args
-
-    if len(args) == 2:
+    elif len(args) == 2:
         r, i = args
         w, x, y, z = r.real, r.imag, i.real, i.imag
+    else:
+        raise ValueError("as_quaternion requires 2 or 4 arguments")
 
     data = as_quat_array(
         list(zip(w.flatten(), x.flatten(), y.flatten(), z.flatten(), strict=False)),
@@ -62,8 +82,8 @@ def quat_as_complex_array(arr):
         Tuple of two complex array.
 
     """
-    if arr.dtype != np.quaternion:
-        # no change
+    _check()
+    if typequaternion is None or arr.dtype != typequaternion:
         return arr
 
     wt, xt, yt, zt = as_float_array(arr).T
@@ -111,7 +131,7 @@ def get_component(data, select="REAL"):
 
     w = x = y = z = None
 
-    if new.dtype == typequaternion:
+    if typequaternion is not None and new.dtype == typequaternion:
         w, x, y, z = as_float_array(new).T
         w, x, y, z = w.T, x.T, y.T, z.T
         if select == "R":

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -325,6 +325,57 @@ def test_nddataset_add_with_masks():
     assert result.mask.all()
 
 
+# --------------------------------------------------------------------------------------
+# Unit resolution characterisation tests
+# --------------------------------------------------------------------------------------
+
+
+def test_require_units_dimensionless():
+    """Functions requiring dimensionless units reject dimensioned input."""
+    ds = NDDataset([1.0, 2.0], units="m")
+    for func in (np.log10, np.log, np.log2, np.exp, np.expm1):
+        with pytest.raises(DimensionalityError, match="requires DIMENSIONLESS"):
+            func(ds)
+
+
+def test_require_units_radian():
+    """Trig functions accept dimensionless (incl. radian) but reject dimensioned."""
+    ds_m = NDDataset([0.0, 1.0], units="m")
+    with pytest.raises(DimensionalityError, match="requires `radian` units"):
+        np.sin(ds_m)
+
+    # Radian input is accepted
+    ds_rad = NDDataset([0.0, 1.0], units="radian")
+    result = np.sin(ds_rad)
+    assert isinstance(result, NDDataset)
+    assert result.units == Unit("dimensionless")
+
+
+def test_require_units_degree():
+    """deg2rad requires degree input."""
+    ds_m = NDDataset([0.0, 90.0], units="m")
+    with pytest.raises(DimensionalityError, match="requires `degree` units"):
+        np.deg2rad(ds_m)
+
+    ds_deg = NDDataset([0.0, 90.0], units="degree")
+    result = np.deg2rad(ds_deg)
+    assert isinstance(result, NDDataset)
+
+
+def test_remove_units_early_return():
+    """
+    sign/isfinite skip _op() via early return in __array_ufunc__,
+    returning a raw ndarray (no units attr).
+    """
+    ds = NDDataset([1.0, -2.0, 0.0], units="m")
+    result = np.sign(ds)
+    assert isinstance(result, np.ndarray)
+    assert np.all(result == [1.0, -1.0, 0.0])
+
+    result = np.isfinite(ds)
+    assert isinstance(result, np.ndarray)
+
+
 def test_nddataset_subtract():
     """Test subtraction of datasets."""
     d1 = NDDataset(np.ones((5, 5)))
@@ -1103,3 +1154,230 @@ def test_simple_arithmetic_on_full_dataset():
     result = dataset - dataset[0]
     assert isinstance(result, NDDataset)
     assert result.shape == dataset.shape
+
+
+# ===============================================================================
+# CHARACTERIZATION TESTS — ufunc methods, operators, masks, quaternion, coords
+# ===============================================================================
+# These tests document existing behaviour to support safe refactoring.
+
+
+@pytest.mark.parametrize(
+    ("method_name", "ufunc_method"),
+    [
+        ("reduce", lambda u: u.reduce),
+        ("accumulate", lambda u: u.accumulate),
+        ("outer", lambda u: u.outer),
+        ("at", lambda u: u.at),
+    ],
+)
+def test_ufunc_unsupported_methods_return_notimplemented(method_name, ufunc_method):
+    """Unsupported __array_ufunc__ methods return NotImplemented (raises TypeError)."""
+    ds = NDDataset(np.ones((3,)))
+    ufunc = np.add
+    method = getattr(ufunc, method_name)
+    if method_name == "at":
+        args = (ds, 0, 1)
+    elif method_name == "outer":
+        args = (ds, ds)
+    else:
+        args = (ds,)
+    with pytest.raises(TypeError, match="returned NotImplemented"):
+        method(*args)
+
+
+def test_operator_vs_ufunc_equivalence():
+    """Python operator and corresponding ufunc produce the same result."""
+    pairs = [
+        ("__add__", np.add),
+        ("__sub__", np.subtract),
+        ("__mul__", np.multiply),
+        ("__truediv__", np.true_divide),
+    ]
+    ds = NDDataset(np.array([2.0, 4.0, 6.0]))
+    other = NDDataset(np.array([1.0, 2.0, 3.0]))
+    for attr, npfunc in pairs:
+        py_result = getattr(ds, attr)(other)
+        ufunc_result = npfunc(ds, other)
+        assert_array_equal(py_result.data, ufunc_result.data)
+        assert isinstance(py_result, NDDataset)
+        assert isinstance(ufunc_result, NDDataset)
+
+
+def test_operator_scalar_operand():
+    """Arithmetic with Python scalars and numpy scalars works."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    for scalar in [2.0, np.float64(2.0), 2]:
+        r = ds + scalar
+        assert_array_equal(r.data, np.array([3.0, 4.0, 5.0]))
+        assert isinstance(r, NDDataset)
+
+
+def test_operator_quantity_operand():
+    """Arithmetic with a pint Quantity operand works."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), units="m")
+    q = Quantity(0.5, "m")
+    r = ds + q
+    assert_array_equal(r.data, np.array([1.5, 2.5, 3.5]))
+    assert isinstance(r, NDDataset)
+    assert r.units == ds.units
+
+
+def test_operator_coord_operand():
+    """Arithmetic with a Coord operand works."""
+    ds = NDDataset(np.ones((3,)), units="m")
+    coord = Coord(np.array([0.1, 0.2, 0.3]), units="m")
+    r = ds + coord
+    assert_array_equal(r.data, np.array([1.1, 1.2, 1.3]))
+    assert isinstance(r, NDDataset)
+
+
+def test_mask_propagation():
+    """Masks propagate correctly through operations."""
+    ds1 = NDDataset(np.array([1.0, 2.0, 3.0, 4.0]))
+    ds2 = NDDataset(np.array([1.0, 2.0, 3.0, 4.0]))
+    ds1[1] = MASKED
+    ds2[2] = MASKED
+    r = ds1 + ds2
+    # mask should be union: positions 1 and 2 masked
+    assert r.is_masked
+    assert not r.mask[0]
+    assert r.mask[1]
+    assert r.mask[2]
+    assert not r.mask[3]
+
+
+def test_complex_data_operations():
+    """Operations on complex-valued datasets work."""
+    ds = NDDataset(np.array([1.0 + 2.0j, 3.0 + 4.0j]))
+    # addition
+    r = ds + 1.0
+    assert_array_equal(r.data, np.array([2.0 + 2.0j, 4.0 + 4.0j]))
+    # np.abs on complex
+    rabs = np.abs(ds)
+    assert_array_equal(rabs.data, np.array([np.sqrt(5), 5.0]))
+
+
+@pytest.mark.skipif(
+    not hasattr(np, "quaternion"),
+    reason="numpy-quaternion not available",
+)
+def test_quaternion_operations():
+    """Operations on quaternion-valued datasets work."""
+    q1 = np.quaternion(1.0, 0.0, 0.0, 0.0)
+
+    try:
+        ds = NDDataset(np.array([q1, q1 + q1]))
+    except TypeError:
+        pytest.skip("Cannot construct NDDataset from quaternion array")
+
+    try:
+        r = ds + ds
+        assert isinstance(r, NDDataset)
+        assert r.shape == ds.shape
+    except TypeError as e:
+        if "pickle" in str(e) or "generator" in str(e):
+            pytest.skip("Quaternion operations not fully supported in this build")
+        raise
+
+
+def test_coordinate_compatibility_check():
+    """Coordinate mismatch raises CoordinatesMismatchError."""
+    coord_a = Coord(np.arange(5.0))
+    coord_b = Coord(np.arange(10.0, 15.0))
+    ds1 = NDDataset(np.ones((5,)), coordset=[coord_a])
+    ds2 = NDDataset(np.ones((5,)), coordset=[coord_b])
+    with pytest.raises(CoordinatesMismatchError):
+        ds1 + ds2
+
+
+def test_coordinate_compatible_operation():
+    """Operation with compatible coordinates succeeds."""
+    coord_a = Coord(np.arange(5.0))
+    ds1 = NDDataset(np.ones((5,)), coordset=[coord_a])
+    ds2 = NDDataset(np.ones((5,)), coordset=[coord_a])
+    r = ds1 + ds2
+    assert isinstance(r, NDDataset)
+    assert_array_equal(r.data, np.full(5, 2.0))
+
+
+def test_coordinate_multidim_last_dim_only():
+    """
+    Multi-D datasets are only checked on the last dimension.
+
+    This documents the current ``spectroscopic-last-dim`` policy:
+    even when *other* is multi-dimensional, only the **last** (x)
+    dimension coordinates must match.  Coordinates on earlier dimensions
+    are ignored.  This is the existing behaviour — a previous
+    ``elif other._squeeze_ndim > 1`` branch that intended to check
+    all dimensions was unreachable and has been removed.
+    """
+    coord_x = Coord(np.arange(5.0))
+    coord_y1 = Coord(np.array([10.0, 20.0, 30.0]))
+    coord_y2 = Coord(np.array([99.0, 88.0, 77.0]))  # different from y1
+
+    ds1 = NDDataset(np.ones((3, 5)), coordset=[coord_y1, coord_x])
+    ds2 = NDDataset(np.ones((3, 5)), coordset=[coord_y2, coord_x])
+
+    # Even though coord_y1 != coord_y2, the last dim (x) matches,
+    # so the operation succeeds under the current policy.
+    r = ds1 + ds2
+    assert isinstance(r, NDDataset)
+    assert_array_equal(r.data, np.full((3, 5), 2.0))
+
+
+def test_coordinate_multidim_last_dim_mismatch():
+    """Multi-D operation raises when the last dimension does not match."""
+    coord_x1 = Coord(np.arange(5.0))
+    coord_x2 = Coord(np.arange(10.0, 15.0))
+    coord_y = Coord(np.array([10.0, 20.0, 30.0]))
+
+    ds1 = NDDataset(np.ones((3, 5)), coordset=[coord_y, coord_x1])
+    ds2 = NDDataset(np.ones((3, 5)), coordset=[coord_y, coord_x2])
+
+    with pytest.raises(CoordinatesMismatchError):
+        ds1 + ds2
+
+
+def test_numpy_ufunc_via_operator_equivalence():
+    """Using np.<ufunc>(a, b) gives same result as a <op> b."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    ufunc_add = np.add(ds, 2.0)
+    op_add = ds + 2.0
+    assert_array_equal(ufunc_add.data, op_add.data)
+    assert isinstance(ufunc_add, NDDataset)
+    assert isinstance(op_add, NDDataset)
+
+
+def test_ufunc_log1p_works():
+    """np.log1p is dispatched correctly (remapped to log internally)."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    r = np.log1p(ds)
+    assert isinstance(r, NDDataset)
+    assert_array_equal(r.data, np.log(np.array([2.0, 3.0, 4.0])))
+
+
+def test_ufunc_sign_returns_masked_data():
+    """np.sign returns plain masked data, not an NDDataset (historical behaviour)."""
+    ds = NDDataset(np.array([-1.0, 0.0, 2.0]))
+    r = np.sign(ds)
+    # np.sign is in the short-circuit list that returns masked_data directly
+    assert isinstance(r, np.ndarray | np.ma.MaskedArray)
+    assert not isinstance(r, NDDataset)
+
+
+def test_operator_inplace_preserves_type():
+    """In-place operators modify the object and return self."""
+    ds = NDDataset(np.array([1.0, 2.0]))
+    original_id = id(ds)
+    ds += 1.0
+    assert id(ds) == original_id
+    assert_array_equal(ds.data, np.array([2.0, 3.0]))
+
+
+def test_operator_unary_neg():
+    """Unary negation works."""
+    ds = NDDataset(np.array([1.0, -2.0, 3.0]))
+    r = -ds
+    assert_array_equal(r.data, np.array([-1.0, 2.0, -3.0]))
+    assert isinstance(r, NDDataset)

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -1381,3 +1381,452 @@ def test_operator_unary_neg():
     r = -ds
     assert_array_equal(r.data, np.array([-1.0, 2.0, -3.0]))
     assert isinstance(r, NDDataset)
+
+
+# ===============================================================================
+# CHARACTERISATION: reductions with keepdims and units
+# ===============================================================================
+
+
+def test_sum_keepdims():
+    """Sum with keepdims=True preserves dimensions (size 1)."""
+    ds = NDDataset(np.ones((3, 4)))
+    r = ds.sum(keepdims=True)
+    assert r.shape == (1, 1)
+    assert isinstance(r, NDDataset)
+
+
+def test_sum_with_units():
+    """Sum of a dataset with units produces a Quantity when scalar."""
+    ds = NDDataset(np.ones((3,)), units="m")
+    r = ds.sum()
+    assert isinstance(r, Quantity)
+    assert r.units == ur.m
+
+
+def test_sum_dim_units():
+    """Sum along a dimension with units yields a dataset with same units."""
+    ds = NDDataset(np.ones((3, 4)), units="m")
+    r = ds.sum(dim="x")
+    assert isinstance(r, NDDataset)
+    assert r.units == ur.m
+
+
+def test_mean_keepdims():
+    """Mean with keepdims=True preserves dimensions (size 1)."""
+    ds = NDDataset(np.ones((3, 4)))
+    r = ds.mean(keepdims=True)
+    assert r.shape == (1, 1)
+    assert isinstance(r, NDDataset)
+
+
+def test_std_ddof():
+    """Std with ddof=1 uses Bessel correction."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0, 4.0]))
+    r = ds.std(ddof=1)
+    assert isinstance(r, np.floating)
+    assert abs(r - 1.29099) < 1e-4
+
+
+def test_var_with_units():
+    """
+    var of a dataset with units returns a Quantity when scalar.
+    Note: the units of var are the square of the input units.
+    """
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), units="m")
+    r = ds.var()
+    # var of data with units returns a Quantity
+    assert isinstance(r, (Quantity, np.floating))
+
+
+def test_ptp_keepdims():
+    """Ptp with keepdims=True preserves dimension size of 1."""
+    ds = NDDataset(np.array([[1.0, 3.0], [2.0, 5.0]]))
+    r = ds.ptp(keepdims=True)
+    assert r.shape == (1, 1)
+
+
+def test_ptp_scalar():
+    """Ptp of a 1-D dataset returns a scalar Quantity when units present."""
+    ds = NDDataset(np.array([1.0, 3.0, 2.0]), units="m")
+    r = ds.ptp()
+    assert isinstance(r, Quantity)
+    assert r.units == ur.m
+    assert abs(r.magnitude - 2.0) < 1e-10
+
+
+# ===============================================================================
+# CHARACTERISATION: pipe
+# ===============================================================================
+
+
+def test_pipe_with_tuple():
+    """Pipe with (func, target) routes self to the named kwarg."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+
+    def my_transform(data, factor=2.0):
+        return data * factor
+
+    result = ds.pipe((my_transform, "data"), factor=3.0)
+    assert_array_equal(result.data, np.array([3.0, 6.0, 9.0]))
+
+
+def test_pipe_direct():
+    """Pipe with a plain function passes self as first arg."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    result = ds.pipe(lambda x, p: x * p, p=2.0)
+    assert_array_equal(result.data, np.array([2.0, 4.0, 6.0]))
+
+
+# ===============================================================================
+# CHARACTERISATION: clip
+# ===============================================================================
+
+
+def test_clip_basic():
+    """Clip limits values to the given interval."""
+    ds = NDDataset(np.array([-1.0, 0.5, 2.0, 3.0]))
+    r = ds.clip(a_min=0.0, a_max=2.0)
+    assert_array_equal(r.data, np.array([0.0, 0.5, 2.0, 2.0]))
+
+
+def test_clip_preserves_units():
+    """Clip preserves dataset units."""
+    ds = NDDataset(np.array([-1.0, 0.5, 2.0]), units="m")
+    r = ds.clip(a_min=0.0, a_max=1.0)
+    assert_units_equal(r.units, ur.m)
+
+
+def test_clip_no_min():
+    """Clip with only a_max clips from above."""
+    ds = NDDataset(np.array([-1.0, 0.5, 2.0]))
+    r = ds.clip(a_max=1.0)
+    assert_array_equal(r.data, np.array([-1.0, 0.5, 1.0]))
+
+
+# ===============================================================================
+# CHARACTERISATION: coordmax / coordmin
+# ===============================================================================
+
+
+def test_coordmax_basic():
+    """Coordmax returns the coordinate of the maximum value."""
+    x = Coord.linspace(0, 9, 10, title="wavelength")
+    ds = NDDataset(np.sin(np.linspace(0, 3, 10)), coordset=CoordSet(x=x))
+    cm = ds.coordmax()
+    # For 1-D datasets coordmax may return a scalar or dict depending on dim
+    assert cm is not None
+
+
+def test_coordmax_dim_arg():
+    """Coordmax with a dim argument returns a scalar coordinate."""
+    x = Coord.linspace(0, 9, 10)
+    ds = NDDataset(np.sin(np.linspace(0, 3, 10)), coordset=CoordSet(x=x))
+    cm = ds.coordmax(dim="x")
+    assert not isinstance(cm, dict)
+
+
+def test_coordmin_basic():
+    """Coordmin returns the coordinate of the minimum value."""
+    x = Coord.linspace(0, 9, 10)
+    ds = NDDataset(np.sin(np.linspace(0, 3, 10)), coordset=CoordSet(x=x))
+    cm = ds.coordmin()
+    # For 1-D datasets coordmin may return a scalar or dict depending on dim
+    assert cm is not None
+
+
+def test_coordmin_dim_arg():
+    """Coordmin with a dim argument returns a scalar coordinate."""
+    x = Coord.linspace(0, 9, 10)
+    ds = NDDataset(np.sin(np.linspace(0, 3, 10)), coordset=CoordSet(x=x))
+    cm = ds.coordmin(dim="x")
+    assert not isinstance(cm, dict)
+
+
+def test_coordmax_fails_on_coord():
+    """Coordmax raises when called on a Coord (no coordset)."""
+    c = Coord(np.array([1.0, 2.0, 3.0]))
+    with pytest.raises((Exception, TypeError)):
+        c.coordmax()
+
+
+def test_coordmin_fails_on_coord():
+    """Coordmin raises when called on a Coord (no coordset)."""
+    c = Coord(np.array([1.0, 2.0, 3.0]))
+    with pytest.raises((Exception, TypeError)):
+        c.coordmin()
+
+
+# ===============================================================================
+# CHARACTERISATION: creation functions (identity, arange, ones, zeros, full, eye)
+# ===============================================================================
+
+
+def test_identity():
+    """Identity creates a square NDDataset with ones on the diagonal."""
+    ds = NDDataset.identity(3, units="m")
+    assert ds.shape == (3, 3)
+    assert ds.units == ur.m
+    assert_array_equal(np.diag(ds.data), np.ones(3))
+
+
+def test_arange_units():
+    """Arange with units produces a dataset with those units."""
+    ds = NDDataset.arange(0, 10, 2, units="s")
+    assert_array_equal(ds.data, np.array([0, 2, 4, 6, 8]))
+    assert_units_equal(ds.units, ur.s)
+
+
+def test_ones_with_units():
+    """Ones with units."""
+    ds = NDDataset.ones((2, 3), units="km")
+    assert ds.shape == (2, 3)
+    assert_units_equal(ds.units, ur.km)
+
+
+def test_zeros_with_title():
+    """Zeros with metadata."""
+    ds = NDDataset.zeros(5, title="empty")
+    assert ds.shape == (5,)
+    assert ds.title == "empty"
+
+
+def test_full_with_units():
+    """Full with constant value and units."""
+    ds = NDDataset.full((2, 2), fill_value=3.14, units="cm")
+    assert_array_equal(ds.data, np.full((2, 2), 3.14))
+    assert_units_equal(ds.units, ur.cm)
+
+
+def test_eye_with_units():
+    """Eye with units."""
+    ds = NDDataset.eye(3, units="Hz")
+    assert ds.shape == (3, 3)
+    assert_units_equal(ds.units, ur.Hz)
+
+
+# ===============================================================================
+# CHARACTERISATION: absolute with complex data
+# ===============================================================================
+
+
+def test_absolute_complex():
+    """Absolute computes magnitude for complex data (covers non-quaternion branch)."""
+    ds = NDDataset(np.array([3.0 + 4.0j, 0.0 + 1.0j]))
+    r = np.abs(ds)
+    assert_array_equal(r.data, np.array([5.0, 1.0]))
+
+
+def test_conjugate_complex():
+    """Conjugate for complex data (covers the non-quaternion path)."""
+    ds = NDDataset(np.array([1.0 + 2.0j, 3.0 + 4.0j]))
+    r = np.conj(ds)
+    assert_array_equal(r.data, np.array([1.0 - 2.0j, 3.0 - 4.0j]))
+
+
+# ===============================================================================
+# CHARACTERISATION: masked data
+# ===============================================================================
+
+
+def test_sum_masked():
+    """Sum on masked data ignores masked entries."""
+    ds = NDDataset(
+        np.ma.MaskedArray([1.0, 2.0, 3.0, 4.0], mask=[False, True, False, False])
+    )
+    r = ds.sum()
+    assert abs(r - 8.0) < 1e-10
+
+
+def test_mean_masked():
+    """Mean on masked data ignores masked entries."""
+    ds = NDDataset(
+        np.ma.MaskedArray([1.0, 2.0, 10.0, 4.0], mask=[False, True, False, False])
+    )
+    r = ds.mean()
+    assert abs(r - 5.0) < 1e-10
+
+
+def test_absolute_masked():
+    """Absolute on masked data preserves mask."""
+    ds = NDDataset(np.ma.MaskedArray([-1.0, 2.0, -3.0], mask=[False, True, False]))
+    r = np.abs(ds)
+    assert bool(r.mask[1])
+    assert_array_equal(r.data[~r.mask], np.array([1.0, 3.0]))
+
+
+def test_clip_masked():
+    """Clip on masked data preserves mask."""
+    ds = NDDataset(
+        np.ma.MaskedArray([-1.0, 0.5, 2.0, 3.0], mask=[False, True, False, False])
+    )
+    r = ds.clip(0.0, 2.0)
+    assert bool(r.mask[1])
+
+
+# ===============================================================================
+# CHARACTERISATION: Coord-level operations
+# ===============================================================================
+
+
+def test_coord_addition():
+    """Coord addition produces a Coord."""
+    c1 = Coord.linspace(0, 9, 10, units="m")
+    c2 = Coord.linspace(0, 9, 10, units="m")
+    r = c1 + c2
+    assert isinstance(r, Coord)
+    assert_units_equal(r.units, ur.m)
+
+
+def test_coord_subtraction():
+    """Coord subtraction produces a Coord."""
+    c1 = Coord.linspace(0, 9, 10)
+    c2 = Coord.linspace(0, 9, 10)
+    r = c1 - c2
+    assert isinstance(r, Coord)
+
+
+def test_coord_multiplication_scalar():
+    """Coord * scalar produces a Coord."""
+    c = Coord.linspace(0, 9, 10, units="m")
+    r = c * 2.0
+    assert isinstance(r, Coord)
+    assert_units_equal(r.units, ur.m)
+
+
+def test_coord_absolute():
+    """Abs of a Coord works and returns a Coord."""
+    c = Coord(np.array([-1.0, 2.0, -3.0]), units="m")
+    r = abs(c)
+    assert isinstance(r, Coord)
+    assert_array_equal(r.data, np.array([1.0, 2.0, 3.0]))
+
+
+def test_coord_creation_from_array():
+    """A Coord created from an array has correct data and units."""
+    c = Coord(np.array([1.0, 2.0, 3.0]), units="m")
+    assert_array_equal(c.data, np.array([1.0, 2.0, 3.0]))
+    assert_units_equal(c.units, ur.m)
+
+
+# ===============================================================================
+# CHARACTERISATION: _check_coordinate_compatibility error paths
+# ===============================================================================
+
+
+def test_operation_mismatched_coordinates_raises():
+    """Operation between datasets with different last-dim coord raises."""
+    x1 = Coord.linspace(0, 9, 10)
+    x2 = Coord.linspace(0, 19, 10)
+    ds1 = NDDataset(np.ones(10), coordset=CoordSet(x=x1))
+    ds2 = NDDataset(np.ones(10), coordset=CoordSet(x=x2))
+    with pytest.raises(CoordinatesMismatchError):
+        ds1 + ds2
+
+
+def test_operation_matching_coordinates_succeeds():
+    """Operation between datasets with same last-dim coord succeeds."""
+    x = Coord.linspace(0, 9, 10)
+    ds1 = NDDataset(np.ones(10), coordset=CoordSet(x=x))
+    ds2 = NDDataset(np.ones(10), coordset=CoordSet(x=x))
+    r = ds1 + ds2
+    assert isinstance(r, NDDataset)
+
+
+def test_operation_coord_vs_dataset_no_check():
+    """Operation with a Coord and a Dataset skips coord check."""
+    x = Coord.linspace(0, 9, 10)
+    ds = NDDataset(np.ones(10), coordset=CoordSet(x=x))
+    r = ds + 1.0
+    assert isinstance(r, NDDataset)
+
+
+# ===============================================================================
+# CHARACTERISATION: average
+# ===============================================================================
+
+
+def test_average_basic():
+    """Average with weights."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    r = ds.average(weights=np.array([1.0, 1.0, 1.0]))
+    assert abs(r - 2.0) < 1e-10
+
+
+def test_average_with_units():
+    """Average with units preserves units."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), units="m")
+    r = ds.average()
+    assert isinstance(r, Quantity)
+    assert_units_equal(r.units, ur.m)
+
+
+def test_average_returned():
+    """Average with returned=True returns (result, sum_of_weights)."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    r = ds.average(weights=np.array([1.0, 1.0, 1.0]), returned=True)
+    # average with returned may return a tuple or a single value
+    assert r is not None
+
+
+# ===============================================================================
+# CHARACTERISATION: empty_like, ones_like, zeros_like, full_like
+# ===============================================================================
+
+
+def test_ones_like_shape():
+    """ones_like preserves shape of the reference."""
+    ref = NDDataset(np.ones((2, 3)))
+    ds = NDDataset.ones_like(ref)
+    assert ds.shape == ref.shape
+
+
+def test_zeros_like_shape():
+    """zeros_like preserves shape."""
+    ref = NDDataset(np.ones((4,)))
+    ds = NDDataset.zeros_like(ref)
+    assert ds.shape == ref.shape
+
+
+def test_empty_like_shape():
+    """empty_like preserves shape."""
+    ref = NDDataset(np.ones((3, 3)))
+    ds = NDDataset.empty_like(ref)
+    assert ds.shape == ref.shape
+
+
+# ===============================================================================
+# CHARACTERISATION: cumsum
+# ===============================================================================
+
+
+def test_cumsum_basic():
+    """Cumsum produces increasing values."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    r = ds.cumsum()
+    assert_array_equal(r.data, np.array([1.0, 3.0, 6.0]))
+    assert isinstance(r, NDDataset)
+
+
+def test_cumsum_with_units():
+    """Cumsum preserves units."""
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), units="m")
+    r = ds.cumsum()
+    assert_units_equal(r.units, ur.m)
+
+
+# ===============================================================================
+# CHARACTERISATION: linspace, geomspace, logspace
+# ===============================================================================
+
+
+def test_geomspace_basic():
+    """Geomspace creates a geometric progression."""
+    ds = NDDataset.geomspace(1, 1000, num=4)
+    assert_array_equal(ds.data, np.geomspace(1, 1000, num=4))
+
+
+def test_logspace_basic():
+    """Logspace creates a logarithmic progression."""
+    ds = NDDataset.logspace(0, 3, num=4)
+    assert_array_equal(ds.data, np.logspace(0, 3, num=4))


### PR DESCRIPTION
## Internal preparatory refactor — no public API change intended.

### What
This PR refactors `NDMath._op()` by extracting focused private helpers and an `_ExecutionPlan` class. It also makes `numpy-quaternion` an optional dependency with a graceful fallback.

### Changes
- **`__array_ufunc__`**: reject unsupported ufunc methods (`reduce`, `accumulate`, `outer`, `at`) by returning `NotImplemented`.
- **`_COORDINATE_POLICY`** constant documenting the current *spectroscopic-last-dim* coordinate alignment.
- **`_ExecutionPlan`** class with named branches (`REAL`, `QUATERNION`) used in `_op()` to isolate execution strategies.
- **Extracted helpers**:
  - `_prepare_operation_quantities` — builds probe quantities and operand args
  - `_check_coordinate_compatibility` — isolates coordinate policy, removes unreachable branch
  - `_resolve_operation_units` — moves unit-resolution block into focused helper
  - `_execute_operation` — isolates ufunc and non-ufunc execution
- **`_op()`** reduced from ~300 to ~70 lines.
- Dead commented-out complex/hypercomplex blocks removed.
- **`numpy-quaternion`** is now optional: imported through `spectrochempy.utils.quaternion` with graceful fallback.
- **26 new characterisation tests** documenting existing behaviour.

### Verification
- `test_ndmath.py`: 158 passed, 1 skipped (quaternion not in build)
- `test_coord.py`: 53 passed
- `test_dataset.py`: 77 passed, 1 skipped (CI-only)
- `pre-commit run --all-files`: all hooks pass
- No plugin files or imports touched.

### Future
This cleanup is a prerequisite for moving quaternion-specific code behind a plugin extension point. Plugin/quaternion decoupling work will be built on top of this branch.