### PR TITLE
Fix Anaconda badge: use shields.io to show stable release only

### DIFF
--- a/docs/sources/index.rst.tmpl
+++ b/docs/sources/index.rst.tmpl
@@ -5,7 +5,7 @@
     .. image:: https://img.shields.io/pypi/v/spectrochempy.svg
         :target: https://pypi.org/project/spectrochempy/
 
-    .. image:: https://anaconda.org/spectrocat/spectrochempy/badges/version.svg
+    .. image:: https://img.shields.io/conda/v/spectrocat/spectrochempy
         :target: https://anaconda.org/spectrocat/spectrochempy/?label=main
 
     .. image:: https://anaconda.org/spectrocat/spectrochempy/badges/platforms.svg


### PR DESCRIPTION
The Anaconda.org version.svg badge reports the highest version across
all labels (including dev/nightly), showing 0.9.3 on dev docs instead
of the latest stable 0.9.2. Switch to shields.io conda/v badge which
reports the version on the default (main) label only.
