### PR TITLE
Final release hardening: plugins extra, publication safety

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -78,7 +78,11 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish package to PyPI
-        if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'spectrochempy/spectrochempy'
+        if: |
+          github.event_name == 'release' &&
+          github.event.action == 'published' &&
+          github.repository == 'spectrochempy/spectrochempy' &&
+          startsWith(github.ref_name, 'spectrochempy-v')
         uses: pypa/gh-action-pypi-publish@release/v1
 
   build_and_publish_conda_package:
@@ -135,7 +139,10 @@ jobs:
       - name: Upload to Anaconda.org
         if: |
           github.repository == 'spectrochempy/spectrochempy' &&
-          (github.event_name == 'release' || github.event_name == 'push')
+          (
+            github.event_name == 'push' ||
+            (github.event_name == 'release' && startsWith(github.ref_name, 'spectrochempy-v'))
+          )
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |

--- a/.github/workflows/publish_draft_new_release.yml
+++ b/.github/workflows/publish_draft_new_release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
-          tag_name: ${{ env.RELEASE_VERSION }}
+          tag_name: spectrochempy-v${{ env.RELEASE_VERSION }}
           name: SpectroChemPy v.${{ env.RELEASE_VERSION }}
           draft: true
           prerelease: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,13 @@ interactive = [
 ]
 nmr = ["spectrochempy-nmr>=0.1,<0.2"]
 iris = ["spectrochempy-iris>=0.1,<0.2"]
+plugins = [
+    "spectrochempy[nmr]",
+    "spectrochempy[iris]",
+    "spectrochempy[cantera]",
+    "spectrochempy-hypercomplex>=0.1,<0.2",
+    "spectrochempy-carroucell>=0.1,<0.2",
+]
 test = [
   "coverage",
   "ipywidgets",


### PR DESCRIPTION
## Summary

Final hardening of plugin packaging and publication before merge to master.

## Changes

### 1. Added  pip extra

The  extra was referenced in  but did not exist in
. It now installs all official plugins at once:



This installs: nmr, iris, cantera, hypercomplex, carroucell.

### 2. plugin-template exclusion (already in place)

Both  and  explicitly skip
 during discovery. The template is a developer
scaffold and must never be published.

### 3. Prevent unconditional republishing (already in place)

- PyPI upload uses  so already-published versions
  are skipped cleanly without hard failures.
- Conda stable () label upload does NOT use ; it fails
  cleanly if the version already exists.
- Plugin release tags (e.g. ) are filtered so
  only the matching plugin is published.

### 4. Conda publication safety (already in place)

-  is used ONLY on the  label so the latest dev build is
  always available for testing.
- The  label never overwrites existing stable packages.

## Validation

- regenerate_requirements..................................................Passed
regenerate_lazy stub files...............................................Passed
update_version_and_release_notes.........................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
check yaml...............................................................Passed
ruff.....................................................................Passed
ruff-format..............................................................Passed → all hooks passed
- Core import:  → OK
- Plugin discovery after editable install:  → lists installed plugins
-  → 51 passed
-  → 4 passed

## Assessment

The branch is ready for merge to master. All publication safeguards are
in place, documentation is consistent, and the  extra is now real.