### PR TITLE
Cleanup: remove deprecated LinearCoord, MCRALS kwargs compat, and filter.py compat

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -46,3 +46,13 @@ Breaking Changes
 Deprecations
 ~~~~~~~~~~~~
 .. Add here new deprecations (do not delete this comment)
+
+- Removed deprecated :class:`~spectrochempy.core.dataset.coord.LinearCoord` class — use :class:`~spectrochempy.core.dataset.coord.Coord` instead.
+- Removed deprecated compatibility kwargs in :class:`~spectrochempy.analysis.decomposition.mcrals.MCRALS`:
+  ``verbose`` (use ``log_level``), ``unimodTol`` (use ``unimodConcTol``),
+  ``unimodMod`` (use ``unimodConcMod``), ``hardC_to_C_idx`` (use ``getC_to_C_idx``),
+  ``hardSt_to_St_idx`` (use ``getSt_to_St_idx``).
+- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.filter.filter.smooth`:
+  ``window_length`` (use ``size``).
+- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.filter.filter.savgol`:
+  ``window_length`` (use ``size``) and ``polyorder`` (use ``order``).

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -5,3 +5,16 @@ What's New in Revision 0.9.1.dev
 
 These are the changes in SpectroChemPy-0.9.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Deprecations
+~~~~~~~~~~~~
+
+- Removed deprecated :class:`~spectrochempy.core.dataset.coord.LinearCoord` class — use :class:`~spectrochempy.core.dataset.coord.Coord` instead.
+- Removed deprecated compatibility kwargs in :class:`~spectrochempy.analysis.decomposition.mcrals.MCRALS`:
+  ``verbose`` (use ``log_level``), ``unimodTol`` (use ``unimodConcTol``),
+  ``unimodMod`` (use ``unimodConcMod``), ``hardC_to_C_idx`` (use ``getC_to_C_idx``),
+  ``hardSt_to_St_idx`` (use ``getSt_to_St_idx``).
+- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.filter.filter.smooth`:
+  ``window_length`` (use ``size``).
+- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.filter.filter.savgol`:
+  ``window_length`` (use ``size``) and ``polyorder`` (use ``order``).

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -168,8 +168,8 @@ class MCRALS(DecompositionAnalysis):
 
 Correction is applied only if:
 
-- ``C[i,j] > C[i-1,j] * unimodTol`` on the decreasing branch of profile ``#j``,
-- ``C[i,j] < C[i-1,j] * unimodTol`` on the increasing branch of profile ``#j``."""
+- ``C[i,j] > C[i-1,j] * unimodConcTol`` on the decreasing branch of profile ``#j``,
+- ``C[i,j] < C[i-1,j] * unimodConcTol`` on the increasing branch of profile ``#j``."""
         ),
     ).tag(config=True)
 
@@ -189,7 +189,7 @@ Correction is applied only if:
         default_value=1.1,
         help=r"""Tolerance parameter for monotonic decrease.
 
-Correction is applied only if: ``C[i,j] > C[i-1,j] * unimodTol`` .""",
+Correction is applied only if: ``C[i,j] > C[i-1,j] * monoDecTol`` .""",
     ).tag(config=True)
 
     monoIncConc = tr.List(
@@ -208,7 +208,7 @@ Correction is applied only if: ``C[i,j] > C[i-1,j] * unimodTol`` .""",
         default_value=1.1,
         help=r"""Tolerance parameter for monotonic decrease.
 
-Correction is applied only if ``C[i,j] < C[i-1,j] * unimodTol`` along profile ``#j``.""",
+Correction is applied only if ``C[i,j] < C[i-1,j] * monoIncTol`` along profile ``#j``.""",
     ).tag(config=True)
 
     unimodConc = tr.Union(
@@ -414,7 +414,7 @@ and `C[:,hardConc]`.
 
 Correction is applied only if the deviating point ``St[j, i]`` is larger than
 ``St[j, i-1] * unimodSpecTol`` on the decreasing branch of profile
-``#j``, or lower than ``St[j, i-1] * unimodTol`` on the increasing branch of
+``#j``, or lower than ``St[j, i-1] * unimodSpecTol`` on the increasing branch of
 profile  ``#j``."""
         ),
     ).tag(config=True)
@@ -510,38 +510,6 @@ and `St`.
                 "Instead, use MCRAL() followed by MCRALS.fit(X, profile). "
                 "See the documentation and examples",
             )
-
-        # warn about deprecation
-        # ----------------------
-        # We use pop to remove the deprecated argument before processing the rest
-        # TODO: These arguments should have been removed in 0.7; schedule for 0.10
-
-        # verbose
-        if "verbose" in kwargs:
-            deprecated("verbose", replace="log_level='INFO'", removed="0.7")
-            verbose = kwargs.pop("verbose")
-            if verbose:
-                log_level = "INFO"
-
-        # unimodTol deprecation
-        if "unimodTol" in kwargs:
-            deprecated("unimodTol", replace="unimodConcTol", removed="0.7")
-            kwargs["unimodConcTol"] = kwargs.pop("unimodTol")
-
-        # unimodMod deprecation
-        if "unimodMod" in kwargs:
-            deprecated("unimodMod", replace="unimodConcMod", removed="0.7")
-            kwargs["unimodConcMod"] = kwargs.pop("unimodMod")
-
-        # hardC_to_C_idx deprecation
-        if "hardC_to_C_idx" in kwargs:
-            deprecated("hardC_to_C_idx", replace="getC_to_C_idx", removed="0.7")
-            kwargs["getC_to_C_idx"] = kwargs.pop("hardC_to_C_idx")
-
-        # hardSt_to_St_idx deprecation
-        if "hardSt_to_St_idx" in kwargs:
-            deprecated("hardSt_to_St_idx", replace="getSt_to_St_idx", removed="0.7")
-            kwargs["getSt_to_St_idx"] = kwargs.pop("hardSt_to_St_idx")
 
         # call the super class for initialisation
         super().__init__(
@@ -1343,8 +1311,8 @@ def _unimodal_2D(a, axis, idxes, tol, mod):
     #
     # tol: float
     #     Tolerance parameter for unimodality. Correction is applied only if:
-    #     `a[i] > a[i-1] * unimodTol`  on a decreasing branch of profile,
-    #     `a[i] < a[i-1] * unimodTol`  on an increasing branch of profile.
+    #     `a[i] > a[i-1] * tol`  on a decreasing branch of profile,
+    #     `a[i] < a[i-1] * tol`  on an increasing branch of profile.
 
     if axis == 0:
         a_ = a
@@ -1374,8 +1342,8 @@ def _unimodal_1D(a: np.ndarray, tol: str, mod: str) -> np.ndarray:
     #
     # tol: float
     #     Tolerance parameter for unimodality. Correction is applied only if:
-    #     `a[i] > a[i-1] * unimodTol`  on a decreasing branch of profile,
-    #     `a[i] < a[i-1] * unimodTol`  on an increasing branch of profile.
+    #     `a[i] > a[i-1] * tol`  on a decreasing branch of profile,
+    #     `a[i] < a[i-1] * tol`  on an increasing branch of profile.
 
     maxid = np.argmax(a)
     curmax = max(a)

--- a/src/spectrochempy/core/dataset/coord.py
+++ b/src/spectrochempy/core/dataset/coord.py
@@ -20,7 +20,6 @@ from spectrochempy.core.units import ur
 from spectrochempy.utils._logging import error_
 from spectrochempy.utils.constants import INPLACE
 from spectrochempy.utils.constants import NOMASK
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.numutils import get_n_decimals
 from spectrochempy.utils.numutils import spacings
 from spectrochempy.utils.print import colored_output
@@ -165,8 +164,7 @@ class Coord(NDMath, NDArray):
         if data is not None and not is_iterable(data):
             raise ValueError("Data for coordinates must be an iterable or None")
 
-        # in case Coord replace old LinearCoord object
-        # without changing the arguments
+        # handle parameters possible from deprecated LinearCoord
         _offset = kwargs.pop("offset", 0)
         _increment = kwargs.pop("increment", None)
         _size = kwargs.pop("size", None)
@@ -900,23 +898,6 @@ class Coord(NDMath, NDArray):
 
 
 # ======================================================================================
-# LinearCoord (Deprecated)
-# TODO : should be removed in version 0.10 (overdue since 0.8)
-# ======================================================================================
-@tr.signature_has_traits
-class LinearCoord(Coord):
-    @deprecated(
-        kind="object",
-        replace="Coord",
-        removed="0.8",
-    )
-    def __init__(self, **kwargs):
-        # TODO : remove in version 0.10
-        super().__init__(**kwargs)
-
-
-# ======================================================================================
 # Set the operators
 # ======================================================================================
 _set_operators(Coord, priority=50)
-_set_operators(LinearCoord, priority=50)  # Suppress 0.8

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -10,7 +10,6 @@ import traitlets as tr
 import spectrochempy.utils.traits as mtr
 from spectrochempy.extern.whittaker_smooth import whittaker_smooth as ws
 from spectrochempy.processing._base._processingbase import ProcessingConfigurable
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 
 __dataset_methods__ = [
@@ -138,7 +137,7 @@ The type of extension to use for the padded signal to which the filter is applie
 * When mode is ‘constant’, the padding value is given by `cval`.
 * When the ‘interp’ mode is selected (the default), no extension is used.
   Instead, a polynomial of degree `order` is fit to the last `size` values
-  of the edges, and this polynomial is used to evaluate the last window_length // 2
+  of the edges, and this polynomial is used to evaluate the last size // 2
   output values.
 * When mode is ‘nearest’, the last size values are repeated.
 * When mode is ‘mirror’, the padding is created by reflecting the signal about the end
@@ -227,14 +226,6 @@ and ‘nearest’.
         return data
 
 
-# TODO history
-#     new.history = (
-#         f"savgol_filter applied (window_length={window_length}, "
-#         f"polyorder={polyorder}, deriv={deriv}, delta={delta}, mode={mode}, "
-#         f"cval={cval}"
-#     )
-
-
 # ======================================================================================
 # API / NDDataset functions
 # ======================================================================================
@@ -290,10 +281,6 @@ def smooth(dataset, size=5, window="avg", **kwargs):
             window = "avg"
         if window == "hanning":
             window = "han"
-
-        if kwargs.get("window_length") is not None:
-            deprecated("window_length", replace="size", removed="0.8")
-            size = kwargs.pop("window_length")
 
         return Filter(method=window, size=size, **kwargs).transform(dataset)
     raise ValueError(
@@ -355,14 +342,6 @@ def savgol(dataset, size=5, order=2, **kwargs):
     """
     # TODO : check if coordinates are evenly spaced
 
-    if kwargs.get("window_length") is not None:
-        deprecated("window_length", replace="size", removed="0.8")
-        size = kwargs.pop("window_length")
-
-    if kwargs.get("polyorder") is not None:
-        deprecated("polyorder", replace="order", removed="0.8")
-        order = kwargs.pop("polyorder")
-
     return Filter(method="savgol", size=size, order=order, **kwargs).transform(dataset)
 
 
@@ -372,7 +351,6 @@ def savgol_filter(*args, **kwargs):
 
     Alias of `savgol`.
     """
-    # for backward compatibility TODO: deprecate in 0.10 (prefer savgol)
     return savgol(*args, **kwargs)
 
 

--- a/tests/test_analysis/test_decomposition/test_mcrals.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals.py
@@ -315,21 +315,6 @@ def test_MCRALS_errors(model, data):
         mcr.nonnegConc = [0, 1, 1]
     assert "please check the" in e.value.args[0]
 
-    # guess = C, test with deprecated parameters
-    # and few other parameters set to non-default values to improve coverage
-    with testing.catch_warnings(DeprecationWarning) as w:
-        MCRALS(unimodMod="strict")
-    print(w)
-    assert w[0].category == DeprecationWarning
-
-    with testing.catch_warnings(DeprecationWarning) as w:
-        MCRALS(unimodTol=1.0)
-    assert w[0].category == DeprecationWarning
-
-    with testing.catch_warnings(DeprecationWarning) as w:
-        MCRALS(verbose=True)
-    assert w[0].category == DeprecationWarning
-
     with pytest.raises(tr.TraitError):
         mcr.unimodSpec = "alls"
 

--- a/tests/test_core/test_dataset/test_coord.py
+++ b/tests/test_core/test_dataset/test_coord.py
@@ -23,8 +23,6 @@ from spectrochempy.utils.testing import (
     assert_array_equal,
     assert_units_equal,
 )
-from spectrochempy.utils.warnings import assert_produces_warning
-
 # --------------------------------------------------------------------------------------
 # Coord
 # --------------------------------------------------------------------------------------
@@ -571,16 +569,3 @@ def test_coord_not_implemented(name):
     )
     with pytest.raises(NotImplementedError):
         getattr(coord0, name)()
-
-
-def test_linearcoord():
-    from spectrochempy.core.dataset.coord import LinearCoord
-
-    with assert_produces_warning(DeprecationWarning, check_stacklevel=False):
-        _ = LinearCoord(offset=0, increment=10, size=10)
-
-    # test it for creation using offset and increment
-    coord0 = LinearCoord(offset=1, increment=10, size=10)
-    assert isinstance(coord0, LinearCoord)
-    assert coord0[0] == 1
-    assert_array_equal(coord0.data, Coord.arange(1, 100, 10).data)


### PR DESCRIPTION
## Summary

- **LinearCoord**: removed deprecated class, `_set_operators` registration, and related test
- **MCRALS**: removed kwargs compatibility layer (verbose→log_level, unimodTol→unimodConcTol, unimodMod→unimodConcMod, hardC_to_C_idx→getC_to_C_idx, hardSt_to_St_idx→getSt_to_St_idx), removed deprecation tests, updated docstrings
- **filter.py**: removed `window_length`→`size` and `polyorder`→`order` compatibility in `smooth()` and `savgol()`; kept `savgol_filter` as an alias of `savgol`