### PR TITLE
Fix 2D hypercomplex NMR coordinate mismatch when set_quaternion halves last dimension

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -116,7 +116,7 @@ jobs:
           uv pip install --no-deps -e plugins/spectrochempy-nmr
           uv pip install --no-deps -e plugins/spectrochempy-iris
           # Install plugin runtime dependencies that --no-deps skips
-          uv pip install osqp scipy
+          uv pip install osqp scipy spectrochempy-hypercomplex
           duration=$((SECONDS - start))
           echo "plugin installation: ${duration}s" | tee -a "$CI_TIMING_FILE"
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
@@ -1201,6 +1201,15 @@ def _read_topspin(*args, **kwargs):
         if meta.iscomplex[axis]:
             if axis != parmode and _hypercomplex_available:  # noqa: SIM102
                 meta.td[axis] = meta.td[axis] // 2
+                # Halve data along this axis to match the td adjustment.
+                # For States/States-TPPI each pair of rows (cos, sin) is
+                # combined into a single complex row.
+                slices = [slice(None)] * data.ndim
+                slices[axis] = slice(0, None, 2)
+                data_even = data[tuple(slices)]
+                slices[axis] = slice(1, None, 2)
+                data_odd = data[tuple(slices)]
+                data = data_even + 1j * data_odd
             meta.tdeff[axis] = meta.tdeff[axis] // 2
 
     meta.sw_h = [
@@ -1303,6 +1312,16 @@ def _read_topspin(*args, **kwargs):
         if cplex and axis > 0:
             try:
                 dataset.hyper.set_quaternion(inplace=True)
+                # set_quaternion halves the last complex dimension.
+                # Update meta.td and rebuild the corresponding coordinate.
+                meta.td[-1] = dataset.data.shape[-1]
+                if not meta.isfreq[-1]:
+                    dw = (1.0 / meta.sw_h[-1]).to("us")
+                    coordpoints = np.arange(meta.td[-1])
+                    coords[-1] = Coord(
+                        coordpoints * dw,
+                        title=coords[-1].title,
+                    )
             except AttributeError:
                 warning_(
                     "2D hypercomplex NMR data requires the spectrochempy-hypercomplex "

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
@@ -1190,9 +1190,12 @@ def _read_topspin(*args, **kwargs):
     # The td adjustment for complex axes (except last) assumes quaternion/hypercomplex
     # conversion which is handled by the spectrochempy-hypercomplex plugin. Without it
     # the raw data shape must be preserved so that coordinates match.
-    from spectrochempy_hypercomplex import (
-        is_available as _hypercomplex_available,  # noqa: PLC0415
-    )
+    try:
+        from spectrochempy_hypercomplex import (  # noqa: PLC0415
+            is_available as _hypercomplex_available,
+        )
+    except ModuleNotFoundError:
+        _hypercomplex_available = False
 
     for axis in range(parmode + 1):
         if meta.iscomplex[axis]:

--- a/plugins/spectrochempy-nmr/tests/test_read_topspin.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_topspin.py
@@ -26,7 +26,7 @@ def test_read_topspin():
     assert str(nd) == "NDDataset: [complex128] pp (size: 16384)"
 
     nd = scp.read_topspin(nmrdir / "topspin_2d/1/ser")
-    assert str(nd) == "NDDataset: [quaternion] pp (shape: (y:96, x:948))"
+    assert str(nd) == "NDDataset: [quaternion] pp (shape: (y:96, x:474))"
 
     nd = scp.read_topspin(nmrdir / "topspin_2d/1/pdata/1/2rr")
     assert str(nd) == "NDDataset: [quaternion] pp (shape: (y:1024, x:2048))"


### PR DESCRIPTION
## Description

When reading 2D hypercomplex NMR data with `spectrochempy-hypercomplex` installed, two coordinate mismatches occurred:

1. **Data not halved along the indirect dimension**: When `meta.td[axis]` was halved for a hypercomplex axis (to account for cos/sin pairs), the `data` array was not correspondingly halved, causing shape mismatch with coordinates.

2. **Coordinates stale after `set_quaternion`**: `dataset.hyper.set_quaternion(inplace=True)` halves the last (direct) dimension (e.g., 948→474) but `meta.td[-1]` and the corresponding `Coord` object were left unchanged, causing `dataset.set_coordset` to fail with a coordinate size mismatch.

## Changes

- **`read_topspin.py`** (`_read_topspin`):
  - After halving `meta.td[axis]`, also halve the data along that axis (combine cos/sin rows into complex).
  - After `set_quaternion`, update `meta.td[-1]` and rebuild the last coordinate to match the new shape.

- **`test_read_topspin.py`**: Updated expected shape from `x:948` → `x:474` (correct post-quaternion dimension).

## Testing

- Without hypercomplex: 1D (12411) and 2D (192×948) work correctly.
- With hypercomplex: 1D (12411) and 2D (96×474) work correctly with matching coordinates.
- `test_readdir_for_nmr` now passes (was failing with `coordinate size=446 != data shape[1]=223` on the base commit).

Closes #...