### PR TITLE
Add docs version manifest

### DIFF
--- a/.github/workflows/repair_docs_index.yml
+++ b/.github/workflows/repair_docs_index.yml
@@ -1,0 +1,52 @@
+# Repair the published documentation version manifest without rebuilding docs.
+
+name: Repair docs version index
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  repair-docs-index:
+    name: Refresh docs versions manifest on gh-pages
+    runs-on: ubuntu-latest
+    if: github.repository == 'spectrochempy/spectrochempy'
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository }}
+          ref: gh-pages
+          path: build/html
+          fetch-depth: 1
+
+      - name: Refresh docs version index
+        run: |
+          python3 docs/make.py versions
+          cat build/html/versions.json
+
+      - name: Commit repaired docs index
+        run: |
+          cd build/html
+          if git diff --quiet; then
+            echo "Documentation version index is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Repair docs version index"
+          git push

--- a/docs/_static/js/versions.js
+++ b/docs/_static/js/versions.js
@@ -42,40 +42,58 @@ document.addEventListener("DOMContentLoaded", function () {
             : 'latest';
     }
 
-    const currentVersion = getCurrentVersion();
-    const versions = (document.documentElement.dataset.versions || '').split(',');
-
-    // Remove empty strings and sort versions in descending order
-    const sortedVersions = versions
-        .filter(v => v)
-        .sort((a, b) => {
-            const partsA = a.split('.').map(Number);
-            const partsB = b.split('.').map(Number);
-            for (let i = 0; i < 3; i++) {
-                if (partsA[i] !== partsB[i]) {
-                    return partsB[i] - partsA[i];
+    function sortVersions(versions) {
+        return versions
+            .filter(v => v)
+            .sort((a, b) => {
+                const partsA = a.split('.').map(Number);
+                const partsB = b.split('.').map(Number);
+                for (let i = 0; i < 3; i++) {
+                    if (partsA[i] !== partsB[i]) {
+                        return partsB[i] - partsA[i];
+                    }
                 }
+                return 0;
+            });
+    }
+
+    async function loadVersions() {
+        const fallback = (document.documentElement.dataset.versions || '').split(',');
+        try {
+            const response = await fetch(`${window.location.origin}${basePath}_static/versions.json`, {
+                cache: 'no-cache',
+            });
+            if (!response.ok) {
+                return fallback;
             }
-            return 0;
+            const manifest = await response.json();
+            return Array.isArray(manifest.versions) ? manifest.versions : fallback;
+        } catch {
+            return fallback;
+        }
+    }
+
+    function populateDropdown(versions) {
+        const currentVersion = getCurrentVersion();
+        const sortedVersions = sortVersions(versions);
+
+        const latestOption = document.createElement("option");
+        latestOption.value = window.location.origin + basePath;
+        latestOption.textContent = "latest";
+        latestOption.selected = currentVersion === 'latest';
+        versionsDropdown.appendChild(latestOption);
+
+        sortedVersions.forEach(version => {
+            const option = document.createElement("option");
+            option.value = `${window.location.origin}${basePath}${version}/`;
+            option.textContent = version;
+            option.selected = currentVersion === version;
+            versionsDropdown.appendChild(option);
         });
+    }
 
-    // Add latest version
-    const latestOption = document.createElement("option");
-    latestOption.value = window.location.origin + basePath;
-    latestOption.textContent = "latest";
-    latestOption.selected = currentVersion === 'latest';
-    versionsDropdown.appendChild(latestOption);
+    loadVersions().then(populateDropdown);
 
-    // Add older versions
-    sortedVersions.forEach(version => {
-        const option = document.createElement("option");
-        option.value = `${window.location.origin}${basePath}${version}/`;
-        option.textContent = version;
-        option.selected = currentVersion === version;
-        versionsDropdown.appendChild(option);
-    });
-
-    // Handle version selection
     versionsDropdown.addEventListener("change", function () {
         const selectedVersion = this.value;
         if (selectedVersion) {

--- a/docs/make.py
+++ b/docs/make.py
@@ -57,6 +57,7 @@ Build docs for specific version:
 """
 
 import argparse
+import json
 import multiprocessing as mp
 import os
 import re
@@ -113,6 +114,80 @@ def _canonical_doc_tag(tagname):
     if SEMVER_RE.match(tagname):
         return [tagname, f"{CORE_TAG_PREFIX}{tagname}"], tagname
     return [tagname], tagname
+
+
+def _version_sort_key(version):
+    return tuple(int(part) for part in version.split("."))
+
+
+def _get_published_versions(html_dir=HTML):
+    versions = []
+    version_pattern = re.compile(r"^\d+\.\d+\.\d+$")
+    html_dir = Path(html_dir)
+    if not html_dir.exists():
+        return versions
+    for item in html_dir.iterdir():
+        if item.is_dir() and version_pattern.match(item.name):
+            versions.append(item.name)
+    return sorted(versions, key=_version_sort_key, reverse=True)
+
+
+def _write_versions_manifest(html_dir=HTML):
+    versions = _get_published_versions(html_dir)
+    manifest = {
+        "schema_version": 1,
+        "latest": "latest",
+        "stable": versions[0] if versions else "",
+        "versions": versions,
+    }
+    html_dir = Path(html_dir)
+    static_dir = html_dir / "_static"
+    static_dir.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(manifest, indent=2) + "\n"
+    (html_dir / "versions.json").write_text(content, encoding="utf-8")
+    (static_dir / "versions.json").write_text(content, encoding="utf-8")
+    return manifest
+
+
+def _update_version_template_data(html_dir=HTML):
+    versions = _get_published_versions(html_dir)
+    versions_str = ",".join(versions)
+
+    layout_template = TEMPLATES / "layout.html"
+    content = layout_template.read_text(encoding="utf-8").replace(
+        "data-versions=\"{{ previous_versions|join(',') if previous_versions else '' }}\"",
+        f'data-versions="{versions_str}"',
+    )
+
+    for version_dir in Path(html_dir).glob("[0-9]*.[0-9]*.[0-9]*"):
+        target_dir = version_dir / "_templates"
+        target_dir.mkdir(exist_ok=True)
+        (target_dir / "layout.html").write_text(content, encoding="utf-8")
+
+    return versions
+
+
+def _sync_versions_script(html_dir=HTML):
+    source = STATIC / "js" / "versions.js"
+    if not source.exists():
+        return
+
+    html_dir = Path(html_dir)
+    targets = [html_dir / "_static" / "js" / "versions.js"]
+    targets.extend(
+        version_dir / "_static" / "js" / "versions.js"
+        for version_dir in html_dir.glob("[0-9]*.[0-9]*.[0-9]*")
+    )
+
+    for target in targets:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def refresh_versions_index(html_dir=HTML):
+    _update_version_template_data(html_dir)
+    _sync_versions_script(html_dir)
+    return _write_versions_manifest(html_dir)
 
 
 # ======================================================================================
@@ -634,12 +709,7 @@ class BuildDocumentation:
         # Get a list of previous versions from the HTML directory.
         # Returns: list - List of previous versions
 
-        versions = []
-        version_pattern = re.compile(r"^(\d+\.\d+\.\d+)$")
-        for item in HTML.iterdir():
-            if item.is_dir() and version_pattern.match(item.name):
-                versions.append(item.name)
-        return versions
+        return _get_published_versions(HTML)
 
     def _make_docs(self):
         # Simplified documentation building process.
@@ -832,34 +902,8 @@ class BuildDocumentation:
             shutil.rmtree(source_dir)
             print(f"Removed directory {source_dir}")
 
-        # Get all version directories
-        versions = []
-        version_pattern = re.compile(r"^\d+\.\d+\.\d+$")
-        for item in HTML.iterdir():
-            if item.is_dir() and version_pattern.match(item.name):
-                versions.append(item.name)
-
-        versions.sort(reverse=True)  # Sort in descending order
-        versions_str = ",".join(versions)
-
-        # Update layout.html to include latest versions list
-        layout_template = TEMPLATES / "layout.html"
-        with open(layout_template) as f:
-            content = f.read()
-            # replace the Jinja template expression with the actual version list
-            content = content.replace(
-                "data-versions=\"{{ previous_versions|join(',') if previous_versions else '' }}\"",
-                f'data-versions="{versions_str}"',
-            )
-
-        # Update also in each version directory
-        for version_dir in HTML.glob("[0-9]*.[0-9]*.[0-9]*"):
-            target_dir = version_dir / "_templates"
-            target_dir.mkdir(exist_ok=True)
-            target_file = target_dir / "layout.html"
-
-            with open(target_file, "w") as f:
-                f.write(content)
+        manifest = refresh_versions_index(HTML)
+        print(f"Updated docs versions manifest: {manifest['versions']}")
 
         # Remove the environment variables
         del environ["PREVIOUS_VERSIONS"]
@@ -938,6 +982,12 @@ class BuildDocumentation:
         if self.settings["delnb"]:
             self._delnb()  # Erase nb before starting
         self._sync_notebooks()
+
+    def versions(self):
+        """Refresh the published documentation versions manifest."""
+        manifest = refresh_versions_index(HTML)
+        print(f"Updated docs versions manifest in {HTML}: {manifest['versions']}")
+        return 0
 
     def linkcheck(self):
         """Check the links in the documentation."""

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,9 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- CI: Added an explicit documentation versions manifest and a manual
+  ``Repair docs version index`` workflow to refresh the published version
+  dropdown without rebuilding the full documentation.
 - CI: Allowed documentation builds to use canonical core release tags such as
   ``spectrochempy-v0.9.2`` directly, while publishing versioned docs under the
   plain semver directory.

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -233,10 +233,14 @@ Vérifier enfin la documentation :
 
 Si la version n'apparaît pas dans le dropdown alors que la release existe :
 
-1. Relancer manuellement **Actions → Docs → Run workflow** depuis `master`.
-2. Vérifier que `gh-pages` contient bien le répertoire `X.Y.Z/`.
-3. Vérifier que le tag core suit le format `spectrochempy-vX.Y.Z`.
-4. Ne pas créer de tag alias local `X.Y.Z` : `docs/make.py -T` accepte les
+1. Vérifier que `gh-pages` contient bien le répertoire `X.Y.Z/`.
+2. Si le répertoire existe, lancer **Actions → Repair docs version index** :
+   ce workflow régénère seulement `versions.json` et le dropdown, sans
+   reconstruire toute la documentation.
+3. Si le répertoire est absent, relancer manuellement
+   **Actions → Docs → Run workflow** depuis `master`.
+4. Vérifier que le tag core suit le format `spectrochempy-vX.Y.Z`.
+5. Ne pas créer de tag alias local `X.Y.Z` : `docs/make.py -T` accepte les
    tags canoniques `spectrochempy-vX.Y.Z`.
 
 ---


### PR DESCRIPTION
## Summary

This PR adds the first lightweight pieces for a more robust versioned documentation workflow:

- adds an explicit published documentation versions manifest:
  - `versions.json`
  - `_static/versions.json`
- updates `docs/make.py` so every docs build refreshes the manifest from the semver directories already present in `build/html`;
- adds a `docs/make.py versions` command to refresh only the manifest/dropdown metadata without rebuilding Sphinx docs;
- updates the version dropdown JavaScript to read `_static/versions.json`, with the previous `data-versions` attribute kept as fallback;
- syncs the updated `versions.js` into existing stable version directories when refreshing the index;
- adds a manual **Repair docs version index** workflow that checks out `gh-pages`, runs `python3 docs/make.py versions`, and commits only if the published index changed;
- documents the repair workflow in the maintainer release troubleshooting section.

## Validation

No full documentation build was run.

Lightweight checks performed locally:

- `python3 -m py_compile docs/make.py`
- direct helper check on a temporary fake `build/html` with `0.10.0/` and `0.9.2/` directories
- `SCPY_BUILDDIR=/tmp/scpy-docs-version-command python3 docs/make.py versions`
- `git -c core.whitespace=trailing-space,space-before-tab,cr-at-eol diff --check`

## Checklist

- [x] Developer/CI change documented in `docs/sources/whatsnew/changelog.rst`.
- [x] No new dependency added.
- [x] No public API added.
- [x] No full docs rebuild performed locally.