### PR TITLE
CI: Restrict plugin conda upload to stable releases only

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -347,18 +347,27 @@ jobs:
             output/**/*.tar.bz2
           retention-days: 5
 
+      - name: Skip dev upload for plugin (dev versions not yet distinct from stable)
+        if: |
+          github.repository == 'spectrochempy/spectrochempy' &&
+          !(github.event_name == 'release' && startsWith(github.ref_name, matrix.plugin.name))
+        run: |
+          echo "Skipping dev upload for plugin ${{ matrix.plugin.name }}: plugin dev versions are not yet distinct from stable versions"
+          echo "Plugin conda builds are still produced for testing, but not uploaded to Anaconda.org."
+          echo "See TODO in docs/sources/devguide/plugins/packaging.rst for context."
+
       - name: Upload plugin to Anaconda.org
         if: |
           github.repository == 'spectrochempy/spectrochempy' &&
-          (
-            github.event_name == 'push' ||
-            (github.event_name == 'release' && startsWith(github.ref_name, matrix.plugin.name))
-          )
+          github.event_name == 'release' &&
+          startsWith(github.ref_name, matrix.plugin.name)
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         run: |
           set -euo pipefail
           shopt -s nullglob globstar
+
+          echo "Stable plugin release detected; uploading ${{ matrix.plugin.name }} to Anaconda label: main"
 
           if [ -z "${ANACONDA_API_TOKEN:-}" ]; then
             echo "::error::ANACONDA_API_TOKEN is not set. Cannot upload to Anaconda.org."
@@ -371,24 +380,14 @@ jobs:
             exit 1
           fi
 
-          label="dev"
-          force_flag="--force"
-          if [ "${{ github.event_name }}" = "release" ]; then
-            label="main"
-            # Use --force so the label is correctly set to "main" even if a
-            # push build already uploaded the same package to "dev" earlier.
-            force_flag="--force"
-          fi
-
           for package in "${packages[@]}"; do
             basename=$(basename "$package")
-            # Skip the core spectrochempy package (spectrochempy-<version>...)
-            # which was already uploaded by the core build job. Only upload
-            # plugin packages (spectrochempy-<pluginname>-<version>...).
             if [[ "$basename" == spectrochempy-[0-9]* ]]; then
               echo "Skipping core package (already uploaded): $package"
               continue
             fi
-            echo "Uploading $package with label: $label"
-            anaconda --token "$ANACONDA_API_TOKEN" upload $force_flag -l "$label" "$package"
+            echo "Uploading $package with label: main"
+            anaconda --token "$ANACONDA_API_TOKEN" upload --force -l "main" "$package"
           done
+
+          echo "::notice::Plugin ${{ matrix.plugin.name }} uploaded to Anaconda label: main"

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -232,17 +232,25 @@ Distribution (conda)
 Official plugins with a ``recipe.yaml`` in their root are built and
 published to Anaconda.org automatically by ``build_package.yml``.
 
-* **Dev builds** (pushes, PRs) are uploaded to the ``dev`` label:
-
-  .. code-block:: bash
-
-      mamba install -c spectrocat/label/dev -c conda-forge spectrochempy-nmr
-
-* **Stable builds** (releases) are uploaded to the ``main`` label:
+* **Stable builds** (releases with a ``spectrochempy-<plugin>-vX.Y.Z`` tag)
+  are uploaded to the ``main`` label:
 
   .. code-block:: bash
 
       mamba install -c spectrocat -c conda-forge spectrochempy-nmr
+
+* **Dev uploads are currently disabled** for plugins (pushes, PRs).  The
+  packages are still built in CI for testing, but not uploaded to
+  Anaconda.org.
+
+  .. TODO / FIXME:
+     Dev conda uploads for official plugins are disabled until plugin recipes
+     generate distinct dev versions/builds, to avoid overwriting stable labels
+     on Anaconda.org.  Once each plugin recipe uses dynamic dev versions
+     (e.g. ``X.Y.Z.dev0``), re-enable dev uploads by adding ``push`` to the
+     upload condition in ``build_package.yml`` (job
+     ``build_and_publish_conda_plugins``, step ``Upload plugin to
+     Anaconda.org``).
 
 Plugin recipes should declare a bounded dependency on the core package,
 e.g. ``spectrochempy >=0.9,<0.10``.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -63,3 +63,11 @@ Developer
 - CI: Added ``confirm_zenodo_enabled`` checkbox to
   ``prepare_new_release.yml`` so maintainers verify Zenodo is active before
   creating a release PR.
+- CI: Disabled automatic dev conda uploads for official plugins
+  (``build_package.yml``).  Plugin conda packages are still built in CI for
+  testing, but only uploaded to Anaconda.org during a stable plugin release
+  (label ``main``).  Dev uploads will be re-enabled once plugin recipes
+  generate distinct dev versions.
+- DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
+  explaining that dev conda uploads for plugins are disabled until distinct
+  dev versions are generated.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -24,3 +24,11 @@ Developer
 - CI: Added ``confirm_zenodo_enabled`` checkbox to
   ``prepare_new_release.yml`` so maintainers verify Zenodo is active before
   creating a release PR.
+- CI: Disabled automatic dev conda uploads for official plugins
+  (``build_package.yml``).  Plugin conda packages are still built in CI for
+  testing, but only uploaded to Anaconda.org during a stable plugin release
+  (label ``main``).  Dev uploads will be re-enabled once plugin recipes
+  generate distinct dev versions.
+- DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
+  explaining that dev conda uploads for plugins are disabled until distinct
+  dev versions are generated.


### PR DESCRIPTION
## Problem

Plugin conda packages were uploaded to the Anaconda `dev` label on every push to `master`. Since plugin versions are hardcoded in `pyproject.toml` and `recipe.yaml` (no `.dev0` suffix like core), dev uploads could overwrite stable labels or shadow stable versions on Anaconda.org.

## Changes

1. `build_package.yml` — Restrict plugin conda upload to release events matching `spectrochempy-<plugin>-vX.Y.Z` (label `main`). Add explicit skip step with log messages. Packages are still built on pushes for testing.
2. `docs/sources/devguide/plugins/packaging.rst` — Update docs with TODO/FIXME about re-enabling dev uploads when plugin recipes support distinct dev versions.
3. `docs/sources/whatsnew/changelog.rst` — Add CI and DEV entries.

## Verification

| Scenario | Expected behavior |
|----------|------------------|
| Push to `master` (non-release) | Build plugin, print skip message, no upload |
| Tag `spectrochempy-nmr-v0.1.3` | Upload `spectrochempy-nmr` to Anaconda label `main` |
| Tag `spectrochempy-v0.9.2` (core) | Build plugins, print skip message (tag doesn't start with plugin name), no upload |
| Core release event | No impact on core upload logic (unchanged)