### PR TITLE
Mock imghdr module for Python 3.13 compat in Sphinx 5.3

### DIFF
--- a/docs/make.py
+++ b/docs/make.py
@@ -684,6 +684,16 @@ class BuildDocumentation:
         # Run the Sphinx build process.
         # Returns: int - Sphinx build result
 
+        # imghdr was removed in Python 3.13 but Sphinx 5.3's epub3 builder still imports it
+        try:
+            import imghdr  # noqa: F401
+        except ImportError:
+            import types as _types
+
+            _imghdr = _types.ModuleType("imghdr")
+            _imghdr.__dict__.update({"what": lambda *a, **kw: None, "tests": []})
+            sys.modules["imghdr"] = _imghdr
+
         from sphinx.application import Sphinx
         from sphinx.errors import ExtensionError
 


### PR DESCRIPTION
Sphinx 5.3 (used for old tag docs builds) loads the epub3 builder on init, which
imports \`imghdr\` — removed in Python 3.13.

Adding a mock \`imghdr\` module into \`sys.modules\` before Sphinx starts so the
electronic publication build is a non-issue since we only build HTML.