### PR TITLE
refactor(coordset): mark lifecycle slicing API as internal

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,6 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
-- MAINT: Introduced a first ``CoordSet`` lifecycle slicing API and migrated
-  ``NDDataset`` slicing to delegate coordinate slicing through it, preserving
-  existing behavior without changing public APIs, storage, or serialization.
+- MAINT: Introduced an initial internal ``CoordSet`` lifecycle slicing API and
+  migrated ``NDDataset`` slicing to use it, preserving existing behavior
+  without changing public APIs, storage, or serialization.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,6 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
-- MAINT: Introduced a first ``CoordSet`` lifecycle slicing API and migrated
-  ``NDDataset`` slicing to delegate coordinate slicing through it, preserving
-  existing behavior without changing public APIs, storage, or serialization.
+- MAINT: Introduced an initial internal ``CoordSet`` lifecycle slicing API and
+  migrated ``NDDataset`` slicing to use it, preserving existing behavior
+  without changing public APIs, storage, or serialization.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -558,41 +558,6 @@ class CoordSet(HasTraits):
         """
         return self.__copy__()
 
-    def slice_dims(self, dims, items):
-        """
-        Return a coordset sliced according to dataset dimensions and indexers.
-
-        This lifecycle wrapper preserves the existing slicing semantics while
-        keeping same-dimension multi-coordinate details inside CoordSet.
-        """
-        names = self.names
-        new_coords = self.copy()
-
-        if isinstance(items, np.ndarray):
-            # Fancy indexing from NDDataset can be returned as a single array.
-            items = (items,)
-
-        for axis, item in enumerate(items):
-            name = dims[axis]
-            idx = names.index(name)
-            coord = self[idx]
-
-            if coord.is_empty:
-                new_coords[idx] = Coord(None, name=name)
-            elif not isinstance(coord, CoordSet):
-                new_coords[idx] = coord[item]
-            else:
-                newc = [c[item] for c in coord._coords]
-                new_coords[idx] = CoordSet(*newc[::-1], name=name)
-                new_coords[idx]._default = coord._default
-                new_coords[idx]._is_same_dim = coord._is_same_dim
-                new_coords[idx]._set_names(
-                    [f"_{i + 1}" for i in range(len(new_coords[idx]))]
-                )
-                new_coords[idx]._set_parent_dim(name)
-
-        return new_coords
-
     def keys(self):
         """
         Alias for names.
@@ -749,6 +714,41 @@ class CoordSet(HasTraits):
     # ----------------------------------------------------------------------------------
     # private methods
     # ----------------------------------------------------------------------------------
+    def _slice_dims(self, dims, items):
+        """
+        Return a coordset sliced according to dataset dimensions and indexers.
+
+        This lifecycle wrapper preserves the existing slicing semantics while
+        keeping same-dimension multi-coordinate details inside CoordSet.
+        """
+        names = self.names
+        new_coords = self.copy()
+
+        if isinstance(items, np.ndarray):
+            # Fancy indexing from NDDataset can be returned as a single array.
+            items = (items,)
+
+        for axis, item in enumerate(items):
+            name = dims[axis]
+            idx = names.index(name)
+            coord = self[idx]
+
+            if coord.is_empty:
+                new_coords[idx] = Coord(None, name=name)
+            elif not isinstance(coord, CoordSet):
+                new_coords[idx] = coord[item]
+            else:
+                newc = [c[item] for c in coord._coords]
+                new_coords[idx] = CoordSet(*newc[::-1], name=name)
+                new_coords[idx]._default = coord._default
+                new_coords[idx]._is_same_dim = coord._is_same_dim
+                new_coords[idx]._set_names(
+                    [f"_{i + 1}" for i in range(len(new_coords[idx]))]
+                )
+                new_coords[idx]._set_parent_dim(name)
+
+        return new_coords
+
     def _append(self, coord):
         # utility function to append coordinate with full validation
         if not isinstance(coord, tuple):

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -348,7 +348,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             return None
 
         if self._coordset is not None:
-            new_coords = self._coordset.slice_dims(self.dims, items)
+            new_coords = self._coordset._slice_dims(self.dims, items)
             new.set_coordset(*new_coords, keepnames=True)
 
         new.history = f"Slice extracted: ({saveditems})"

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -505,11 +505,11 @@ def test_coordset_deepcopy_isolation(coord0, coord1):
     assert "x" not in coords_copy.names
 
 
-def test_coordset_slice_dims_preserves_multicoord_default(coord0, coord1, coord2):
+def test_coordset__slice_dims_preserves_multicoord_default(coord0, coord1, coord2):
     coords = CoordSet(coord2, [coord0, coord0.copy()], coord1)
     coords.y.select(2)
 
-    sliced = coords.slice_dims(["z", "y", "x"], (slice(1, 4), slice(2, 5)))
+    sliced = coords._slice_dims(["z", "y", "x"], (slice(1, 4), slice(2, 5)))
 
     assert sliced.z.size == 2
     assert sliced.y.is_same_dim


### PR DESCRIPTION
## Summary

This PR renames the CoordSet lifecycle slicing method introduced in PR1 to make it explicitly internal.

## Motivation

The lifecycle API is intended as an internal architectural seam between NDDataset and CoordSet internals. It is not intended to become a documented user-facing CoordSet API.

Using an underscore-prefixed name avoids accidentally creating a new public contract.

## Changes

- Renamed the lifecycle slicing method with an internal API name.
- Moved the helper into the private-method section of `coordset.py` for consistency.
- Updated NDDataset slicing and the focused regression test accordingly.
- Clarified changelog / lifecycle wording to describe the helper as internal.

## Compatibility

- No public API changes.
- No behavior changes.
- No storage changes.
- No serialization changes.

## Testing

```bash
conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset.py::test_coordset__slice_dims_preserves_multicoord_default tests/test_core/test_dataset/test_dataset_coords_behavior.py -q -k "slice"
```

Result: `10 passed, 20 deselected`

```bash
pre-commit run --files docs/sources/whatsnew/changelog.rst docs/sources/whatsnew/latest.rst src/spectrochempy/core/dataset/coordset.py src/spectrochempy/core/dataset/nddataset.py tests/test_core/test_dataset/test_coordset.py
```

Result: passed