### PR TITLE
Docs: install spectrochempy-hypercomplex in CI and guard its import

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -116,7 +116,7 @@ jobs:
           uv pip install --no-deps -e plugins/spectrochempy-nmr
           uv pip install --no-deps -e plugins/spectrochempy-iris
           # Install plugin runtime dependencies that --no-deps skips
-          uv pip install osqp scipy
+          uv pip install osqp scipy spectrochempy-hypercomplex
           duration=$((SECONDS - start))
           echo "plugin installation: ${duration}s" | tee -a "$CI_TIMING_FILE"
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
@@ -1190,9 +1190,12 @@ def _read_topspin(*args, **kwargs):
     # The td adjustment for complex axes (except last) assumes quaternion/hypercomplex
     # conversion which is handled by the spectrochempy-hypercomplex plugin. Without it
     # the raw data shape must be preserved so that coordinates match.
-    from spectrochempy_hypercomplex import (
-        is_available as _hypercomplex_available,  # noqa: PLC0415
-    )
+    try:
+        from spectrochempy_hypercomplex import (  # noqa: PLC0415
+            is_available as _hypercomplex_available,
+        )
+    except ModuleNotFoundError:
+        _hypercomplex_available = False
 
     for axis in range(parmode + 1):
         if meta.iscomplex[axis]:


### PR DESCRIPTION
## Description

Two fixes for the broken NMR gallery examples (all return `None` → `AttributeError: 'NoneType' object has no attribute 'plot'`):

**Root cause**: `read_topspin.py:1193` unconditionally imports `spectrochempy_hypercomplex`, which is an optional dependency. When absent, the `ModuleNotFoundError` is swallowed by the bare `except Exception` in `importer.py:225`, logged as a warning, and the reader returns `None`. The CI workflow also uses `--no-deps` (added in #993), which skips all plugin dependencies.

### Changes

1. **`.github/workflows/build_docs.yml`**: add `spectrochempy-hypercomplex` to the explicit `uv pip install` on line 119 so that `--no-deps` does not skip it.

2. **`plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py`**: wrap the `spectrochempy_hypercomplex` import in a `try/except ModuleNotFoundError` and set `_hypercomplex_available = False` when the package is absent. The code already handles this flag gracefully (it skips the `meta.td[axis] //= 2` halving).