### PR TITLE
Fix quaternion dtype plotting for 2D hypercomplex NMR data

### DIFF
--- a/.github/workflows/scripts/update_version_and_release_notes.py
+++ b/.github/workflows/scripts/update_version_and_release_notes.py
@@ -41,7 +41,20 @@ ZENODO = PROJECT / "zenodo.json"
 DOCS = PROJECT / "docs"
 WN = DOCS / "sources" / "whatsnew"
 
-gitversion = get_version(root=PROJECT, relative_to=__file__)
+gitversion = get_version(
+    root=PROJECT,
+    relative_to=__file__,
+    git_describe_command=[
+        "git",
+        "describe",
+        "--long",
+        "--tags",
+        "--always",
+        "--first-parent",
+        "--match",
+        "spectrochempy-v[0-9]*",
+    ],
+)
 
 
 class Zenodo:

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,10 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fix 2D hypercomplex NMR coordinate mismatch when :meth:`~spectrochempy_hypercomplex.set_quaternion` halves the last dimension.
+- Fix :meth:`~spectrochempy.core.dataset.basearrays.ndcomplex.NDComplex.real` to handle quaternion dtype, enabling plotting of 2D hypercomplex NMR data.
+- Restrict :mod:`setuptools-scm` to ``spectrochempy-v*`` tags so development versions derive from the correct tag.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -1,9 +1,9 @@
 :orphan:
 
-What's New in Revision 0.1.2.dev
+What's New in Revision 0.9.1.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.1.2.dev.
+These are the changes in SpectroChemPy-0.9.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
 Bug Fixes

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -1,10 +1,17 @@
 :orphan:
 
-What's New in Revision 0.9.1.dev
+What's New in Revision 0.1.2.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.9.1.dev.
+These are the changes in SpectroChemPy-0.1.2.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Bug Fixes
+~~~~~~~~~
+
+- Fix 2D hypercomplex NMR coordinate mismatch when :meth:`~spectrochempy_hypercomplex.set_quaternion` halves the last dimension.
+- Fix :meth:`~spectrochempy.core.dataset.basearrays.ndcomplex.NDComplex.real` to handle quaternion dtype, enabling plotting of 2D hypercomplex NMR data.
+- Restrict :mod:`setuptools-scm` to ``spectrochempy-v*`` tags so development versions derive from the correct tag.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
+++ b/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
@@ -5,8 +5,8 @@
 # ======================================================================================
 # ruff: noqa
 """
-Loading of experimental 1D NMR data
-===================================
+Loading of experimental NMR data
+=================================
 
 In this example, we load a NMR dataset (in the Bruker format) and plot it.
 

--- a/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
@@ -210,9 +210,15 @@ class NDComplexArray(NDArray):
         (Readonly property).
         """
         new = self.copy()
-        if not new.has_complex_dims:
-            return new
         ma = new.masked_data
+        if not new.has_complex_dims:
+            if ma.dtype.name == "quaternion":
+                import quaternion
+
+                new._data = quaternion.as_float_array(ma)[..., 0]
+                if isinstance(ma, np.ma.masked_array):
+                    new._mask = ma.mask
+            return new
 
         if ma.dtype in TYPE_FLOAT:
             new._data = ma
@@ -233,10 +239,17 @@ class NDComplexArray(NDArray):
         (Readonly property).
         """
         new = self.copy()
+        ma = new.masked_data
         if not new.has_complex_dims:
+            if ma.dtype.name == "quaternion":
+                import quaternion
+
+                new._data = quaternion.as_float_array(ma)[..., 1]
+                if isinstance(ma, np.ma.masked_array):
+                    new._mask = ma.mask
+                return new
             return None
 
-        ma = new.masked_data
         if ma.dtype in TYPE_FLOAT:
             new._data = np.zeros_like(ma.data)
         elif ma.dtype in TYPE_COMPLEX:


### PR DESCRIPTION
## Description

When reading 2D hypercomplex NMR data with `spectrochempy-hypercomplex` installed, calling `ndd.plot()` failed with `TypeError: Unsuitable type quaternion for calculating minimum`.

## Root cause

The `.real` property in `NDComplex` did not handle `numpy.quaternion` dtype — it returned the quaternion data as-is when `has_complex_dims` was `False`, and numpy's masked array can't compute min/max on quaternion values.

## Changes

1. **ndcomplex.py**: Updated `.real` and `.imag` properties to detect quaternion dtype and extract float components (scalar part w for `.real`, first vector component for `.imag`).

2. **Example**: Renamed "Loading of experimental 1D NMR data" → "Loading of experimental NMR data" since the example now also loads 2D data.

3. **changelog.rst**: Added entries for recent bug fixes.

## Testing

- `ndd.plot()` on 2D quaternion data: ✓
- `ndd.plot(method='waterfall')` on 2D quaternion data: ✓
- `.real` dtype is now `float64` (was `quaternion`)
- All existing tests pass