### PR TITLE
Remove deprecated compatibility kwargs marked for removal in 0.7/0.8

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -40,6 +40,23 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
 
+- Removed deprecated compatibility kwargs in :class:`~spectrochempy.analysis.decomposition.efa.EFA`,
+  :class:`~spectrochempy.analysis.decomposition.pca.PCA`,
+  and :class:`~spectrochempy.analysis.decomposition.nmf.NMF`:
+  ``used_components`` (use ``n_components``).
+- Removed deprecated compatibility kwargs in :class:`~spectrochempy.analysis.decomposition.simplisma.SIMPLISMA`:
+  ``verbose`` (use ``log_level``),
+  ``n_pc`` (use ``n_components``),
+  ``max_components`` (use ``n_components``).
+- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.baselineprocessing.baselineprocessing.detrend`:
+  ``type`` (use ``order``), ``dim`` (no longer needed), ``inplace`` (no longer supported).
+- Removed deprecated :meth:`~spectrochempy.utils.metaconfigurable.MetaConfigurable.parameters`
+  method (use :meth:`~spectrochempy.utils.metaconfigurable.MetaConfigurable.params` instead).
+- Removed deprecated ``n_pc`` fallback in
+  :meth:`~spectrochempy.analysis._base._analysisbase.DecompositionAnalysis.transform`
+  and :meth:`~spectrochempy.analysis._base._analysisbase.DecompositionAnalysis.inverse_transform`
+  (use ``n_components`` instead).
+
 
 .. section
 

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.9
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.9.1
     v0.9.0
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -1,39 +1,27 @@
 :orphan:
 
-What's New in Revision 0.9.1
+What's New in Revision 0.9.2.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.9.1.
+These are the changes in SpectroChemPy-0.9.2.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
-
-New Features
-~~~~~~~~~~~~
-
-- Add PyPI ``README.md`` description to all official plugin packages (``spectrochempy-nmr``,
-  ``spectrochempy-iris``, ``spectrochempy-hypercomplex``, ``spectrochempy-carroucell``,
-  ``spectrochempy-cantera``).
-- Add :mod:`spectrochempy-hypercomplex` to CI test selection and install from local checkout in docs CI.
-- Vectorise :func:`~spectrochempy_hypercomplex._quaternion.as_quaternion` with :func:`numpy.stack` for better performance.
-- Add :mod:`bump_plugin_init_version.py` script to bump plugin class ``version`` attribute on release, with cross-source verification.
-- Sync plugin class ``version`` to ``0.1.1`` for all official plugins, matching ``pyproject.toml``.
-
-Bug Fixes
-~~~~~~~~~
-
-- Fix 2D hypercomplex NMR coordinate mismatch when :meth:`~spectrochempy_hypercomplex.set_quaternion` halves the last dimension.
-- Fix :meth:`~spectrochempy.core.dataset.basearrays.ndcomplex.NDComplex.real` to handle quaternion dtype, enabling plotting of 2D hypercomplex NMR data.
-- Restrict :mod:`setuptools-scm` to ``spectrochempy-v*`` tags so development versions derive from the correct tag.
-- Replace fragile ``.T`` pattern with ``float_arr[..., 0:4]`` in :func:`~spectrochempy_hypercomplex._quaternion.quat_as_complex_array` and :func:`~spectrochempy_hypercomplex._quaternion.get_component` for correct ND handling.
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- Removed deprecated :class:`~spectrochempy.core.dataset.coord.LinearCoord` class — use :class:`~spectrochempy.core.dataset.coord.Coord` instead.
-- Removed deprecated compatibility kwargs in :class:`~spectrochempy.analysis.decomposition.mcrals.MCRALS`:
-  ``verbose`` (use ``log_level``), ``unimodTol`` (use ``unimodConcTol``),
-  ``unimodMod`` (use ``unimodConcMod``), ``hardC_to_C_idx`` (use ``getC_to_C_idx``),
-  ``hardSt_to_St_idx`` (use ``getSt_to_St_idx``).
-- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.filter.filter.smooth`:
-  ``window_length`` (use ``size``).
-- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.filter.filter.savgol`:
-  ``window_length`` (use ``size``) and ``polyorder`` (use ``order``).
+- Removed deprecated compatibility kwargs in :class:`~spectrochempy.analysis.decomposition.efa.EFA`,
+  :class:`~spectrochempy.analysis.decomposition.pca.PCA`,
+  and :class:`~spectrochempy.analysis.decomposition.nmf.NMF`:
+  ``used_components`` (use ``n_components``).
+- Removed deprecated compatibility kwargs in :class:`~spectrochempy.analysis.decomposition.simplisma.SIMPLISMA`:
+  ``verbose`` (use ``log_level``),
+  ``n_pc`` (use ``n_components``),
+  ``max_components`` (use ``n_components``).
+- Removed deprecated compatibility kwargs in :func:`~spectrochempy.processing.baselineprocessing.baselineprocessing.detrend`:
+  ``type`` (use ``order``), ``dim`` (no longer needed), ``inplace`` (no longer supported).
+- Removed deprecated :meth:`~spectrochempy.utils.metaconfigurable.MetaConfigurable.parameters`
+  method (use :meth:`~spectrochempy.utils.metaconfigurable.MetaConfigurable.params` instead).
+- Removed deprecated ``n_pc`` fallback in
+  :meth:`~spectrochempy.analysis._base._analysisbase.DecompositionAnalysis.transform`
+  and :meth:`~spectrochempy.analysis._base._analysisbase.DecompositionAnalysis.inverse_transform`
+  (use ``n_components`` instead).

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -324,10 +324,7 @@ class DecompositionAnalysis(AnalysisConfigurable):
         X_transform = self._transform(newX)
 
         # Slice according to n_components
-        n_components = kwargs.pop(
-            "n_components",
-            kwargs.pop("n_pc", self._n_components),
-        )
+        n_components = kwargs.pop("n_components", self._n_components)
         if n_components > self._n_components:
             warnings.warn(
                 "The number of components required for reduction "
@@ -378,10 +375,7 @@ class DecompositionAnalysis(AnalysisConfigurable):
             raise NotFittedError
 
         # get optional n_components
-        n_components = kwargs.pop(
-            "n_components",
-            kwargs.pop("n_pc", self._n_components),
-        )
+        n_components = kwargs.pop("n_components", self._n_components)
         if n_components > self._n_components:
             warnings.warn(
                 "The number of components required for reduction "

--- a/src/spectrochempy/analysis/decomposition/efa.py
+++ b/src/spectrochempy/analysis/decomposition/efa.py
@@ -11,7 +11,6 @@ import traitlets as tr
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.application.application import info_
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 
 __all__ = ["EFA"]
@@ -104,9 +103,6 @@ class EFA(DecompositionAnalysis):
             warm_start=warm_start,
             **kwargs,
         )
-        if "used_components" in kwargs:
-            deprecated("used_components", replace="n_components", removed="0.7")
-            kwargs["n_components"] = kwargs.pop("used_components")
 
     def _fit(self, X, Y=None):
         # X has already been validated and eventually

--- a/src/spectrochempy/analysis/decomposition/nmf.py
+++ b/src/spectrochempy/analysis/decomposition/nmf.py
@@ -12,7 +12,6 @@ from numpy.random import RandomState
 from sklearn import decomposition
 
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 
 __all__ = ["NMF"]
@@ -182,10 +181,6 @@ class NMF(DecompositionAnalysis):
         warm_start=False,
         **kwargs,
     ):
-        if "used_components" in kwargs:
-            deprecated("used_components", replace="n_components", removed="0.7")
-            kwargs["n_components"] = kwargs.pop("used_components")
-
         # call the super class for initialisation of the configuration parameters
         # to do before anything else!
         super().__init__(

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -16,7 +16,6 @@ from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
 from spectrochempy.application.application import info_
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 
 __all__ = ["PCA"]
@@ -178,10 +177,6 @@ for reproducible results across multiple function calls.""",
         warm_start=False,
         **kwargs,
     ):
-        if "used_components" in kwargs:
-            deprecated("used_components", replace="n_components", removed="0.7")
-            kwargs["n_components"] = kwargs.pop("used_components")
-
         # call the super class for initialisation of the configuration parameters
         # to do before anything else!
         super().__init__(

--- a/src/spectrochempy/analysis/decomposition/simplisma.py
+++ b/src/spectrochempy/analysis/decomposition/simplisma.py
@@ -16,7 +16,6 @@ import traitlets as tr
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.application.application import info_
 from spectrochempy.utils import exceptions
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 
 
@@ -110,22 +109,6 @@ class SIMPLISMA(DecompositionAnalysis):
                 "Instead, use SIMPLISMA() followed by SIMPLISMA.fit(X). "
                 "See the documentation and exemples",
             )
-
-        # warn about deprecations
-        # -----------------------
-        if "verbose" in kwargs:
-            deprecated("verbose", replace="log_level='INFO'", removed="0.7")
-            verbose = kwargs.pop("verbose")
-            if verbose:
-                log_level = "INFO"
-
-        if "n_pc" in kwargs:
-            deprecated("n_pc", replace="n_components", removed="0.7")
-            kwargs["n_components"] = kwargs.pop("n_pc")
-
-        if "max_components" in kwargs:
-            deprecated("max_components", replace="n_components", removed="0.7")
-            kwargs["n_components"] = kwargs.pop("max_components")
 
         # call the super class for initialisation
         super().__init__(

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -25,7 +25,6 @@ from spectrochempy.utils.constants import TYPE_FLOAT
 from spectrochempy.utils.constants import TYPE_INTEGER
 from spectrochempy.utils.coordrange import trim_ranges
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 from spectrochempy.utils.exceptions import NotFittedError
 from spectrochempy.utils.traits import NDDatasetType
@@ -965,25 +964,8 @@ def detrend(dataset, order="linear", breakpoints=None, **kwargs):
     detrend : Remove polynomial trend along a dimension from dataset.
 
     """
-    # kwargs will be removed in version 0.8
     if breakpoints is None:
         breakpoints = []
-    inplace = kwargs.pop("inplace", None)
-    if inplace is not None:
-        warning_("inplace parameter was removed in version 0.7 and has no more effect.")
-
-    type = kwargs.pop("type", None)
-    if type is not None:
-        deprecated("type", replace="order", removed="0.8")
-        order = type
-
-    dim = kwargs.pop("dim", None)
-    if dim is not None:
-        deprecated(
-            "dim",
-            extra_msg="Transpose your data before processing if needed.",
-            removed="0.8",
-        )
 
     blc = Baseline()
     blc.model = "detrend"

--- a/src/spectrochempy/utils/metaconfigurable.py
+++ b/src/spectrochempy/utils/metaconfigurable.py
@@ -23,7 +23,6 @@ from traitlets.config import Config
 from traitlets.config.configurable import Configurable
 from traitlets.config.loader import LazyConfigValue
 
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.objects import Adict
 
 ur = UnitRegistry()
@@ -107,16 +106,6 @@ class MetaConfigurable(Configurable):
         else:
             d.update(self.trait_defaults(config=True))
         return d
-
-    @deprecated(replace="params", removed="0.8.0")
-    def parameters(self, default=False):
-        """
-        Alias for `params` method.
-
-        .. deprecated:: 0.8.0
-            Use `params` instead.
-        """
-        return self.params(default=default)
 
     def reset(self):
         """Reset configuration parameters to their default values."""

--- a/tests/test_utils/test_metaconfigurable.py
+++ b/tests/test_utils/test_metaconfigurable.py
@@ -93,15 +93,6 @@ def test_params(test_configurable):
     assert default_params.test_param == 42
 
 
-def test_parameters_deprecated(test_configurable):
-    """Test that parameters method is deprecated but works."""
-    with pytest.warns(DeprecationWarning):
-        params = test_configurable.parameters()
-
-    assert params.test_param == 42
-    assert params.another_param == "default"
-
-
 def test_reset(test_configurable):
     """Test reset method."""
     test_configurable.test_param = 100


### PR DESCRIPTION
Remove old deprecated compatibility paths promised for removal in v0.7/v0.8, in preparation for SpectroChemPy 0.9.2.

## Breaking changes

- **EFA/PCA/NMF**: removed ``used_components`` (use ``n_components``)
- **SIMPLISMA**: removed ``verbose`` (use ``log_level``), ``n_pc`` and ``max_components`` (use ``n_components``)
- **detrend**: removed ``type`` (use ``order``), ``dim`` and ``inplace``
- **MetaConfigurable**: removed deprecated ``parameters()`` method (use ``params()``)
- **DecompositionAnalysis**: removed ``n_pc`` fallback in ``transform()`` and ``inverse_transform()`` (use ``n_components``)

## Tests

- Removed `test_parameters_deprecated` in `test_metaconfigurable.py`
- Targeted tests pass: metaconfigurable (5 passed), simplisma (1 passed)

## Files changed

11 files modified, pre-commit hooks run successfully.