### PR TITLE
CI: Replace hardcoded docs version with dynamic tag loop

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -241,12 +241,21 @@ jobs:
         if: steps.preview.outputs.is_preview != 'true'
         run: |
           . .venv/bin/activate
-          if [ ! -d build/html/0.9.0 ]; then
-            echo "Creating local alias tag for v0.9.0"
-            git tag 0.9.0 spectrochempy-v0.9.0
-            echo "Building v0.9.0 docs"
-            python3 docs/make.py -j1 html -T 0.9.0
-          fi
+          # Iterate over all core release tags (spectrochempy-vX.Y.Z),
+          # excluding plugin tags (spectrochempy-*-vX.Y.Z).
+          for tag in $(git tag --list 'spectrochempy-v*' | sort -V); do
+            version="${tag#spectrochempy-v}"
+            # Create a local lightweight alias tag so make.py -T can find it
+            if ! git rev-parse --verify "$version" >/dev/null 2>&1; then
+              echo "Creating local alias tag for $tag"
+              git tag "$version" "$tag"
+            fi
+            # Build docs for this version if not already present
+            if [ ! -d "build/html/$version" ]; then
+              echo "Building v$version docs"
+              python3 docs/make.py -j1 html -T "$version"
+            fi
+          done
 
       # ---------- install branch preview into gh-pages clone ----------
       - name: Install branch preview into gh-pages

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -125,3 +125,6 @@ Developer
   MAINT:, CI:, DEV:) in a new ``Developer`` section at the end.
 - DOC: Updated contributing guide and PR template to document the new
   changelog convention and the ``Developer`` section.
+- CI: Replaced hardcoded ``0.9.0`` stable docs build with a dynamic loop
+  over all ``spectrochempy-v*`` core tags, so new releases (e.g. ``0.9.1``)
+  are automatically included in the version dropdown.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -95,3 +95,6 @@ Developer
   MAINT:, CI:, DEV:) in a new ``Developer`` section at the end.
 - DOC: Updated contributing guide and PR template to document the new
   changelog convention and the ``Developer`` section.
+- CI: Replaced hardcoded ``0.9.0`` stable docs build with a dynamic loop
+  over all ``spectrochempy-v*`` core tags, so new releases (e.g. ``0.9.1``)
+  are automatically included in the version dropdown.


### PR DESCRIPTION
Replaces the hardcoded ``0.9.0`` stable docs build in ``build_docs.yml`` with a dynamic loop over all ``spectrochempy-v*`` core tags, so new releases are automatically included in the version dropdown without manual updates.