### PR TITLE
Modernize SIMPLISMA analysis tests with synthetic datasets

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -61,6 +61,14 @@ Developer
 - DEV: Modernized selected analysis tests with deterministic synthetic datasets,
   reducing unnecessary real-data dependencies and strengthening numerical,
   shape, metadata, masking, and reporting assertions.
+- DEV: Modernized SIMPLISMA analysis tests using deterministic synthetic datasets,
+  removing the dependency on ``als2004dataset.MAT`` and strengthening validation
+  of pure-variable selection, decomposition outputs, reconstruction behavior,
+  and error handling.
+- DEV: Modernized baseline analysis tests using deterministic synthetic datasets,
+  removing dependencies on external IR and MS test files and strengthening
+  validation of baseline estimation, masking, preprocessing APIs, and
+  multivariate baseline workflows.
 - DEV: Converted NMF analysis tests from the legacy MATLAB fixture to a
   deterministic non-negative synthetic dataset with focused parity,
   reconstruction, masking, metadata, and non-negativity checks.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -25,6 +25,14 @@ Developer
 - DEV: Modernized selected analysis tests with deterministic synthetic datasets,
   reducing unnecessary real-data dependencies and strengthening numerical,
   shape, metadata, masking, and reporting assertions.
+- DEV: Modernized SIMPLISMA analysis tests using deterministic synthetic datasets,
+  removing the dependency on ``als2004dataset.MAT`` and strengthening validation
+  of pure-variable selection, decomposition outputs, reconstruction behavior,
+  and error handling.
+- DEV: Modernized baseline analysis tests using deterministic synthetic datasets,
+  removing dependencies on external IR and MS test files and strengthening
+  validation of baseline estimation, masking, preprocessing APIs, and
+  multivariate baseline workflows.
 - DEV: Converted NMF analysis tests from the legacy MATLAB fixture to a
   deterministic non-negative synthetic dataset with focused parity,
   reconstruction, masking, metadata, and non-negativity checks.

--- a/tests/test_analysis/test_decomposition/conftest.py
+++ b/tests/test_analysis/test_decomposition/conftest.py
@@ -1,0 +1,40 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+
+
+@pytest.fixture()
+def simplisma_dataset():
+    n_observations = 20
+    n_variables = 100
+
+    t = np.linspace(0, 1, n_observations)
+    c1 = np.exp(-((t - 0.3) ** 2) / 0.02)
+    c2 = np.exp(-((t - 0.7) ** 2) / 0.02)
+    C_true = np.column_stack([c1, c2])
+
+    w = np.linspace(0, 100, n_variables)
+    s1 = np.exp(-((w - 30) ** 2) / 20)
+    s2 = np.exp(-((w - 70) ** 2) / 20)
+    St_true = np.vstack([s1, s2])
+
+    data = C_true @ St_true
+
+    dataset = scp.NDDataset(
+        data,
+        coordset=[
+            scp.Coord(t, title="time", units="hours"),
+            scp.Coord(w, title="wavelength", units="nm"),
+        ],
+        title="synthetic SIMPLISMA mixture",
+        units="absorbance",
+    )
+    return dataset

--- a/tests/test_analysis/test_decomposition/test_simplisma.py
+++ b/tests/test_analysis/test_decomposition/test_simplisma.py
@@ -7,13 +7,14 @@
 
 import os
 
+import numpy as np
 import pytest
 
 import spectrochempy as scp
 from spectrochempy.analysis.decomposition.simplisma import SIMPLISMA
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.utils import docutils as chd
-from spectrochempy.utils.mplutils import show
+from spectrochempy.utils import testing
 
 
 # test docstring
@@ -33,34 +34,87 @@ def test_SIMPLISMA_docstrings():
     )
 
 
-def test_simplisma():
-    print("")
-    data = scp.read_matlab(
-        os.path.join("matlabdata", "als2004dataset.MAT"), merge=False
-    )
-    print("Dataset (Jaumot et al., Chemometr. Intell. Lab. 76 (2005) 101-110)):")
-    print("")
-    for mat in data:
-        print("    " + mat.name, str(mat.shape))
+def test_simplisma_fit_returns_estimator(simplisma_dataset):
+    sma = SIMPLISMA(n_components=2, log_level="WARNING")
+    result = sma.fit(simplisma_dataset)
+    assert result is sma
 
-    ds = data[-1]
-    assert ds.name == "m1"
 
-    ds.title = "absorbance"
-    ds.units = "absorbance"
-    ds.set_coordset(None, None)
-    ds.y.title = "elution time"
-    ds.x.title = "wavelength"
-    ds.y.units = "hours"
-    ds.x.units = "cm^-1"
+def test_simplisma_fit_shapes(simplisma_dataset):
+    sma = SIMPLISMA(n_components=2, log_level="WARNING")
+    sma.fit(simplisma_dataset)
 
-    sma = SIMPLISMA(n_components=20, tol=0.2, noise=3, log_level="INFO")
-    sma.fit(ds)
+    assert sma.C.shape == (20, 2)
+    assert sma.St.shape == (2, 100)
+    assert sma.Pt.shape == (2, 100)
+    assert sma.s.shape == (2, 100)
+    assert sma.n_components == 2
 
-    sma.C.T.plot(title="Concentration")
-    sma.St.plot(title="Components")
-    sma.plot_merit(offset=0, nb_traces=10)
+    testing.assert_dataset_equal(sma.X, simplisma_dataset)
 
-    # assert "3     29      29.0     0.0072     0.9981" in pure.logs
 
-    show()
+def test_simplisma_finite_outputs(simplisma_dataset):
+    sma = SIMPLISMA(n_components=2, log_level="WARNING")
+    sma.fit(simplisma_dataset)
+
+    assert np.all(np.isfinite(sma.C.data))
+    assert np.all(np.isfinite(sma.St.data))
+    assert np.all(np.isfinite(sma.Pt.data))
+    assert np.all(np.isfinite(sma.s.data))
+
+
+def test_simplisma_pure_variable_selection(simplisma_dataset):
+    sma = SIMPLISMA(n_components=2, log_level="WARNING")
+    sma.fit(simplisma_dataset)
+
+    pure_idx = np.argmax(sma.Pt.data, axis=1)
+
+    w = simplisma_dataset.x.data
+    expected_1 = np.argmin(np.abs(w - 30.0))
+    expected_2 = np.argmin(np.abs(w - 70.0))
+
+    assert any(abs(idx - expected_1) <= 2 for idx in pure_idx)
+    assert any(abs(idx - expected_2) <= 2 for idx in pure_idx)
+
+
+def test_simplisma_transform(simplisma_dataset):
+    sma = SIMPLISMA(n_components=2, log_level="WARNING")
+    sma.fit(simplisma_dataset)
+
+    C_from_transform = sma.transform()
+    assert C_from_transform.shape == (20, 2)
+    assert np.allclose(C_from_transform.data, sma.C.data)
+
+    C_from_transform_with_X = sma.transform(simplisma_dataset)
+    assert np.allclose(C_from_transform_with_X.data, sma.C.data)
+
+
+def test_simplisma_inverse_transform(simplisma_dataset):
+    sma = SIMPLISMA(n_components=2, log_level="WARNING")
+    sma.fit(simplisma_dataset)
+
+    X_recon = sma.inverse_transform()
+    assert X_recon.shape == simplisma_dataset.shape
+    assert np.all(np.isfinite(X_recon.data))
+    assert X_recon.units == simplisma_dataset.units
+
+
+def test_simplisma_n_components_validation(simplisma_dataset):
+    with pytest.raises(ValueError, match="larger than 2"):
+        SIMPLISMA(n_components=1).fit(simplisma_dataset)
+
+
+def test_simplisma_3d_raises():
+    data_3d = np.arange(60.0).reshape(3, 4, 5)
+    ds_3d = NDDataset(data_3d)
+
+    with pytest.raises(ValueError, match="only handles 2D"):
+        SIMPLISMA(n_components=2).fit(ds_3d)
+
+
+def test_simplisma_negative_warning(simplisma_dataset):
+    ds_neg = simplisma_dataset.copy()
+    ds_neg.data -= 0.5
+
+    with pytest.warns(UserWarning, match="does not handle easily negative"):
+        SIMPLISMA(n_components=2).fit(ds_neg)


### PR DESCRIPTION
## Summary

Modernize SIMPLISMA analysis tests using deterministic synthetic datasets.

Changes:
* remove dependency on `matlabdata/als2004dataset.MAT`
* replace the legacy workflow test with focused behavior tests
* add deterministic synthetic SIMPLISMA fixture with known pure variables
* validate pure-variable selection through SIMPLISMA purity scores
* strengthen coverage for fit, transform, inverse transform, metadata, and error paths
* remove plotting-driven validation from algorithmic tests

## Validation

```bash
conda run -n scpy-core python -m pytest     tests/test_analysis/test_decomposition/test_simplisma.py -ra
```

Result:

```text
10 passed
```

Additional decomposition validation:

```bash
conda run -n scpy-core python -m pytest     tests/test_analysis/test_decomposition/ -ra
```

Result:

```text
45 passed, 2 skipped
```

(skips are expected when optional tensor decomposition dependencies are unavailable)

## Notes

This PR is test-only.

No production code, APIs, workflows, or plugin behavior were modified.