### PR TITLE
Fix TestPyPI development uploads

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -69,7 +69,10 @@ jobs:
           if [[ "${{ github.ref_name }}" == spectrochempy-v* ]]; then
             CORE_VERSION="${GITHUB_REF_NAME#spectrochempy-v}"
           else
-            CORE_VERSION="${LATEST_CORE_TAG#spectrochempy-v}.dev0"
+            LATEST_CORE_VERSION="${LATEST_CORE_TAG#spectrochempy-v}"
+            IFS=. read -r CORE_MAJOR CORE_MINOR CORE_PATCH <<< "$LATEST_CORE_VERSION"
+            COMMITS_SINCE_CORE_TAG=$(git rev-list --count "$LATEST_CORE_TAG"..HEAD)
+            CORE_VERSION="${CORE_MAJOR}.${CORE_MINOR}.$((CORE_PATCH + 1)).dev${COMMITS_SINCE_CORE_TAG}"
           fi
           echo "Using core version: $CORE_VERSION (latest core tag: $LATEST_CORE_TAG)"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$CORE_VERSION" >> "$GITHUB_ENV"
@@ -140,7 +143,10 @@ jobs:
           if [[ "${{ github.ref_name }}" == spectrochempy-v* ]]; then
             CORE_VERSION="${GITHUB_REF_NAME#spectrochempy-v}"
           else
-            CORE_VERSION="${LATEST_CORE_TAG#spectrochempy-v}.dev0"
+            LATEST_CORE_VERSION="${LATEST_CORE_TAG#spectrochempy-v}"
+            IFS=. read -r CORE_MAJOR CORE_MINOR CORE_PATCH <<< "$LATEST_CORE_VERSION"
+            COMMITS_SINCE_CORE_TAG=$(git rev-list --count "$LATEST_CORE_TAG"..HEAD)
+            CORE_VERSION="${CORE_MAJOR}.${CORE_MINOR}.$((CORE_PATCH + 1)).dev${COMMITS_SINCE_CORE_TAG}"
           fi
           echo "Using core version: $CORE_VERSION (latest core tag: $LATEST_CORE_TAG)"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$CORE_VERSION" >> "$GITHUB_ENV"

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -22,6 +22,7 @@ name: Publish plugin packages
 on:
   push:
     branches:
+      - master
       - test/plugin-publish-workflow
     paths:
       - ".github/workflows/publish_plugins.yml"
@@ -158,6 +159,7 @@ jobs:
       - name: Publish plugin package to TestPyPI
         if: |
           github.repository == 'spectrochempy/spectrochempy' &&
+          steps.plugin-version.outputs.has_changes == 'true' &&
           (
             github.event_name == 'push' ||
             (github.event_name == 'workflow_dispatch' && inputs.publish_to == 'testpypi')

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -58,6 +58,9 @@ Developer
   ``next_patch.devN`` metadata injection for plugin development builds, with
   automatic conda uploads to ``spectrocat/label/dev`` on ``master`` when
   release-relevant plugin files changed.
+- CI: Restored unique TestPyPI development uploads by deriving core push builds
+  from the next patch version and publishing plugin TestPyPI builds from
+  ``master`` only when release-relevant plugin files changed.
 - CI: Added an explicit documentation versions manifest and a manual
   ``Repair docs version index`` workflow to refresh the published version
   dropdown without rebuilding the full documentation.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -19,6 +19,9 @@ Developer
   ``next_patch.devN`` metadata injection for plugin development builds, with
   automatic conda uploads to ``spectrocat/label/dev`` on ``master`` when
   release-relevant plugin files changed.
+- CI: Restored unique TestPyPI development uploads by deriving core push builds
+  from the next patch version and publishing plugin TestPyPI builds from
+  ``master`` only when release-relevant plugin files changed.
 - CI: Added an explicit documentation versions manifest and a manual
   ``Repair docs version index`` workflow to refresh the published version
   dropdown without rebuilding the full documentation.


### PR DESCRIPTION
## Summary
- derive core TestPyPI push versions from the next patch and commit distance, e.g. 0.9.3.devN instead of reusing 0.9.2.dev0
- run the plugin TestPyPI workflow on master pushes
- publish plugin TestPyPI dev builds only when plugin_version_status reports release-relevant plugin changes

## Validation
- pre-commit run --files .github/workflows/build_package.yml .github/workflows/publish_plugins.yml docs/sources/whatsnew/changelog.rst docs/sources/whatsnew/latest.rst
- checked current core derivation: spectrochempy-v0.9.2 -> 0.9.3.dev19