### PR TITLE
MAINT: Add Coord and CoordSet behavioral hardening tests

### DIFF
--- a/tests/test_core/test_dataset/test_coord_behavior.py
+++ b/tests/test_core/test_dataset/test_coord_behavior.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (see LICENSE.txt for details)
+
+"""
+Behavioral tests for Coord.
+
+Tests focus on public API behavior, not private implementation details.
+Uses deterministic synthetic data only. No external files, no plotting.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.units import DimensionalityError
+from spectrochempy.core.units import ur
+from spectrochempy.utils.testing import assert_array_equal
+from spectrochempy.utils.testing import assert_units_equal
+
+# ==============================================================================
+# Construction
+# ==============================================================================
+
+
+class TestCoordConstruction:
+    """Coord creation from various inputs."""
+
+    def test_from_list(self):
+        c = Coord([1, 2, 3])
+        assert c.size == 3
+        assert c.shape == (3,)
+
+    def test_from_ndarray(self):
+        c = Coord(np.array([10.0, 20.0, 30.0]))
+        assert c.size == 3
+        assert np.issubdtype(c.dtype, np.floating)
+
+    def test_from_linspace(self):
+        c = Coord(np.linspace(0, 10, 11))
+        assert c.size == 11
+        assert c.linear
+
+    def test_from_arange(self):
+        c = Coord(np.arange(5))
+        assert c.size == 5
+
+    def test_from_float_list(self):
+        c = Coord([1.5, 2.5, 3.5])
+        assert c.size == 3
+        assert np.issubdtype(c.dtype, np.floating)
+
+    def test_with_name(self):
+        c = Coord([1, 2, 3], name="wavelength")
+        assert c.name == "wavelength"
+
+    def test_with_units(self):
+        c = Coord([1, 2, 3], units="cm^-1")
+        assert_units_equal(c.units, ur("cm^-1"))
+
+    def test_with_title(self):
+        c = Coord([1, 2, 3], title="Wavenumber")
+        assert c.title == "Wavenumber"
+
+    def test_with_labels(self):
+        labels = ["a", "b", "c"]
+        c = Coord([1, 2, 3], labels=labels)
+        assert_array_equal(c.labels, labels)
+
+    def test_empty(self):
+        c = Coord([])
+        assert c.size == 0
+        assert c.is_empty
+
+    def test_single_element(self):
+        c = Coord([42.0])
+        assert c.size == 1
+        assert c.shape == (1,)
+
+    def test_non_monotonic(self):
+        c = Coord([3, 1, 4, 1, 5])
+        assert c.size == 5
+        assert not c.linear
+
+    def test_duplicate_values(self):
+        c = Coord([1, 1, 2, 2, 3])
+        assert c.size == 5
+
+    def test_dtype_preservation(self):
+        c = Coord([1, 2, 3])
+        assert np.issubdtype(c.dtype, np.floating)
+        c2 = Coord([1.0, 2.0, 3.0])
+        assert np.issubdtype(c2.dtype, np.floating)
+
+    def test_name_dimension(self):
+        c = Coord([1, 2, 3], name="time")
+        dims = c.dims
+        assert isinstance(dims, list)
+        assert "time" not in dims  # Coord dims are always ["x"], independent of name
+
+    def test_default_dims_list(self):
+        c = Coord([1, 2, 3])
+        dims = c.dims
+        assert isinstance(dims, list)
+        assert len(dims) == 1
+
+    def test_non_iterable_data_raises(self):
+        with pytest.raises(ValueError):
+            Coord(42)
+
+
+# ==============================================================================
+# Properties
+# ==============================================================================
+
+
+class TestCoordProperties:
+    """Coord public property behavior."""
+
+    def test_data_returns_numpy_array(self):
+        c = Coord([1.0, 2.0, 3.0])
+        data = c.data
+        assert_array_equal(data, np.array([1.0, 2.0, 3.0]))
+
+    def test_umasked_data(self):
+        c = Coord([1.0, 2.0, 3.0])
+        d = c.umasked_data
+        assert d is not None
+
+    def test_linear_returns_bool(self):
+        c = Coord([1, 2, 3, 4, 5])
+        assert isinstance(c.linear, bool)
+
+    def test_reversed_returns_bool(self):
+        c = Coord([5, 4, 3, 2, 1])
+        assert isinstance(c.reversed, bool)
+
+    def test_reversed_true_for_wavenumber(self):
+        c = Coord([4000, 3000, 2000, 1000], units="cm^-1")
+        assert c.reversed
+
+    def test_reversed_true_for_ppm(self):
+        c = Coord([10, 5, 0], units="ppm")
+        assert c.reversed
+
+    def test_is_descendant_true_for_decreasing(self):
+        c = Coord([5, 4, 3, 2, 1])
+        assert c.is_descendant
+
+    def test_spacing_linear(self):
+        c = Coord(np.arange(10, dtype=float))
+        spacing = c.spacing
+        assert spacing is not None
+
+    def test_sigdigits_returns_int(self):
+        c = Coord([1.0, 2.0, 3.0])
+        digits = c.sigdigits
+        assert isinstance(digits, (int, np.integer))
+
+    def test_limits(self):
+        c = Coord([1.0, 5.0, 3.0])
+        lim = c.limits
+        assert len(lim) == 2
+
+    def test_show_datapoints_default(self):
+        c = Coord([1, 2, 3])
+        assert isinstance(c.show_datapoints, bool)
+
+    def test_show_datapoints_default_false(self):
+        c = Coord([1, 2, 3], units="cm^-1")
+        # show_datapoints only returns True when laser_frequency is set
+        # and units are time or length
+        assert isinstance(c.show_datapoints, bool)
+
+    def test_laser_frequency_default_none(self):
+        c = Coord([1, 2, 3], units="cm^-1")
+        assert c.laser_frequency is None
+
+    def test_laser_frequency_settable(self):
+        c = Coord([1, 2, 3], units="cm^-1")
+        c.laser_frequency = 15798.0
+        assert c.laser_frequency == 15798.0
+
+    def test_has_data(self):
+        c = Coord([1, 2, 3])
+        assert c.has_data
+
+    def test_has_data_false_empty(self):
+        c = Coord([])
+        assert not c.has_data
+
+    def test_values_property(self):
+        c = Coord([1.0, 2.0, 3.0])
+        v = c.values
+        assert v is not None
+
+    def test_dtype(self):
+        c = Coord([1, 2, 3])
+        assert np.issubdtype(c.dtype, np.floating)
+
+
+# ==============================================================================
+# Unit conversion
+# ==============================================================================
+
+
+class TestCoordUnitConversion:
+    """Coord unit conversion behavior."""
+
+    def test_to_compatible_units(self):
+        c = Coord([1, 2, 3], units="m")
+        c2 = c.to("cm")
+        assert_units_equal(c2.units, ur("cm"))
+
+    def test_to_incompatible_units_raises(self):
+        c = Coord([1, 2, 3], units="cm^-1")
+        with pytest.raises(DimensionalityError):
+            c.to("s")
+
+    def test_to_with_force(self):
+        c = Coord([1, 2, 3], units="cm^-1")
+        c2 = c.to("nm^-1", force=True)
+        assert c2.units is not None
+
+    def test_original_unchanged_after_to(self):
+        c = Coord([1, 2, 3], units="m")
+        c.to("cm")
+        assert_units_equal(c.units, ur("m"))
+
+
+# ==============================================================================
+# loc2index
+# ==============================================================================
+
+
+class TestCoordLoc2Index:
+    """Location-to-index conversion behavior."""
+
+    def test_by_exact_value(self):
+        c = Coord([10, 20, 30, 40, 50])
+        idx = c.loc2index(30)
+        assert idx == 2
+
+    def test_nearest_value(self):
+        c = Coord([10.0, 20.0, 30.0, 40.0])
+        idx = c.loc2index(25.0)
+        assert isinstance(idx, (int, np.integer))
+
+    def test_by_sequence(self):
+        c = Coord([10, 20, 30, 40, 50])
+        idxs = c.loc2index([20, 40])
+        assert len(idxs) == 2
+
+    def test_by_int_location(self):
+        c = Coord(np.linspace(0, 100, 101))
+        idx = c.loc2index(50)
+        assert 0 <= idx < c.size
+
+
+# ==============================================================================
+# linearize / set_laser_frequency
+# ==============================================================================
+
+
+class TestCoordTransform:
+    """Coord transformation methods."""
+
+    def test_linearize(self):
+        c = Coord([1, 2, 3, 5, 8, 13])
+        result = c.linearize()
+        assert result is None  # linearize operates in-place
+        assert isinstance(c.linear, bool)
+
+    def test_set_laser_frequency(self):
+        c = Coord([1, 2, 3], units="cm^-1")
+        result = c.set_laser_frequency(15798.0)
+        assert result is None  # operates in-place
+        assert c.laser_frequency is not None
+
+
+# ==============================================================================
+# Copy
+# ==============================================================================
+
+
+class TestCoordCopy:
+    """Coord copy behavior."""
+
+    def test_copy_preserves_name(self):
+        c = Coord([1, 2, 3], name="x", units="cm^-1")
+        c2 = c.copy()
+        assert c2.name == c.name
+
+    def test_copy_preserves_units(self):
+        c = Coord([1, 2, 3], name="x", units="cm^-1")
+        c2 = c.copy()
+        assert_units_equal(c2.units, c.units)
+
+    def test_copy_independence(self):
+        c = Coord([1, 2, 3])
+        c2 = c.copy()
+        c2.name = "changed"
+        assert c.name != c2.name
+
+    def test_copy_preserves_data(self):
+        c = Coord([1.0, 2.0, 3.0])
+        c2 = c.copy()
+        assert_array_equal(c2.data, c.data)
+
+
+# ==============================================================================
+# Transpose
+# ==============================================================================
+
+
+class TestCoordTranspose:
+    """Coord transpose behavior."""
+
+    def test_transpose_preserves_size(self):
+        c = Coord([1, 2, 3])
+        ct = c.transpose()
+        assert ct.size == c.size
+
+    def test_transpose_returns_coord(self):
+        c = Coord([1, 2, 3])
+        ct = c.transpose()
+        assert isinstance(ct, Coord)
+
+
+# ==============================================================================
+# Edge cases
+# ==============================================================================
+
+
+class TestCoordEdgeCases:
+    """Coord edge case behavior."""
+
+    def test_labels_get_set(self):
+        c = Coord([1, 2, 3])
+        labels = ["a", "b", "c"]
+        c.labels = labels
+        assert_array_equal(c.labels, labels)
+
+    def test_empty_coord_properties(self):
+        c = Coord([])
+        assert c.size == 0
+        assert c.is_empty
+        assert not c.has_data
+
+    def test_integer_to_float_promotion(self):
+        c = Coord([1, 2, 3])
+        c2 = c.to("m", force=True)
+        assert c2 is not None
+
+    def test_linear_returns_true_for_equal_spacing(self):
+        c = Coord(np.linspace(100, 200, 50))
+        assert c.linear
+
+    def test_linear_returns_false_for_unequal_spacing(self):
+        c = Coord([1, 2, 4, 8, 16])
+        assert not c.linear
+
+    def test_is_masked_always_false(self):
+        c = Coord([1, 2, 3])
+        assert not c.is_masked
+
+    def test_mask_always_nomask(self):
+        from spectrochempy.core.dataset.coord import NOMASK
+
+        c = Coord([1, 2, 3])
+        assert c.mask is NOMASK
+
+    def test_ndim_always_one(self):
+        c = Coord([1, 2, 3])
+        assert c.ndim == 1
+
+    def test_is_1d_always_true(self):
+        c = Coord([1, 2, 3])
+        assert c.is_1d
+
+    def test_T_returns_self(self):
+        c = Coord([1, 2, 3])
+        assert c.T is c
+
+
+# ==============================================================================
+# Arithmetic
+# ==============================================================================
+
+
+class TestCoordArithmetic:
+    """Coord arithmetic behavior (operators set via coord.py)."""
+
+    def test_add_with_value(self):
+        c = Coord([1, 2, 3])
+        c2 = c + 1
+        assert c2.size == 3
+
+    def test_sub_with_value(self):
+        c = Coord([1, 2, 3])
+        c2 = c - 1
+        assert c2.size == 3
+
+    def test_mul_with_scalar(self):
+        c = Coord([1, 2, 3])
+        c2 = c * 2
+        assert c2.size == 3
+
+    def test_truediv_with_scalar(self):
+        c = Coord([2, 4, 6])
+        c2 = c / 2
+        assert c2.size == 3
+
+    def test_neg(self):
+        c = Coord([1, 2, 3])
+        c2 = -c
+        assert c2.size == 3
+
+    def test_abs(self):
+        c = Coord([-1, -2, 3])
+        c2 = abs(c)
+        assert c2.size == 3
+
+
+# ==============================================================================
+# Equality
+# ==============================================================================
+
+
+class TestCoordEquality:
+    """Coord equality behavior."""
+
+    def test_eq_same_data(self):
+        c1 = Coord([1, 2, 3])
+        c2 = Coord([1, 2, 3])
+        assert c1 == c2
+
+    def test_eq_different_data(self):
+        c1 = Coord([1, 2, 3])
+        c2 = Coord([4, 5, 6])
+        assert c1 != c2
+
+    def test_eq_different_shape(self):
+        c1 = Coord([1, 2, 3])
+        c2 = Coord([1, 2])
+        assert c1 != c2
+
+    def test_eq_with_units(self):
+        c1 = Coord([1, 2, 3], units="m")
+        c2 = Coord([1, 2, 3], units="m")
+        assert c1 == c2
+
+    def test_eq_different_units(self):
+        c1 = Coord([1, 2, 3], units="m")
+        c2 = Coord([1, 2, 3], units="cm")
+        assert c1 != c2
+
+
+# ==============================================================================
+# Indexing & slicing
+# ==============================================================================
+
+
+class TestCoordIndexing:
+    """Coord indexing behavior."""
+
+    def test_getitem_int(self):
+        c = Coord([10, 20, 30, 40])
+        assert c[0] == 10
+        assert c[2] == 30
+
+    def test_getitem_slice(self):
+        c = Coord([10, 20, 30, 40])
+        sliced = c[1:3]
+        assert sliced.size == 2
+        assert_array_equal(sliced.data, [20, 30])
+
+    def test_getitem_step(self):
+        c = Coord([10, 20, 30, 40, 50])
+        sliced = c[::2]
+        assert sliced.size == 3
+        assert_array_equal(sliced.data, [10, 30, 50])
+
+    def test_getitem_name_preserved(self):
+        c = Coord([10, 20, 30], name="x")
+        sliced = c[0:2]
+        assert sliced.name == "x"

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (see LICENSE.txt for details)
+
+"""
+Behavioral tests for CoordSet.
+
+Tests focus on public API behavior, not private implementation details.
+Uses deterministic synthetic data only. No external files, no plotting.
+"""
+
+import pytest
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
+from spectrochempy.utils.testing import assert_array_equal
+
+# ==============================================================================
+# Construction
+# ==============================================================================
+
+
+class TestCoordSetConstruction:
+    """CoordSet creation from Coord objects and other inputs."""
+
+    def test_from_single_coord(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        assert len(cs) == 1
+        assert cs.names == ["x"]
+
+    def test_from_two_coords(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2)
+        assert len(cs) == 2
+
+    def test_preserves_coord_data(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        cs = CoordSet(c)
+        assert_array_equal(cs["x"].data, [1.0, 2.0, 3.0])
+
+    def test_from_list_of_coords(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        # Using individual args (not wrapped in a list) creates multi-dim CoordSet
+        cs = CoordSet(c1, c2, keepnames=True)
+        assert len(cs) == 2
+
+    def test_from_kwargs(self):
+        cs = CoordSet(x=Coord([1, 2, 3]), y=Coord([10, 20]))
+        assert "x" in cs.names
+        assert "y" in cs.names
+
+    def test_with_coord_names_and_dim_names(self):
+        c = Coord([1, 2, 3], name="wavelength")
+        cs = CoordSet(c, keepnames=True)
+        assert cs.names == ["wavelength"]
+
+    def test_with_dims_kwarg(self):
+        c1 = Coord([1, 2, 3])
+        c2 = Coord([10, 20])
+        cs = CoordSet(c1, c2, dims=["x", "y"])
+        assert len(cs.names) == 2
+
+    def test_all_coords_have_names(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([10, 20], name="b")
+        cs = CoordSet(c1, c2, keepnames=True)
+        for name in cs.names:
+            assert isinstance(name, str)
+            assert len(name) > 0
+
+    def test_construction_without_args(self):
+        # CoordSet() currently raises TypeError (existing bug in _coords validator)
+        with pytest.raises(TypeError):
+            CoordSet()
+
+
+# ==============================================================================
+# Properties
+# ==============================================================================
+
+
+class TestCoordSetProperties:
+    """CoordSet public property behavior."""
+
+    def test_names_returns_list_of_strings(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"), Coord([10, 20], name="y"))
+        names = cs.names
+        assert isinstance(names, list)
+        assert all(isinstance(n, str) for n in names)
+
+    def test_sizes_returns_list(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        sizes = cs.sizes
+        assert isinstance(sizes, list)
+        assert len(sizes) == 2
+
+    def test_sizes_match_coord_sizes(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        sizes = cs.sizes
+        # sizes order corresponds to _coords order
+        assert 3 in sizes
+        assert 2 in sizes
+
+    def test_is_empty_false_with_coords(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        assert not cs.is_empty
+
+    def test_default_returns_coord(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        default = cs.default
+        assert isinstance(default, Coord)
+
+    def test_default_coord_name(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        assert cs.default.name == "x"
+
+    def test_data_is_default_coord_data(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        assert_array_equal(cs.data, c.data)
+
+    def test_titles_returns_list(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"), Coord([10, 20], name="y"))
+        titles = cs.titles
+        assert isinstance(titles, list)
+        assert len(titles) == len(cs)
+
+    def test_labels_returns_none_for_unlabeled(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2)
+        labs = cs.labels
+        assert all(label is None for label in labs)
+
+    def test_units_returns_list_for_mixed(self):
+        c1 = Coord([1, 2, 3], name="x", units="cm^-1")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        units = cs.units
+        assert len(units) == 2
+
+    def test_is_labeled_false_no_labels(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        assert not cs.is_labeled
+
+    def test_is_labeled_true_with_labels(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x", labels=["a", "b", "c"]))
+        assert cs.is_labeled
+
+
+# ==============================================================================
+# Access by name
+# ==============================================================================
+
+
+class TestCoordSetAccess:
+    """CoordSet item access behavior."""
+
+    def test_getitem_by_name(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        retrieved = cs["x"]
+        assert isinstance(retrieved, Coord)
+        assert_array_equal(retrieved.data, c.data)
+
+    def test_getitem_by_integer(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        retrieved = cs[0]
+        assert isinstance(retrieved, Coord)
+
+    def test_getitem_missing_name_raises(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        with pytest.raises((KeyError, IndexError)):
+            _ = cs["nonexistent"]
+
+    def test_getitem_integer_out_of_range(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        with pytest.raises((IndexError, KeyError)):
+            _ = cs[10]
+
+    def test_contains_via_names(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"), Coord([10, 20], name="y"))
+        assert "x" in cs.names
+        assert "z" not in cs.names
+
+    def test_len_returns_coord_count(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"), Coord([10, 20], name="y"))
+        assert len(cs) == 2
+        cs2 = CoordSet(Coord([1, 2, 3], name="x"))
+        assert len(cs2) == 1
+
+    def test_keys_returns_names(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([10, 20], name="b")
+        cs = CoordSet(c1, c2, keepnames=True)
+        keys = cs.keys()
+        assert "a" in keys
+        assert "b" in keys
+
+    def test_to_dict(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        d = cs.to_dict()
+        assert isinstance(d, dict)
+        assert "x" in d
+        assert "y" in d
+        assert isinstance(d["x"], Coord)
+
+    def test_to_dict_values(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        cs = CoordSet(c)
+        d = cs.to_dict()
+        assert_array_equal(d["x"].data, [1.0, 2.0, 3.0])
+
+
+# ==============================================================================
+# Mutation
+# ==============================================================================
+
+
+class TestCoordSetMutation:
+    """CoordSet modification behavior."""
+
+    def test_setitem_by_name_replaces(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        cs["x"] = Coord([10, 20, 30], name="x")
+        assert_array_equal(cs["x"].data, [10, 20, 30])
+
+    def test_setitem_new_name_adds(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        cs["y"] = Coord([10, 20], name="y")
+        assert "y" in cs.names
+        assert len(cs) == 2
+
+    def test_delitem_removes_coord(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        del cs["x"]
+        assert "x" not in cs.names
+        assert len(cs) == 1
+
+    def test_delitem_missing_name_raises(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        with pytest.raises(KeyError):
+            del cs["nonexistent"]
+
+    def test_set_coord_updates_data(self):
+        c1 = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c1)
+        new_x = Coord([4, 5, 6], name="x")
+        cs.set(x=new_x)
+        assert_array_equal(cs["x"].data, [4, 5, 6])
+
+    def test_set_multiple_coords(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        cs.set(x=Coord([7, 8, 9], name="x"), y=Coord([30, 40], name="y"))
+        assert_array_equal(cs["x"].data, [7, 8, 9])
+        assert_array_equal(cs["y"].data, [30, 40])
+
+    def test_set_titles_by_kwargs(self):
+        c1 = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c1)
+        cs.set_titles(x="Wavenumber")
+        assert cs["x"].title == "Wavenumber"
+
+    def test_set_units_by_kwargs(self):
+        c1 = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c1)
+        cs.set_units(x="cm^-1", force=True)
+        assert cs["x"].units is not None
+
+    def test_update_replaces_coord(self):
+        c1 = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c1)
+        cs.update(x=[4, 5, 6])
+        assert_array_equal(cs["x"].data, [4, 5, 6])
+
+
+# ==============================================================================
+# Call syntax
+# ==============================================================================
+
+
+class TestCoordSetCall:
+    """CoordSet __call__ behavior."""
+
+    def test_call_no_args_returns_all(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        result = cs()
+        assert isinstance(result, CoordSet)
+
+    def test_call_with_index_returns_coord(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        result = cs(0)
+        assert isinstance(result, Coord)
+
+    def test_call_with_axis(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        result = cs(axis="x")
+        assert isinstance(result, Coord)
+
+
+# ==============================================================================
+# Copy
+# ==============================================================================
+
+
+class TestCoordSetCopy:
+    """CoordSet copy behavior."""
+
+    def test_copy_preserves_names(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        cs2 = cs.copy()
+        assert cs2.names == cs.names
+
+    def test_copy_independence(self):
+        c1 = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c1)
+        cs2 = cs.copy()
+        cs2["x"] = Coord([7, 8, 9], name="x")
+        assert_array_equal(cs["x"].data, [1, 2, 3])
+
+    def test_copy_preserves_data(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        cs = CoordSet(c)
+        cs2 = cs.copy()
+        assert_array_equal(cs2["x"].data, cs["x"].data)
+
+
+# ==============================================================================
+# Arithmetic
+# ==============================================================================
+
+
+class TestCoordSetArithmetic:
+    """CoordSet arithmetic behavior."""
+
+    def test_add_two_coordsets(self):
+        c1 = Coord([1, 2, 3], name="x")
+        cs1 = CoordSet(c1)
+        cs2 = CoordSet(Coord([10, 20, 30], name="x"))
+        cs_sum = cs1 + cs2
+        assert cs_sum is not None
+        assert isinstance(cs_sum, CoordSet)
+
+    def test_sub_two_coordsets(self):
+        c1 = Coord([10, 20, 30], name="x")
+        cs1 = CoordSet(c1)
+        cs2 = CoordSet(Coord([1, 2, 3], name="x"))
+        cs_diff = cs1 - cs2
+        assert cs_diff is not None
+        assert isinstance(cs_diff, CoordSet)
+
+
+# ==============================================================================
+# Edge cases
+# ==============================================================================
+
+
+class TestCoordSetEdgeCases:
+    """CoordSet edge case behavior."""
+
+    def test_coords_with_different_sizes(self):
+        """CoordSet allows coords of different sizes for different dims."""
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        assert cs.sizes == [3, 2]  # order depends on _coords storage
+
+    def test_preserves_coord_units(self):
+        c1 = Coord([1, 2, 3], name="x", units="cm^-1")
+        c2 = Coord([10, 20], name="y", units="s")
+        cs = CoordSet(c1, c2, keepnames=True)
+        units = cs.units
+        assert any(u is not None for u in units)
+
+    def test_preserves_coord_titles(self):
+        c1 = Coord([1, 2, 3], name="x", title="Wavenumber")
+        cs = CoordSet(c1)
+        assert "Wavenumber" in cs.titles
+
+    def test_coord_with_labels_in_set(self):
+        c = Coord([1, 2, 3], name="x", labels=["a", "b", "c"])
+        cs = CoordSet(c)
+        assert cs.is_labeled
+        # labels are returned as list of arrays
+        assert len(cs.labels[0]) == 3
+
+    def test_select_changes_default(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        cs.select(0)
+        # just check it doesn't raise
+        assert cs.default is not None
+
+    def test_select_second_coord(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        cs.select(0)
+        cs.select(2)  # select second (1-indexed)
+        # default may or may not change depending on count
+        assert cs is not None
+
+
+# ==============================================================================
+# Equality
+# ==============================================================================
+
+
+class TestCoordSetEquality:
+    """CoordSet equality behavior."""
+
+    def test_eq_same_coords(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([1, 2, 3], name="x")
+        cs1 = CoordSet(c1)
+        cs2 = CoordSet(c2)
+        assert cs1 == cs2
+
+    def test_eq_different_coords(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([4, 5, 6], name="x")
+        cs1 = CoordSet(c1)
+        cs2 = CoordSet(c2)
+        assert cs1 != cs2
+
+    def test_eq_with_none(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        assert cs != None  # noqa: E711
+
+    def test_eq_different_count(self):
+        cs1 = CoordSet(Coord([1, 2, 3], name="x"))
+        cs2 = CoordSet(Coord([1, 2, 3], name="x"), Coord([10, 20], name="y"))
+        assert cs1 != cs2

--- a/tests/test_core/test_dataset/test_dataset_coords_behavior.py
+++ b/tests/test_core/test_dataset/test_dataset_coords_behavior.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (see LICENSE.txt for details)
+
+"""
+Behavioral tests for NDDataset + Coord/CoordSet integration.
+
+Tests focus on public API behavior — CoordSet consistency with dataset
+shape, dims, slicing, and coordinate assignment.
+Uses deterministic synthetic data. No external files, no plotting.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
+from spectrochempy.core.dataset.nddataset import NDDataset
+from spectrochempy.core.units import ur
+from spectrochempy.utils.testing import assert_array_equal
+from spectrochempy.utils.testing import assert_units_equal
+
+# ==============================================================================
+# Creation with explicit CoordSet
+# ==============================================================================
+
+
+class TestNDDatasetCreationWithCoordSet:
+    """Creating NDDataset with an explicit CoordSet."""
+
+    def test_1d_with_single_coord(self):
+        c = Coord([100.0, 200.0, 300.0], name="x", units="cm^-1")
+        ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(c))
+        assert ds.shape == (3,)
+        assert "x" in ds.coordset.names
+        assert_array_equal(ds.coordset["x"].data, [100.0, 200.0, 300.0])
+
+    def test_2d_with_two_coords(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0], name="x")
+        ds = NDDataset(np.ones((3, 2)), coordset=[coord_y, coord_x])
+        assert ds.shape == (3, 2)
+        assert len(ds.dims) == 2
+
+    def test_coord_order_in_2d_list(self):
+        """Coord passed as list should define the dimensions."""
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0], name="x")
+        ds = NDDataset(np.ones((3, 2)), coordset=[coord_y, coord_x])
+        assert ds.shape[0] == 3  # y size
+        assert ds.shape[1] == 2  # x size
+
+    def test_with_units_on_dataset(self):
+        c = Coord([100, 200, 300], name="x", units="nm")
+        ds = NDDataset([1, 2, 3], coordset=CoordSet(c), units="absorbance")
+        assert ds.units is not None
+
+
+# ==============================================================================
+# Dims / Shape / CoordSet consistency
+# ==============================================================================
+
+
+class TestNDDatasetDimsConsistency:
+    """Consistency between dataset shape, dims, and coordset."""
+
+    def test_dims_match_coord_names(self):
+        coord_x = Coord([10, 20], name="x")
+        coord_y = Coord([1, 2, 3], name="y")
+        ds = NDDataset(np.ones((3, 2)), coordset=[coord_y, coord_x])
+        assert ds.shape == (3, 2)
+        # each coord in coordset has a size matching the corresponding dim
+        for i, dim in enumerate(ds.dims):
+            assert ds.coordset[dim].size == ds.shape[i]
+
+    def test_shape_agrees_with_coord_sizes(self):
+        coord_x = Coord(np.linspace(4000, 1000, 10), name="x")
+        coord_y = Coord(np.linspace(0, 60, 100), name="y")
+        ds = NDDataset(np.ones((100, 10)), coordset=[coord_y, coord_x])
+        shape = ds.shape
+        assert shape[0] == 100  # y
+        assert shape[1] == 10  # x
+
+    def test_dims_are_strings(self):
+        c = Coord([1, 2, 3], name="wavelength")
+        ds = NDDataset([1, 2, 3], coordset=CoordSet(c))
+        assert all(isinstance(d, str) for d in ds.dims)
+
+
+# ==============================================================================
+# Assigning coordinates to existing dataset
+# ==============================================================================
+
+
+class TestNDDatasetCoordAssignment:
+    """Assigning CoordSet to an existing NDDataset."""
+
+    def test_assign_coordset_to_dataset(self):
+        c = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0])
+        assert ds.coordset is None
+        ds.coordset = CoordSet(c)
+        assert ds.coordset is not None
+        assert "x" in ds.coordset.names
+
+    def test_assign_coordset_with_name_in_names(self):
+        c = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0])
+        ds.coordset = CoordSet(c)
+        retrieved = ds.coordset["x"]
+        assert_array_equal(retrieved.data, [100.0, 200.0, 300.0])
+
+    def test_replace_coordset(self):
+        c1 = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0])
+        ds.coordset = CoordSet(c1)
+        c2 = Coord([400.0, 500.0, 600.0], name="x")
+        ds.coordset = CoordSet(c2)
+        assert_array_equal(ds.coordset["x"].data, [400.0, 500.0, 600.0])
+
+
+# ==============================================================================
+# Coord replacement through CoordSet API
+# ==============================================================================
+
+
+class TestNDDatasetCoordReplacement:
+    """Replacing coordinate data through the CoordSet API."""
+
+    def test_replace_coord_via_coordset(self):
+        c = Coord([1, 2, 3], name="x")
+        ds = NDDataset([10, 20, 30], coordset=CoordSet(c))
+        ds.coordset["x"] = Coord([100, 200, 300], name="x")
+        assert_array_equal(ds.coordset["x"].data, [100, 200, 300])
+
+    def test_add_new_coord_via_coordset(self):
+        c = Coord([1, 2, 3], name="x")
+        ds = NDDataset([10, 20, 30])
+        ds.coordset = CoordSet(c)
+        ds.coordset["y"] = Coord([100, 200], name="y")
+        assert "y" in ds.coordset.names
+
+    def test_set_units_on_coord_in_dataset(self):
+        c = Coord([1, 2, 3])
+        ds = NDDataset([10, 20, 30])
+        ds.coordset = CoordSet(c)
+        ds.coordset.set_units(x="cm^-1", force=True)
+        units = ds.coordset.units
+        assert any(u is not None for u in units)
+
+
+# ==============================================================================
+# Slicing → CoordSet interaction
+# ==============================================================================
+
+
+class TestNDDatasetSliceCoordSet:
+    """Slicing an NDDataset and verifying the resulting CoordSet."""
+
+    def test_slice_1d_trims_coord(self):
+        c = Coord([100, 200, 300, 400, 500], name="x")
+        ds = NDDataset([1, 2, 3, 4, 5], coordset=CoordSet(c))
+        ds_slice = ds[1:4]
+        assert ds_slice.shape == (3,)
+        assert_array_equal(ds_slice.coordset["x"].data, [200, 300, 400])
+
+    def test_slice_2d_trims_first_dim_coord(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0, 30.0, 40.0], name="x")
+        ds = NDDataset(np.ones((3, 4)), coordset=[coord_y, coord_x])
+        ds_slice = ds[0:2, :]
+        assert ds_slice.shape == (2, 4)
+        assert_array_equal(ds_slice.coordset["y"].data, [1.0, 2.0])
+
+    def test_slice_2d_trims_second_dim_coord(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0, 30.0, 40.0], name="x")
+        ds = NDDataset(np.ones((3, 4)), coordset=[coord_y, coord_x])
+        ds_slice = ds[:, 1:3]
+        assert ds_slice.shape == (3, 2)
+        assert_array_equal(ds_slice.coordset["x"].data, [20.0, 30.0])
+
+    def test_slice_both_dims(self):
+        coord_y = Coord([1.0, 2.0, 3.0, 4.0, 5.0], name="y")
+        coord_x = Coord([10.0, 20.0, 30.0], name="x")
+        ds = NDDataset(np.ones((5, 3)), coordset=[coord_y, coord_x])
+        ds_slice = ds[1:4, 0:2]
+        assert ds_slice.shape == (3, 2)
+        assert_array_equal(ds_slice.coordset["y"].data, [2.0, 3.0, 4.0])
+        assert_array_equal(ds_slice.coordset["x"].data, [10.0, 20.0])
+
+    def test_fancy_index_trims_coord(self):
+        c = Coord([100, 200, 300, 400, 500], name="x")
+        ds = NDDataset([1, 2, 3, 4, 5], coordset=CoordSet(c))
+        ds_slice = ds[[0, 2, 4]]
+        assert ds_slice.shape == (3,)
+        assert_array_equal(ds_slice.coordset["x"].data, [100, 300, 500])
+
+
+# ==============================================================================
+# Coord metadata preservation after slicing
+# ==============================================================================
+
+
+class TestCoordMetadataAfterSlice:
+    """Coord units, name, title preservation after slicing."""
+
+    def test_units_preserved_after_slice(self):
+        c = Coord([100, 200, 300, 400], name="x", units="cm^-1")
+        ds = NDDataset([1, 2, 3, 4], coordset=CoordSet(c))
+        ds_slice = ds[1:3]
+        assert_units_equal(ds_slice.coordset["x"].units, ur("cm^-1"))
+
+    def test_name_preserved_after_slice(self):
+        c = Coord([100, 200, 300, 400], name="x")
+        ds = NDDataset([1, 2, 3, 4], coordset=CoordSet(c))
+        ds_slice = ds[1:3]
+        assert ds_slice.coordset["x"].name == "x"
+
+    def test_title_preserved_after_slice(self):
+        c = Coord([100, 200, 300, 400], name="x", title="Wavenumber")
+        ds = NDDataset([1, 2, 3, 4], coordset=CoordSet(c))
+        ds_slice = ds[1:3]
+        assert ds_slice.coordset["x"].title == "Wavenumber"
+
+    def test_labels_preserved_after_slice(self):
+        c = Coord([100, 200, 300, 400], name="x", labels=["a", "b", "c", "d"])
+        ds = NDDataset([1, 2, 3, 4], coordset=CoordSet(c))
+        ds_slice = ds[1:3]
+        assert_array_equal(ds_slice.coordset["x"].labels, ["b", "c"])
+
+
+# ==============================================================================
+# Edge cases
+# ==============================================================================
+
+
+class TestNDDatasetCoordEdgeCases:
+    """Edge cases for dataset-coord integration."""
+
+    def test_dataset_without_coords(self):
+        ds = NDDataset([1, 2, 3])
+        assert ds.coordset is None or len(ds.coordset) >= 0
+
+    def test_coord_size_mismatch(self):
+        coord_x = Coord([1, 2], name="x")  # size 2
+        data = np.ones(3)  # size 3
+        with pytest.raises((ValueError, TypeError)):
+            NDDataset(data, coordset=CoordSet(coord_x))
+
+    def test_2d_coord_size_mismatch(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")  # size 3
+        coord_x = Coord([10.0, 20.0], name="x")  # size 2
+        data = np.ones((3, 5))  # x dim size 5, coord says 2
+        with pytest.raises((ValueError, TypeError)):
+            NDDataset(data, coordset=[coord_y, coord_x])
+
+    def test_coords_after_squeeze(self):
+        coord_x = Coord([1, 2, 3], name="x")
+        ds = NDDataset(np.ones((3, 1)), coordset=[coord_x, Coord([0], name="y")])
+        ds_sq = ds.squeeze()
+        assert ds_sq is not None
+
+    def test_coord_arange_from_dataset(self):
+        # coord supports arange-like creation
+        c2 = Coord(np.arange(5))
+        ds2 = NDDataset(np.ones(5), coordset=CoordSet(c2))
+        assert ds2.shape == (5,)
+
+    def test_dim_order_after_transpose(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0, 30.0], name="x")
+        ds = NDDataset(np.ones((3, 3)), coordset=[coord_y, coord_x])
+        ds_t = ds.T
+        assert ds_t.shape == (3, 3)
+
+    def test_coordset_after_bool_index(self):
+        c = Coord([100, 200, 300, 400], name="x")
+        ds = NDDataset([1, 2, 3, 4], coordset=CoordSet(c))
+        mask = np.array([True, False, True, False])
+        ds_masked = ds[mask]
+        assert ds_masked.coordset is not None


### PR DESCRIPTION
## Summary

Add the previously prepared behavioral hardening tests for `Coord`, `CoordSet`, and their integration with `NDDataset`.

## Motivation

The Coord/CoordSet audit work identified a need for a stronger behavioral safety net before architectural refactoring. These three test modules were prepared during the earlier hardening phase but were never actually committed, so this PR catches up that missing deliverable.

## Changes

- add `tests/test_core/test_dataset/test_coord_behavior.py`
- add `tests/test_core/test_dataset/test_coordset_behavior.py`
- add `tests/test_core/test_dataset/test_dataset_coords_behavior.py`
- cover coordinate construction, properties, slicing, units, lookup, replacement, and dataset integration paths with deterministic synthetic tests

## Testing

These tests were previously validated during the hardening/audit phase:

```bash
conda run -n scpy-core python -m pytest \
  tests/test_core/test_dataset/test_coord_behavior.py \
  tests/test_core/test_dataset/test_coordset_behavior.py \
  tests/test_core/test_dataset/test_dataset_coords_behavior.py \
  --no-header -q
```

Result recorded in the audit notes: `162 passed`

## Compatibility

- no source changes
- no public API changes
- no serialization changes
- test-only PR

## Follow-up

A separate lifecycle PR will build on this safety net by introducing the first narrow `CoordSet` lifecycle abstraction for dataset slicing.