### PR TITLE
Clarify Trusted Publishing vs API tokens in maintainer docs

### DIFF
--- a/maintainers/emergency-recovery.md
+++ b/maintainers/emergency-recovery.md
@@ -108,18 +108,23 @@ du core publiée (ex. `spectrochempy >=0.9.0,<0.10`).
 
 ---
 
-## Publication PyPI échouée
+## Publication PyPI échouée — core (`build_package.yml`)
 
 ### Symptôme
 
 Le job `build-and-publish_pypi` échoue dans le workflow
-`build_package.yml`.
+`build_package.yml` (package **core**).
 
 ### Vérifications
 
-1. **Token PyPI** : vérifier que `PYPI_API_TOKEN` est défini dans les
-   [secrets du dépôt](https://github.com/spectrochempy/spectrochempy/settings/secrets/actions)
-   et qu'il n'a pas expiré ou été révoqué
+1. **Trusted Publishing / OIDC** : le package core utilise
+   [Trusted Publishing](https://docs.pypi.org/trusted-publishers/).
+   Il n'utilise **pas** `PYPI_API_TOKEN` ou `TEST_PYPI_API_TOKEN`.
+   Vérifier la configuration sur PyPI/TestPyPI :
+   - Aller sur les paramètres du projet `spectrochempy` sur PyPI
+   - Vérifier que le workflow `build_package.yml` du dépôt
+     `spectrochempy/spectrochempy` est bien listé dans Trusted Publishers
+   - L'environment `pypi` doit correspondre à celui du workflow
 2. **Permissions GitHub** : le workflow nécessite `contents: read`,
    `packages: write` et `id-token: write` dans les permissions du
    workflow
@@ -142,16 +147,37 @@ Do not treat this as a packaging regression. Either:
 This differs from some TestPyPI/dev workflows where ``skip-existing`` may be used
 to avoid hard failures during repeated test uploads.
 
-### Résolution
+### Résolution manuelle
 
 ```bash
 # Vérifier si la version existe déjà sur PyPI
 pip index versions spectrochempy
 
-# Si nécessaire, forcer la publication depuis une machine locale
+# Si nécessaire, forcer la publication depuis une machine locale (token API nécessaire)
 python -m build
 python -m twine upload dist/*
 ```
+
+---
+
+## Publication PyPI échouée — plugins (`publish_plugins.yml`)
+
+### Symptôme
+
+Le job `build-and-publish_plugins` échoue dans le workflow
+`publish_plugins.yml`.
+
+### Vérifications
+
+1. **Token PyPI / TestPyPI** : les plugins utilisent les **API tokens** :
+   - `PYPI_API_TOKEN` pour PyPI
+   - `TEST_PYPI_API_TOKEN` pour TestPyPI
+   Vérifier qu'ils sont définis dans les
+   [secrets du dépôt](https://github.com/spectrochempy/spectrochempy/settings/secrets/actions)
+   et qu'ils n'ont pas expiré ou été révoqués
+2. **Version déjà publiée** : le workflow publie les plugins avec
+   `skip-existing: true` sur TestPyPI. Sur PyPI stable, une version
+   déjà publiée provoque un échec (pas de `--skip-existing`).
 
 ---
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -10,10 +10,22 @@ du dépôt `spectrochempy/spectrochempy` :
 
 | Secret | Usage |
 |--------|-------|
-| `PYPI_API_TOKEN` | Publication sur PyPI (via `pypa/gh-action-pypi-publish`) |
-| `TEST_PYPI_API_TOKEN` | Publication sur Test PyPI (poussées vers master) |
-| `ANACONDA_API_TOKEN` | Publication sur Anaconda.org (compte `spectrocat`) |
+| `PYPI_API_TOKEN` | Publication **plugins** sur PyPI (via `pypa/gh-action-pypi-publish` avec `password`) |
+| `TEST_PYPI_API_TOKEN` | Publication **plugins** sur Test PyPI (workflow `publish_plugins.yml`) |
+| `ANACONDA_API_TOKEN` | Publication sur Anaconda.org (compte `spectrocat`) — core + plugins |
 | `BOT_TOKEN` | PAT personnel utilisé pour contourner la protection de branche lors des releases de plugins (expire tous les 3 mois — penser à le renouveler et mettre à jour le secret) |
+
+> **Note PyPI core** : le package **core** (`spectrochempy`) utilise
+> [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC)
+> via le workflow `build_package.yml`.  Il n'utilise **pas**
+> `PYPI_API_TOKEN` ni `TEST_PYPI_API_TOKEN`.  Les secrets API token ne
+> sont requis que pour la publication des **plugins**
+> (`publish_plugins.yml`).
+>
+> Avant la première release core via Trusted Publishing, vérifier que
+> le workflow `build_package.yml` est bien configuré comme Trusted
+> Publisher dans les paramètres PyPI et TestPyPI du projet
+> `spectrochempy`.
 
 ### Comptes externes
 
@@ -358,8 +370,9 @@ entrées sont incorrectes car :
 
 ### Avant toute release
 
-- [ ] Vérifier que les secrets GitHub (`PYPI_API_TOKEN`, `ANACONDA_API_TOKEN`,
-      `BOT_TOKEN`) sont valides et non expirés
+- [ ] Vérifier que les secrets GitHub nécessaires sont valides et non expirés :
+      - Core : `ANACONDA_API_TOKEN` (Trusted Publishing PyPI ne nécessite pas de token secret)
+      - Plugins : `PYPI_API_TOKEN`, `TEST_PYPI_API_TOKEN`, `ANACONDA_API_TOKEN`, `BOT_TOKEN`
 - [ ] Vérifier l'état des services externes (Zenodo, PyPI, Anaconda.org)
 - [ ] Lancer les tests CI sur la branche cible
 - [ ] Vérifier que le Colab smoke test passe (`install_on_colab.yml`)
@@ -367,6 +380,11 @@ entrées sont incorrectes car :
 ### Release du core
 
 - [ ] Vérifier que l'intégration GitHub → Zenodo est active
+- [ ] Vérifier que le workflow `build_package.yml` est configuré comme
+      Trusted Publisher sur PyPI et TestPyPI (paramètres du projet
+      `spectrochempy` sur PyPI → Trusted Publishers → GitHub repository
+      `spectrochempy/spectrochempy`, workflow `build_package.yml`,
+      environment `pypi`)
 - [ ] Lancer **Prepare a new release** avec la version X.Y.Z
 - [ ] Vérifier la PR de release (CITATION.cff, zenodo.json, whatsnew)
 - [ ] Merger la PR → attendre la Draft Release
@@ -378,6 +396,8 @@ entrées sont incorrectes car :
 
 ### Release des plugins
 
+- [ ] Vérifier que `PYPI_API_TOKEN` et `TEST_PYPI_API_TOKEN` sont valides
+- [ ] Vérifier que `BOT_TOKEN` est valide (expire tous les 3 mois)
 - [ ] Désactiver l'intégration GitHub → Zenodo
 - [ ] Lancer **Release an official plugin** avec `confirm_zenodo_disabled=true`
 - [ ] Vérifier PyPI : `pip install spectrochempy-XXX==X.Y.Z`


### PR DESCRIPTION
- Update release-process.md secrets table to distinguish:
  - Core package: uses Trusted Publishing (OIDC), no API tokens needed
  - Plugins: use PYPI_API_TOKEN / TEST_PYPI_API_TOKEN
- Add Trusted Publisher verification step to core release checklist
- Split emergency-recovery.md PyPI section into two:
  - Core PyPI failure (Trusted Publishing / OIDC)
  - Plugin PyPI failure (API tokens)
- No workflow or code changes — documentation only.
