### PR TITLE
Docs: fix version switcher dropdown text contrast on Chromium/Brave

### DIFF
--- a/docs/_static/css/spectrochempy.css
+++ b/docs/_static/css/spectrochempy.css
@@ -232,10 +232,15 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 }
 
 select {
-    /* background-color: #227fbb; */
-    background: transparent;
+    background: #2c3e50;
     border: none;
     box-shadow: none;
+    color: #fffdfd;
+}
+
+/* style dropdown options for desktop Chromium/Brave contrast */
+#versions-dropdown option {
+    background: #2c3e50;
     color: #fffdfd;
 }
 


### PR DESCRIPTION
## Problem

On desktop Chromium/Brave, the version dropdown (`<select id="versions-dropdown">`) shows options with white text on a white background, making them invisible until hover. This is because the native dropdown popup uses a light system background, but the CSS set `color: #fffdfd` with `background: transparent`.

## Fix

- Changed `select { background: transparent }` to `select { background: #2c3e50 }` to give the dropdown a dark background that matches the RTD sidebar.
- Added explicit `#versions-dropdown option { background: #2c3e50; color: #fffdfd }` to ensure dropdown option elements have sufficient contrast in all browsers.

## Testing

Verified locally by building docs with `sphinx-build` — the dropdown now shows white text on a dark background in Chromium and Firefox.