### PR TITLE
Docs: fix version popup link, dropdown list, and add v0.9.0 build

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -227,6 +227,18 @@ jobs:
             python3 docs/make.py -j1 html -T 0.6.10
           fi
 
+      # ---------- build missing stable versions for dropdown ----------
+      - name: Build missing stable versions
+        if: steps.preview.outputs.is_preview != 'true'
+        run: |
+          . .venv/bin/activate
+          if [ ! -d build/html/0.9.0 ]; then
+            echo "Creating local alias tag for v0.9.0"
+            git tag 0.9.0 spectrochempy-v0.9.0
+            echo "Building v0.9.0 docs"
+            python3 docs/make.py -j1 html -T 0.9.0
+          fi
+
       # ---------- install branch preview into gh-pages clone ----------
       - name: Install branch preview into gh-pages
         if: steps.preview.outputs.is_preview == 'true'

--- a/docs/_static/css/spectrochempy.css
+++ b/docs/_static/css/spectrochempy.css
@@ -232,10 +232,15 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 }
 
 select {
-    /* background-color: #227fbb; */
-    background: transparent;
+    background: #2c3e50;
     border: none;
     box-shadow: none;
+    color: #fffdfd;
+}
+
+/* style dropdown options for desktop Chromium/Brave contrast */
+#versions-dropdown option {
+    background: #2c3e50;
     color: #fffdfd;
 }
 

--- a/docs/make.py
+++ b/docs/make.py
@@ -557,12 +557,15 @@ class BuildDocumentation:
 
     @staticmethod
     def _get_previous_tag():
-        # Get the previous tag from the git repository.
+        # Get the previous core release tag from the git repository.
+        # Filters for plain semver tags (e.g., 0.9.0) to exclude plugin tags.
         # Returns: str - The previous release tag
 
         sh("git fetch --tags", silent=True)
-        rev = sh("git rev-list --tags --max-count=1", silent=True)
-        result = sh(f"git describe --tags {rev}", silent=True)
+        result = sh(
+            "git tag -l '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1",
+            silent=True,
+        )
         return result.strip()
 
     def _make_dirs(self):
@@ -788,8 +791,9 @@ class BuildDocumentation:
         layout_template = TEMPLATES / "layout.html"
         with open(layout_template) as f:
             content = f.read()
+            # replace the Jinja template expression with the actual version list
             content = content.replace(
-                "data-versions=\"{{ os.environ.get('PREVIOUS_VERSIONS', '') }}\"",
+                "data-versions=\"{{ previous_versions|join(',') if previous_versions else '' }}\"",
                 f'data-versions="{versions_str}"',
             )
 

--- a/docs/make.py
+++ b/docs/make.py
@@ -562,11 +562,13 @@ class BuildDocumentation:
         # Returns: str - The previous release tag
 
         sh("git fetch --tags", silent=True)
-        result = sh(
-            "git tag -l '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1",
+        tags = sh(
+            "git tag -l '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname",
             silent=True,
         )
-        return result.strip()
+        if tags:
+            return tags.strip().split("\n")[0]
+        return ""
 
     def _make_dirs(self):
         # Create the directories required to build the documentation.


### PR DESCRIPTION
## Diagnostics

### Issue 1: Popup warning link broken
`_get_previous_tag()` returned the most recent git tag which could be a plugin tag (e.g. `spectrochempy-carroucell-v0.1.1`), breaking the stable-release link in the dev version popup.

**Fix**: Filter for plain semver tags (`[0-9]*.[0-9]*.[0-9]*`) instead of using the raw most recent tag.

### Issue 2: `_post_build()` replacement string mismatch
The replacement pattern in `_post_build()` was looking for `{{ os.environ.get('PREVIOUS_VERSIONS', '') }}` but the actual template has `{{ previous_versions|join(',') if previous_versions else '' }}`. The replacement silently did nothing, so old version subdirectories never got the correct `data-versions` list.

**Fix**: Updated the replacement pattern to match the actual template content.

### Issue 3: v0.9.0 missing from dropdown
The stable v0.9.0 tag exists as `spectrochempy-v0.9.0` but no plain `0.9.0` tag. The CI only built the oldest version (0.6.10). 0.9.0 docs were never built, so the dropdown couldn't list them.

**Fix**: Added a CI step to create a local alias tag `0.9.0` → `spectrochempy-v0.9.0` and build the docs.