### PR TITLE
Fix: detect pyproject.toml in _install_tagged_version for v0.9.0 docs build

### DIFF
--- a/docs/make.py
+++ b/docs/make.py
@@ -208,16 +208,23 @@ class BuildOldTagDocs:
             print(f"Contents of {workingdir}:")
             sh(f"ls -la {workingdir}", silent=False)
 
-            # Check for setup.py in different locations
+            # Check for setup.py or pyproject.toml in different locations
             install_dir = workingdir
-            if not (install_dir / "setup.py").exists():
+            has_setup = (
+                (install_dir / "setup.py").exists()
+                or (install_dir / "pyproject.toml").exists()
+            )
+            if not has_setup:
                 install_dir = install_dir / "scp"
                 print(f"Checking alternate location: {install_dir}")
-                if not install_dir.exists():
-                    print(f"scp directory not found at {install_dir}")
-                if not (install_dir / "setup.py").exists():
+                has_setup = (
+                    (install_dir / "setup.py").exists()
+                    or (install_dir / "pyproject.toml").exists()
+                )
+                if not has_setup:
                     raise FileNotFoundError(
-                        f"No setup.py found in version {tagname} (checked {workingdir} and {install_dir})"
+                        f"No setup.py or pyproject.toml found in version {tagname} "
+                        f"(checked {workingdir} and {install_dir})"
                     )
 
             print(f"Installing from: {install_dir}")

--- a/docs/make.py
+++ b/docs/make.py
@@ -210,17 +210,15 @@ class BuildOldTagDocs:
 
             # Check for setup.py or pyproject.toml in different locations
             install_dir = workingdir
-            has_setup = (
-                (install_dir / "setup.py").exists()
-                or (install_dir / "pyproject.toml").exists()
-            )
+            has_setup = (install_dir / "setup.py").exists() or (
+                install_dir / "pyproject.toml"
+            ).exists()
             if not has_setup:
                 install_dir = install_dir / "scp"
                 print(f"Checking alternate location: {install_dir}")
-                has_setup = (
-                    (install_dir / "setup.py").exists()
-                    or (install_dir / "pyproject.toml").exists()
-                )
+                has_setup = (install_dir / "setup.py").exists() or (
+                    install_dir / "pyproject.toml"
+                ).exists()
                 if not has_setup:
                     raise FileNotFoundError(
                         f"No setup.py or pyproject.toml found in version {tagname} "


### PR DESCRIPTION
The "Build missing stable versions" step failed because `_install_tagged_version` only checked for `setup.py`, but v0.9.0 uses `pyproject.toml`.\n\nUpdated the detection to also accept `pyproject.toml` as a valid build descriptor.