### PR TITLE
Parallelize full documentation builds

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -199,9 +199,9 @@ jobs:
             python3 docs/make.py --no-exec -j auto html
           elif [[ "${{ steps.preview.outputs.is_preview }}" == "true" ]]; then
             SCPY_BUILDDIR=${{ steps.preview.outputs.build_subdir }} \
-              python3 docs/make.py -j1 html
+              python3 docs/make.py -j auto html
           else
-            python3 docs/make.py -j1 html
+            python3 docs/make.py -j auto html
           fi
           duration=$((SECONDS - start))
           echo "documentation build: ${duration}s" | tee -a "$CI_TIMING_FILE"


### PR DESCRIPTION
## Summary
- keep full documentation execution for branch previews and stable docs
- switch complete docs builds from `-j1` to `-j auto`
- leave the already-fast pull request `--no-exec` path unchanged

## Notes
This is intentionally a small CI experiment. The branch preview behavior is preserved; this only lets Sphinx use parallel workers during complete builds. CI will tell us whether Sphinx-Gallery and the current extensions are parallel-safe in this workflow.

## Validation
- `pre-commit run --files .github/workflows/build_docs.yml`