### PR TITLE
Skip coverage on pull request tests

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -187,7 +187,7 @@ jobs:
             exit 0
           fi
           run_tests() {
-            if [[ "${{ matrix.coverage }}" == "true" ]]; then
+            if [[ "${{ matrix.coverage }}" == "true" && "${{ github.event_name }}" != "pull_request" ]]; then
               coverage run --source=spectrochempy -m pytest $targets "${pytest_extra_args[@]}" -s -ra --durations=10
             else
               python -m pytest $targets "${pytest_extra_args[@]}" -s -ra --durations=10
@@ -207,7 +207,7 @@ jobs:
             --timings "$CI_TIMING_FILE"
 
       - name: Debug info coverage content
-        if: ${{ always() && matrix.coverage && !(env.ACT && matrix.pythonVersion == '3.14') }}
+        if: ${{ always() && matrix.coverage && github.event_name != 'pull_request' && !(env.ACT && matrix.pythonVersion == '3.14') }}
         run: |
           coverage report -m || echo "coverage report unavailable"
 


### PR DESCRIPTION
## Summary
- run the canonical Ubuntu test job without coverage on `pull_request` events
- keep coverage enabled for non-PR runs where Codecov/reporting can use it
- skip the coverage debug report on PRs when no coverage data is produced

## Notes
Local timing from the same suite showed coverage adding about 2 minutes to the full test run. This keeps the test selection unchanged and only removes PR-only coverage overhead.

## Validation
- `pre-commit run --files .github/workflows/test_package.yml`