### PR TITLE
CI: Add standalone plugin release status workflow

### DIFF
--- a/.github/workflows/plugin_release_status.yml
+++ b/.github/workflows/plugin_release_status.yml
@@ -1,0 +1,105 @@
+# This workflow provides a read-only overview of official plugin changes since
+# their last release tag.  It is intended to be run manually before deciding
+# which plugin to release, so maintainers can inspect the state of each plugin
+# at a glance.
+#
+# No packages are built, no tags/releases are created, and nothing is
+# published during this workflow.
+
+name: Check plugin release status
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-status:
+    name: List official plugin changes since last release tag
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Build plugin status table
+        run: |
+          python3 << 'PYEOF'
+          import os, subprocess, re
+
+          plugins = [
+              'spectrochempy-nmr',
+              'spectrochempy-iris',
+              'spectrochempy-hypercomplex',
+              'spectrochempy-carroucell',
+          ]
+
+          lines = []
+          lines.append('## Plugin release status')
+          lines.append('')
+          lines.append('| Plugin | Status | Last tag | Changed files |')
+          lines.append('|--------|--------|----------|---------------|')
+
+          any_changes = False
+
+          for plugin in plugins:
+              plugin_dir = f'plugins/{plugin}'
+              if not os.path.isdir(plugin_dir):
+                  lines.append(f'| {plugin} | :warning: directory missing | -- | -- |')
+                  any_changes = True
+                  continue
+
+              result = subprocess.run(
+                  ['git', 'tag', '--list', f'{plugin}-v*'],
+                  capture_output=True, text=True,
+              )
+              tags = [t for t in result.stdout.strip().split('\n') if t]
+              tags.sort(key=lambda t: [int(x) for x in t.split('-v')[-1].split('.')])
+              last_tag = tags[-1] if tags else ''
+
+              if not last_tag:
+                  lines.append(f'| {plugin} | :new: no previous plugin tag | -- | -- |')
+                  any_changes = True
+              else:
+                  ret = subprocess.run(
+                      ['git', 'diff', '--quiet', last_tag, '--', f'{plugin_dir}/'],
+                  )
+                  if ret.returncode == 0:
+                      lines.append(f'| {plugin} | :white_check_mark: unchanged | `{last_tag}` | 0 |')
+                  else:
+                      stat_ret = subprocess.run(
+                          ['git', 'diff', '--stat', last_tag, '--', f'{plugin_dir}/'],
+                          capture_output=True, text=True,
+                      )
+                      stat_text = stat_ret.stdout.strip()
+                      changed_count = '?'
+                      if stat_text:
+                          m = re.search(r'(\d+) file[s]? changed', stat_text)
+                          if m:
+                              changed_count = m.group(1)
+                      lines.append(f'| {plugin} | :large_orange_diamond: modified since `{last_tag}` | {changed_count} |')
+                      any_changes = True
+
+          lines.append('')
+
+          if any_changes:
+              lines.append('_Some plugins have changes since their last release. Consider releasing them._')
+          else:
+              lines.append('**No official plugin changes detected since their last release tags.**')
+
+          output = '\n'.join(lines)
+
+          summary_path = os.environ.get('GITHUB_STEP_SUMMARY')
+          if summary_path:
+              with open(summary_path, 'a') as f:
+                  f.write(output + '\n')
+
+          print(output)
+          PYEOF

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -54,6 +54,10 @@ jobs:
           fi
 
       - name: List official plugins with changes since last tag
+        # Use the separate "Check plugin release status" workflow
+        # (.github/workflows/plugin_release_status.yml) to inspect plugin
+        # status before running a release.  This step provides a final
+        # confirmation during the release workflow itself.
         run: |
           python3 << 'PYEOF'
           import os, subprocess

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -71,3 +71,8 @@ Developer
 - DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
   explaining that dev conda uploads for plugins are disabled until distinct
   dev versions are generated.
+- CI: Added ``plugin_release_status.yml`` workflow (``workflow_dispatch``)
+  to inspect official plugin changes since their last release tag before
+  deciding to run a release.  Writes a Markdown table (plugin, status, last
+  tag, changed files count) to the workflow summary.  Read-only — no
+  packages, tags, or releases are created.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -32,3 +32,8 @@ Developer
 - DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
   explaining that dev conda uploads for plugins are disabled until distinct
   dev versions are generated.
+- CI: Added ``plugin_release_status.yml`` workflow (``workflow_dispatch``)
+  to inspect official plugin changes since their last release tag before
+  deciding to run a release.  Writes a Markdown table (plugin, status, last
+  tag, changed files count) to the workflow summary.  Read-only — no
+  packages, tags, or releases are created.


### PR DESCRIPTION
## Problem

The plugin status table in `release_plugin.yml` is only visible *after* running the release workflow, so it does not help maintainers decide *which* plugin to release from the `workflow_dispatch` screen.

## Solution

Add a new read-only workflow `plugin_release_status.yml` that can be triggered manually at any time to inspect all official plugins.

## New workflow: `plugin_release_status.yml`

- Trigger: `workflow_dispatch` only
- Permissions: `contents: read` (no side effects)
- Steps:
  1. Checkout with `fetch-depth: 0`
  2. Python script lists 4 official plugins, finds their last release tag, compares `HEAD` with that tag on `plugins/<name>/`, writes a Markdown table to `$GITHUB_STEP_SUMMARY`

### Table columns

| Plugin | Status | Last tag | Changed files |

### Expected output

| Plugin | Status | Last tag | Changed files |
|--------|--------|----------|---------------|
| spectrochempy-nmr | :white_check_mark: unchanged | `spectrochempy-nmr-v0.1.3` | 0 |
| spectrochempy-iris | :large_orange_diamond: modified since `spectrochempy-iris-v0.1.0` | 3 |
| spectrochempy-hypercomplex | :new: no previous plugin tag | -- | -- |
| spectrochempy-carroucell | :white_check_mark: unchanged | `spectrochempy-carroucell-v0.1.0` | 0 |

Edge cases handled:
- No previous tag: `:new: no previous plugin tag`
- No changes: `:white_check_mark: unchanged` with 0 changed files
- Changes detected: `:large_orange_diamond: modified since `<last_tag>`` with file count
- All plugins unchanged: bold summary message
- Directory missing: `:warning: directory missing`

### Bonus

Brief comment added in `release_plugin.yml` referencing the new workflow.