### PR TITLE
Docs: add maintainer links to dev guide and PyPI re-run note

### DIFF
--- a/docs/sources/devguide/contributing.rst
+++ b/docs/sources/devguide/contributing.rst
@@ -129,3 +129,13 @@ Tips for Success
 * Ensure tests pass
 * Update your PR regularly
 * Follow the code style guidelines
+
+Maintainer and Release Notes
+============================
+
+Some project-maintenance procedures are documented separately in the
+``maintainers/`` directory. These notes cover operational topics such as release
+publishing, PyPI/TestPyPI behavior, conda builds, Zenodo issues, and emergency
+recovery procedures.
+
+See the `maintainers/ <https://github.com/spectrochempy/spectrochempy/tree/master/maintainers>`__ directory for details.

--- a/maintainers/emergency-recovery.md
+++ b/maintainers/emergency-recovery.md
@@ -128,6 +128,20 @@ Le job `build-and-publish_pypi` échoue dans le workflow
    le build échoue. Dans ce cas, supprimer la version sur PyPI ou
    incrémenter le numéro de version
 
+### Re-running a stable PyPI release
+
+Stable PyPI releases cannot overwrite an already published version. If a release
+workflow is re-run after the package version has already been uploaded to PyPI,
+the PyPI upload step is expected to fail.
+
+Do not treat this as a packaging regression. Either:
+
+- create a new release/tag with a new version, or
+- skip the PyPI upload if the existing artifact is already correct.
+
+This differs from some TestPyPI/dev workflows where ``skip-existing`` may be used
+to avoid hard failures during repeated test uploads.
+
 ### Résolution
 
 ```bash


### PR DESCRIPTION
## Summary

- Added `Maintainer and Release Notes` section at the end of `docs/sources/devguide/contributing.rst`, linking to the `maintainers/` directory
- Added `Re-running a stable PyPI release` subsection to `maintainers/emergency-recovery.md`, clarifying that PyPI cannot overwrite existing versions and what to do instead