### PR TITLE
Fix: support src layout in _install_tagged_version and remove --no-deps

### DIFF
--- a/docs/make.py
+++ b/docs/make.py
@@ -245,12 +245,15 @@ class BuildOldTagDocs:
                 raise FileNotFoundError(f"Requirements file not found at {req_file}")
             os.system(f"{uv} pip install -r {req_file} --force-reinstall")
             print("Installing package in development mode...")
-            os.system(f"{uv} pip install -e {str(install_dir)} --no-deps")
+            os.system(f"{uv} pip install -e {str(install_dir)}")
 
             # Add package directory to Python path
+            # Supports both flat layout (install_dir/spectrochempy) and src layout (install_dir/src/spectrochempy)
             package_dir = workingdir / "spectrochempy"
             if not package_dir.exists():
                 package_dir = install_dir / "spectrochempy"
+            if not package_dir.exists():
+                package_dir = install_dir / "src" / "spectrochempy"
             if package_dir.exists() and str(package_dir.parent) not in sys.path:
                 sys.path.insert(0, str(package_dir.parent))
 


### PR DESCRIPTION
_install_tagged_version failed for v0.9.0 because:

1. `uv pip install -e . --no-deps` doesn't create a proper editable install for src-layout packages → removed `--no-deps`
2. The sys.path fallback only checked `install_dir/spectrochempy` (flat layout) but v0.9.0 uses `src/spectrochempy` → added `install_dir/src/spectrochempy` check