### PR TITLE
Fix: detect docs/sources dir and src/spectrochempy dir in old tag builds

### DIFF
--- a/docs/make.py
+++ b/docs/make.py
@@ -348,7 +348,13 @@ class BuildDocumentation:
         self.tagname = settings["tagname"]
         if self.tagname:
             self.SRC = SRC = Path(kwargs.get("workingdir")) / "docs"
+            if (SRC / "sources").exists():
+                self.SRC = SRC = SRC / "sources"
             self.PROJECT_SOURCES = Path(kwargs.get("workingdir")) / "spectrochempy"
+            if not self.PROJECT_SOURCES.exists():
+                self.PROJECT_SOURCES = (
+                    Path(kwargs.get("workingdir")) / "src" / "spectrochempy"
+                )
         else:
             self.SRC = SRC = DOCS / "sources"
             self.PROJECT_SOURCES = PROJECT / "src" / "spectrochempy"


### PR DESCRIPTION
Successive fixes for the v0.9.0 docs build:

1. `uv pip install -e . --no-deps` -> `uv pip install -e .` (already in master via PR #990)
2. Added `src/spectrochempy` fallback in sys.path for src layout packages
3. `SRC` now checks if `docs/sources` exists (v0.7.0+) before falling back to `docs/` (v0.6.10)
4. `PROJECT_SOURCES` now falls back to `src/spectrochempy` when root `spectrochempy` dir does not exist