### PR TITLE
Remove IRIS.plotdistribution and add removed=0.10.0 to remaining deprecations

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -76,3 +76,17 @@ Breaking Changes
 Deprecations
 ~~~~~~~~~~~~
 .. Add here new deprecations (do not delete this comment)
+
+- Removed ``IRIS.plotdistribution()`` from the ``spectrochempy-iris`` plugin
+  (target ``removed="0.9.0"`` was reached). Use ``IRIS.f[index].plot()`` instead.
+- Added explicit ``removed="0.10.0`` to all remaining API deprecations that
+  did not yet specify a removal version :
+  ``Baseline.show_regions``, ``PCA.screeplot``, ``PCA.scoreplot``,
+  ``DecompositionAnalysis.reduce``, ``DecompositionAnalysis.reconstruct``,
+  ``MCRALS.St_unconstrained``, ``MCRALS.S_soft``,
+  ``concatenate(force_stack=...)``, ``read_jdx``, ``read_dx``,
+  ``trapz``, ``multiplot_stack``, ``multiplot_map``, ``multiplot_image``,
+  ``Project.remove_all_dataset``, ``Project.remove_all_project``,
+  ``Project.remove_all_script``, ``restore_rcparams``,
+  ``get_import_time_rcparams``, and legacy plot-method aliases
+  (``stack`` → ``lines``, ``map`` → ``contour``, ``image`` → ``contourf``).

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -41,3 +41,20 @@ Breaking Changes
   :meth:`~spectrochempy.analysis._base._analysisbase.DecompositionAnalysis.transform`
   and :meth:`~spectrochempy.analysis._base._analysisbase.DecompositionAnalysis.inverse_transform`
   (use ``n_components`` instead).
+
+Deprecations
+~~~~~~~~~~~~
+
+- Removed ``IRIS.plotdistribution()`` from the ``spectrochempy-iris`` plugin
+  (target ``removed="0.9.0"`` was reached). Use ``IRIS.f[index].plot()`` instead.
+- Added explicit ``removed="0.10.0`` to all remaining API deprecations that
+  did not yet specify a removal version :
+  ``Baseline.show_regions``, ``PCA.screeplot``, ``PCA.scoreplot``,
+  ``DecompositionAnalysis.reduce``, ``DecompositionAnalysis.reconstruct``,
+  ``MCRALS.St_unconstrained``, ``MCRALS.S_soft``,
+  ``concatenate(force_stack=...)``, ``read_jdx``, ``read_dx``,
+  ``trapz``, ``multiplot_stack``, ``multiplot_map``, ``multiplot_image``,
+  ``Project.remove_all_dataset``, ``Project.remove_all_project``,
+  ``Project.remove_all_script``, ``restore_rcparams``,
+  ``get_import_time_rcparams``, and legacy plot-method aliases
+  (``stack`` → ``lines``, ``map`` → ``contour``, ``image`` → ``contourf``).

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
@@ -23,7 +23,6 @@ from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.extern.traittypes import Array
 from spectrochempy.utils.constants import EPSILON
-from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 from spectrochempy.utils.traits import CoordType
 from spectrochempy.utils.traits import NDDatasetType
@@ -903,81 +902,6 @@ class IRIS(DecompositionAnalysis):
             markersize=markersize,
             **kwargs,
         )
-
-    @deprecated(
-        replace="IRIS.f[index].plot",
-        removed="0.9.0",
-        extra_msg='Use the plot method of the distribution function instead: IRIS.f[index].plot(method="map")',
-    )
-    def plotdistribution(
-        self,
-        index=None,
-        ax=None,
-        clear=True,
-        show=True,
-        title=None,
-        cmap=None,
-        cmap_mode="auto",
-        center=None,
-        **kwargs,
-    ):
-        """
-        Plot the distribution function.
-
-        This function plots the distribution function f of the `IRIS` object.
-
-        Parameters
-        ----------
-        index : `int` , `list` or `tuple` of `int`, optional, default: `None`
-            Index(es) of the inversions (i.e. of the :term:`regularization` parameter)
-            to consider.
-            If `None`, plots all indices.
-        ax : matplotlib.axes.Axes, optional
-            Axes to plot on. If provided, used for single index only.
-        clear : bool, optional
-            Whether to clear the axes before plotting. Default: True.
-        show : bool, optional
-            Whether to display the figure. Default: True.
-        title : str, optional
-            Plot title. If None, default lambda-aware title is used.
-        cmap : str or Colormap, optional
-            Colormap name or object.
-        cmap_mode : str, optional
-            Colormap mode ("auto", "sequential", "diverging").
-            Default: "auto".
-        center : float, optional
-            Center value for diverging colormaps.
-        **kwargs
-            Other optional arguments passed to the plots.
-
-        Returns
-        -------
-        `~matplotlib.axes.Axes`
-            The matplotlib axes.
-
-        """
-        from spectrochempy.plotting.plot2d import plot_map
-        from spectrochempy.utils.mplutils import show as mpl_show
-
-        target = self.f if index is None else self.f[index]
-
-        plot_kwargs = {
-            "show": False,
-            "clear": clear,
-            "ax": ax,
-            "title": title,
-            "cmap": cmap,
-            "cmap_mode": cmap_mode,
-            "center": center,
-        }
-        plot_kwargs.update(kwargs)
-
-        ax = plot_map(target, **plot_kwargs)
-
-        if show:
-            mpl_show()
-
-        return ax
 
 
 # --------------------------------------------------------------------------------------

--- a/plugins/spectrochempy-iris/tests/test_iris_core.py
+++ b/plugins/spectrochempy-iris/tests/test_iris_core.py
@@ -159,7 +159,7 @@ def test_IRIS():
     assert f2.shape == (reg_par[2], q[2], X.shape[1])
 
     iris2.plotlcurve()
-    iris2.plotdistribution(-2)
+    _ = iris2.f[-2].plot(method="contour")
     _ = iris2.plot_merit(-2)
 
     # with automated search, keeping the previous kernel

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -433,18 +433,26 @@ class DecompositionAnalysis(AnalysisConfigurable):
     def reduce(self, X=None, **kwargs):
         # deprecated decorator do not preserve signature, so
         # i use a workaround
-        return deprecated(replace="transform")(self.transform)(X, **kwargs)
+        return deprecated(replace="transform", removed="0.10.0")(self.transform)(
+            X, **kwargs
+        )
 
-    reduce.__doc__ = transform.__doc__ + "\nNotes\n-----\nDeprecated in version 0.6.\n"
+    reduce.__doc__ = (
+        transform.__doc__
+        + "\nNotes\n-----\nDeprecated in version 0.6, will be removed in 0.10.0.\n"
+    )
 
     def reconstruct(self, X_transform=None, **kwargs):
-        return deprecated(replace="inverse_transform")(self.inverse_transform)(
+        return deprecated(replace="inverse_transform", removed="0.10.0")(
+            self.inverse_transform
+        )(
             X_transform,
             **kwargs,
         )
 
     reconstruct.__doc__ = (
-        inverse_transform.__doc__ + "\nNotes\n-----\nDeprecated in version 0.6.\n"
+        inverse_transform.__doc__
+        + "\nNotes\n-----\nDeprecated in version 0.6, will be removed in 0.10.0.\n"
     )
 
     @_wrap_ndarray_output_to_nddataset(units=None, title=None, typey="components")

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -1188,13 +1188,14 @@ and `St`.
         return self._outfit[3]
 
     @property
-    @deprecated(replace="St_ls")
+    @property
+    @deprecated(replace="St_ls", removed="0.10.0")
     def St_unconstrained(self):
         """Deprecated. Equivalent to `St_ls`."""
         return self.St_ls
 
     @property
-    @deprecated(replace="St_ls")
+    @deprecated(replace="St_ls", removed="0.10.0")
     def S_soft(self):
         """Deprecated. Equivalent to `St_ls`."""
         return self.St_ls

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -466,6 +466,7 @@ for reproducible results across multiple function calls.""",
 
         .. deprecated:: 0.7.4
             Use :meth:`plot_scree` instead.
+            Will be removed in version 0.10.0.
 
         Parameters
         ----------
@@ -480,7 +481,8 @@ for reproducible results across multiple function calls.""",
             The primary axes.
         """
         warnings.warn(
-            "PCA.screeplot() is deprecated; use PCA.plot_scree() instead.",
+            "PCA.screeplot() is deprecated and will be removed in 0.10.0; "
+            "use PCA.plot_scree() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -573,6 +575,7 @@ for reproducible results across multiple function calls.""",
 
         .. deprecated:: 0.7.4
             Use :meth:`plot_score` instead.
+            Will be removed in version 0.10.0.
 
         Parameters
         ----------
@@ -589,7 +592,8 @@ for reproducible results across multiple function calls.""",
             The matplotlib axes.
         """
         warnings.warn(
-            "PCA.scoreplot() is deprecated; use PCA.plot_score() instead.",
+            "PCA.scoreplot() is deprecated and will be removed in 0.10.0; "
+            "use PCA.plot_score() instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/spectrochempy/analysis/integration/integrate.py
+++ b/src/spectrochempy/analysis/integration/integrate.py
@@ -109,7 +109,7 @@ def trapezoid(dataset, **kwargs):
     return scipy.integrate.trapezoid(dataset.data, **kwargs)
 
 
-@deprecated(replace="Trapezoid")
+@deprecated(replace="Trapezoid", removed="0.10.0")
 def trapz(dataset, **kwargs):
     return trapezoid(dataset, **kwargs)
 

--- a/src/spectrochempy/core/plotters/plot_setup.py
+++ b/src/spectrochempy/core/plotters/plot_setup.py
@@ -123,12 +123,13 @@ def restore_rcparams() -> None:
 
     DEPRECATED: This is now a no-op since SpectroChemPy no longer modifies
     global matplotlib rcParams. The function is kept for backward compatibility.
+    Will be removed in version 0.10.0.
     """
     import warnings
 
     warnings.warn(
-        "restore_rcparams() is deprecated and has no effect. "
-        "SpectroChemPy no longer modifies global matplotlib rcParams.",
+        "restore_rcparams() is deprecated and will be removed in 0.10.0. "
+        "It has no effect since SpectroChemPy no longer modifies global matplotlib rcParams.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -142,12 +143,13 @@ def get_import_time_rcparams():
 
     DEPRECATED: This now returns None since SpectroChemPy no longer modifies
     global matplotlib rcParams and therefore doesn't need to snapshot them.
+    Will be removed in version 0.10.0.
     """
     import warnings
 
     warnings.warn(
-        "get_import_time_rcparams() is deprecated and now returns None. "
-        "SpectroChemPy no longer modifies global matplotlib rcParams.",
+        "get_import_time_rcparams() is deprecated and will be removed in 0.10.0. "
+        "It now returns None since SpectroChemPy no longer modifies global matplotlib rcParams.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -505,13 +505,15 @@ class Project(AbstractProject, NDIO):
 
         .. deprecated::
             Use :meth:`clear_datasets` instead.
+            Will be removed in version 0.10.0.
 
         See Also
         --------
         clear_datasets : Remove all datasets.
         """
         warnings.warn(
-            "remove_all_dataset() is deprecated; use clear_datasets() instead.",
+            "remove_all_dataset() is deprecated and will be removed in 0.10.0; "
+            "use clear_datasets() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -582,13 +584,15 @@ class Project(AbstractProject, NDIO):
 
         .. deprecated::
             Use :meth:`clear_projects` instead.
+            Will be removed in version 0.10.0.
 
         See Also
         --------
         clear_projects : Remove all subprojects.
         """
         warnings.warn(
-            "remove_all_project() is deprecated; use clear_projects() instead.",
+            "remove_all_project() is deprecated and will be removed in 0.10.0; "
+            "use clear_projects() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -649,13 +653,15 @@ class Project(AbstractProject, NDIO):
 
         .. deprecated::
             Use :meth:`clear_scripts` instead.
+            Will be removed in version 0.10.0.
 
         See Also
         --------
         clear_scripts : Remove all scripts.
         """
         warnings.warn(
-            "remove_all_script() is deprecated; use clear_scripts() instead.",
+            "remove_all_script() is deprecated and will be removed in 0.10.0; "
+            "use clear_scripts() instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -130,12 +130,12 @@ def read_jcamp(*paths, **kwargs):
     return importer(*paths, **kwargs)
 
 
-@deprecated(replace="read__jcamp")
+@deprecated(replace="read__jcamp", removed="0.10.0")
 def read_jdx(*args, **kwargs):
     return read_jcamp(*args, **kwargs)
 
 
-@deprecated(replace="read_jcamp")
+@deprecated(replace="read_jcamp", removed="0.10.0")
 def read_dx(*args, **kwargs):  # pragma: no cover
     return read_jcamp(*args, **kwargs)
 

--- a/src/spectrochempy/plotting/backends/matplotlib_backend.py
+++ b/src/spectrochempy/plotting/backends/matplotlib_backend.py
@@ -51,7 +51,8 @@ def _normalize_method(method: str | None) -> str | None:
         if method not in _WARNED_ALIASES:
             _WARNED_ALIASES.add(method)
             warnings.warn(
-                f'method="{method}" is deprecated, use method="{canonical}" instead',
+                f'method="{method}" is deprecated and will be removed in 0.10.0. '
+                f'Use method="{canonical}" instead.',
                 DeprecationWarning,
                 stacklevel=3,
             )

--- a/src/spectrochempy/plotting/multiplot.py
+++ b/src/spectrochempy/plotting/multiplot.py
@@ -101,6 +101,7 @@ def multiplot_stack(datasets, **kwargs):
 
     .. deprecated::
         Use :func:`multiplot_lines` instead.
+        Will be removed in version 0.10.0.
 
     Parameters
     ----------
@@ -115,7 +116,8 @@ def multiplot_stack(datasets, **kwargs):
         The matplotlib figure.
     """
     warnings.warn(
-        "multiplot_stack is deprecated, use multiplot_lines instead",
+        "multiplot_stack is deprecated and will be removed in 0.10.0. "
+        "Use multiplot_lines instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -129,6 +131,7 @@ def multiplot_map(datasets, **kwargs):
 
     .. deprecated::
         Use :func:`multiplot_contour` instead.
+        Will be removed in version 0.10.0.
 
     Parameters
     ----------
@@ -143,7 +146,8 @@ def multiplot_map(datasets, **kwargs):
         The matplotlib figure.
     """
     warnings.warn(
-        "multiplot_map is deprecated, use multiplot_contour instead",
+        "multiplot_map is deprecated and will be removed in 0.10.0. "
+        "Use multiplot_contour instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -157,6 +161,7 @@ def multiplot_image(datasets, **kwargs):
 
     .. deprecated::
         Use :func:`multiplot_contourf` instead.
+        Will be removed in version 0.10.0.
 
     Parameters
     ----------
@@ -171,7 +176,8 @@ def multiplot_image(datasets, **kwargs):
         The matplotlib figure.
     """
     warnings.warn(
-        "multiplot_image is deprecated, use multiplot_contourf instead",
+        "multiplot_image is deprecated and will be removed in 0.10.0. "
+        "Use multiplot_contourf instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -742,6 +742,7 @@ baseline/trends for different segments of the data.
 
         .. deprecated:: 0.8
             Use `Baseline.plot(show_regions=True)` instead.
+            Will be removed in version 0.10.0.
 
         Parameters
         ----------
@@ -751,10 +752,11 @@ baseline/trends for different segments of the data.
         Warns
         -----
         DeprecationWarning
-            This method is deprecated. Use `plot(show_regions=True)` instead.
+            This method is deprecated and will be removed in 0.10.0.
+            Use `plot(show_regions=True)` instead.
         """
         warnings.warn(
-            "Baseline.show_regions() is deprecated. "
+            "Baseline.show_regions() is deprecated and will be removed in 0.10.0. "
             "Use Baseline.plot(show_regions=True) instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -79,7 +79,7 @@ def concatenate(*datasets, **kwargs):
     """
     # check uise
     if "force_stack" in kwargs:
-        deprecated("force_stack", replace="method stack()")
+        deprecated("force_stack", replace="method stack()", removed="0.10.0")
         return stack(datasets)
 
     # get a copy of input datasets in order that input data are not modified


### PR DESCRIPTION
- Delete IRIS.plotdistribution() (marked removed=0.9.0, now past due).
- Add removed=0.10.0 to 20 remaining deprecations that lacked a removal target:
  - Baseline.show_regions, PCA.screeplot/scoreplot,
  - DecompositionAnalysis.reduce/reconstruct,
  - MCRALS.St_unconstrained/S_soft,
  - concatenate(force_stack), read_jdx/read_dx, trapz,
  - multiplot_stack/map/image,
  - Project.remove_all_dataset/project/script,
  - restore_rcparams, get_import_time_rcparams,
  - plot method aliases (stack→lines, map→contour, image→contourf).
- Update changelog.rst and regenerate latest.rst.
