### PR TITLE
Docs revision

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -245,15 +245,10 @@ jobs:
           # excluding plugin tags (spectrochempy-*-vX.Y.Z).
           for tag in $(git tag --list 'spectrochempy-v*' | sort -V); do
             version="${tag#spectrochempy-v}"
-            # Create a local lightweight alias tag so make.py -T can find it
-            if ! git rev-parse --verify "$version" >/dev/null 2>&1; then
-              echo "Creating local alias tag for $tag"
-              git tag "$version" "$tag"
-            fi
             # Build docs for this version if not already present
             if [ ! -d "build/html/$version" ]; then
               echo "Building v$version docs"
-              python3 docs/make.py -j1 html -T "$version"
+              python3 docs/make.py -j1 html -T "$tag"
             fi
           done
 

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -3,9 +3,11 @@
 # - Anaconda Cloud
 #
 # Conda publication strategy:
-#   - Non-release builds (pushes, PRs) are uploaded to the Anaconda dev label.
-#   - Release builds are uploaded to the main (stable) label.
-#   - The dev label is used for testing; stable packages should not be overwritten.
+#   - Core non-release builds (pushes, PRs) are uploaded to the Anaconda dev label.
+#   - Core release builds are uploaded to the main (stable) label.
+#   - Plugin release builds are uploaded to the main label only.
+#   - Plugin dev uploads are disabled until plugin recipes generate distinct
+#     dev versions/builds; plugin conda packages are still built in CI.
 #   - Plugin conda recipes should declare a bounded dependency on the core
 #     package, e.g.  spectrochempy >=0.9.0.dev0,<0.10
 

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -15,8 +15,7 @@
 #   - plugin-template is excluded from discovery — it is a developer scaffold.
 #   - PyPI upload uses skip-existing so an already-published version never
 #     causes a hard failure.
-#   - Conda upload uses --force only on the dev label; stable (main) uploads
-#     fail cleanly if the version already exists.
+#   - Conda plugin publication is handled by build_package.yml.
 
 name: Publish plugin packages
 

--- a/docs/make.py
+++ b/docs/make.py
@@ -100,6 +100,19 @@ DOWNLOADS = HTML / "downloads"
 TEMPDIRS = PROJECT.parent / "tempdirs"
 
 ON_GITHUB = os.environ.get("GITHUB_ACTIONS") == "true"
+CORE_TAG_PREFIX = "spectrochempy-v"
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _canonical_doc_tag(tagname):
+    """Return possible git tags and the version directory for a docs tag."""
+    if tagname.startswith(CORE_TAG_PREFIX):
+        version = tagname.removeprefix(CORE_TAG_PREFIX)
+        if SEMVER_RE.match(version):
+            return [tagname], version
+    if SEMVER_RE.match(tagname):
+        return [tagname, f"{CORE_TAG_PREFIX}{tagname}"], tagname
+    return [tagname], tagname
 
 
 # ======================================================================================
@@ -123,9 +136,13 @@ class BuildOldTagDocs:
     """
 
     def __init__(self, **kwargs):
-        self.tagname = kwargs.get("tagname")
-        if not self.tagname:
+        self.requested_tagname = kwargs.get("tagname")
+        if not self.requested_tagname:
             raise ValueError("Please provide a tag name.")
+        self.git_tag_candidates, self.doc_version = _canonical_doc_tag(
+            self.requested_tagname
+        )
+        self.git_tagname = self.git_tag_candidates[0]
 
         self.verbose = kwargs.get("verbose")
 
@@ -167,14 +184,15 @@ class BuildOldTagDocs:
             If setup.py is missing
         """
         workingdir = self.workingdir
-        tagname = self.tagname
+        tagname = self.git_tagname
 
         try:
             if self.verbose:
                 # Debug prints
                 print(f"Project directory: {PROJECT}")
                 print(f"Temporary directory: {workingdir}")
-                print(f"Working with tag: {tagname}")
+                print(f"Requested docs tag: {self.requested_tagname}")
+                print(f"Documentation version directory: {self.doc_version}")
             self.uv = uv = shutil.which("uv")
             print("UV : ", uv)
             # Ensure we're in a git repository and tag exists
@@ -185,15 +203,19 @@ class BuildOldTagDocs:
                     raise RuntimeError(f"{PROJECT} is not a git repository")
 
                 # Check if tag exists locally
-                tag_exists = sh("git tag -l " + tagname, silent=True).strip()
+                tag_exists = self._find_existing_git_tag()
                 if not tag_exists:
                     print("Tag not found locally, trying to fetch...")
                     sh("git fetch origin --tags", silent=False)
-                    tag_exists = sh("git tag -l " + tagname, silent=True).strip()
+                    tag_exists = self._find_existing_git_tag()
                     if not tag_exists:
-                        raise RuntimeError(f"Tag {tagname} not found in repository")
+                        candidates = ", ".join(self.git_tag_candidates)
+                        raise RuntimeError(
+                            f"None of the expected tags were found: {candidates}"
+                        )
 
-                print(f"Found tag: {tag_exists}")
+                self.git_tagname = tagname = tag_exists
+                print(f"Found git tag: {tagname}")
 
                 # Create a worktree from the local repository at the specific tag
                 sh(
@@ -278,6 +300,13 @@ class BuildOldTagDocs:
             if hasattr(e, "stderr"):
                 print(f"Error output: {e.stderr}")
             return None
+
+    def _find_existing_git_tag(self):
+        for candidate in self.git_tag_candidates:
+            tag_exists = sh("git tag -l " + candidate, silent=True).strip()
+            if tag_exists:
+                return tag_exists.splitlines()[0]
+        return ""
 
     def cleanup(self):
         """Cleanup the worktree and temporary directory."""
@@ -1103,7 +1132,7 @@ def _main():
             # Create BuildDocumentation instance directly (don't import it)
             build = BuildDocumentation(
                 jobs=args.jobs,
-                tagname=build_old.tagname,
+                tagname=build_old.doc_version,
                 workingdir=build_old.workingdir,
             )
 

--- a/docs/sources/devguide/contributing.rst
+++ b/docs/sources/devguide/contributing.rst
@@ -30,7 +30,8 @@ Version Control Setup
      or `git-scm.com <https://git-scm.com/download/mac>`__
      or `Homebrew <https://brew.sh>`__ using ``brew install git``
    * Windows: From `git-scm.com <https://git-scm.com/download/win>`__
-   * Linux: ``sudo apt-get install git`` or ``pip install gitpython``
+   * Linux: use your distribution package manager, for example
+     ``sudo apt-get install git``
 
 Optional: Install a GUI client like `SourceTree <https://www.sourcetreeapp.com>`__
 or `GitHub Desktop <https://desktop.github.com>`__
@@ -83,7 +84,7 @@ Making Changes
 
    .. sourcecode:: bash
 
-       git checkout -b my-new-feature
+       git switch -c my-new-feature
 
 2. Make your changes and commit them:
 
@@ -116,10 +117,22 @@ To update your PR with upstream changes:
 
 .. sourcecode:: bash
 
-    git checkout my-new-feature
+    git switch my-new-feature
     git fetch upstream
     git merge upstream/master
     git push origin my-new-feature
+
+Before asking for review, use the pull request template as the source of truth
+for required items. In practice, make sure your branch is focused and that the
+checks matching your change have been run locally when practical:
+
+* targeted tests around the changed code
+* an entry in ``docs/sources/whatsnew/changelog.rst`` when the change affects
+  users, developers, tests, CI, packaging, or documentation
+* any new dependencies, public API entries, contributor metadata, or reference
+  docs requested by the pull request template
+* ``pre-commit run --all-files`` for formatting and generated docs files before
+  the final commit when practical
 
 Tips for Success
 ----------------

--- a/docs/sources/devguide/contributing_codebase.rst
+++ b/docs/sources/devguide/contributing_codebase.rst
@@ -20,6 +20,10 @@ do not make sudden changes to the code that could have the potential to break
 a lot of user code as a result, that is, we need it to be as *backwards compatible*
 as possible to avoid mass breakages.
 
+Prefer small, focused changes. If a patch affects public APIs, packaging,
+release workflows, or broad test behavior, document the risk in the pull request
+and keep unrelated cleanups for a separate change.
+
 Some extra checks can be run by
 ``pre-commit`` - see :ref:`here <contributing.pre-commit>` for how to
 run them.
@@ -312,6 +316,10 @@ The tests can then be run directly inside your Git clone by typing:
 The test suite is exhaustive and takes several minutes to run.  Often it is
 worth running only a subset of tests first around your changes before running the
 entire suite.
+
+When opening a pull request, prefer a small local test selection that matches
+the edited area and let CI cover the full matrix across operating systems and
+Python versions.
 
 The easiest way to do this is with:
 

--- a/docs/sources/devguide/contributing_documentation.rst
+++ b/docs/sources/devguide/contributing_documentation.rst
@@ -49,33 +49,40 @@ Building Documentation
 Quick Start
 ~~~~~~~~~~~
 1. Set up development environment (:ref:`guide <contributing.environment>`)
-2. Navigate to ``docs/`` directory
-3. Build HTML::
+2. From the repository root, build HTML::
 
-    python make.py html
+    python docs/make.py html
 
-4. View at ``docs/build/html/latest/index.html``
+3. View at ``build/html/index.html``
+
+For documentation-only edits where executing examples is not needed, use::
+
+    python docs/make.py --no-exec html
+
+On the published site, the root of ``gh-pages`` is the ``latest``
+documentation. Stable releases are published under version directories such as
+``0.9.2/``.
 
 Build Options
 ~~~~~~~~~~~~~
 
 - Full rebuild::
 
-    python make.py clean
-    python make.py html
+    python docs/make.py clean
+    python docs/make.py html
 
 - Build a single file::
 
-    python make.py --single-doc <path-to-file-relative-to-docs>.rst
-    python make.py --single-doc <path-to-file-relative-to-docs>.ipynb
+    python docs/make.py --single-doc <path-to-file-relative-to-docs>.rst
+    python docs/make.py --single-doc <path-to-file-relative-to-docs>.ipynb
 
 - Build a single directory::
 
-    python make.py --directory <path-to-directory-relative-to-docs>
+    python docs/make.py --directory <path-to-directory-relative-to-docs>
 
 - Build a single API entry::
 
-    python make.py --single-doc spectrochempy.<class-or-method-name>
+    python docs/make.py --single-doc spectrochempy.<class-or-method-name>
     # where ``<class-or-method-name>`` is the name of an importable method in the API.
 
 Writing Tips

--- a/docs/sources/devguide/index.rst
+++ b/docs/sources/devguide/index.rst
@@ -4,11 +4,17 @@
 Developer's Guide
 *****************************************************
 
+This guide is for contributors and maintainers working on SpectroChemPy code,
+documentation, tests, or official plugins.
 
 .. note::
 
    A large part of the content/structure of this guide has been copied and adapted from the `Pandas developer guide <https://pandas.pydata.org/docs/development/contributing.html>`__.
 
+Start with :doc:`contributing` for the development setup and pull request
+workflow. Use :doc:`contributing_codebase` for testing, formatting, deprecations,
+and changelog entries. Plugin-specific architecture and packaging guidance lives
+under :doc:`plugins/index`.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -181,7 +181,7 @@ Release policy
 
 Plugins are released **independently** from the core package.
 
-* A core release tag such as ``0.9.0`` publishes the core wheel only;
+* A core release tag such as ``spectrochempy-v0.9.0`` publishes the core wheel only;
   it does **not** trigger plugin uploads.
 * A plugin release tag such as ``spectrochempy-nmr-v0.1.1`` triggers the
   ``publish_plugins.yml`` and ``build_package.yml`` workflows for that
@@ -204,9 +204,9 @@ The recommended way to release a plugin is through the
 3. Enter:
    - Plugin name: ``spectrochempy-nmr``
    - Version: ``0.1.1``
-4. The workflow bumps ``pyproject.toml`` and ``recipe.yaml``, commits,
-   pushes to the ``plugins`` branch, and creates the release tag
-   ``spectrochempy-nmr-v0.1.1`` automatically.
+4. The workflow bumps ``pyproject.toml``, ``recipe.yaml``, and the plugin
+   ``__init__.py`` version string, commits to the current branch, and creates
+   the release tag ``spectrochempy-nmr-v0.1.1`` automatically.
 5. The tag triggers CI which builds and publishes the wheel to PyPI and
    Anaconda.org.
 
@@ -215,9 +215,10 @@ Manual fallback::
     # 1. Bump version in plugins/<name>/pyproject.toml
     # 2. Bump version in plugins/<name>/recipe.yaml (conda)
     # 3. Commit and push:
-    git add plugins/<name>/pyproject.toml plugins/<name>/recipe.yaml
+    git add plugins/<name>/pyproject.toml plugins/<name>/recipe.yaml \
+        plugins/<name>/src/spectrochempy_<name>/__init__.py
     git commit -m "Bump spectrochempy-<name> to 0.1.1"
-    git push upstream plugins
+    git push upstream master
 
     # 4. Create and push the release tag:
     git tag spectrochempy-<name>-v0.1.1

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -199,15 +199,17 @@ repository, which leads to version collisions).
 The recommended way to release a plugin is through the
 ``release_plugin.yml`` workflow:
 
-1. Go to **Actions → Release an official plugin** in the GitHub UI.
-2. Click **Run workflow**.
-3. Enter:
+1. Optionally run **Actions → Check plugin release status** first to inspect
+   which official plugins changed since their last release tag.
+2. Go to **Actions → Release an official plugin** in the GitHub UI.
+3. Click **Run workflow** from the ``master`` branch.
+4. Enter:
    - Plugin name: ``spectrochempy-nmr``
    - Version: ``0.1.1``
-4. The workflow bumps ``pyproject.toml``, ``recipe.yaml``, and the plugin
-   ``__init__.py`` version string, commits to the current branch, and creates
+5. The workflow bumps ``pyproject.toml``, ``recipe.yaml``, and the plugin
+   ``__init__.py`` version string, commits to ``master``, and creates
    the release tag ``spectrochempy-nmr-v0.1.1`` automatically.
-5. The tag triggers CI which builds and publishes the wheel to PyPI and
+6. The tag triggers CI which builds and publishes the wheel to PyPI and
    Anaconda.org.
 
 Manual fallback::

--- a/docs/sources/gettingstarted/install/install_adds.rst
+++ b/docs/sources/gettingstarted/install/install_adds.rst
@@ -78,15 +78,10 @@ the corresponding feature is accessed.
 
    **Development builds**
 
-   Pre-release (dev) versions of plugins are published to the ``dev`` label
-   on Anaconda.org. To install the latest development build::
-
-      mamba install -c spectrocat/label/dev -c conda-forge spectrochempy-nmr
-
-   Dev builds may depend on the latest dev core package, so include the
-   dev channel for core as well::
-
-      mamba install -c spectrocat/label/dev -c conda-forge spectrochempy
+   Conda development builds are available for the core package, but official
+   plugin development builds are not currently uploaded automatically. Stable
+   plugin packages are published on the main ``spectrocat`` channel. For plugin
+   development, install the plugin from a local source checkout as shown above.
 
 .. seealso::
 

--- a/docs/sources/userguide/plugins/index.rst
+++ b/docs/sources/userguide/plugins/index.rst
@@ -35,9 +35,14 @@ Conda users can install from the ``spectrocat`` channel::
 
     mamba install -c spectrocat -c conda-forge spectrochempy-nmr
 
-Development (pre-release) builds are available on the ``dev`` label::
+Plugin versions are independent from the SpectroChemPy core version. For
+example, ``spectrochempy 0.9.2`` may be used with
+``spectrochempy-nmr 0.1.3``. Use ``scp.plugins(verbose=True)`` to inspect the
+plugin versions discovered in the current environment.
 
-    mamba install -c spectrocat/label/dev -c conda-forge spectrochempy-nmr
+Conda development builds for official plugins are not published automatically
+at the moment. Stable plugin packages are available from the main
+``spectrocat`` channel.
 
 Using plugins
 -------------

--- a/docs/sources/userguide/plugins/official_plugins.rst
+++ b/docs/sources/userguide/plugins/official_plugins.rst
@@ -63,6 +63,19 @@ or directly:
 Once installed, plugins are discovered automatically. No explicit plugin
 loading call is required in user code.
 
+Versions and compatibility
+==========================
+
+Official plugins are versioned independently from the SpectroChemPy core
+package. A core release and a plugin release therefore do not need to share the
+same version number. For example, a stable ``spectrochempy 0.9.2`` environment
+may use ``spectrochempy-nmr 0.1.3``.
+
+Stable plugin packages are published on PyPI and on the main ``spectrocat``
+conda channel. Conda development builds for official plugins are currently not
+published automatically; they will be re-enabled once plugin development builds
+use versions distinct from stable releases.
+
 Inspect installed plugins
 =========================
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,8 +54,12 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- CI: Allowed documentation builds to use canonical core release tags such as
+  ``spectrochempy-v0.9.2`` directly, while publishing versioned docs under the
+  plain semver directory.
 - DOC: Improved maintainer release documentation with explicit Zenodo
-  verification steps, docs build note, and roadmap for modular docs.
+  verification steps, versioned docs checks, docs build note, and roadmap for
+  modular docs.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -75,6 +75,9 @@ Developer
   Anaconda ``main`` upload behavior.
 - DOC: Clarified that official plugin releases must be run from ``master`` and
   can be prepared with the read-only plugin release status workflow.
+- DOC: Finished maintainer release notes cleanup for master checkout, draft
+  release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
+  internal recovery links.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -78,6 +78,9 @@ Developer
 - DOC: Finished maintainer release notes cleanup for master checkout, draft
   release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
   internal recovery links.
+- DOC: Tightened the developer guide entry points, Git commands, pull request
+  template guidance, and testing guidance without expanding the guide
+  substantially.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -65,6 +65,8 @@ Developer
   automatically.
 - DOC: Updated contributor documentation build instructions to use the
   repository-root ``docs/make.py`` entry point and current ``build/html`` output.
+- DOC: Updated optional plugin installation notes so conda development
+  channels no longer imply automatic plugin dev uploads.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -60,6 +60,9 @@ Developer
 - DOC: Improved maintainer release documentation with explicit Zenodo
   verification steps, versioned docs checks, docs build note, and roadmap for
   modular docs.
+- DOC: Clarified that official plugin versions are independent from the core
+  package version and that conda dev plugin builds are not currently published
+  automatically.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -70,6 +70,9 @@ Developer
 - DOC: Aligned workflow comments and recovery notes with the current plugin
   conda policy: stable plugin releases upload to ``main`` and dev uploads are
   disabled until distinct dev versions exist.
+- DOC: Updated plugin release documentation to use canonical core tags,
+  current branch pushes, plugin ``__init__.py`` version bumps, and the current
+  Anaconda ``main`` upload behavior.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -63,6 +63,8 @@ Developer
 - DOC: Clarified that official plugin versions are independent from the core
   package version and that conda dev plugin builds are not currently published
   automatically.
+- DOC: Updated contributor documentation build instructions to use the
+  repository-root ``docs/make.py`` entry point and current ``build/html`` output.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -67,6 +67,9 @@ Developer
   repository-root ``docs/make.py`` entry point and current ``build/html`` output.
 - DOC: Updated optional plugin installation notes so conda development
   channels no longer imply automatic plugin dev uploads.
+- DOC: Aligned workflow comments and recovery notes with the current plugin
+  conda policy: stable plugin releases upload to ``main`` and dev uploads are
+  disabled until distinct dev versions exist.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -73,6 +73,8 @@ Developer
 - DOC: Updated plugin release documentation to use canonical core tags,
   current branch pushes, plugin ``__init__.py`` version bumps, and the current
   Anaconda ``main`` upload behavior.
+- DOC: Clarified that official plugin releases must be run from ``master`` and
+  can be prepared with the read-only plugin release status workflow.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -28,6 +28,9 @@ Developer
   repository-root ``docs/make.py`` entry point and current ``build/html`` output.
 - DOC: Updated optional plugin installation notes so conda development
   channels no longer imply automatic plugin dev uploads.
+- DOC: Aligned workflow comments and recovery notes with the current plugin
+  conda policy: stable plugin releases upload to ``main`` and dev uploads are
+  disabled until distinct dev versions exist.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -34,6 +34,8 @@ Developer
 - DOC: Updated plugin release documentation to use canonical core tags,
   current branch pushes, plugin ``__init__.py`` version bumps, and the current
   Anaconda ``main`` upload behavior.
+- DOC: Clarified that official plugin releases must be run from ``master`` and
+  can be prepared with the read-only plugin release status workflow.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,8 +15,12 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
+- CI: Allowed documentation builds to use canonical core release tags such as
+  ``spectrochempy-v0.9.2`` directly, while publishing versioned docs under the
+  plain semver directory.
 - DOC: Improved maintainer release documentation with explicit Zenodo
-  verification steps, docs build note, and roadmap for modular docs.
+  verification steps, versioned docs checks, docs build note, and roadmap for
+  modular docs.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -36,6 +36,9 @@ Developer
   Anaconda ``main`` upload behavior.
 - DOC: Clarified that official plugin releases must be run from ``master`` and
   can be prepared with the read-only plugin release status workflow.
+- DOC: Finished maintainer release notes cleanup for master checkout, draft
+  release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
+  internal recovery links.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,13 @@ Developer
 - DOC: Improved maintainer release documentation with explicit Zenodo
   verification steps, versioned docs checks, docs build note, and roadmap for
   modular docs.
+- DOC: Clarified that official plugin versions are independent from the core
+  package version and that conda dev plugin builds are not currently published
+  automatically.
+- DOC: Updated contributor documentation build instructions to use the
+  repository-root ``docs/make.py`` entry point and current ``build/html`` output.
+- DOC: Updated optional plugin installation notes so conda development
+  channels no longer imply automatic plugin dev uploads.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -39,6 +39,9 @@ Developer
 - DOC: Finished maintainer release notes cleanup for master checkout, draft
   release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
   internal recovery links.
+- DOC: Tightened the developer guide entry points, Git commands, pull request
+  template guidance, and testing guidance without expanding the guide
+  substantially.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,6 +31,9 @@ Developer
 - DOC: Aligned workflow comments and recovery notes with the current plugin
   conda policy: stable plugin releases upload to ``main`` and dev uploads are
   disabled until distinct dev versions exist.
+- DOC: Updated plugin release documentation to use canonical core tags,
+  current branch pushes, plugin ``__init__.py`` version bumps, and the current
+  Anaconda ``main`` upload behavior.
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
   listing all official plugins and whether they have changed since their
   last release tag — shows a "no changes" message when all plugins are

--- a/maintainers/emergency-recovery.md
+++ b/maintainers/emergency-recovery.md
@@ -198,11 +198,11 @@ Le job `build_and_publish_conda_package` échoue.
    anaconda show spectrocat/spectrochempy
    ```
 3. **Labels** :
-   - Sur release : upload vers le label `main` (sans `--force`)
+   - Sur release : upload vers le label `main` (avec `--force`, pour déplacer
+     si nécessaire une build déjà publiée sur `dev` vers le label stable)
    - Sur push : upload vers le label `dev` (avec `--force`)
-4. **Version déjà publiée** : si le label `main` contient déjà la même
-   version, le build échoue (pas de `--force` sur la release). Supprimer
-   la version sur Anaconda si nécessaire :
+4. **Version déjà publiée** : si Anaconda refuse malgré tout l'upload,
+   supprimer la version sur Anaconda si nécessaire :
    ```bash
    anaconda remove spectrocat/spectrochempy/X.Y.Z
    ```

--- a/maintainers/emergency-recovery.md
+++ b/maintainers/emergency-recovery.md
@@ -251,8 +251,9 @@ le solveur exclut les versions plus récentes de `spectrocat` à cause
 de la priorité stricte.
 
 *Résolution* : l'ordre des canaux dans le build des plugins a été
-inversé : `spectrocat/label/dev` et `spectrocat` passent avant
-`conda-forge`.
+inversé : `spectrocat/label/dev` (pour le core dev construit sur push) et
+`spectrocat` passent avant `conda-forge`. Les plugins eux-mêmes ne sont
+uploadés sur Anaconda.org que pendant une release stable de plugin.
 
 ### Résolution pour une release déjà publiée
 

--- a/maintainers/emergency-recovery.md
+++ b/maintainers/emergency-recovery.md
@@ -176,8 +176,9 @@ Le job `build-and-publish_plugins` échoue dans le workflow
    [secrets du dépôt](https://github.com/spectrochempy/spectrochempy/settings/secrets/actions)
    et qu'ils n'ont pas expiré ou été révoqués
 2. **Version déjà publiée** : le workflow publie les plugins avec
-   `skip-existing: true` sur TestPyPI. Sur PyPI stable, une version
-   déjà publiée provoque un échec (pas de `--skip-existing`).
+   `skip-existing: true` sur TestPyPI et PyPI stable. Une version déjà
+   publiée est donc ignorée, mais PyPI ne remplace jamais un artefact
+   existant. Si le contenu publié est incorrect, incrémenter la version.
 
 ---
 
@@ -392,7 +393,7 @@ les GitHub Releases, y compris celles des plugins (tags
 ### Prévention
 
 - Suivre la procédure décrite dans
-  [release-process.md — Zenodo and plugin releases](../release-process.md#zenodo-and-plugin-releases)
+  [release-process.md — Zenodo and plugin releases](release-process.md#zenodo-and-plugin-releases)
 - Ne jamais laisser l'intégration Zenodo active pendant une phase de
   release plugin
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -325,8 +325,11 @@ généralement pas de publication :
 
 ### Workflow
 
-Depuis **Actions** → **Release an official plugin**, exécuter le workflow avec les
-paramètres :
+Si nécessaire, lancer d'abord **Actions** → **Check plugin release status**
+pour vérifier quels plugins ont changé depuis leur dernier tag publié.
+
+Ensuite, depuis **Actions** → **Release an official plugin**, exécuter le
+workflow depuis la branche `master` avec les paramètres :
 
 ```
 plugin_name: spectrochempy-XXX
@@ -347,8 +350,9 @@ confirm_zenodo_disabled: true   # ← doit être coché
 ### Déroulement
 
 1. Le workflow **Release an official plugin** (`release_plugin.yml`) :
+   - Vérifie que le workflow est déclenché depuis `master`
    - Vérifie que le plugin est dans la liste officielle
-   - Bump la version dans `pyproject.toml` et `recipe.yaml`
+   - Bump la version dans `pyproject.toml`, `recipe.yaml` et `__init__.py`
    - Pousse le commit sur `master` (via `BOT_TOKEN`)
    - Crée le tag `spectrochempy-XXX-vX.Y.Z`
    - Crée une Release GitHub

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -76,14 +76,12 @@ services externes.
   ```
 
 - **Première release d'un plugin** : si le package n'existe pas encore sur
-  Anaconda, la commande `anaconda show` échouera — c'est normal. Le
-  workflow `build_package.yml` utilise une commande `anaconda show` en
-  diagnostic avant l'upload. Si le package n'existe pas encore, cette
-  commande peut échouer et bloquer le script à cause de `set -e`.
+  Anaconda, vérifier que `ANACONDA_API_TOKEN` a les droits de création de
+  nouveaux packages sur l'organisation `spectrocat`.
 
-  → Solution : soit supprimer la ligne `anaconda show` du workflow pour
-  les plugins, soit créer le package vide manuellement avant la première
-  release (`anaconda upload --skip-existing -l main <fichier>.conda`).
+  → Si la création automatique échoue, créer le package manuellement avec le
+  fichier `.conda` construit par CI, puis relancer la release :
+  `anaconda upload -l main <fichier>.conda`.
 
   Le `ANACONDA_API_TOKEN` utilisé par le workflow doit avoir les droits
   de **création** de nouveaux packages sur l'organisation `spectrocat`.
@@ -172,7 +170,8 @@ pour vérifier la Draft.
   **Build and publish packages** qui publie sur :
 
   - **PyPI** (label stable, sans `--force`)
-  - **Anaconda.org** (label `main`, sans `--force`)
+  - **Anaconda.org** (label `main`, avec `--force` pour déplacer une build
+    déjà publiée sur `dev` vers le label stable)
   - **Zenodo** (via l'intégration GitHub)
 
 - La publication déclenche également le workflow **Docs** (`build_docs.yml`)

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -99,7 +99,8 @@ services externes.
 
 ```bash
 git fetch upstream
-git checkout upstream/master
+git switch master
+git merge --ff-only upstream/master
 git status
 ```
 
@@ -156,7 +157,7 @@ Dans la Pull Request :
 Le workflow `publish_draft_new_release.yml` crée une **Draft Release** avec :
 
 - Tag : `spectrochempy-vX.Y.Z`
-- Titre : `SpectroChemPy v.X.Y.Z`
+- Titre : `SpectroChemPy vX.Y.Z`
 
 Aller sur la
 [page des releases](https://github.com/spectrochempy/spectrochempy/releases)
@@ -498,8 +499,8 @@ entrées sont incorrectes car :
 
 ### TestPyPI cleanup
 
-- [ ] Les pushes sur `master` publient automatiquement sur TestPyPI
-- [ ] Les releases plugins sur TestPyPI ne remplacent pas les versions
+- [ ] Les pushes sur `master` publient automatiquement le core sur TestPyPI
+- [ ] Les publications plugins vers TestPyPI ne remplacent pas les versions
       existantes (le workflow utilise `skip-existing: true`)
 - [ ] Si une version a été publiée sur TestPyPI puis modifiée, supprimer
       manuellement l'ancienne version sur

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -184,6 +184,24 @@ pour vérifier la Draft.
   > versionnée (accessible sous `/<version>/`) et le dropdown des versions.
   > **Ne pas supprimer ce job** dans le workflow `build_docs.yml`.
 
+### Modèle actuel de documentation versionnée
+
+Le site publié par GitHub Pages est construit dans la branche `gh-pages` :
+
+- la documentation `latest` est publiée à la racine du site et correspond à
+  l'état courant de `master` ;
+- chaque release stable du core est publiée dans un répertoire `X.Y.Z/`
+  (par exemple `0.9.2/`) ;
+- le dropdown des versions est généré à partir des répertoires semver présents
+  dans `gh-pages` ;
+- les tags Git du core utilisent le format canonique `spectrochempy-vX.Y.Z`,
+  mais le répertoire public de documentation reste `X.Y.Z/` ;
+- les tags plugins (`spectrochempy-<plugin>-vX.Y.Z`) ne doivent pas créer de
+  documentation stable séparée.
+
+`latest.rst` ne doit pas être modifié manuellement : il est régénéré depuis
+`docs/sources/whatsnew/changelog.rst` par le hook pre-commit.
+
 ---
 
 ## Vérifications post-release
@@ -204,6 +222,22 @@ python -c "import spectrochempy; print(spectrochempy.__version__)"
 
 Vérifier également que le DOI Zenodo a été mis à jour sur la
 [page Zenodo](https://zenodo.org/communities/spectrochempy).
+
+Vérifier enfin la documentation :
+
+- le workflow **Docs** (`build_docs.yml`) a réussi après publication de la
+  release ;
+- `https://www.spectrochempy.fr/X.Y.Z/` existe pour la nouvelle version ;
+- le dropdown des versions contient `X.Y.Z` ;
+- la racine du site affiche toujours la documentation `latest`.
+
+Si la version n'apparaît pas dans le dropdown alors que la release existe :
+
+1. Relancer manuellement **Actions → Docs → Run workflow** depuis `master`.
+2. Vérifier que `gh-pages` contient bien le répertoire `X.Y.Z/`.
+3. Vérifier que le tag core suit le format `spectrochempy-vX.Y.Z`.
+4. Ne pas créer de tag alias local `X.Y.Z` : `docs/make.py -T` accepte les
+   tags canoniques `spectrochempy-vX.Y.Z`.
 
 ---
 
@@ -496,5 +530,4 @@ entrées sont incorrectes car :
 - Éviter de reconstruire inutilement des versions inchangées (build complet
   même quand seuls quelques fichiers RST ont changé)
 - Rendre le version selector moins dépendant des détails de tagging
-  (actuellement lié aux répertoires `X.Y.Z` dans le HTML et aux alias de
-  tags locaux)
+  (actuellement lié aux répertoires `X.Y.Z` dans le HTML)


### PR DESCRIPTION
## Summary

This PR consolidates the release, documentation, plugin, and developer documentation after the 0.9.x release cycle.

Main changes:

- Clarifies the versioned documentation model:
  - `latest` is published at the root of `gh-pages`.
  - Stable core docs are published under `X.Y.Z/` directories.
  - Core release tags use `spectrochempy-vX.Y.Z`, while public docs directories keep the plain `X.Y.Z` form.
  - Plugin tags do not create separate stable documentation directories.
- Updates the docs release workflow documentation:
  - post-release checks for the Docs workflow, version URL, dropdown, and `gh-pages` contents;
  - troubleshooting steps when a release is missing from the version dropdown;
  - reminder that `latest.rst` is generated from `changelog.rst` by pre-commit.
- Clarifies official plugin versioning and distribution:
  - plugin versions are independent from the core version;
  - stable plugin packages are published on PyPI and the main `spectrocat` conda channel;
  - conda dev uploads for plugins are currently disabled until plugin dev builds use distinct versions.
- Aligns maintainer and recovery docs with the current release workflows:
  - `Prepare a new release` / Zenodo checks;
  - `Release an official plugin` must run from `master`;
  - `Check plugin release status` can be used before deciding which plugin to release;
  - plugin releases bump `pyproject.toml`, `recipe.yaml`, and plugin `__init__.py` versions;
  - Anaconda `main` upload behavior and recovery wording are updated.
- Refreshes developer/contributor documentation:
  - clearer developer guide entry points;
  - modern Git commands (`git switch`);
  - local docs build instructions using `python docs/make.py` from the repository root;
  - PR checklist guidance aligned with `.github/PULL_REQUEST_TEMPLATE.md`.
- Keeps the technical scope light:
  - no docs architecture split yet;
  - no plugin docs separation yet;
  - no changes to release publication behavior beyond documentation/workflow-comment alignment.

## Checklist

- [x] Developer/documentation changes are documented in `docs/sources/whatsnew/changelog.rst`.
- [x] No new dependencies were added.
- [x] No new public API methods were added.
- [x] No tests were added; this is documentation/workflow-comment cleanup.
- [x] `latest.rst` was not edited manually; any change there is expected to come from the pre-commit changelog hook.