### PR TITLE
Tag-driven versioning for official plugins

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -248,6 +248,16 @@ jobs:
             python=3.11
           cache-environment: true
 
+      - name: Update recipe version from release tag
+        if: github.event_name == 'release'
+        run: |
+          # Extract version from tag such as spectrochempy-nmr-v0.1.1 → 0.1.1
+          tag="${{ github.ref_name }}"
+          version="${tag#*-v}"
+          sed -i "s/version: \".*\"/version: \"$version\"/" ${{ matrix.plugin.recipe }}/${{ matrix.plugin.recipe_file }}
+          echo "Updated recipe version to $version from tag $tag"
+          cat ${{ matrix.plugin.recipe }}/${{ matrix.plugin.recipe_file }}
+
       - name: Build conda plugin package
         uses: prefix-dev/rattler-build-action@v0.2.38
         env:
@@ -279,7 +289,10 @@ jobs:
       - name: Upload plugin to Anaconda.org
         if: |
           github.repository == 'spectrochempy/spectrochempy' &&
-          (github.event_name == 'release' || github.event_name == 'push')
+          (
+            github.event_name == 'push' ||
+            (github.event_name == 'release' && startsWith(github.ref_name, matrix.plugin.name))
+          )
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -248,16 +248,6 @@ jobs:
             python=3.11
           cache-environment: true
 
-      - name: Update recipe version from release tag
-        if: github.event_name == 'release'
-        run: |
-          # Extract version from tag such as spectrochempy-nmr-v0.1.1 → 0.1.1
-          tag="${{ github.ref_name }}"
-          version="${tag#*-v}"
-          sed -i "s/version: \".*\"/version: \"$version\"/" ${{ matrix.plugin.recipe }}/${{ matrix.plugin.recipe_file }}
-          echo "Updated recipe version to $version from tag $tag"
-          cat ${{ matrix.plugin.recipe }}/${{ matrix.plugin.recipe_file }}
-
       - name: Build conda plugin package
         uses: prefix-dev/rattler-build-action@v0.2.38
         env:

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -154,7 +154,8 @@ jobs:
         if: |
           github.repository == 'spectrochempy/spectrochempy' &&
           github.event_name == 'release' &&
-          github.event.action == 'published'
+          github.event.action == 'published' &&
+          startsWith(github.ref_name, matrix.plugin.name)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/${{ matrix.plugin.name }}

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -1,0 +1,94 @@
+name: Release an official plugin
+
+# This workflow prepares and releases a single official plugin.
+# It bumps the plugin version, commits, pushes, and creates the release tag.
+# The tag triggers publish_plugins.yml (PyPI) and build_package.yml (conda).
+#
+# Usage:
+#   1. Run this workflow manually (workflow_dispatch).
+#   2. Enter the plugin name (e.g. "spectrochempy-nmr") and version (e.g. "0.1.1").
+#   3. The workflow bumps pyproject.toml and recipe.yaml, commits, and creates
+#      the tag spectrochempy-nmr-v0.1.1.
+#   4. The tag automatically triggers the CI publish jobs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin_name:
+        description: "Plugin package name (e.g. spectrochempy-nmr)"
+        required: true
+        type: string
+      version:
+        description: "Version to release (e.g. 0.1.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release-plugin:
+    name: "Release ${{ inputs.plugin_name }} v${{ inputs.version }}"
+    runs-on: ubuntu-latest
+    if: github.repository == 'spectrochempy/spectrochempy'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate plugin name
+        run: |
+          plugin_dir="plugins/${{ inputs.plugin_name }}"
+          if [ ! -d "$plugin_dir" ]; then
+            echo "::error::Plugin directory $plugin_dir does not exist"
+            exit 1
+          fi
+          if [ ! -f "$plugin_dir/pyproject.toml" ]; then
+            echo "::error::$plugin_dir/pyproject.toml not found"
+            exit 1
+          fi
+
+      - name: Bump version in pyproject.toml
+        run: |
+          plugin_dir="plugins/${{ inputs.plugin_name }}"
+          sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' "$plugin_dir/pyproject.toml"
+          echo "Updated $plugin_dir/pyproject.toml"
+          grep "^version =" "$plugin_dir/pyproject.toml"
+
+      - name: Bump version in recipe.yaml (if present)
+        run: |
+          plugin_dir="plugins/${{ inputs.plugin_name }}"
+          recipe="$plugin_dir/recipe.yaml"
+          if [ -f "$recipe" ]; then
+            sed -i 's/version: ".*"/version: "${{ inputs.version }}"/' "$recipe"
+            echo "Updated $recipe"
+            grep "version:" "$recipe"
+          else
+            echo "No recipe.yaml found; skipping conda version bump"
+          fi
+
+      - name: Configure git
+        run: |
+          git config user.email "github-actions@users.noreply.github.com"
+          git config user.name "GitHub Actions"
+
+      - name: Commit version bump
+        run: |
+          git add plugins/${{ inputs.plugin_name }}/pyproject.toml
+          if [ -f "plugins/${{ inputs.plugin_name }}/recipe.yaml" ]; then
+            git add plugins/${{ inputs.plugin_name }}/recipe.yaml
+          fi
+          git commit --no-verify -m "Bump ${{ inputs.plugin_name }} to v${{ inputs.version }}"
+
+      - name: Push commit to plugins branch
+        run: git push origin HEAD:plugins
+
+      - name: Create and push release tag
+        run: |
+          tag="${{ inputs.plugin_name }}-v${{ inputs.version }}"
+          git tag "$tag"
+          git push origin "$tag"
+          echo "Created and pushed tag: $tag"

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -63,9 +63,8 @@ Key points:
   range, e.g. ``spectrochempy>=0.8,<0.10``.
 * Use ``requires-python = ">=3.11"`` to match SpectroChemPy's minimum.
 * Official plugins in the monorepo use a static ``version`` field.
-  When a plugin is moved to its own repository, ``setuptools_scm``
-  is recommended so that tags such as ``spectrochempy-nmr-v0.1.1``
-  drive the published version automatically.
+  ``setuptools_scm`` is not used because plugin and core tags share the
+  same Git repository, which would cause version collisions.
 
 Local editable development
 ==========================
@@ -178,38 +177,36 @@ Release policy
 
 Plugins are released **independently** from the core package.
 
-* A core release tag such as ``spectrochempy-v0.8.3`` publishes the core
-  wheel only; it does **not** trigger plugin uploads.
+* A core release tag such as ``0.8.3`` publishes the core wheel only;
+  it does **not** trigger plugin uploads.
 * A plugin release tag such as ``spectrochempy-nmr-v0.1.1`` triggers the
-  ``publish_plugins.yml`` workflow for that plugin only.
+  ``publish_plugins.yml`` and ``build_package.yml`` workflows for that
+  plugin only.
 * The workflow uses ``skip-existing: true`` on PyPI so an already-published
   version never causes a hard failure.
 
-Tag-based versioning
---------------------
+Bumping a plugin version
+------------------------
 
-Official plugins use `setuptools-scm <https://setuptools-scm.readthedocs.io/>`_
-to derive their version from Git tags.  The tag convention is::
+Plugin versions are declared **statically** in the monorepo (``setuptools-scm``
+is not used for plugins because plugin and core tags share the same Git
+repository, which leads to version collisions).
 
-    spectrochempy-<plugin>-v<version>
+To release a plugin::
 
-Examples::
+    # 1. Bump version in plugins/<name>/pyproject.toml
+    # 2. Bump version in plugins/<name>/recipe.yaml (conda)
+    # 3. Commit and push:
+    git add plugins/<name>/pyproject.toml plugins/<name>/recipe.yaml
+    git commit -m "Bump spectrochempy-<name> to 0.1.1"
+    git push upstream plugins
 
-    spectrochempy-nmr-v0.1.1
-    spectrochempy-iris-v0.2.0
-    spectrorochempy-cantera-v0.1.0
+    # 4. Create and push the release tag:
+    git tag spectrochempy-<name>-v0.1.1
+    git push upstream spectrochempy-<name>-v0.1.1
 
-When a matching tag is pushed, the CI workflow builds the wheel with that
-version and publishes it.  If no tag exists, ``fallback_version`` (set in
-``pyproject.toml``) is used for local or dev builds.
-
-To bump a plugin version in the monorepo::
-
-    # 1. Update the fallback_version in plugins/<name>/pyproject.toml
-    # 2. Update the version in plugins/<name>/recipe.yaml (conda)
-    # 3. Commit, tag, and push:
-    git tag spectrochempy-nmr-v0.1.1
-    git push upstream spectrochempy-nmr-v0.1.1
+The tag is a pure CI trigger; the actual package version comes from
+``pyproject.toml`` (pip) and ``recipe.yaml`` (conda).
 
 Distribution (conda)
 ====================

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -185,6 +185,32 @@ Plugins are released **independently** from the core package.
 * The workflow uses ``skip-existing: true`` on PyPI so an already-published
   version never causes a hard failure.
 
+Tag-based versioning
+--------------------
+
+Official plugins use `setuptools-scm <https://setuptools-scm.readthedocs.io/>`_
+to derive their version from Git tags.  The tag convention is::
+
+    spectrochempy-<plugin>-v<version>
+
+Examples::
+
+    spectrochempy-nmr-v0.1.1
+    spectrochempy-iris-v0.2.0
+    spectrorochempy-cantera-v0.1.0
+
+When a matching tag is pushed, the CI workflow builds the wheel with that
+version and publishes it.  If no tag exists, ``fallback_version`` (set in
+``pyproject.toml``) is used for local or dev builds.
+
+To bump a plugin version in the monorepo::
+
+    # 1. Update the fallback_version in plugins/<name>/pyproject.toml
+    # 2. Update the version in plugins/<name>/recipe.yaml (conda)
+    # 3. Commit, tag, and push:
+    git tag spectrochempy-nmr-v0.1.1
+    git push upstream spectrochempy-nmr-v0.1.1
+
 Distribution (conda)
 ====================
 

--- a/plugins/plugin-template/pyproject.toml
+++ b/plugins/plugin-template/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-myplugin"
-dynamic = ["version"]
+version = "0.1.0"
 description = "A SpectroChemPy plugin"
 requires-python = ">=3.11"
 dependencies = [
@@ -19,6 +19,3 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-
-[tool.setuptools_scm]
-fallback_version = "0.1.0"

--- a/plugins/plugin-template/pyproject.toml
+++ b/plugins/plugin-template/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-myplugin"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A SpectroChemPy plugin"
 requires-python = ">=3.11"
 dependencies = [
@@ -19,3 +19,6 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"

--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-cantera"
-dynamic = ["version"]
+version = "0.1.0"
 description = "Cantera-based thermodynamics and reactive chemistry for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -25,6 +25,3 @@ testpaths = ["tests"]
 markers = [
     "network: tests requiring network access",
 ]
-
-[tool.setuptools_scm]
-fallback_version = "0.1.0"

--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-cantera"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Cantera-based thermodynamics and reactive chemistry for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -25,3 +25,6 @@ testpaths = ["tests"]
 markers = [
     "network: tests requiring network access",
 ]
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"

--- a/plugins/spectrochempy-carroucell/pyproject.toml
+++ b/plugins/spectrochempy-carroucell/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-carroucell"
-dynamic = ["version"]
+version = "0.1.0"
 description = "Carroucell experiment reader for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -21,6 +21,3 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-
-[tool.setuptools_scm]
-fallback_version = "0.1.0"

--- a/plugins/spectrochempy-carroucell/pyproject.toml
+++ b/plugins/spectrochempy-carroucell/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-carroucell"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Carroucell experiment reader for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -21,3 +21,6 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"

--- a/plugins/spectrochempy-hypercomplex/pyproject.toml
+++ b/plugins/spectrochempy-hypercomplex/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-hypercomplex"
-dynamic = ["version"]
+version = "0.1.0"
 description = "Hypercomplex / quaternion support plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -21,6 +21,3 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-
-[tool.setuptools_scm]
-fallback_version = "0.1.0"

--- a/plugins/spectrochempy-hypercomplex/pyproject.toml
+++ b/plugins/spectrochempy-hypercomplex/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-hypercomplex"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Hypercomplex / quaternion support plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -21,3 +21,6 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"

--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-iris"
-version = "0.1.0"
+dynamic = ["version"]
 description = "IRIS analysis extension for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -24,3 +24,6 @@ testpaths = ["tests"]
 markers = [
     "network: tests requiring network access",
 ]
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"

--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-iris"
-dynamic = ["version"]
+version = "0.1.0"
 description = "IRIS analysis extension for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -24,6 +24,3 @@ testpaths = ["tests"]
 markers = [
     "network: tests requiring network access",
 ]
-
-[tool.setuptools_scm]
-fallback_version = "0.1.0"

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-nmr"
-version = "0.1.0"
+dynamic = ["version"]
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -24,3 +24,6 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectrochempy-nmr"
-dynamic = ["version"]
+version = "0.1.0"
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
@@ -24,6 +24,3 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-
-[tool.setuptools_scm]
-fallback_version = "0.1.0"


### PR DESCRIPTION
## Summary

This PR adds a unified release workflow for official plugins and hardens CI filters so that plugin and core releases do not interfere with each other.

## Why not setuptools_scm for plugins?

An earlier attempt used `setuptools_scm` so that tags such as `spectrochempy-nmr-v0.1.1` would drive the plugin version automatically.  This proved **unsafe** in a monorepo because plugin and core tags share the same Git repository.  `setuptools_scm` on the core interprets a plugin tag (`spectrochempy-nmr-v0.1.1`) as a core version, producing a version like `0.1.2.dev1` which no longer satisfies `spectrochempy>=0.8,<0.10`.  Consequently `pip` reinstalls the stable core from PyPI (which does not yet contain the plugin system), breaking all plugin imports.

**Decision**: plugin versions remain **static** in the monorepo.  The release tag is a pure CI trigger.

## What this PR changes

### New workflow: `release_plugin.yml`

A single `workflow_dispatch` workflow that automates the entire plugin release:

1. Validates that the plugin directory exists.
2. Bumps `version` in `pyproject.toml`.
3. Bumps `version` in `recipe.yaml` (if present).
4. Commits and pushes to the `plugins` branch.
5. Creates and pushes the release tag (e.g. `spectrochempy-nmr-v0.1.1`).

The tag then triggers the existing `publish_plugins.yml` (PyPI) and `build_package.yml` (conda) jobs automatically.

### CI hardening already in place (kept from previous commits)

- `publish_plugins.yml` PyPI upload only runs when the release tag starts with the plugin name.
- `build_package.yml` conda upload uses the same filter.
- `plugin-template` is excluded from discovery in both workflows.
- `skip-existing: true` on PyPI prevents hard failures on duplicate versions.
- Conda stable (`main`) label upload does **not** use `--force`; it fails cleanly if the version already exists.
- Conda plugin builds include `-c spectrocat/label/dev` so dev plugin packages can resolve the latest dev core.

## Tag convention

```
spectrochempy-<plugin>-v<version>
```

Examples:
- `spectrochempy-nmr-v0.1.1`
- `spectrochempy-iris-v0.2.0`
- `spectrochempy-cantera-v0.1.0`

Core releases (e.g. `0.8.5`) do **not** trigger plugin uploads.

## How to release a plugin after this PR

Use the GitHub Actions UI:

1. Go to **Actions → Release an official plugin**.
2. Click **Run workflow**.
3. Enter:
   - Plugin name: `spectrochempy-nmr`
   - Version: `0.1.1`
4. The workflow bumps the files, commits, and creates the tag automatically.
5. The tag triggers CI which builds and publishes the wheel to PyPI and Anaconda.org.

## Manual fallback (if needed)

```bash
# 1. Bump version in pyproject.toml and recipe.yaml
# 2. Commit and push
# 3. Create and push tag manually
git tag spectrochempy-nmr-v0.1.1
git push upstream spectrochempy-nmr-v0.1.1
```

## Backward compatibility

- Existing `0.1.0` plugin wheels on PyPI are untouched.
- Local/dev builds work unchanged (static versions).
- Core release process (`prepare_new_release.yml` / `publish_draft_new_release.yml`) is unaffected.
