### PR TITLE
fix(plugins): preserve composed importer handlers in CI

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -189,6 +189,25 @@ jobs:
               print('NMR dir contents:', [p.name for p in nmr_dir.iterdir()])
           else:
               print('WARNING: NMR dir does not exist:', nmr_dir)
+          # Validate plugin directory resolution and reads used by documentation.
+          # An old cache can contain file names while holding incomplete data.
+          def validate_nmr_reads():
+              nmr_root = nmr_dir.parents[1]
+              for sample, expno in [('topspin_1d', 1), ('h3po4', 4), ('cadmium', 100)]:
+                  nd = scp.nmr.read_topspin(
+                      nmr_root / sample,
+                      expno=expno,
+                      remove_digital_filter=True,
+                      local_only=True,
+                  )
+                  print(f'NMR TopSpin read verified: {sample}/{expno} {nd.shape}')
+
+          try:
+              validate_nmr_reads()
+          except Exception as exc:
+              print(f'NMR read validation failed ({exc!r}); forcing re-download...')
+              download_full_testdata_directory(datadir, force=True)
+              validate_nmr_reads()
           print('Test data ready.')
           "
           duration=$((SECONDS - start))

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -161,58 +161,6 @@ jobs:
           duration=$((SECONDS - start))
           echo "plugin installation: ${duration}s" | tee -a "$CI_TIMING_FILE"
 
-      - name: Download test data
-        if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
-        run: |
-          set -e
-          start=$SECONDS
-          python -c "
-          import spectrochempy as scp
-          from spectrochempy.application.testdata import download_full_testdata_directory
-          datadir = scp.preferences.datadir
-          print(f'Downloading test data to {datadir}...')
-          download_full_testdata_directory(datadir, force=False)
-          # Verify key NMR data is present (docs scripts need this)
-          nmr_dir = datadir / 'nmrdata' / 'bruker' / 'tests' / 'nmr' / 'topspin_1d' / '1'
-          required = ['acqu', 'acqus', 'fid']
-          missing = [f for f in required if not (nmr_dir / f).exists()]
-          if missing:
-              print(f'NMR files missing: {missing}, forcing re-download...')
-              download_full_testdata_directory(datadir, force=True)
-              missing = [f for f in required if not (nmr_dir / f).exists()]
-              if missing:
-                  raise RuntimeError(f'Failed to download NMR files: {missing}')
-          else:
-              print('NMR test data verified.')
-          # List NMR dir contents for debugging
-          if nmr_dir.exists():
-              print('NMR dir contents:', [p.name for p in nmr_dir.iterdir()])
-          else:
-              print('WARNING: NMR dir does not exist:', nmr_dir)
-          # Validate plugin directory resolution and reads used by documentation.
-          # An old cache can contain file names while holding incomplete data.
-          def validate_nmr_reads():
-              nmr_root = nmr_dir.parents[1]
-              for sample, expno in [('topspin_1d', 1), ('h3po4', 4), ('cadmium', 100)]:
-                  nd = scp.nmr.read_topspin(
-                      nmr_root / sample,
-                      expno=expno,
-                      remove_digital_filter=True,
-                      local_only=True,
-                  )
-                  print(f'NMR TopSpin read verified: {sample}/{expno} {nd.shape}')
-
-          try:
-              validate_nmr_reads()
-          except Exception as exc:
-              print(f'NMR read validation failed ({exc!r}); forcing re-download...')
-              download_full_testdata_directory(datadir, force=True)
-              validate_nmr_reads()
-          print('Test data ready.')
-          "
-          duration=$((SECONDS - start))
-          echo "test data download: ${duration}s" | tee -a "$CI_TIMING_FILE"
-
       - name: Environment and plugin diagnostics
         if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
         run: |

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -161,6 +161,39 @@ jobs:
           duration=$((SECONDS - start))
           echo "plugin installation: ${duration}s" | tee -a "$CI_TIMING_FILE"
 
+      - name: Download test data
+        if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
+        run: |
+          set -e
+          start=$SECONDS
+          python -c "
+          import spectrochempy as scp
+          from spectrochempy.application.testdata import download_full_testdata_directory
+          datadir = scp.preferences.datadir
+          print(f'Downloading test data to {datadir}...')
+          download_full_testdata_directory(datadir, force=False)
+          # Verify key NMR data is present (docs scripts need this)
+          nmr_dir = datadir / 'nmrdata' / 'bruker' / 'tests' / 'nmr' / 'topspin_1d' / '1'
+          required = ['acqu', 'acqus', 'fid']
+          missing = [f for f in required if not (nmr_dir / f).exists()]
+          if missing:
+              print(f'NMR files missing: {missing}, forcing re-download...')
+              download_full_testdata_directory(datadir, force=True)
+              missing = [f for f in required if not (nmr_dir / f).exists()]
+              if missing:
+                  raise RuntimeError(f'Failed to download NMR files: {missing}')
+          else:
+              print('NMR test data verified.')
+          # List NMR dir contents for debugging
+          if nmr_dir.exists():
+              print('NMR dir contents:', [p.name for p in nmr_dir.iterdir()])
+          else:
+              print('WARNING: NMR dir does not exist:', nmr_dir)
+          print('Test data ready.')
+          "
+          duration=$((SECONDS - start))
+          echo "test data download: ${duration}s" | tee -a "$CI_TIMING_FILE"
+
       - name: Environment and plugin diagnostics
         if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
         run: |

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
@@ -115,6 +115,8 @@ def _resolve_topspin_directory_target(filename, **kwargs):
     """Resolve a TopSpin experiment directory to concrete data files."""
     if not _is_topspin_protocol(**kwargs):
         return None
+    if filename.name in _VALID_TOPSPIN_FILENAMES:
+        return None
 
     if kwargs.get("iterdir", False) or kwargs.get("glob") is not None:
         glob = kwargs.get("glob")
@@ -133,7 +135,9 @@ def _resolve_topspin_directory_target(filename, **kwargs):
 
         if expno is None:
             expnos = sorted(filename.glob("[0-9]*"))
-            expno = expnos[0] if expnos else expno
+            # A missing local directory can still be fetched remotely. TopSpin
+            # experiment directories conventionally begin at experiment 1.
+            expno = expnos[0] if expnos else 1
 
         if procno is None:
             f = filename / str(expno)

--- a/src/spectrochempy/application/testdata.py
+++ b/src/spectrochempy/application/testdata.py
@@ -7,10 +7,12 @@
 
 from pathlib import Path
 
-
 # --------------------------------------------------------------------------------------
 # Testdata
 # --------------------------------------------------------------------------------------
+_TESTDATA_CACHE_MARKER = "spectrochempy-testdata-v1\n"
+
+
 def download_full_testdata_directory(datadir, force=False):
     """
     Download and extract the full SpectroChemPy test data directory.
@@ -21,13 +23,17 @@ def download_full_testdata_directory(datadir, force=False):
         Target directory where test data should be extracted.
     force : bool, optional
         If True, force re-download even if already downloaded.
-        If False, skip download if marker file exists.
+        If False, skip download if a current cache marker exists.
     """
 
-    # Marker file used to prevent repeated downloads
-    # This avoids re-downloading test data on every docs build.
+    # Only a marker created by this extraction contract is trusted. Legacy empty
+    # markers may represent partial caches restored by CI.
     downloaded = datadir / "__downloaded__"
-    if downloaded.exists() and not force:
+    if (
+        downloaded.exists()
+        and downloaded.read_text(encoding="utf8") == _TESTDATA_CACHE_MARKER
+        and not force
+    ):
         return
 
     # GitHub archive URL (zip of master branch)
@@ -120,4 +126,4 @@ def download_full_testdata_directory(datadir, force=False):
     # This prevents re-running the download on subsequent builds
     # unless force=True is explicitly passed.
     # ------------------------------------------------------------------
-    downloaded.touch(exist_ok=True)
+    downloaded.write_text(_TESTDATA_CACHE_MARKER, encoding="utf8")

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -184,11 +184,27 @@ class Importer(HasTraits):
                 dataset = read_(self.objtype(), filename, **kwargs)
 
             except (FileNotFoundError, OSError) as exc:
-                # file was not found.
-                # it is an url we raise an error
                 local_only = kwargs.get("local_only", False)
-                if _is_url(filename) or local_only:
-                    raise (FileNotFoundError) from exc
+                is_url = _is_url(filename)
+                protocol = kwargs.get("protocol", [])
+                protocol = [protocol] if isinstance(protocol, str) else protocol
+                is_topspin = "topspin" in protocol
+
+                # TopSpin data is resolved to a concrete binary before reading.
+                # Preserve errors on that local binary instead of obscuring
+                # them with a failed remote download attempt.
+                local_target_exists = not is_url and pathclean(filename).exists()
+                if (
+                    is_topspin
+                    and isinstance(exc, OSError)
+                    and not isinstance(exc, FileNotFoundError)
+                    and local_target_exists
+                ):
+                    raise
+
+                # An explicitly local request or URL cannot use the fallback.
+                if is_url or local_only:
+                    raise FileNotFoundError from exc
 
                 # else, we try on github
                 try:

--- a/src/spectrochempy/plugins/registry.py
+++ b/src/spectrochempy/plugins/registry.py
@@ -72,7 +72,8 @@ class PluginRegistry:
         self.visualization._visualizers.update(other.visualization._visualizers)
         for category, entries in other.extensions._extensions.items():
             self.extensions._extensions.setdefault(category, {}).update(entries)
-        self.handlers._handlers.update(other.handlers._handlers)
+        for name, handlers in other.handlers._handlers.items():
+            self.handlers._handlers.setdefault(name, []).extend(handlers)
 
     # ------------------------------------------------------------------
     # Capability-based query

--- a/src/spectrochempy/utils/file.py
+++ b/src/spectrochempy/utils/file.py
@@ -330,7 +330,7 @@ def check_filenames(*args, **kwargs):
             if fexist:
                 filename = fexist
 
-            if filename.is_dir():
+            if filename.is_dir() or fexist is None:
                 filename = _resolve_directory_target(filename, **kwargs)
 
             if not isinstance(filename, (list, tuple)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,6 +215,7 @@ def pytest_sessionfinish(session, exitstatus):  # pragma: no cover
             f.name not in ["zenodo.json", "versions.json", "preferences.json"]
             and ".vscode" not in f.parts
             and ".venv" not in f.parts
+            and ".git" not in f.parts
         ):
             f.unlink()
     for f in list(cwd.glob("**/*.log")):

--- a/tests/test_application/test_testdata.py
+++ b/tests/test_application/test_testdata.py
@@ -1,0 +1,63 @@
+# ======================================================================================
+# Copyright (C) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Tests for the testdata cache marker contract."""
+
+from io import BytesIO
+from zipfile import ZipFile
+
+from spectrochempy.application.testdata import _TESTDATA_CACHE_MARKER
+from spectrochempy.application.testdata import download_full_testdata_directory
+
+
+class _Response:
+    def __init__(self, content):
+        self._content = content
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size):
+        yield self._content
+
+
+def _testdata_archive():
+    archive = BytesIO()
+    with ZipFile(archive, "w") as zipfile:
+        zipfile.writestr(
+            "spectrochempy_data-master/testdata/example/sample.dat",
+            b"complete",
+        )
+    return archive.getvalue()
+
+
+def test_legacy_marker_does_not_hide_incomplete_cache(tmp_path, monkeypatch):
+    datadir = tmp_path / "testdata"
+    datadir.mkdir()
+    (datadir / "__downloaded__").touch()
+    monkeypatch.setattr(
+        "requests.get",
+        lambda *args, **kwargs: _Response(_testdata_archive()),
+    )
+
+    download_full_testdata_directory(datadir)
+
+    assert (datadir / "example" / "sample.dat").read_bytes() == b"complete"
+    assert (datadir / "__downloaded__").read_text(encoding="utf8") == (
+        _TESTDATA_CACHE_MARKER
+    )
+
+
+def test_current_marker_skips_download(tmp_path, monkeypatch):
+    datadir = tmp_path / "testdata"
+    datadir.mkdir()
+    (datadir / "__downloaded__").write_text(_TESTDATA_CACHE_MARKER, encoding="utf8")
+
+    def fail_download(*args, **kwargs):
+        raise AssertionError("current testdata cache should not be downloaded again")
+
+    monkeypatch.setattr("requests.get", fail_download)
+
+    download_full_testdata_directory(datadir)

--- a/tests/test_core/test_readers/test_importer.py
+++ b/tests/test_core/test_readers/test_importer.py
@@ -195,6 +195,32 @@ class TestBasicImporter:
         assert nd.shape == (1, 3)  # Check shape
         assert nd.name == self.test_file.stem  # Check name preserved
 
+    def test_existing_local_reader_oserror_is_preserved(self, tmp_path, monkeypatch):
+        """A reader failure on existing data must not be reported as missing data."""
+        filename = tmp_path / "local.fake"
+        filename.touch()
+        importer = Importer()
+        importer.objtype = NDDataset
+
+        def fail_to_read(*args, **kwargs):
+            raise OSError("local parse failure")
+
+        def unexpected_remote_fallback(*args, **kwargs):
+            raise AssertionError("remote fallback should not be attempted")
+
+        monkeypatch.setattr(importer, "_read_topspin", fail_to_read, raising=False)
+        monkeypatch.setattr(
+            "spectrochempy.core.readers.importer._read_remote",
+            unexpected_remote_fallback,
+        )
+
+        with pytest.raises(OSError, match="local parse failure"):
+            importer._switch_protocol(
+                ".topspin",
+                {".topspin": [filename]},
+                protocol=["topspin"],
+            )
+
 
 class TestImporterMerging:
     """Test dataset merging behavior."""

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -1433,7 +1433,7 @@ class TestRegisterHandlers:
         pm = PluginManager(registry=registry)
 
         def handler_a():
-            return None
+            return "a"
 
         def handler_b():
             return "b"
@@ -1456,7 +1456,8 @@ class TestRegisterHandlers:
 
         pm.register(PluginA())
         pm.register(PluginB())
-        assert registry.get_handler("dup.handler")() == "b"
+        assert registry.get_handler("dup.handler")() == "a"
+        assert registry.available_handlers["dup.handler"] == [handler_a, handler_b]
 
     def test_coord_reversed_no_handler_uses_default(self):
         """Without any coord.reversed handler, ppm and 1/centimeter still reverse."""

--- a/tests/test_plugins/test_nmr_importer_handlers.py
+++ b/tests/test_plugins/test_nmr_importer_handlers.py
@@ -1,0 +1,46 @@
+# ======================================================================================
+# Copyright (C) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Regression tests for the NMR plugin importer handlers."""
+
+from pathlib import Path
+
+from spectrochempy_nmr import _resolve_topspin_directory_target
+from spectrochempy_nmr import _topspin_remote_download_target
+
+
+def _norm(path: str) -> str:
+    """Normalise un chemin retourné par les handlers pour comparaison portable."""
+    return path.rstrip("/\\").replace("\\", "/")
+
+
+def test_missing_topspin_directory_resolves_remote_default_experiment():
+    directory = Path("/missing/topspin_1d")
+
+    resolved = _resolve_topspin_directory_target(directory, protocol=["topspin"])
+
+    assert resolved == [directory / "1" / "fid"]
+    target = _topspin_remote_download_target(resolved[0], protocol=["topspin"])
+    assert _norm(target) == "/missing/topspin_1d/1"
+
+
+def test_missing_topspin_directory_preserves_expno_for_remote_target():
+    directory = Path("/missing/h3po4")
+
+    resolved = _resolve_topspin_directory_target(
+        directory,
+        protocol=["topspin"],
+        expno=4,
+    )
+
+    assert resolved == [directory / "4" / "fid"]
+
+
+def test_missing_explicit_topspin_file_is_not_resolved_as_directory():
+    filename = Path("/missing/topspin_1d/1/fid")
+
+    assert _resolve_topspin_directory_target(filename, protocol=["topspin"]) is None
+    target = _topspin_remote_download_target(filename, protocol=["topspin"])
+    assert _norm(target) == "/missing/topspin_1d/1"

--- a/tests/test_utils/test_file.py
+++ b/tests/test_utils/test_file.py
@@ -357,6 +357,25 @@ class TestImporterHandlers:
         with patch("spectrochempy.utils.file._get_importer_handler", return_value=None):
             assert _resolve_directory_target(directory) == directory
 
+    def test_missing_directory_target_can_be_resolved_by_plugin(self, tmp_path):
+        directory = tmp_path / "missing_dataset"
+        resolved = directory / "1" / "data"
+
+        def get_handler(name):
+            if name == "importer.resolve_directory_target":
+                return lambda filename, **kwargs: [resolved]
+            if name == "importer.infer_filetype_key":
+                return lambda filename, **kwargs: "myformat"
+            return None
+
+        with patch(
+            "spectrochempy.utils.file._get_importer_handler",
+            side_effect=get_handler,
+        ):
+            result = check_filename_to_open(directory, protocol=["myformat"])
+
+        assert result == {".myformat": [resolved]}
+
     def test_infer_filetype_key_normalizes_key(self):
         filename = Path("/path/to/extensionless")
 


### PR DESCRIPTION
## Summary

- preserve handler composition when multiple plugins register the same extension point
- fix the NMR + Carroucell interaction that caused TopSpin `fid` paths to lose NMR file-type inference in the Ubuntu all-plugins CI environment
- retain the generic importer/NMR resolution regressions and defensive stale-testdata recovery already added while investigating the failure
- remove the temporary NMR data-validation workflow step; the workflow is back to the `plugins` branch version

## Root cause

Ubuntu was not failing because the Bruker files were absent. In CI, all official plugins are installed, including both NMR and Carroucell. Both plugins register `importer.infer_filetype_key`.

`PluginRegistry.merge_from()` merged handler registries with a dictionary update, replacing the NMR handler list when Carroucell was registered later. Consequently, an existing TopSpin `fid` file could no longer be inferred as `.topspin`, and the importer surfaced a misleading `FileNotFoundError`. Local executions that did not load Carroucell did not reproduce the problem.

The fix extends handler lists during registry merging, matching the existing first-non-`None` handler contract, and adds a regression test for multiple plugin registrations.

## Validation

- reproduced the CI plugin combination locally with NMR and Carroucell: `fid` resolves as `.topspin` and `read_topspin(...)` succeeds
- `conda run --no-capture-output -n scpy python -m pytest tests/test_plugins/test_integration.py::TestRegisterHandlers::test_handler_composable_first_non_none_wins tests/test_plugins/test_registry.py tests/test_plugins/test_nmr_importer_handlers.py tests/test_core/test_readers/test_importer.py -q -ra` (`74 passed`)
- `conda run --no-capture-output -n scpy python -m pytest tests/test_docs/test_py_in_docs.py -q -ra -k 'apodization or dataset or fourier or project or td_baseline'` (`7 passed`)
- `conda run --no-capture-output -n scpy pre-commit run --all-files` (passed)
- GitHub Actions run `26514774933` passed on Ubuntu Python 3.11, Ubuntu Python 3.14, macOS, and Windows

The full docs test run locally also reached the former NMR failures successfully; its remaining failures required external Eigenvector downloads unavailable from the sandbox.