### PR TITLE
Improve missing official plugin errors

### DIFF
--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -79,6 +79,7 @@ application.start.set_warnings()
 from spectrochempy.plugins.features import KNOWN_PLUGIN_NAMESPACES
 from spectrochempy.plugins.features import plugin_namespace_install_hint
 from spectrochempy.plugins.features import plugin_reader_missing_stub
+from spectrochempy.plugins.features import plugin_symbol_install_hint
 from spectrochempy.plugins.manager import plugin_manager
 from spectrochempy.plugins.registry import registry
 
@@ -261,6 +262,9 @@ def __getattr__(name):
             from spectrochempy.plugins.deps import MissingPluginNamespaceError
 
             raise MissingPluginNamespaceError(hint) from err
+        symbol_hint = plugin_symbol_install_hint(name)
+        if symbol_hint:
+            raise AttributeError(symbol_hint) from err
         raise AttributeError(
             f"module 'spectrochempy' has no attribute '{name}'"
         ) from err

--- a/src/spectrochempy/plugins/features.py
+++ b/src/spectrochempy/plugins/features.py
@@ -58,6 +58,52 @@ OFFICIAL_PLUGINS = {
     },
 }
 
+PLUGIN_SYMBOL_HINTS = {
+    "IRIS": {
+        "plugin_title": "IRIS plugin",
+        "plugin_package": "spectrochempy-iris",
+        "namespace": "scp.iris.IRIS",
+    },
+    "IrisKernel": {
+        "plugin_title": "IRIS plugin",
+        "plugin_package": "spectrochempy-iris",
+        "namespace": "scp.iris.IrisKernel",
+    },
+    "batch_iris": {
+        "plugin_title": "IRIS plugin",
+        "plugin_package": "spectrochempy-iris",
+        "namespace": "scp.iris.batch_iris",
+    },
+    "compare_kernels": {
+        "plugin_title": "IRIS plugin",
+        "plugin_package": "spectrochempy-iris",
+        "namespace": "scp.iris.compare_kernels",
+    },
+    "iris_report": {
+        "plugin_title": "IRIS plugin",
+        "plugin_package": "spectrochempy-iris",
+        "namespace": "scp.iris.iris_report",
+    },
+}
+
+
+def plugin_symbol_install_hint(symbol: str) -> str | None:
+    """Return an AttributeError message for a missing official plugin symbol."""
+    info = PLUGIN_SYMBOL_HINTS.get(symbol)
+    if info is None:
+        return None
+
+    return (
+        f"module 'spectrochempy' has no attribute '{symbol}'.\n\n"
+        "Did you mean:\n"
+        f"    {info['namespace']}\n\n"
+        f"The official {info['plugin_title']} is not installed.\n\n"
+        "Install it with:\n"
+        f"    pip install {info['plugin_package']}\n\n"
+        "or:\n"
+        "    pip install spectrochempy[plugins]"
+    )
+
 
 def plugin_reader_install_hint(reader_name: str) -> str | None:
     """Return an install hint if *reader_name* belongs to an optional plugin."""

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -320,6 +320,14 @@ class TestMissingPluginError:
         manager = PluginManager(registry=registry)
         return PluginNamespace(ns_name, manager, registry)
 
+    def _simulate_no_discovered_plugins(self, monkeypatch):
+        """Point the package-level plugin manager at an empty registry."""
+        registry = PluginRegistry()
+        manager = PluginManager(registry=registry)
+        monkeypatch.setattr(im, "entry_points", lambda group=None: [])
+        monkeypatch.setattr(spectrochempy, "registry", registry)
+        monkeypatch.setattr(spectrochempy, "plugin_manager", manager)
+
     def test_missing_known_namespace_attribute_error(self, monkeypatch):
         """Accessing an attribute on a missing known namespace raises MissingPluginNamespaceError."""
         from spectrochempy.plugins.deps import MissingPluginNamespaceError
@@ -338,6 +346,42 @@ class TestMissingPluginError:
             _ = ns.something
         msg = str(excinfo.value)
         assert "has no attribute" in msg
+
+    def test_missing_official_root_symbol_guides_install(self, monkeypatch):
+        """A missing official plugin root symbol gives an actionable AttributeError."""
+        self._simulate_no_discovered_plugins(monkeypatch)
+
+        with pytest.raises(AttributeError) as excinfo:
+            _ = spectrochempy.IRIS
+
+        msg = str(excinfo.value)
+        assert "module 'spectrochempy' has no attribute 'IRIS'" in msg
+        assert "Did you mean:" in msg
+        assert "scp.iris.IRIS" in msg
+        assert "The official IRIS plugin is not installed" in msg
+        assert "pip install spectrochempy-iris" in msg
+        assert "pip install spectrochempy[plugins]" in msg
+
+    def test_missing_official_root_symbol_preserves_hasattr(self, monkeypatch):
+        """The richer AttributeError remains compatible with hasattr()."""
+        self._simulate_no_discovered_plugins(monkeypatch)
+
+        assert hasattr(spectrochempy, "IRIS") is False
+
+    def test_experimental_root_symbol_has_no_special_hint(self, monkeypatch):
+        """Experimental plugin symbols are not promoted by install guidance."""
+        from spectrochempy.plugins.features import plugin_symbol_install_hint
+
+        assert plugin_symbol_install_hint("PFR") is None
+        self._simulate_no_discovered_plugins(monkeypatch)
+
+        with pytest.raises(AttributeError) as excinfo:
+            _ = spectrochempy.CanteraReactor
+
+        msg = str(excinfo.value)
+        assert "module 'spectrochempy' has no attribute 'CanteraReactor'" in msg
+        assert "Did you mean:" not in msg
+        assert "spectrochempy-cantera" not in msg
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a small static registry for stable root symbols provided by official plugins
- enrich missing-symbol `AttributeError` messages with namespaced usage and install commands
- keep experimental plugin symbols out of the hint registry

## Validation
- `pytest tests/test_plugins/test_integration.py::TestMissingPluginError -q -ra`
- `pre-commit run --files src/spectrochempy/__init__.py src/spectrochempy/plugins/features.py tests/test_plugins/test_integration.py`