### PR TITLE
Fix: unpin pyzmq in req_old_scpy.txt for v0.9.0 docs build

### DIFF
--- a/docs/tools/req_old_scpy.txt
+++ b/docs/tools/req_old_scpy.txt
@@ -30,7 +30,7 @@ pint>=0.24
 pypandoc
 pytz
 pyyaml
-pyzmq==25.1.2
+pyzmq
 requests
 scikit-image
 scikit-learn


### PR DESCRIPTION
The old `pyzmq==25.1.2` can't compile on current Ubuntu runners (C++ `strlcpy` error). Unpinning lets `uv` resolve the latest compatible version.