### PR TITLE
Move IRIS import tests (TestIrisImports) to plugin suite

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -67,6 +67,11 @@ Developer
 - DEV: Moved IRIS ``plot_merit`` coverage out of core analysis tests into the
   IRIS plugin test suite, clarifying plugin ownership for plugin/data plotting
   integration checks.
+- DEV: Moved IRIS plugin import/export checks (``TestIrisImports`` for
+  ``plot_iris_lcurve``, ``plot_iris_distribution``, ``plot_iris_merit``) from
+  the core composite plotting test module into the IRIS plugin test suite,
+  removing all direct IRIS plugin runtime import references from the core
+  test tree.
 - DEV: Classified plugin-dependent tests with explicit markers and skip guards
   so optional plugin imports do not fail during core-only collection, while
   keeping core-only and plugin/integration validation clearly separated.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,6 +31,11 @@ Developer
 - DEV: Moved IRIS ``plot_merit`` coverage out of core analysis tests into the
   IRIS plugin test suite, clarifying plugin ownership for plugin/data plotting
   integration checks.
+- DEV: Moved IRIS plugin import/export checks (``TestIrisImports`` for
+  ``plot_iris_lcurve``, ``plot_iris_distribution``, ``plot_iris_merit``) from
+  the core composite plotting test module into the IRIS plugin test suite,
+  removing all direct IRIS plugin runtime import references from the core
+  test tree.
 - DEV: Classified plugin-dependent tests with explicit markers and skip guards
   so optional plugin imports do not fail during core-only collection, while
   keeping core-only and plugin/integration validation clearly separated.

--- a/plugins/spectrochempy-iris/tests/test_plot_merit.py
+++ b/plugins/spectrochempy-iris/tests/test_plot_merit.py
@@ -1,3 +1,4 @@
+# ruff: noqa: S101, PLC0415  # assert/local imports allowed in plugin tests
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT

--- a/plugins/spectrochempy-iris/tests/test_plotting_imports.py
+++ b/plugins/spectrochempy-iris/tests/test_plotting_imports.py
@@ -1,0 +1,45 @@
+# ruff: noqa: S101, PLC0415  # assert/local imports allowed in plugin tests
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""IRIS plugin integration checks for exported plotting helpers."""
+
+import pytest
+
+
+@pytest.mark.plugin
+class TestIrisImports:
+    """IRIS plugin integration checks for exported plotting helpers."""
+
+    @staticmethod
+    def _check_plugin():
+        pytest.importorskip(
+            "spectrochempy_iris",
+            reason="requires the optional spectrochempy-iris plugin",
+        )
+
+    @pytest.mark.plugin
+    def test_plot_iris_lcurve_import(self):
+        """Test import of plot_iris_lcurve."""
+        self._check_plugin()
+        from spectrochempy_iris import plot_iris_lcurve
+
+        assert callable(plot_iris_lcurve)
+
+    @pytest.mark.plugin
+    def test_plot_iris_distribution_import(self):
+        """Test import of plot_iris_distribution."""
+        self._check_plugin()
+        from spectrochempy_iris import plot_iris_distribution
+
+        assert callable(plot_iris_distribution)
+
+    @pytest.mark.plugin
+    def test_plot_iris_merit_import(self):
+        """Test import of plot_iris_merit."""
+        self._check_plugin()
+        from spectrochempy_iris import plot_iris_merit
+
+        assert callable(plot_iris_merit)

--- a/tests/test_plotting/test_composite_imports.py
+++ b/tests/test_plotting/test_composite_imports.py
@@ -9,8 +9,6 @@ Minimal tests for composite plotting modules to improve coverage.
 These tests ensure the modules can be imported and basic functions are callable.
 """
 
-import pytest
-
 
 class TestPlotMeritImports:
     """Test that plotmerit module can be imported and has expected functions."""
@@ -26,42 +24,6 @@ class TestPlotMeritImports:
         from spectrochempy.plotting.composite.plotmerit import plot_compare
 
         assert callable(plot_compare)
-
-
-@pytest.mark.plugin
-class TestIrisImports:
-    """IRIS plugin integration checks for exported plotting helpers."""
-
-    @staticmethod
-    def _check_plugin():
-        pytest.importorskip(
-            "spectrochempy_iris",
-            reason="requires the optional spectrochempy-iris plugin",
-        )
-
-    @pytest.mark.plugin
-    def test_plot_iris_lcurve_import(self):
-        """Test import of plot_iris_lcurve."""
-        self._check_plugin()
-        from spectrochempy_iris import plot_iris_lcurve
-
-        assert callable(plot_iris_lcurve)
-
-    @pytest.mark.plugin
-    def test_plot_iris_distribution_import(self):
-        """Test import of plot_iris_distribution."""
-        self._check_plugin()
-        from spectrochempy_iris import plot_iris_distribution
-
-        assert callable(plot_iris_distribution)
-
-    @pytest.mark.plugin
-    def test_plot_iris_merit_import(self):
-        """Test import of plot_iris_merit."""
-        self._check_plugin()
-        from spectrochempy_iris import plot_iris_merit
-
-        assert callable(plot_iris_merit)
 
 
 class TestMultiplotImports:


### PR DESCRIPTION
Move the `TestIrisImports` class (which checks that `plot_iris_lcurve`, `plot_iris_distribution`, `plot_iris_merit` are importable from `spectrochempy_iris`) from the core composite plotting test module into the IRIS plugin test suite, removing all direct IRIS plugin runtime import references from the core test tree.

- **New:** `plugins/spectrochempy-iris/tests/test_plotting_imports.py` - moved `TestIrisImports` with identical logic
- **Removed:** `TestIrisImports` class and its now-unused `import pytest` from `tests/test_plotting/test_composite_imports.py`
- **Cleanup:** Added missing `# ruff: noqa` header to `test_plot_merit.py` (pre-existing omission, same pattern as other plugin test files)
- **Changelog:** Updated `changelog.rst` (auto-regenerated `latest.rst`)
- **Validation:** 8 tests pass in core file, 3 skip gracefully in plugin file (expected, plugin not installed in core-only env)