### PR TITLE
CI: Ignore CRLF differences when checking plugin changes

### DIFF
--- a/.github/workflows/plugin_release_status.yml
+++ b/.github/workflows/plugin_release_status.yml
@@ -69,13 +69,13 @@ jobs:
                   any_changes = True
               else:
                   ret = subprocess.run(
-                      ['git', 'diff', '--quiet', last_tag, '--', f'{plugin_dir}/'],
+                      ['git', 'diff', '--ignore-cr-at-eol', '--quiet', last_tag, '--', f'{plugin_dir}/'],
                   )
                   if ret.returncode == 0:
                       lines.append(f'| {plugin} | :white_check_mark: unchanged | `{last_tag}` | 0 |')
                   else:
                       stat_ret = subprocess.run(
-                          ['git', 'diff', '--stat', last_tag, '--', f'{plugin_dir}/'],
+                          ['git', 'diff', '--ignore-cr-at-eol', '--stat', last_tag, '--', f'{plugin_dir}/'],
                           capture_output=True, text=True,
                       )
                       stat_text = stat_ret.stdout.strip()

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -96,7 +96,7 @@ jobs:
                   has_changes = True
               else:
                   ret = subprocess.run(
-                      ['git', 'diff', '--quiet', last_tag, '--', f'{plugin_dir}/'],
+                      ['git', 'diff', '--ignore-cr-at-eol', '--quiet', last_tag, '--', f'{plugin_dir}/'],
                   )
                   if ret.returncode == 0:
                       lines.append(f'| {plugin} | :white_check_mark: unchanged since last tag | ```{last_tag}``` |')


### PR DESCRIPTION
## Problem

The `Check plugin release status` workflow (`plugin_release_status.yml`) was reporting all official plugins as modified, even when no plugin files had been touched.  The same issue affects the confirmation table in `release_plugin.yml`.

Root cause: diff --git a/docs/sources/whatsnew/latest.rst b/docs/sources/whatsnew/latest.rst
index 78f67134c..56743e6cc 100644
--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -1,39 +1,39 @@
-..
-   NOTE: This file is automatically generated from ``changelog.rst``.
-   Do not edit it manually — your changes will be overwritten.
-   Edit ``changelog.rst`` in the same directory instead.
-   (This note is read by AI agents; manual edits belong in changelog.rst)
-
-:orphan:
-
-What's New in Revision 0.9.3.dev
----------------------------------------------------------------------------------------
-
-These are the changes in SpectroChemPy-0.9.3.dev.
-See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
-
-Developer
-~~~~~~~~~
-
-- DOC: Improved maintainer release documentation with explicit Zenodo
-  verification steps, docs build note, and roadmap for modular docs.
-- CI: Added plugin status table to ``release_plugin.yml`` step summary,
-  listing all official plugins and whether they have changed since their
-  last release tag — shows a "no changes" message when all plugins are
-  unchanged, or highlights modified plugins when some need a release.
-- CI: Added ``confirm_zenodo_enabled`` checkbox to
-  ``prepare_new_release.yml`` so maintainers verify Zenodo is active before
-  creating a release PR.
-- CI: Disabled automatic dev conda uploads for official plugins
-  (``build_package.yml``).  Plugin conda packages are still built in CI for
-  testing, but only uploaded to Anaconda.org during a stable plugin release
-  (label ``main``).  Dev uploads will be re-enabled once plugin recipes
-  generate distinct dev versions.
-- DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
-  explaining that dev conda uploads for plugins are disabled until distinct
-  dev versions are generated.
-- CI: Added ``plugin_release_status.yml`` workflow (``workflow_dispatch``)
-  to inspect official plugin changes since their last release tag before
-  deciding to run a release.  Writes a Markdown table (plugin, status, last
-  tag, changed files count) to the workflow summary.  Read-only — no
-  packages, tags, or releases are created.
+..
+   NOTE: This file is automatically generated from ``changelog.rst``.
+   Do not edit it manually — your changes will be overwritten.
+   Edit ``changelog.rst`` in the same directory instead.
+   (This note is read by AI agents; manual edits belong in changelog.rst)
+
+:orphan:
+
+What's New in Revision 0.9.3.dev
+---------------------------------------------------------------------------------------
+
+These are the changes in SpectroChemPy-0.9.3.dev.
+See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Developer
+~~~~~~~~~
+
+- DOC: Improved maintainer release documentation with explicit Zenodo
+  verification steps, docs build note, and roadmap for modular docs.
+- CI: Added plugin status table to ``release_plugin.yml`` step summary,
+  listing all official plugins and whether they have changed since their
+  last release tag — shows a "no changes" message when all plugins are
+  unchanged, or highlights modified plugins when some need a release.
+- CI: Added ``confirm_zenodo_enabled`` checkbox to
+  ``prepare_new_release.yml`` so maintainers verify Zenodo is active before
+  creating a release PR.
+- CI: Disabled automatic dev conda uploads for official plugins
+  (``build_package.yml``).  Plugin conda packages are still built in CI for
+  testing, but only uploaded to Anaconda.org during a stable plugin release
+  (label ``main``).  Dev uploads will be re-enabled once plugin recipes
+  generate distinct dev versions.
+- DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
+  explaining that dev conda uploads for plugins are disabled until distinct
+  dev versions are generated.
+- CI: Added ``plugin_release_status.yml`` workflow (``workflow_dispatch``)
+  to inspect official plugin changes since their last release tag before
+  deciding to run a release.  Writes a Markdown table (plugin, status, last
+  tag, changed files count) to the workflow summary.  Read-only — no
+  packages, tags, or releases are created. detects CRLF → LF line-ending differences as content changes.  This happens locally when `core.autocrlf` converts files on checkout, or when a commit mixes line endings.

## Fix

Add `--ignore-cr-at-eol` to both `git diff` commands:

- `.github/workflows/plugin_release_status.yml` — `git diff --ignore-cr-at-eol` (both `--quiet` and `--stat` variants)
- `.github/workflows/release_plugin.yml` — `git diff --ignore-cr-at-eol --quiet`

This ensures that pure line-ending differences do not falsely flag a plugin as modified.