### PR TITLE
Fix coordinate propagation in decorator when typey=features and typex=components

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,10 +29,6 @@ Bug Fixes
 - Fixed ``NDDataset.squeeze()`` for singleton dimensions without explicit
   coordinates and aligned Labspec in-memory byte decoding with the Latin-1
   fallback already used for local files.
-- Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
-  when ``typey="features"`` and ``typex="components"`` are both set —
-  replaced sequential ``if`` blocks with an ``elif`` chain and added an
-  explicit combined case to prevent conflicting coordinate assignments.
 
 
 .. section
@@ -73,6 +69,10 @@ Developer
   mixtures, removing the dependency on ``als2004dataset.MAT`` and strengthening
   wrapper parity, transform, inverse-transform, masking, and validation
   coverage.
+- DEV: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+  when ``typey="features"`` and ``typex="components"`` are both set —
+  replaced sequential ``if`` blocks with an ``elif`` chain and added an
+  explicit combined case to prevent conflicting coordinate assignments.
 - DEV: Modernized baseline analysis tests using deterministic synthetic datasets,
   removing dependencies on external IR and MS test files and strengthening
   validation of baseline estimation, masking, preprocessing APIs, and

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,10 @@ Bug Fixes
 - Fixed ``NDDataset.squeeze()`` for singleton dimensions without explicit
   coordinates and aligned Labspec in-memory byte decoding with the Latin-1
   fallback already used for local files.
+- Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+  when ``typey="features"`` and ``typex="components"`` are both set —
+  replaced sequential ``if`` blocks with an ``elif`` chain and added an
+  explicit combined case to prevent conflicting coordinate assignments.
 
 
 .. section
@@ -58,126 +62,149 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
-- DEV: Modernized selected analysis tests with deterministic synthetic datasets,
+- MAINT: Modernized selected analysis tests with deterministic synthetic datasets,
   reducing unnecessary real-data dependencies and strengthening numerical,
   shape, metadata, masking, and reporting assertions.
-- DEV: Modernized SIMPLISMA analysis tests using deterministic synthetic datasets,
+
+- MAINT: Modernized SIMPLISMA analysis tests using deterministic synthetic datasets,
   removing the dependency on ``als2004dataset.MAT`` and strengthening validation
   of pure-variable selection, decomposition outputs, reconstruction behavior,
   and error handling.
-- DEV: Modernized FastICA analysis tests using deterministic synthetic ICA
+
+- MAINT: Modernized FastICA analysis tests using deterministic synthetic ICA
   mixtures, removing the dependency on ``als2004dataset.MAT`` and strengthening
   wrapper parity, transform, inverse-transform, masking, and validation
   coverage.
-- FIX: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
-  when ``typey="features"`` and ``typex="components"`` are both set —
-  replaced sequential ``if`` blocks with an ``elif`` chain and added an
-  explicit combined case to prevent conflicting coordinate assignments.
-- DEV: Modernized baseline analysis tests using deterministic synthetic datasets,
-  removing dependencies on external IR and MS test files and strengthening
-  validation of baseline estimation, masking, preprocessing APIs, and
-  multivariate baseline workflows.
-- DEV: Converted NMF analysis tests from the legacy MATLAB fixture to a
+
+- MAINT: Modernized baseline analysis tests using deterministic synthetic
+  datasets, removing dependencies on external IR and MS test files and
+  strengthening validation of baseline estimation, masking, preprocessing APIs,
+  and multivariate baseline workflows.
+
+- MAINT: Converted NMF analysis tests from the legacy MATLAB fixture to a
   deterministic non-negative synthetic dataset with focused parity,
   reconstruction, masking, metadata, and non-negativity checks.
-- DEV: Moved IRIS ``plot_merit`` coverage out of core analysis tests into the
+
+- MAINT: Moved IRIS ``plot_merit`` coverage out of core analysis tests into the
   IRIS plugin test suite, clarifying plugin ownership for plugin/data plotting
   integration checks.
-- DEV: Moved IRIS plugin import/export checks (``TestIrisImports`` for
+
+- MAINT: Moved IRIS plugin import/export checks (``TestIrisImports`` for
   ``plot_iris_lcurve``, ``plot_iris_distribution``, ``plot_iris_merit``) from
   the core composite plotting test module into the IRIS plugin test suite,
   removing all direct IRIS plugin runtime import references from the core
   test tree.
-- DEV: Classified plugin-dependent tests with explicit markers and skip guards
+
+- MAINT: Classified plugin-dependent tests with explicit markers and skip guards
   so optional plugin imports do not fail during core-only collection, while
   keeping core-only and plugin/integration validation clearly separated.
-- CI: Added a dedicated core-only package-test validation row that skips
-  official plugin installation, plugin diagnostics, documentation script
-  execution, external testdata restore, coverage generation, and Codecov upload.
-- CI: Aligned the plugin release workflow status summary with the shared
-  release-relevant plugin change detector used by the read-only status workflow.
-- DEV: Modernized core dataset tests with stronger ``NDDataset``, ``NDMath``,
-  ``Coord``, ``CoordSet``, ``NDArray``, and ``NDComplexArray`` validation and
-  split the large dataset test module into focused test files.
-- DEV: Converted legacy plotting tests (1D, 2D, 3D, multiplot) from external
+
+- MAINT: Modernized core dataset tests with stronger ``NDDataset``,
+  ``NDMath``, ``Coord``, ``CoordSet``, ``NDArray``, and ``NDComplexArray``
+  validation and split the large dataset test module into focused test files.
+
+- MAINT: Converted legacy plotting tests (1D, 2D, 3D, multiplot) from external
   spectroscopy files to deterministic synthetic fixtures, making them runnable
   in core-only CI without testdata downloads.
-- DEV: Converted PCA plotting tests (``plot_score``, ``plot_scree``) from
+
+- MAINT: Converted PCA plotting tests (``plot_score``, ``plot_scree``) from
   external IR data to deterministic synthetic datasets; decoupled 5 tests from
   PCA computation using precomputed score fixtures.
-- DEV: Classified documentation plotting tests as ``docs``/``integration`` tests
-  with explicit ``pytest.mark.docs`` and ``pytest.mark.data`` markers; added
-  graceful skip when IR testdata is unavailable.
-- DEV: Registered ``docs`` and ``data`` pytest markers in the top-level
+
+- MAINT: Classified documentation plotting tests as ``docs``/``integration``
+  tests with explicit ``pytest.mark.docs`` and ``pytest.mark.data`` markers;
+  added graceful skip when IR testdata is unavailable.
+
+- MAINT: Registered ``docs`` and ``data`` pytest markers in the top-level
   conftest for use across the test suite.
-- CI: Added reusable plugin version-status tooling and temporary
+
+- MAINT: Classified all reader/writer I/O tests with explicit
+  ``pytest.mark.data`` (real instrument format files) or
+  ``pytest.mark.network`` (remote downloads); core-safe synthetic I/O tests are
+  selectable via ``-m "not data and not network"``.
+
+- MAINT: Converted ``test_write_csv.py`` from a real IR dataset fixture to
+  deterministic synthetic ``NDDataset`` and ``Coord`` objects, removing its
+  hidden external testdata dependency.
+
+- MAINT: Split the monolithic ``test_read.py::test_read`` into focused tests
+  with explicit marker separation and shared skip helpers.
+
+- DEV: Added TODO/FIXME note in
+  ``docs/sources/devguide/plugins/packaging.rst`` explaining that dev conda
+  uploads for plugins are disabled until distinct dev versions are generated.
+
+- DEV: Added reusable plugin version-status tooling and temporary
   ``next_patch.devN`` metadata injection for plugin development builds, with
   automatic conda uploads to ``spectrocat/label/dev`` on ``master`` when
   release-relevant plugin files changed.
+
+- CI: Added a dedicated core-only package-test validation row that skips
+  official plugin installation, plugin diagnostics, documentation script
+  execution, external testdata restore, coverage generation, and Codecov upload.
+
+- CI: Aligned the plugin release workflow status summary with the shared
+  release-relevant plugin change detector used by the read-only status workflow.
+
 - CI: Restored unique TestPyPI development uploads by deriving core push builds
   from the next patch version and publishing plugin TestPyPI builds from
   ``master`` only when release-relevant plugin files changed.
-- CI: Limited the slow Colab compatibility workflow to manual runs and
-  pull requests labeled ``needs-colab``.
+
+- CI: Limited the slow Colab compatibility workflow to manual runs and pull
+  requests labeled ``needs-colab``.
+
 - CI: Added an explicit documentation versions manifest and a manual
   ``Repair docs version index`` workflow to refresh the published version
   dropdown without rebuilding the full documentation.
+
 - CI: Allowed documentation builds to use canonical core release tags such as
   ``spectrochempy-v0.9.2`` directly, while publishing versioned docs under the
   plain semver directory.
-- DOC: Improved maintainer release documentation with explicit Zenodo
-  verification steps, versioned docs checks, docs build note, and roadmap for
-  modular docs.
-- DOC: Clarified that official plugin versions are independent from the core
-  package version and that conda dev plugin builds are not currently published
-  automatically.
-- DOC: Updated contributor documentation build instructions to use the
-  repository-root ``docs/make.py`` entry point and current ``build/html`` output.
-- DOC: Updated optional plugin installation notes so conda development
-  channels no longer imply automatic plugin dev uploads.
-- DOC: Aligned workflow comments and recovery notes with the current plugin
-  conda policy: stable plugin releases upload to ``main`` and dev uploads are
-  disabled until distinct dev versions exist.
-- DOC: Updated plugin release documentation to use canonical core tags,
-  current branch pushes, plugin ``__init__.py`` version bumps, and the current
-  Anaconda ``main`` upload behavior.
-- DOC: Clarified that official plugin releases must be run from ``master`` and
-  can be prepared with the read-only plugin release status workflow.
-- DOC: Finished maintainer release notes cleanup for master checkout, draft
-  release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
-  internal recovery links.
-- DOC: Tightened the developer guide entry points, Git commands, pull request
-  template guidance, and testing guidance without expanding the guide
-  substantially.
+
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
-  listing all official plugins and whether they have changed since their
-  last release tag — shows a "no changes" message when all plugins are
-  unchanged, or highlights modified plugins when some need a release.
+  listing official plugins and whether they have changed since their last
+  release tag.
+
 - CI: Added ``confirm_zenodo_enabled`` checkbox to
   ``prepare_new_release.yml`` so maintainers verify Zenodo is active before
   creating a release PR.
-- CI: Disabled automatic dev conda uploads for official plugins
-  (``build_package.yml``).  Plugin conda packages are still built in CI for
-  testing, but only uploaded to Anaconda.org during a stable plugin release
-  (label ``main``).  Dev uploads will be re-enabled once plugin recipes
-  generate distinct dev versions.
-- DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
-  explaining that dev conda uploads for plugins are disabled until distinct
-  dev versions are generated.
-- CI: Added ``plugin_release_status.yml`` workflow (``workflow_dispatch``)
-  to inspect official plugin changes since their last release tag before
-  deciding to run a release.  Writes a Markdown table (plugin, status, last
-  tag, changed files count) to the workflow summary.  Read-only — no
-  packages, tags, or releases are created.
-- DEV: Classified all reader/writer I/O tests with explicit ``pytest.mark.data``
-  (real instrument format files) or ``pytest.mark.network`` (remote downloads);
-  core-safe synthetic I/O tests are selectable via ``-m "not data and not
-  network"`` (18 tests, all pass with ``scpy-core``).
-- DEV: Converted ``test_write_csv.py`` from a real IR dataset fixture to
-  deterministic synthetic ``NDDataset`` and ``Coord`` objects, removing its
-  hidden external testdata dependency.
-- DEV: Split the monolithic ``test_read.py::test_read`` into four focused tests
-  — local file read (``data``), remote GitHub fallback (``data + network``),
-  missing file error (synthetic), and invalid URL type error (synthetic) —
-  with explicit marker separation and a shared ``_requires_irdata()`` skip
-  helper.
+
+- CI: Disabled automatic dev conda uploads for official plugins. Plugin conda
+  packages are still built in CI for testing, but only uploaded during stable
+  plugin releases.
+
+- CI: Added ``plugin_release_status.yml`` workflow
+  (``workflow_dispatch``) to inspect official plugin changes since their last
+  release tag before deciding to run a release.
+
+- DOC: Improved maintainer release documentation with explicit Zenodo
+  verification steps, versioned docs checks, docs build notes, and roadmap
+  guidance.
+
+- DOC: Clarified that official plugin versions are independent from the core
+  package version and that conda dev plugin builds are not currently published
+  automatically.
+
+- DOC: Updated contributor documentation build instructions to use the
+  repository-root ``docs/make.py`` entry point and current ``build/html``
+  output.
+
+- DOC: Updated optional plugin installation notes so conda development
+  channels no longer imply automatic plugin dev uploads.
+
+- DOC: Aligned workflow comments and recovery notes with the current plugin
+  conda policy.
+
+- DOC: Updated plugin release documentation to use canonical core tags,
+  current branch pushes, plugin ``__init__.py`` version bumps, and current
+  Anaconda upload behavior.
+
+- DOC: Clarified that official plugin releases must be run from ``master`` and
+  can be prepared with the read-only plugin release status workflow.
+
+- DOC: Finished maintainer release notes cleanup for master checkout, draft
+  release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
+  recovery links.
+
+- DOC: Tightened the developer guide entry points, Git commands, pull request
+  template guidance, and testing guidance.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,10 @@ Bug Fixes
 - Fixed ``NDDataset.squeeze()`` for singleton dimensions without explicit
   coordinates and aligned Labspec in-memory byte decoding with the Latin-1
   fallback already used for local files.
+- Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+  when ``typey="features"`` and ``typex="components"`` are both set —
+  replaced sequential ``if`` blocks with an ``elif`` chain and added an
+  explicit combined case to prevent conflicting coordinate assignments.
 
 
 .. section

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -69,7 +69,7 @@ Developer
   mixtures, removing the dependency on ``als2004dataset.MAT`` and strengthening
   wrapper parity, transform, inverse-transform, masking, and validation
   coverage.
-- DEV: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+- FIX: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
   when ``typey="features"`` and ``typex="components"`` are both set —
   replaced sequential ``if`` blocks with an ``elif`` chain and added an
   explicit combined case to prevent conflicting coordinate assignments.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,10 +18,6 @@ Bug Fixes
 - Fixed ``NDDataset.squeeze()`` for singleton dimensions without explicit
   coordinates and aligned Labspec in-memory byte decoding with the Latin-1
   fallback already used for local files.
-- Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
-  when ``typey="features"`` and ``typex="components"`` are both set —
-  replaced sequential ``if`` blocks with an ``elif`` chain and added an
-  explicit combined case to prevent conflicting coordinate assignments.
 
 Developer
 ~~~~~~~~~
@@ -37,6 +33,10 @@ Developer
   mixtures, removing the dependency on ``als2004dataset.MAT`` and strengthening
   wrapper parity, transform, inverse-transform, masking, and validation
   coverage.
+- DEV: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+  when ``typey="features"`` and ``typex="components"`` are both set —
+  replaced sequential ``if`` blocks with an ``elif`` chain and added an
+  explicit combined case to prevent conflicting coordinate assignments.
 - DEV: Modernized baseline analysis tests using deterministic synthetic datasets,
   removing dependencies on external IR and MS test files and strengthening
   validation of baseline estimation, masking, preprocessing APIs, and

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -33,7 +33,7 @@ Developer
   mixtures, removing the dependency on ``als2004dataset.MAT`` and strengthening
   wrapper parity, transform, inverse-transform, masking, and validation
   coverage.
-- DEV: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+- FIX: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
   when ``typey="features"`` and ``typex="components"`` are both set —
   replaced sequential ``if`` blocks with an ``elif`` chain and added an
   explicit combined case to prevent conflicting coordinate assignments.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,130 +18,157 @@ Bug Fixes
 - Fixed ``NDDataset.squeeze()`` for singleton dimensions without explicit
   coordinates and aligned Labspec in-memory byte decoding with the Latin-1
   fallback already used for local files.
+- Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+  when ``typey="features"`` and ``typex="components"`` are both set —
+  replaced sequential ``if`` blocks with an ``elif`` chain and added an
+  explicit combined case to prevent conflicting coordinate assignments.
 
 Developer
 ~~~~~~~~~
 
-- DEV: Modernized selected analysis tests with deterministic synthetic datasets,
+- MAINT: Modernized selected analysis tests with deterministic synthetic datasets,
   reducing unnecessary real-data dependencies and strengthening numerical,
   shape, metadata, masking, and reporting assertions.
-- DEV: Modernized SIMPLISMA analysis tests using deterministic synthetic datasets,
+
+- MAINT: Modernized SIMPLISMA analysis tests using deterministic synthetic datasets,
   removing the dependency on ``als2004dataset.MAT`` and strengthening validation
   of pure-variable selection, decomposition outputs, reconstruction behavior,
   and error handling.
-- DEV: Modernized FastICA analysis tests using deterministic synthetic ICA
+
+- MAINT: Modernized FastICA analysis tests using deterministic synthetic ICA
   mixtures, removing the dependency on ``als2004dataset.MAT`` and strengthening
   wrapper parity, transform, inverse-transform, masking, and validation
   coverage.
-- FIX: Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
-  when ``typey="features"`` and ``typex="components"`` are both set —
-  replaced sequential ``if`` blocks with an ``elif`` chain and added an
-  explicit combined case to prevent conflicting coordinate assignments.
-- DEV: Modernized baseline analysis tests using deterministic synthetic datasets,
-  removing dependencies on external IR and MS test files and strengthening
-  validation of baseline estimation, masking, preprocessing APIs, and
-  multivariate baseline workflows.
-- DEV: Converted NMF analysis tests from the legacy MATLAB fixture to a
+
+- MAINT: Modernized baseline analysis tests using deterministic synthetic
+  datasets, removing dependencies on external IR and MS test files and
+  strengthening validation of baseline estimation, masking, preprocessing APIs,
+  and multivariate baseline workflows.
+
+- MAINT: Converted NMF analysis tests from the legacy MATLAB fixture to a
   deterministic non-negative synthetic dataset with focused parity,
   reconstruction, masking, metadata, and non-negativity checks.
-- DEV: Moved IRIS ``plot_merit`` coverage out of core analysis tests into the
+
+- MAINT: Moved IRIS ``plot_merit`` coverage out of core analysis tests into the
   IRIS plugin test suite, clarifying plugin ownership for plugin/data plotting
   integration checks.
-- DEV: Moved IRIS plugin import/export checks (``TestIrisImports`` for
+
+- MAINT: Moved IRIS plugin import/export checks (``TestIrisImports`` for
   ``plot_iris_lcurve``, ``plot_iris_distribution``, ``plot_iris_merit``) from
   the core composite plotting test module into the IRIS plugin test suite,
   removing all direct IRIS plugin runtime import references from the core
   test tree.
-- DEV: Classified plugin-dependent tests with explicit markers and skip guards
+
+- MAINT: Classified plugin-dependent tests with explicit markers and skip guards
   so optional plugin imports do not fail during core-only collection, while
   keeping core-only and plugin/integration validation clearly separated.
-- CI: Added a dedicated core-only package-test validation row that skips
-  official plugin installation, plugin diagnostics, documentation script
-  execution, external testdata restore, coverage generation, and Codecov upload.
-- CI: Aligned the plugin release workflow status summary with the shared
-  release-relevant plugin change detector used by the read-only status workflow.
-- DEV: Modernized core dataset tests with stronger ``NDDataset``, ``NDMath``,
-  ``Coord``, ``CoordSet``, ``NDArray``, and ``NDComplexArray`` validation and
-  split the large dataset test module into focused test files.
-- DEV: Converted legacy plotting tests (1D, 2D, 3D, multiplot) from external
+
+- MAINT: Modernized core dataset tests with stronger ``NDDataset``,
+  ``NDMath``, ``Coord``, ``CoordSet``, ``NDArray``, and ``NDComplexArray``
+  validation and split the large dataset test module into focused test files.
+
+- MAINT: Converted legacy plotting tests (1D, 2D, 3D, multiplot) from external
   spectroscopy files to deterministic synthetic fixtures, making them runnable
   in core-only CI without testdata downloads.
-- DEV: Converted PCA plotting tests (``plot_score``, ``plot_scree``) from
+
+- MAINT: Converted PCA plotting tests (``plot_score``, ``plot_scree``) from
   external IR data to deterministic synthetic datasets; decoupled 5 tests from
   PCA computation using precomputed score fixtures.
-- DEV: Classified documentation plotting tests as ``docs``/``integration`` tests
-  with explicit ``pytest.mark.docs`` and ``pytest.mark.data`` markers; added
-  graceful skip when IR testdata is unavailable.
-- DEV: Registered ``docs`` and ``data`` pytest markers in the top-level
+
+- MAINT: Classified documentation plotting tests as ``docs``/``integration``
+  tests with explicit ``pytest.mark.docs`` and ``pytest.mark.data`` markers;
+  added graceful skip when IR testdata is unavailable.
+
+- MAINT: Registered ``docs`` and ``data`` pytest markers in the top-level
   conftest for use across the test suite.
-- CI: Added reusable plugin version-status tooling and temporary
+
+- MAINT: Classified all reader/writer I/O tests with explicit
+  ``pytest.mark.data`` (real instrument format files) or
+  ``pytest.mark.network`` (remote downloads); core-safe synthetic I/O tests are
+  selectable via ``-m "not data and not network"``.
+
+- MAINT: Converted ``test_write_csv.py`` from a real IR dataset fixture to
+  deterministic synthetic ``NDDataset`` and ``Coord`` objects, removing its
+  hidden external testdata dependency.
+
+- MAINT: Split the monolithic ``test_read.py::test_read`` into focused tests
+  with explicit marker separation and shared skip helpers.
+
+- DEV: Added TODO/FIXME note in
+  ``docs/sources/devguide/plugins/packaging.rst`` explaining that dev conda
+  uploads for plugins are disabled until distinct dev versions are generated.
+
+- DEV: Added reusable plugin version-status tooling and temporary
   ``next_patch.devN`` metadata injection for plugin development builds, with
   automatic conda uploads to ``spectrocat/label/dev`` on ``master`` when
   release-relevant plugin files changed.
+
+- CI: Added a dedicated core-only package-test validation row that skips
+  official plugin installation, plugin diagnostics, documentation script
+  execution, external testdata restore, coverage generation, and Codecov upload.
+
+- CI: Aligned the plugin release workflow status summary with the shared
+  release-relevant plugin change detector used by the read-only status workflow.
+
 - CI: Restored unique TestPyPI development uploads by deriving core push builds
   from the next patch version and publishing plugin TestPyPI builds from
   ``master`` only when release-relevant plugin files changed.
-- CI: Limited the slow Colab compatibility workflow to manual runs and
-  pull requests labeled ``needs-colab``.
+
+- CI: Limited the slow Colab compatibility workflow to manual runs and pull
+  requests labeled ``needs-colab``.
+
 - CI: Added an explicit documentation versions manifest and a manual
   ``Repair docs version index`` workflow to refresh the published version
   dropdown without rebuilding the full documentation.
+
 - CI: Allowed documentation builds to use canonical core release tags such as
   ``spectrochempy-v0.9.2`` directly, while publishing versioned docs under the
   plain semver directory.
-- DOC: Improved maintainer release documentation with explicit Zenodo
-  verification steps, versioned docs checks, docs build note, and roadmap for
-  modular docs.
-- DOC: Clarified that official plugin versions are independent from the core
-  package version and that conda dev plugin builds are not currently published
-  automatically.
-- DOC: Updated contributor documentation build instructions to use the
-  repository-root ``docs/make.py`` entry point and current ``build/html`` output.
-- DOC: Updated optional plugin installation notes so conda development
-  channels no longer imply automatic plugin dev uploads.
-- DOC: Aligned workflow comments and recovery notes with the current plugin
-  conda policy: stable plugin releases upload to ``main`` and dev uploads are
-  disabled until distinct dev versions exist.
-- DOC: Updated plugin release documentation to use canonical core tags,
-  current branch pushes, plugin ``__init__.py`` version bumps, and the current
-  Anaconda ``main`` upload behavior.
-- DOC: Clarified that official plugin releases must be run from ``master`` and
-  can be prepared with the read-only plugin release status workflow.
-- DOC: Finished maintainer release notes cleanup for master checkout, draft
-  release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
-  internal recovery links.
-- DOC: Tightened the developer guide entry points, Git commands, pull request
-  template guidance, and testing guidance without expanding the guide
-  substantially.
+
 - CI: Added plugin status table to ``release_plugin.yml`` step summary,
-  listing all official plugins and whether they have changed since their
-  last release tag — shows a "no changes" message when all plugins are
-  unchanged, or highlights modified plugins when some need a release.
+  listing official plugins and whether they have changed since their last
+  release tag.
+
 - CI: Added ``confirm_zenodo_enabled`` checkbox to
   ``prepare_new_release.yml`` so maintainers verify Zenodo is active before
   creating a release PR.
-- CI: Disabled automatic dev conda uploads for official plugins
-  (``build_package.yml``).  Plugin conda packages are still built in CI for
-  testing, but only uploaded to Anaconda.org during a stable plugin release
-  (label ``main``).  Dev uploads will be re-enabled once plugin recipes
-  generate distinct dev versions.
-- DEV: Added TODO/FIXME note in ``docs/sources/devguide/plugins/packaging.rst``
-  explaining that dev conda uploads for plugins are disabled until distinct
-  dev versions are generated.
-- CI: Added ``plugin_release_status.yml`` workflow (``workflow_dispatch``)
-  to inspect official plugin changes since their last release tag before
-  deciding to run a release.  Writes a Markdown table (plugin, status, last
-  tag, changed files count) to the workflow summary.  Read-only — no
-  packages, tags, or releases are created.
-- DEV: Classified all reader/writer I/O tests with explicit ``pytest.mark.data``
-  (real instrument format files) or ``pytest.mark.network`` (remote downloads);
-  core-safe synthetic I/O tests are selectable via ``-m "not data and not
-  network"`` (18 tests, all pass with ``scpy-core``).
-- DEV: Converted ``test_write_csv.py`` from a real IR dataset fixture to
-  deterministic synthetic ``NDDataset`` and ``Coord`` objects, removing its
-  hidden external testdata dependency.
-- DEV: Split the monolithic ``test_read.py::test_read`` into four focused tests
-  — local file read (``data``), remote GitHub fallback (``data + network``),
-  missing file error (synthetic), and invalid URL type error (synthetic) —
-  with explicit marker separation and a shared ``_requires_irdata()`` skip
-  helper.
+
+- CI: Disabled automatic dev conda uploads for official plugins. Plugin conda
+  packages are still built in CI for testing, but only uploaded during stable
+  plugin releases.
+
+- CI: Added ``plugin_release_status.yml`` workflow
+  (``workflow_dispatch``) to inspect official plugin changes since their last
+  release tag before deciding to run a release.
+
+- DOC: Improved maintainer release documentation with explicit Zenodo
+  verification steps, versioned docs checks, docs build notes, and roadmap
+  guidance.
+
+- DOC: Clarified that official plugin versions are independent from the core
+  package version and that conda dev plugin builds are not currently published
+  automatically.
+
+- DOC: Updated contributor documentation build instructions to use the
+  repository-root ``docs/make.py`` entry point and current ``build/html``
+  output.
+
+- DOC: Updated optional plugin installation notes so conda development
+  channels no longer imply automatic plugin dev uploads.
+
+- DOC: Aligned workflow comments and recovery notes with the current plugin
+  conda policy.
+
+- DOC: Updated plugin release documentation to use canonical core tags,
+  current branch pushes, plugin ``__init__.py`` version bumps, and current
+  Anaconda upload behavior.
+
+- DOC: Clarified that official plugin releases must be run from ``master`` and
+  can be prepared with the read-only plugin release status workflow.
+
+- DOC: Finished maintainer release notes cleanup for master checkout, draft
+  release titles, TestPyPI wording, plugin PyPI ``skip-existing`` behavior, and
+  recovery links.
+
+- DOC: Tightened the developer guide entry points, Git commands, pull request
+  template guidance, and testing guidance.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,6 +18,10 @@ Bug Fixes
 - Fixed ``NDDataset.squeeze()`` for singleton dimensions without explicit
   coordinates and aligned Labspec in-memory byte decoding with the Latin-1
   fallback already used for local files.
+- Fixed coordinate propagation in ``@_wrap_ndarray_output_to_nddataset``
+  when ``typey="features"`` and ``typex="components"`` are both set —
+  replaced sequential ``if`` blocks with an ``elif`` chain and added an
+  explicit combined case to prevent conflicting coordinate assignments.
 
 Developer
 ~~~~~~~~~

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -480,7 +480,46 @@ class _set_output:
                 X_transf.dims = X.dims
                 X_transf.set_coordset({X.dims[0]: X.coord(0), X.dims[1]: X.coord(1)})
             else:
-                if self.typey == "components":
+                if self.typesingle == "components":
+                    # occurs when the data are 1D such as ev_ratio...
+                    X_transf.dims = ["k"]
+                    X_transf.set_coordset(
+                        k=Coord(
+                            None,
+                            labels=[f"#{i}" for i in range(X_transf.shape[-1])],
+                            title="components",
+                        ),
+                    )
+                elif self.typesingle == "targets":
+                    # occurs when the data are 1D such as PLSRegression intercept...
+                    if X.coordset[0].labels is not None:
+                        labels = X.coordset[0].labels
+                    else:
+                        labels = [f"#{i + 1}" for i in range(X.shape[-1])]
+                    X_transf.dims = ["j"]
+                    X_transf.set_coordset(
+                        j=Coord(
+                            None,
+                            labels=labels,
+                            title="targets",
+                        ),
+                    )
+                elif self.typey == "features" and self.typex == "components":
+                    # combined: dim[0]=features, dim[1]=components
+                    X_transf.dims = [X.dims[1], "k"]
+                    X_transf.set_coordset(
+                        {
+                            X.dims[1]: (
+                                X.coord(1).copy() if X.coord(1) is not None else None
+                            ),
+                            "k": Coord(
+                                None,
+                                labels=[f"#{i}" for i in range(X_transf.shape[-1])],
+                                title="components",
+                            ),
+                        },
+                    )
+                elif self.typey == "components":
                     X_transf.dims = ["k", X.dims[1]]
                     X_transf.set_coordset(
                         {
@@ -494,7 +533,7 @@ class _set_output:
                             ),
                         },
                     )
-                if self.typex == "components":
+                elif self.typex == "components":
                     X_transf.dims = [X.dims[0], "k"]
                     X_transf.set_coordset(
                         {
@@ -509,7 +548,7 @@ class _set_output:
                             ),
                         },
                     )
-                if self.typex == "features":
+                elif self.typex == "features":
                     X_transf.dims = ["k", X.dims[1]]
                     X_transf.set_coordset(
                         {
@@ -523,7 +562,7 @@ class _set_output:
                             ),
                         },
                     )
-                if self.typey == "features":
+                elif self.typey == "features":
                     X_transf.dims = [X.dims[1], "k"]
                     X_transf.set_coordset(
                         {
@@ -536,30 +575,6 @@ class _set_output:
                                 title="components",
                             ),
                         },
-                    )
-                if self.typesingle == "components":
-                    # occurs when the data are 1D such as ev_ratio...
-                    X_transf.dims = ["k"]
-                    X_transf.set_coordset(
-                        k=Coord(
-                            None,
-                            labels=[f"#{i}" for i in range(X_transf.shape[-1])],
-                            title="components",
-                        ),
-                    )
-                if self.typesingle == "targets":
-                    # occurs when the data are 1D such as PLSRegression intercept...
-                    if X.coordset[0].labels is not None:
-                        labels = X.coordset[0].labels
-                    else:
-                        labels = [f"#{i + 1}" for i in range(X.shape[-1])]
-                    X_transf.dims = ["j"]
-                    X_transf.set_coordset(
-                        j=Coord(
-                            None,
-                            labels=labels,
-                            title="targets",
-                        ),
                     )
 
             # eventually restore masks

--- a/tests/test_analysis/test_decomposition/test_fast_ica.py
+++ b/tests/test_analysis/test_decomposition/test_fast_ica.py
@@ -60,12 +60,9 @@ def test_fastica_fit_shapes(fastica_dataset, ica_model):
     assert ica.mean.shape == (8,)
     assert ica.n_iter > 0
 
-    # mixing, St, whitening properties trigger a pre-existing coordinate bug
-    # when input has named coords (set_coordset(None, None) was used to mask it).
-    # TODO: Revert to public properties when the coordinate propagation bug is fixed.
-    # Validate via sklearn attributes for now.
-    assert ica._fast_ica.mixing_.shape == (8, 4)
-    assert ica._fast_ica.whitening_.shape == (4, 8)
+    assert ica.mixing.shape == (8, 4)
+    assert ica.St.shape == (4, 8)
+    assert ica.whitening.shape == (4, 8)
 
     testing.assert_dataset_equal(ica.X, fastica_dataset)
 
@@ -75,9 +72,10 @@ def test_fastica_finite_outputs(fastica_dataset, ica_model):
     ica.fit(fastica_dataset)
 
     assert np.all(np.isfinite(ica.components.data))
+    assert np.all(np.isfinite(ica.mixing.data))
+    assert np.all(np.isfinite(ica.St.data))
     assert np.all(np.isfinite(ica.mean.data))
-    assert np.all(np.isfinite(ica._fast_ica.mixing_))
-    assert np.all(np.isfinite(ica._fast_ica.whitening_))
+    assert np.all(np.isfinite(ica.whitening.data))
 
 
 def test_fastica_fit_transform(fastica_dataset, ica_model):
@@ -118,9 +116,10 @@ def test_fastica_sklearn_parity(fastica_dataset):
     skl_ica.fit(X_np)
 
     assert_allclose(scp_ica.components.data, skl_ica.components_)
-    assert_allclose(scp_ica._fast_ica.mixing_, skl_ica.mixing_)
+    assert_allclose(scp_ica.mixing.data, skl_ica.mixing_)
+    assert_allclose(scp_ica.St.data, skl_ica.mixing_.T)
     assert_allclose(scp_ica.mean.data, skl_ica.mean_)
-    assert_allclose(scp_ica._fast_ica.whitening_, skl_ica.whitening_)
+    assert_allclose(scp_ica.whitening.data, skl_ica.whitening_)
     assert scp_ica.n_iter == skl_ica.n_iter_
 
     U_scp = scp_ica.transform()


### PR DESCRIPTION
Fix `@_wrap_ndarray_output_to_nddataset` where sequential `if` blocks caused `ValueError` when both `typey="features"` and `typex="components"` were set, affecting `FastICA.mixing`, `.St`, `.whitening`.

Fixes #1033

- Replaced sequential `if` blocks with `elif` chain
- Added explicit combined case for `typey="features" + typex="components"`
- All 53 decomposition tests pass (FastICA now uses public properties)