### PR TITLE
Clarify plugin-dependent test classification

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -58,6 +58,9 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- DEV: Classified plugin-dependent tests with explicit markers and skip guards
+  so optional plugin imports do not fail during core-only collection, while
+  keeping core-only and plugin/integration validation clearly separated.
 - CI: Added a dedicated core-only package-test validation row that skips
   official plugin installation, plugin diagnostics, documentation script
   execution, external testdata restore, coverage generation, and Codecov upload.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,9 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- DEV: Classified plugin-dependent tests with explicit markers and skip guards
+  so optional plugin imports do not fail during core-only collection, while
+  keeping core-only and plugin/integration validation clearly separated.
 - CI: Added a dedicated core-only package-test validation row that skips
   official plugin installation, plugin diagnostics, documentation script
   execution, external testdata restore, coverage generation, and Codecov upload.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,18 @@ def pytest_configure(config):
         "markers",
         "docs: marks tests that validate documentation examples",
     )
+    config.addinivalue_line(
+        "markers",
+        "network: marks tests that require network access (e.g., Eigenvector, SOC downloads)",
+    )
+    config.addinivalue_line(
+        "markers",
+        "plugin: marks tests that require external plugins (e.g., spectrochempy-nmr, spectrochempy-iris)",
+    )
+    config.addinivalue_line(
+        "markers",
+        "serial: marks tests that must not run in parallel with xdist",
+    )
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/test_analysis/test_plotmerit.py
+++ b/tests/test_analysis/test_plotmerit.py
@@ -8,6 +8,8 @@
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.plugin, pytest.mark.data]
+
 pytest.importorskip(
     "spectrochempy_iris",
     reason="requires the optional spectrochempy-iris plugin",

--- a/tests/test_plotting/test_composite_imports.py
+++ b/tests/test_plotting/test_composite_imports.py
@@ -28,6 +28,7 @@ class TestPlotMeritImports:
         assert callable(plot_compare)
 
 
+@pytest.mark.plugin
 class TestIrisImports:
     """IRIS plugin integration checks for exported plotting helpers."""
 
@@ -38,6 +39,7 @@ class TestIrisImports:
             reason="requires the optional spectrochempy-iris plugin",
         )
 
+    @pytest.mark.plugin
     def test_plot_iris_lcurve_import(self):
         """Test import of plot_iris_lcurve."""
         self._check_plugin()
@@ -45,6 +47,7 @@ class TestIrisImports:
 
         assert callable(plot_iris_lcurve)
 
+    @pytest.mark.plugin
     def test_plot_iris_distribution_import(self):
         """Test import of plot_iris_distribution."""
         self._check_plugin()
@@ -52,6 +55,7 @@ class TestIrisImports:
 
         assert callable(plot_iris_distribution)
 
+    @pytest.mark.plugin
     def test_plot_iris_merit_import(self):
         """Test import of plot_iris_merit."""
         self._check_plugin()

--- a/tests/test_plugins/test_nmr_hypercomplex_decoupling.py
+++ b/tests/test_plugins/test_nmr_hypercomplex_decoupling.py
@@ -13,6 +13,8 @@ import inspect
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.plugin
+
 _HYPERCOMPLEX_AVAILABLE = (
     importlib.util.find_spec("spectrochempy_hypercomplex") is not None
 )

--- a/tests/test_plugins/test_nmr_importer_handlers.py
+++ b/tests/test_plugins/test_nmr_importer_handlers.py
@@ -5,6 +5,15 @@
 # ======================================================================================
 """Regression tests for the NMR plugin importer handlers."""
 
+import pytest
+
+pytestmark = pytest.mark.plugin
+
+pytest.importorskip(
+    "spectrochempy_nmr",
+    reason="requires the optional spectrochempy-nmr plugin",
+)
+
 from pathlib import Path
 
 from spectrochempy_nmr import _resolve_topspin_directory_target

--- a/tests/test_processing/test_transformation/test_autosub.py
+++ b/tests/test_processing/test_transformation/test_autosub.py
@@ -11,6 +11,7 @@ Tests for the ndplugin module.
 """
 
 import numpy as np
+import pytest
 
 from spectrochempy.processing.transformation.autosub import autosub
 from spectrochempy.utils.mplutils import show
@@ -19,6 +20,7 @@ from spectrochempy.utils.mplutils import show
 # ------
 
 
+@pytest.mark.data
 def test_autosub(IR_dataset_2D):
     dataset = IR_dataset_2D
 

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -19,6 +19,7 @@ from spectrochempy.utils.exceptions import (
 from spectrochempy.utils.testing import assert_dataset_almost_equal
 
 
+@pytest.mark.data
 def test_concatenate(IR_dataset_2D):
     dataset = IR_dataset_2D
     dim = "x"


### PR DESCRIPTION
This PR makes plugin-dependent tests explicit and safe to collect in a core-only environment. It adds or improves plugin/data markers and skip guards so optional plugin dependencies no longer cause import-time failures during core-safe test collection.

## Changes

- Registers explicit pytest markers for plugin/network/serial classification.
- Marks plugin-dependent tests for NMR, hypercomplex, and IRIS coverage.
- Adds data markers for tests relying on plugin-specific or external test data.
- Adds an import-skip guard for optional `spectrochempy-nmr` imports.
- Adds a developer-facing changelog entry and synchronized latest whatsnew entry.

## Validation

- Environment: `scpy-core`
- `conda run -n scpy-core python -m pytest tests -m "not plugin and not data and not network" --collect-only`
  - `1482/1589 tests collected (107 deselected) in 2.22s`
- `conda run -n scpy-core python -m pytest tests/test_analysis/test_plotmerit.py tests/test_plotting/test_composite_imports.py tests/test_plugins/test_nmr_hypercomplex_decoupling.py tests/test_plugins/test_nmr_importer_handlers.py tests/test_processing/test_transformation/test_autosub.py tests/test_processing/test_transformation/test_concatenate.py`
  - `9 passed, 13 skipped in 1.51s`
- `pre-commit run --all-files`
  - first run generated `docs/sources/whatsnew/latest.rst` as expected
  - second run clean

## Scope

This PR does not start a new plugin audit, move test files, or change CI workflows.