### PR TITLE
Reader/writer test classification and core-safe I/O cleanup

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -136,3 +136,15 @@ Developer
   deciding to run a release.  Writes a Markdown table (plugin, status, last
   tag, changed files count) to the workflow summary.  Read-only — no
   packages, tags, or releases are created.
+- DEV: Classified all reader/writer I/O tests with explicit ``pytest.mark.data``
+  (real instrument format files) or ``pytest.mark.network`` (remote downloads);
+  core-safe synthetic I/O tests are selectable via ``-m "not data and not
+  network"`` (18 tests, all pass with ``scpy-core``).
+- DEV: Converted ``test_write_csv.py`` from a real IR dataset fixture to
+  deterministic synthetic ``NDDataset`` and ``Coord`` objects, removing its
+  hidden external testdata dependency.
+- DEV: Split the monolithic ``test_read.py::test_read`` into four focused tests
+  — local file read (``data``), remote GitHub fallback (``data + network``),
+  missing file error (synthetic), and invalid URL type error (synthetic) —
+  with explicit marker separation and a shared ``_requires_irdata()`` skip
+  helper.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -100,3 +100,15 @@ Developer
   deciding to run a release.  Writes a Markdown table (plugin, status, last
   tag, changed files count) to the workflow summary.  Read-only — no
   packages, tags, or releases are created.
+- DEV: Classified all reader/writer I/O tests with explicit ``pytest.mark.data``
+  (real instrument format files) or ``pytest.mark.network`` (remote downloads);
+  core-safe synthetic I/O tests are selectable via ``-m "not data and not
+  network"`` (18 tests, all pass with ``scpy-core``).
+- DEV: Converted ``test_write_csv.py`` from a real IR dataset fixture to
+  deterministic synthetic ``NDDataset`` and ``Coord`` objects, removing its
+  hidden external testdata dependency.
+- DEV: Split the monolithic ``test_read.py::test_read`` into four focused tests
+  — local file read (``data``), remote GitHub fallback (``data + network``),
+  missing file error (synthetic), and invalid URL type error (synthetic) —
+  with explicit marker separation and a shared ``_requires_irdata()`` skip
+  helper.

--- a/tests/test_core/test_readers/test_read.py
+++ b/tests/test_core/test_readers/test_read.py
@@ -52,37 +52,44 @@ def _read_scpy_data_or_skip(reader, path):
     return dataset
 
 
-@pytest.mark.data
-def test_read(tmp_path):
-    filename = IRDATA / "CO@Mo_Al2O3.SPG"
-    backup = tmp_path / filename.name
+def _requires_irdata():
+    if not IRDATA.exists():
+        pytest.skip("IR test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
 
-    # read normally
+
+@pytest.mark.data
+def test_read_local_file():
+    """Read a local SPG file and verify content."""
+    _requires_irdata()
+    filename = IRDATA / "CO@Mo_Al2O3.SPG"
+
     nd1 = scp.read(filename)
     assert str(nd1) == "NDDataset: [float64] a.u. (shape: (y:19, x:3112))"
 
     nd1 = scp.read_omnic(filename)
     assert str(nd1) == "NDDataset: [float64] a.u. (shape: (y:19, x:3112))"
 
+
+@pytest.mark.data
+@pytest.mark.network
+def test_read_remote_fallback(tmp_path):
+    """Test remote download from GitHub when local file is moved away."""
+    _requires_irdata()
+    filename = IRDATA / "CO@Mo_Al2O3.SPG"
+    backup = tmp_path / filename.name
     filename.replace(backup)
     try:
-        # now try to download from github s not found locally (use _read_remote)
         nd2 = _read_scpy_data_or_skip(
             scp.read_omnic,
             "irdata/CO@Mo_Al2O3.SPG",
         )
         assert str(nd2) == "NDDataset: [float64] a.u. (shape: (y:19, x:3112))"
 
-        # delete file to simulate its absence:
-        filename.unlink()
-
-        # now try to download from github s not found locally (use _read_remote)
-        # but file doesn't exist on github
+        if filename.exists():
+            filename.unlink()
         with pytest.raises(FileNotFoundError):
             scp.read_omnic("irdata/nh4y-active.spg")
 
-        # now try a using generic read
-        # macOS CI: unlink() may not immediately reflect in exists()
         if filename.exists():
             filename.unlink()
         nd2 = _read_scpy_data_or_skip(scp.read, "irdata/CO@Mo_Al2O3.SPG")
@@ -94,11 +101,15 @@ def test_read(tmp_path):
         if backup.exists():
             backup.replace(filename)
 
-    # now try a using generic read with a missing
+
+def test_read_missing_file():
+    """Reading a non-existent relative path should raise FileNotFoundError."""
     with pytest.raises(FileNotFoundError):
         scp.read("irdata/nh4y-acti.spg")
 
-    # not a scpy readable type
+
+def test_read_invalid_url_type():
+    """Reading a non-scpy-readable URL should raise TypeError."""
     with pytest.raises(TypeError):
         scp.read("https://www.spectrochempy.fr/latest/index.html")
 

--- a/tests/test_core/test_readers/test_read.py
+++ b/tests/test_core/test_readers/test_read.py
@@ -52,6 +52,7 @@ def _read_scpy_data_or_skip(reader, path):
     return dataset
 
 
+@pytest.mark.data
 def test_read(tmp_path):
     filename = IRDATA / "CO@Mo_Al2O3.SPG"
     backup = tmp_path / filename.name

--- a/tests/test_core/test_readers/test_read_csv.py
+++ b/tests/test_core/test_readers/test_read_csv.py
@@ -15,6 +15,14 @@ DATADIR = prefs.datadir
 AGIR_FOLDER = DATADIR / "agirdata"
 IR_FOLDER = DATADIR / "irdata"
 
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not DATADIR.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
+
 
 def test_read_csv():
     prefs.csv_delimiter = ","

--- a/tests/test_core/test_readers/test_read_labspec.py
+++ b/tests/test_core/test_readers/test_read_labspec.py
@@ -15,6 +15,14 @@ from spectrochempy.core.readers.read_labspec import _read_txt
 
 RAMANDIR = scp.preferences.datadir / "ramandata/labspec"
 
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not RAMANDIR.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
+
 
 def test_read_labspec():
     # single file

--- a/tests/test_core/test_readers/test_read_matlab.py
+++ b/tests/test_core/test_readers/test_read_matlab.py
@@ -12,6 +12,14 @@ from spectrochempy import preferences as prefs
 
 MATLABDATA = prefs.datadir / "matlabdata"
 
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not MATLABDATA.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
+
 
 def test_read_matlab():
     A = read_matlab(MATLABDATA / "als2004dataset.MAT")

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -15,6 +15,14 @@ from spectrochempy.utils.testing import assert_dataset_equal
 DATADIR = prefs.datadir
 IRDATA = DATADIR / "irdata"
 
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not IRDATA.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
+
 
 def test_read_omnic():
     # Class method opening a dialog (but for test it is preset)

--- a/tests/test_core/test_readers/test_read_quadera.py
+++ b/tests/test_core/test_readers/test_read_quadera.py
@@ -13,6 +13,14 @@ from spectrochempy import preferences as prefs
 DATADIR = prefs.datadir
 MSDATA = DATADIR / "msdata"
 
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not MSDATA.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
+
 
 def test_read_quadera():
     # single file

--- a/tests/test_core/test_readers/test_read_spc.py
+++ b/tests/test_core/test_readers/test_read_spc.py
@@ -5,7 +5,20 @@
 # ======================================================================================
 # ruff: noqa
 
+import pytest
+
 import spectrochempy as scp
+from spectrochempy.application.preferences import preferences as prefs
+
+DATADIR = prefs.datadir
+
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not (DATADIR / "galacticdata").exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
 
 
 def test_read_spc_merge_behavior():

--- a/tests/test_core/test_readers/test_read_wire.py
+++ b/tests/test_core/test_readers/test_read_wire.py
@@ -1,4 +1,17 @@
+import pytest
+
 import spectrochempy as scp
+from spectrochempy.application.preferences import preferences as prefs
+
+WIREDATA = prefs.datadir / "ramandata" / "wire"
+
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not WIREDATA.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
 
 
 def test_read_wire():

--- a/tests/test_core/test_readers/test_read_zip.py
+++ b/tests/test_core/test_readers/test_read_zip.py
@@ -14,6 +14,14 @@ from spectrochempy import read_zip
 DATADIR = prefs.datadir
 AGIRDATA = DATADIR / "agirdata"
 
+pytestmark = pytest.mark.data
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_no_testdata():
+    if not AGIRDATA.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
+
 
 def test_read_zip():
     A = read_zip(

--- a/tests/test_core/test_writers/test_write_csv.py
+++ b/tests/test_core/test_writers/test_write_csv.py
@@ -5,12 +5,26 @@
 # ======================================================================================
 # ruff: noqa
 
+import numpy as np
 import pytest
 
 import spectrochempy as scp
 
 
-def test_write_csv(mock_cwd, IR_dataset_2D):
+@pytest.fixture
+def ds_1d_with_coords():
+    coord = scp.Coord(np.linspace(4000, 1000, 5), title="wavenumber", units="cm^-1")
+    return scp.NDDataset(np.array([1.0, 2.0, 3.0, 4.0, 5.0]), coordset=[coord])
+
+
+@pytest.fixture
+def ds_2d_with_coords(ds_1d_with_coords):
+    coord = ds_1d_with_coords.coordset[-1]
+    y_coord = scp.Coord([1.0, 2.0, 3.0], title="time", units="s")
+    return scp.NDDataset(np.ones((3, 5)), coordset=[y_coord, coord])
+
+
+def test_write_csv(mock_cwd):
     # 1D dataset without coords
     ds = scp.NDDataset([1, 2, 3])
     f = ds.write_csv("myfile.csv")
@@ -23,19 +37,19 @@ def test_write_csv(mock_cwd, IR_dataset_2D):
     assert f.name == "myfile.csv"
     f.unlink()
 
+
+def test_write_csv_with_coords(mock_cwd, ds_1d_with_coords, ds_2d_with_coords):
     # 1D dataset with coords
-    ds = IR_dataset_2D[0]
+    ds = ds_1d_with_coords
     f = ds.write_csv("myfile.csv")
     assert f.name == "myfile.csv"
     f.unlink()
 
-    # 2D dataset with coords
-    ds = IR_dataset_2D
+    # 2D dataset with coords - should raise NotImplementedError
     with pytest.raises(NotImplementedError):
-        ds.write_csv("myfile.csv")
+        ds_2d_with_coords.write_csv("myfile.csv")
 
-    # test_issue_706(mock_cwd, IR_dataset_2D):
-    ds = IR_dataset_2D[0]
+    # Relative path handling (issue 706)
     ds.write_csv("myfile.csv")
     assert mock_cwd.joinpath("myfile.csv").exists()
     f = ds.write_csv("../myfile.csv")


### PR DESCRIPTION
## Motivation

Reader/writer I/O tests were previously unclassified — real-file-format, network-dependent, and synthetic tests were mixed without markers, making it impossible to select only core-safe tests in CI or offline environments.

## Changes

This PR classifies all 49 I/O tests into three categories with explicit pytest markers:

- `@pytest.mark.data` — 25 tests requiring real instrument format files; skip gracefully when external testdata is absent
- `@pytest.mark.network` — 5 tests that download from external servers; skip on network errors
- No marker — 18 synthetic/mocked tests that run in any environment; selectable via `-m "not data and not network"`

**New marker + skip fixture on 8 reader test files** (pattern from `test_read_opus.py`):
- test_read_csv, test_read_labspec, test_read_matlab, test_read_omnic
- test_read_quadera, test_read_spc, test_read_wire, test_read_zip

**Converted `test_write_csv.py`** from real IR dataset fixture to deterministic synthetic `NDDataset` and `Coord` objects, removing its hidden external testdata dependency.

**Split `test_read.py::test_read`** into four focused tests:
- `test_read_local_file` (`@pytest.mark.data`)
- `test_read_remote_fallback` (`@pytest.mark.data` + `@pytest.mark.network`)
- `test_read_missing_file` (synthetic, no marker)
- `test_read_invalid_url_type` (synthetic, no marker)

## Validation

All 18 core-safe tests pass with `scpy-core`:

```
conda run -n scpy-core python -m pytest tests/test_core/test_readers/ tests/test_core/test_writers/ tests/test_core/test_dataset/test_mixins/test_ndio.py -m "not data and not network" -ra
→ 18 passed, 31 deselected in 2.83s
```

Modified files also pass individually:

```
conda run -n scpy-core python -m pytest tests/test_core/test_writers/test_write_csv.py -ra
→ 2 passed

conda run -n scpy-core python -m pytest tests/test_core/test_readers/test_read.py -ra
→ 7 passed
```

## Review notes

- No production code changed
- No CI workflows changed
- No reader/writer API changed
- Real instrument format tests intentionally remain `@pytest.mark.data` — they validate real format parsing
- Git history is clean (3 commits, all test-only)