### PR TITLE
MAINT: final analysis test cleanup

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -82,6 +82,11 @@ Developer
   and known centre-value regression for all six 1-D models; removed all dead
   code (commented plotting blocks, unused imports, always-true guard).
 
+- MAINT: Final analysis test cleanup: replaced legacy ``np.random.seed`` /
+  ``np.random.rand`` usage in CP decomposition tests with
+  ``np.random.default_rng(42)`` and removed dead/commented test code from
+  ``test_base.py``.
+
 - MAINT: Modernized selected analysis tests with deterministic synthetic datasets,
   reducing unnecessary real-data dependencies and strengthening numerical,
   shape, metadata, masking, and reporting assertions.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -46,6 +46,11 @@ Developer
   and known centre-value regression for all six 1-D models; removed all dead
   code (commented plotting blocks, unused imports, always-true guard).
 
+- MAINT: Final analysis test cleanup: replaced legacy ``np.random.seed`` /
+  ``np.random.rand`` usage in CP decomposition tests with
+  ``np.random.default_rng(42)`` and removed dead/commented test code from
+  ``test_base.py``.
+
 - MAINT: Modernized selected analysis tests with deterministic synthetic datasets,
   reducing unnecessary real-data dependencies and strengthening numerical,
   shape, metadata, masking, and reporting assertions.

--- a/tests/test_analysis/test_base/test_base.py
+++ b/tests/test_analysis/test_base/test_base.py
@@ -141,11 +141,3 @@ def test_analysisconfigurable_validation():
     X[1] = scp.MASKED
     foo.fit(X)
     assert repr(foo.X) == "NDDataset: [float64] m (shape: (u:1, x:3))"
-
-
-# def test_decompositionanalysis():
-#
-#     X = scp.NDDataset(np.arange(3) + 1.5, coordset=[range(3)], units="m")
-#     # with a mask
-#     foo.fit(X)
-#     assert repr(foo.X) == "NDDataset: [float64] m (shape: (y:1, x:3))"

--- a/tests/test_analysis/test_decomposition/test_cp.py
+++ b/tests/test_analysis/test_decomposition/test_cp.py
@@ -21,11 +21,11 @@ tensorly = pytest.importorskip("tensorly")
 
 def _make_synthetic_3d():
     """Create synthetic 3D NDDataset for testing."""
-    np.random.seed(42)
+    rng = np.random.default_rng(42)
     # Create a 3D tensor with known CP structure (6 samples, 8 features, 10 time points)
-    A = np.random.rand(6, 2)
-    B = np.random.rand(8, 2)
-    C = np.random.rand(10, 2)
+    A = rng.random((6, 2))
+    B = rng.random((8, 2))
+    C = rng.random((10, 2))
     X = np.zeros((6, 8, 10))
     for r in range(2):
         X += np.outer(np.outer(A[:, r], B[:, r]), C[:, r]).reshape(6, 8, 10)
@@ -191,7 +191,7 @@ class TestCP:
 
     def test_cp_invalid_2d_input(self):
         """Test error on 2D input."""
-        ds = NDDataset(np.random.rand(10, 20))
+        ds = NDDataset(np.zeros((10, 20)))
         ds.dims = ["x", "y"]
         ds.set_coordset(x=Coord(np.arange(10)), y=Coord(np.arange(20)))
 


### PR DESCRIPTION
## Summary

This PR performs the final cleanup identified during the analysis/test modernization audit.

## Changes

- Replaced legacy NumPy global RNG usage in CP decomposition tests with `np.random.default_rng(42)`.
- Removed dead/commented legacy test code from `test_base.py`.
- Added a small developer changelog entry.

## Validation

- `pytest tests/test_analysis/test_decomposition/test_cp.py` — 2 skipped (tensorly), no failures
- `pytest tests/test_analysis/test_base/test_base.py` — 2 passed, 1 pre-existing docstring failure (SS04)
- `pytest tests/test_analysis` — 143 passed, 2 pre-existing docstring failures, 4 skipped
- `pre-commit run --files ...` — all hooks passed

## Notes

This PR contains only small cleanup changes and does not modify analysis algorithms or public APIs.