### PR TITLE
Require spectrochempy>=0.9.0.dev0 across all official plugins

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -98,6 +98,8 @@ jobs:
           echo "uv installation: ${duration}s" | tee -a "$CI_TIMING_FILE"
 
       - name: Install spectrochempy
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: 0.9.0.dev0
         run: |
           set -e
           . .venv/bin/activate

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -272,10 +272,17 @@ jobs:
 
       - name: Setup local conda channel from core build
         run: |
+          echo "=== Artifact structure ==="
+          find /tmp/core-pkg -type f 2>/dev/null || echo "(empty)"
+          echo "=== Copying to local channel ==="
           PARENT=$(dirname "${{ github.workspace }}")
           mkdir -p "$PARENT/output"
-          cp -r /tmp/core-pkg/output/* "$PARENT/output/"
-          echo "Local channel contents:"
+          if [ -d /tmp/core-pkg/output ]; then
+            cp -r /tmp/core-pkg/output/* "$PARENT/output/"
+          else
+            cp -r /tmp/core-pkg/* "$PARENT/output/"
+          fi
+          echo "=== Local channel contents ==="
           find "$PARENT/output" -type f
 
       - name: Build conda plugin package

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -109,6 +109,8 @@ jobs:
           cache-environment: true
 
       - name: Generate conda recipe
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: 0.9.0.dev0
         run: |
           python3 .github/workflows/scripts/generate_conda_recipe.py
           cat recipe/recipe.yaml
@@ -261,6 +263,20 @@ jobs:
           create-args: >-
             python=3.11
           cache-environment: true
+
+      - name: Download core conda package
+        uses: actions/download-artifact@v4
+        with:
+          name: conda-package
+          path: /tmp/core-pkg
+
+      - name: Setup local conda channel from core build
+        run: |
+          PARENT=$(dirname "${{ github.workspace }}")
+          mkdir -p "$PARENT/output"
+          cp -r /tmp/core-pkg/output/* "$PARENT/output/"
+          echo "Local channel contents:"
+          find "$PARENT/output" -type f
 
       - name: Build conda plugin package
         uses: prefix-dev/rattler-build-action@v0.2.38

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -7,7 +7,7 @@
 #   - Release builds are uploaded to the main (stable) label.
 #   - The dev label is used for testing; stable packages should not be overwritten.
 #   - Plugin conda recipes should declare a bounded dependency on the core
-#     package, e.g.  spectrochempy >=0.8,<0.10
+#     package, e.g.  spectrochempy >=0.9.0.dev0,<0.10
 
 name: Build and publish packages 📦
 

--- a/.github/workflows/install_on_colab.yml
+++ b/.github/workflows/install_on_colab.yml
@@ -66,7 +66,7 @@ jobs:
             -c "
               pip install -q setuptools wheel build setuptools-scm && \
               git config --global --add safe.directory /workspace && \
-              SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SPECTROCHEMPY=0.8.5.dev0 \
+              SETUPTOOLS_SCM_PRETEND_VERSION=0.9.0.dev0 \
                 pip install --no-build-isolation --no-deps /workspace && \
               pip install -q colorama pint && \
               python3 /workspace/.github/workflows/scripts/test_colab_plugins.py --mode core-only
@@ -82,7 +82,7 @@ jobs:
             -c "
               pip install -q setuptools wheel build setuptools-scm && \
               git config --global --add safe.directory /workspace && \
-              SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SPECTROCHEMPY=0.8.5.dev0 \
+              SETUPTOOLS_SCM_PRETEND_VERSION=0.9.0.dev0 \
                 pip install --no-build-isolation --no-deps /workspace && \
               pip install -q colorama pint numpy-quaternion && \
               pip install --no-build-isolation --no-deps /workspace/plugins/spectrochempy-iris && \

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -11,7 +11,7 @@
 #   - Official plugins are released independently from the core package.
 #   - Plugin releases are triggered by GitHub releases whose tag matches the
 #     plugin name, e.g.  spectrochempy-nmr-v0.1.1
-#   - A core release tag (e.g. spectrochempy-v0.8.3) does NOT publish plugins.
+#   - A core release tag (e.g. spectrochempy-v0.9.0) does NOT publish plugins.
 #   - plugin-template is excluded from discovery — it is a developer scaffold.
 #   - PyPI upload uses skip-existing so an already-published version never
 #     causes a hard failure.

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -130,6 +130,8 @@ jobs:
 
       - name: Install spectrochempy
         if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: 0.9.0.dev0
         run: |
           set -e
           start=$SECONDS

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -43,7 +43,7 @@ to discover your plugin automatically:
     description = "My SpectroChemPy plugin"
     requires-python = ">=3.11"
     dependencies = [
-        "spectrochempy>=0.8,<0.9",
+        "spectrochempy>=0.9.0.dev0,<0.10",
     ]
 
     [project.entry-points."spectrochempy.plugins"]
@@ -60,7 +60,7 @@ Key points:
 * The **entry point name** (``myplugin``) must match your plugin's
   ``name`` attribute.
 * ``spectrochempy`` must be listed as a dependency with a compatibility
-  range, e.g. ``spectrochempy>=0.8,<0.10``.
+  range, e.g. ``spectrochempy>=0.9.0.dev0,<0.10``.
 * Use ``requires-python = ">=3.11"`` to match SpectroChemPy's minimum.
 * Official plugins in the monorepo use a static ``version`` field.
   ``setuptools_scm`` is not used because plugin and core tags share the
@@ -127,7 +127,7 @@ Your plugin class must implement the
         name = "myplugin"
         version = "0.1.0"
         description = "My SpectroChemPy plugin"
-        spectrochempy_min_version = "0.8.0"
+        spectrochempy_min_version = "0.9.0.dev0"
         PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
 
         def register_readers(self) -> list[dict]:
@@ -181,7 +181,7 @@ Release policy
 
 Plugins are released **independently** from the core package.
 
-* A core release tag such as ``0.8.3`` publishes the core wheel only;
+* A core release tag such as ``0.9.0`` publishes the core wheel only;
   it does **not** trigger plugin uploads.
 * A plugin release tag such as ``spectrochempy-nmr-v0.1.1`` triggers the
   ``publish_plugins.yml`` and ``build_package.yml`` workflows for that
@@ -245,7 +245,7 @@ published to Anaconda.org automatically by ``build_package.yml``.
       mamba install -c spectrocat -c conda-forge spectrochempy-nmr
 
 Plugin recipes should declare a bounded dependency on the core package,
-e.g. ``spectrochempy >=0.8,<0.10``.
+e.g. ``spectrochempy >=0.9.0.dev0,<0.10``.
 
 The ``plugin-template`` directory is excluded from discovery; it is a
 developer scaffold and must never be published.

--- a/plugins/plugin-template/pyproject.toml
+++ b/plugins/plugin-template/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A SpectroChemPy plugin"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.10",
+    "spectrochempy>=0.9.0.dev0,<0.10",
 ]
 
 [project.entry-points."spectrochempy.plugins"]

--- a/plugins/plugin-template/src/plugin_name/__init__.py
+++ b/plugins/plugin-template/src/plugin_name/__init__.py
@@ -47,7 +47,7 @@ class MyPlugin(SpectroChemPyPlugin):
     name = "myplugin"
     version = "0.1.0"
     description = "My SpectroChemPy plugin"
-    spectrochempy_min_version = "0.8.0"
+    spectrochempy_min_version = "0.9.0.dev0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [
         PluginCapability.READER,

--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Cantera-based thermodynamics and reactive chemistry for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.10",
+    "spectrochempy>=0.9.0.dev0,<0.10",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-cantera/recipe.yaml
+++ b/plugins/spectrochempy-cantera/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.8,<0.10
+    - spectrochempy >=0.9.0.dev0,<0.10
     - cantera >=3.0
     - numpy
     - scipy

--- a/plugins/spectrochempy-cantera/src/spectrochempy_cantera/__init__.py
+++ b/plugins/spectrochempy-cantera/src/spectrochempy_cantera/__init__.py
@@ -29,7 +29,7 @@ class CanteraPlugin(SpectroChemPyPlugin):
     name = "cantera"
     version = "0.1.0"
     description = "Plug-flow reactor (PFR) simulation via Cantera"
-    spectrochempy_min_version = "0.8.0"
+    spectrochempy_min_version = "0.9.0.dev0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [
         PluginCapability.SIMULATION,

--- a/plugins/spectrochempy-carroucell/pyproject.toml
+++ b/plugins/spectrochempy-carroucell/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Carroucell experiment reader for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.10",
+    "spectrochempy>=0.9.0.dev0,<0.10",
     "xlrd",
     "scipy",
 ]

--- a/plugins/spectrochempy-carroucell/recipe.yaml
+++ b/plugins/spectrochempy-carroucell/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.8,<0.10
+    - spectrochempy >=0.9.0.dev0,<0.10
     - xlrd
     - scipy
 

--- a/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/__init__.py
+++ b/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/__init__.py
@@ -34,7 +34,7 @@ class CarroucellPlugin(SpectroChemPyPlugin):
     name = "carroucell"
     version = "0.1.0"
     description = "Carroucell experiment reader for SpectroChemPy"
-    spectrochempy_min_version = "0.8.0"
+    spectrochempy_min_version = "0.9.0.dev0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [PluginCapability.READER]
 

--- a/plugins/spectrochempy-hypercomplex/pyproject.toml
+++ b/plugins/spectrochempy-hypercomplex/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Hypercomplex / quaternion support plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.10",
+    "spectrochempy>=0.9.0.dev0,<0.10",
     "numpy",
     "numpy-quaternion>=2024.0.7",
 ]

--- a/plugins/spectrochempy-hypercomplex/recipe.yaml
+++ b/plugins/spectrochempy-hypercomplex/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.8,<0.10
+    - spectrochempy >=0.9.0.dev0,<0.10
     - numpy
     - quaternion >=2024.0.7
 

--- a/plugins/spectrochempy-hypercomplex/src/spectrochempy_hypercomplex/__init__.py
+++ b/plugins/spectrochempy-hypercomplex/src/spectrochempy_hypercomplex/__init__.py
@@ -312,7 +312,7 @@ class HyperComplexPlugin(SpectroChemPyPlugin):
     name = "hypercomplex"
     version = "0.1.0"
     description = "Hypercomplex / quaternion data support"
-    spectrochempy_min_version = "0.8.0"
+    spectrochempy_min_version = "0.9.0.dev0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [PluginCapability.ACCESSOR]
 

--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "IRIS analysis extension for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.10",
+    "spectrochempy>=0.9.0.dev0,<0.10",
     "scipy",
     "osqp",
 ]

--- a/plugins/spectrochempy-iris/recipe.yaml
+++ b/plugins/spectrochempy-iris/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.8,<0.10
+    - spectrochempy >=0.9.0.dev0,<0.10
     - scipy
     - osqp
 

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
@@ -81,7 +81,7 @@ class IrisPlugin(SpectroChemPyPlugin):
     name = "iris"
     version = "0.1.0"
     description = "Extended IRIS analysis: custom kernels, batch analysis, model comparison, enhanced plots"
-    spectrochempy_min_version = "0.8.0"
+    spectrochempy_min_version = "0.9.0.dev0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [
         PluginCapability.ANALYSIS,

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.10",
+    "spectrochempy>=0.9.0.dev0,<0.10",
     "numpy",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.
 ]

--- a/plugins/spectrochempy-nmr/recipe.yaml
+++ b/plugins/spectrochempy-nmr/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.8,<0.10
+    - spectrochempy >=0.9.0.dev0,<0.10
     - numpy
 
 tests:

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
@@ -189,7 +189,7 @@ class NMRPlugin(SpectroChemPyPlugin):
     name = "nmr"
     version = "0.1.0"
     description = "NMR readers and tools for SpectroChemPy"
-    spectrochempy_min_version = "0.8.0"
+    spectrochempy_min_version = "0.9.0.dev0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [PluginCapability.READER]
 

--- a/tests/test_plugins/test_compat.py
+++ b/tests/test_plugins/test_compat.py
@@ -135,6 +135,12 @@ class TestSatisfiesMinVersion:
     def test_malformed(self):
         assert _satisfies_min_version("abc", "1.0.0") is False
 
+    def test_pre_release(self):
+        assert _satisfies_min_version("0.9.0.dev42", "0.9.0.dev0") is True
+        assert _satisfies_min_version("0.9.0.dev0", "0.9.0.dev0") is True
+        assert _satisfies_min_version("0.9.0", "0.9.0.dev0") is True
+        assert _satisfies_min_version("0.8.0", "0.9.0.dev0") is False
+
 
 # ------------------------------------------------------------------
 # Compatibility validation


### PR DESCRIPTION
## Summary

Update the minimum SpectroChemPy version required by all official plugins from `>=0.8` to `>=0.9.0.dev0` to prevent installation on the 0.8.x series.

## Changes

### Dependency constraints (18 files)
- **`plugins/*/pyproject.toml`** (6 files): `"spectrochempy>=0.8,<0.10"` → `"spectrochempy>=0.9.0.dev0,<0.10"`
- **`plugins/*/recipe.yaml`** (5 files): `spectrochempy >=0.8,<0.10` → `spectrochempy >=0.9.0.dev0,<0.10`
- **`plugins/*/src/*/__init__.py`** (6 files): `spectrochempy_min_version = "0.8.0"` → `spectrochempy_min_version = "0.9.0.dev0"`

### Dev docs (1 file)
- **`docs/sources/devguide/plugins/packaging.rst`**: Updated all 4 example version references + 1 release tag example

### Workflow comments (2 files)
- **`build_package.yml`**, **`publish_plugins.yml`**: Updated commented examples

### Test (1 file)
- **`tests/test_plugins/test_compat.py`**: Added `test_pre_release` to verify PEP 440 pre-release comparison

## Version compatibility

Constraint `>=0.9.0.dev0,<0.10`:
| Version | Compatible |
|---------|-----------|
| `0.9.0.dev0` (CI) | ✅ yes |
| `0.9.0.dev42` (development) | ✅ yes |
| `0.9.0` (stable) | ✅ yes |
| `0.9.1` (future) | ✅ yes |
| `0.8.0` (old series) | ❌ no |
| `0.10.0` (next major) | ❌ no (upper bound)