### PR TITLE
CI: Run plugin release status workflow on every push to master

### DIFF
--- a/.github/workflows/plugin_release_status.yml
+++ b/.github/workflows/plugin_release_status.yml
@@ -1,7 +1,7 @@
 # This workflow provides a read-only overview of official plugin changes since
-# their last release tag.  It is intended to be run manually before deciding
-# which plugin to release, so maintainers can inspect the state of each plugin
-# at a glance.
+# their last release tag.  It runs automatically on every push to master, so
+# maintainers can inspect the latest state before deciding which plugin to
+# release.  It can also be triggered manually at any time.
 #
 # No packages are built, no tags/releases are created, and nothing is
 # published during this workflow.
@@ -9,6 +9,9 @@
 name: Check plugin release status
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -212,6 +212,29 @@ Vérifier également que le DOI Zenodo a été mis à jour sur la
 Avant de publier un plugin, comparer les changements depuis son dernier
 tag publié.
 
+### Workflow automatique (recommandé)
+
+Le workflow **Check plugin release status** (`plugin_release_status.yml`)
+s'exécute automatiquement à chaque push sur `master` et peut aussi être
+déclenché manuellement depuis Actions → **Check plugin release status** →
+**Run workflow**.
+
+Il produit un tableau de synthèse dans le *workflow summary* (onglet
+Summary du run) listant les 4 plugins officiels avec :
+
+- Statut (unchanged / modified / no previous tag)
+- Dernier tag publié
+- Nombre de commits ayant touché le répertoire du plugin
+- Nombre de fichiers modifiés
+
+Ce tableau permet de décider en un coup d'œil si un plugin mérite une
+nouvelle release.
+
+> **Attention** : le workflow ne vérifie pas la *nature* des changements
+> (un commit CI qui touche accidentellement des fichiers plugins peut
+> suffire à marquer le plugin comme modifié). Utiliser la commande
+> `git log` ci-dessous pour inspecter le détail si nécessaire.
+
 ### Trouver le dernier tag
 
 ```bash


### PR DESCRIPTION
## Changes

- Add `push` trigger (master branch) to `plugin_release_status.yml` so the status table is automatically generated after every merge
- Document the automated workflow in `maintainers/release-process.md` as the recommended way to check plugin status before a release

The workflow remains read-only (no packages, tags, or releases) and can still be triggered manually.