### PR TITLE
MAINT: Add internal CoordSet lifecycle API for dimension dropping

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,11 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Added an internal ``CoordSet`` lifecycle API for coordinate
+  assignment/replacement and migrated a focused ``NDDataset`` coordinate
+  assignment path to use it, preserving existing behavior while reducing
+  direct CoordSet internal coupling.
+
 - MAINT: Introduced a first ``CoordSet`` lifecycle slicing API and migrated
   ``NDDataset`` slicing to delegate coordinate slicing through it, preserving
   existing behavior without changing public APIs, storage, or serialization.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Added an internal ``CoordSet`` lifecycle API for dimension dropping
+  and migrated ``NDDataset.squeeze()`` to use it, preserving existing behavior
+  without changing public APIs, storage, or serialization.
+
 - MAINT: Added an internal ``CoordSet`` lifecycle API for coordinate
   assignment/replacement and migrated a focused ``NDDataset`` coordinate
   assignment path to use it, preserving existing behavior while reducing

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,10 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
+- MAINT: Added an internal ``CoordSet`` lifecycle API for dimension dropping
+  and migrated ``NDDataset.squeeze()`` to use it, preserving existing behavior
+  without changing public APIs, storage, or serialization.
+
 - MAINT: Added an internal ``CoordSet`` lifecycle API for coordinate
   assignment/replacement and migrated a focused ``NDDataset`` coordinate
   assignment path to use it, preserving existing behavior while reducing

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,11 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
+- MAINT: Added an internal ``CoordSet`` lifecycle API for coordinate
+  assignment/replacement and migrated a focused ``NDDataset`` coordinate
+  assignment path to use it, preserving existing behavior while reducing
+  direct CoordSet internal coupling.
+
 - MAINT: Introduced a first ``CoordSet`` lifecycle slicing API and migrated
   ``NDDataset`` slicing to delegate coordinate slicing through it, preserving
   existing behavior without changing public APIs, storage, or serialization.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -558,41 +558,6 @@ class CoordSet(HasTraits):
         """
         return self.__copy__()
 
-    def slice_dims(self, dims, items):
-        """
-        Return a coordset sliced according to dataset dimensions and indexers.
-
-        This lifecycle wrapper preserves the existing slicing semantics while
-        keeping same-dimension multi-coordinate details inside CoordSet.
-        """
-        names = self.names
-        new_coords = self.copy()
-
-        if isinstance(items, np.ndarray):
-            # Fancy indexing from NDDataset can be returned as a single array.
-            items = (items,)
-
-        for axis, item in enumerate(items):
-            name = dims[axis]
-            idx = names.index(name)
-            coord = self[idx]
-
-            if coord.is_empty:
-                new_coords[idx] = Coord(None, name=name)
-            elif not isinstance(coord, CoordSet):
-                new_coords[idx] = coord[item]
-            else:
-                newc = [c[item] for c in coord._coords]
-                new_coords[idx] = CoordSet(*newc[::-1], name=name)
-                new_coords[idx]._default = coord._default
-                new_coords[idx]._is_same_dim = coord._is_same_dim
-                new_coords[idx]._set_names(
-                    [f"_{i + 1}" for i in range(len(new_coords[idx]))]
-                )
-                new_coords[idx]._set_parent_dim(name)
-
-        return new_coords
-
     def keys(self):
         """
         Alias for names.
@@ -749,6 +714,74 @@ class CoordSet(HasTraits):
     # ----------------------------------------------------------------------------------
     # private methods
     # ----------------------------------------------------------------------------------
+    def _slice_dims(self, dims, items):
+        """
+        Return a coordset sliced according to dataset dimensions and indexers.
+
+        This lifecycle wrapper preserves the existing slicing semantics while
+        keeping same-dimension multi-coordinate details inside CoordSet.
+        """
+        names = self.names
+        new_coords = self.copy()
+
+        if isinstance(items, np.ndarray):
+            # Fancy indexing from NDDataset can be returned as a single array.
+            items = (items,)
+
+        for axis, item in enumerate(items):
+            name = dims[axis]
+            idx = names.index(name)
+            coord = self[idx]
+
+            if coord.is_empty:
+                new_coords[idx] = Coord(None, name=name)
+            elif not isinstance(coord, CoordSet):
+                new_coords[idx] = coord[item]
+            else:
+                newc = [c[item] for c in coord._coords]
+                new_coords[idx] = CoordSet(*newc[::-1], name=name)
+                new_coords[idx]._default = coord._default
+                new_coords[idx]._is_same_dim = coord._is_same_dim
+                new_coords[idx]._set_names(
+                    [f"_{i + 1}" for i in range(len(new_coords[idx]))]
+                )
+                new_coords[idx]._set_parent_dim(name)
+
+        return new_coords
+
+    def _replace_dim(self, dim, value):
+        """
+        Return a coordset with one dimension coordinate replaced.
+
+        This lifecycle wrapper preserves the existing assignment semantics used
+        by ``NDDataset`` for simple coordinates and same-dimension
+        multi-coordinate groups.
+        """
+        new_coords = self.copy()
+        idx = new_coords.names.index(dim)
+
+        listcoord = False
+        if isinstance(value, list):
+            listcoord = all(isinstance(item, Coord) for item in value)
+
+        if listcoord:
+            new_coords[idx] = list(CoordSet(value).to_dict().values())[0]
+            new_coords[idx].name = dim
+            new_coords[idx]._is_same_dim = True
+        elif isinstance(value, CoordSet):
+            if len(value) > 1:
+                value = CoordSet(value)
+            new_coords[idx] = list(value.to_dict().values())[0]
+            new_coords[idx].name = dim
+            new_coords[idx]._is_same_dim = True
+        elif isinstance(value, Coord):
+            value.name = dim
+            new_coords[idx] = value
+        else:
+            new_coords[idx] = Coord(value, name=dim)
+
+        return new_coords
+
     def _append(self, coord):
         # utility function to append coordinate with full validation
         if not isinstance(coord, tuple):

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -782,6 +782,28 @@ class CoordSet(HasTraits):
 
         return new_coords
 
+    def _drop_dims(self, dims, *, missing="ignore"):
+        """
+        Return a coordset with the given dimension coordinates removed.
+
+        This lifecycle wrapper preserves the existing squeeze-time semantics
+        while keeping missing-dimension handling inside ``CoordSet``.
+        """
+        if missing not in {"ignore", "raise"}:
+            raise ValueError("missing must be either 'ignore' or 'raise'")
+
+        if isinstance(dims, str):
+            dims = (dims,)
+
+        new_coords = self.copy()
+        for dim in dims:
+            if dim in new_coords.names:
+                del new_coords[dim]
+            elif missing == "raise":
+                raise KeyError(dim)
+
+        return new_coords
+
     def _append(self, coord):
         # utility function to append coordinate with full validation
         if not isinstance(coord, tuple):

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -1132,17 +1132,12 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         new, axis = super().squeeze(*dims, inplace=inplace, return_axis=True)
 
         if axis is not None and new._coordset is not None:
-            # if there are coordinates they have to be squeezed as well (remove
-            # coordinate for the squeezed axis)
-
-            for i in axis:
-                dim = old[i]
-                # Delete the coord for the squeezed dimension, if it exists.
-                # A dimension might have no explicit coord (e.g., singleton
-                # dim auto-created without a coord), in which case there is
-                # nothing to clean up.
-                with suppress(KeyError):
-                    del new._coordset[dim]
+            # Remove coordinates for squeezed axes, tolerating singleton dims
+            # that never had an explicit coordinate assigned.
+            new._coordset = new._coordset._drop_dims(
+                [old[i] for i in axis],
+                missing="ignore",
+            )
 
         return new
 

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -348,7 +348,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             return None
 
         if self._coordset is not None:
-            new_coords = self._coordset.slice_dims(self.dims, items)
+            new_coords = self._coordset._slice_dims(self.dims, items)
             new.set_coordset(*new_coords, keepnames=True)
 
         new.history = f"Slice extracted: ({saveditems})"
@@ -471,26 +471,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
                 if self._coordset is None:
                     # we need to create a coordset first
                     self.set_coordset({self.dims[i]: None for i in range(self.ndim)})
-                idx = self._coordset.names.index(key)
-                _coordset = self._coordset
-                listcoord = False
-                if isinstance(value, list):
-                    listcoord = all(isinstance(item, Coord) for item in value)
-                if listcoord:
-                    _coordset[idx] = list(CoordSet(value).to_dict().values())[0]
-                    _coordset[idx].name = key
-                    _coordset[idx]._is_same_dim = True
-                elif isinstance(value, CoordSet):
-                    if len(value) > 1:
-                        value = CoordSet(value)
-                    _coordset[idx] = list(value.to_dict().values())[0]
-                    _coordset[idx].name = key
-                    _coordset[idx]._is_same_dim = True
-                elif isinstance(value, Coord):
-                    value.name = key
-                    _coordset[idx] = value
-                else:
-                    _coordset[idx] = Coord(value, name=key)
+                _coordset = self._coordset._replace_dim(key, value)
                 _coordset = self._valid_coordset(_coordset)
                 self._coordset.set(_coordset)
             else:

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -532,6 +532,22 @@ def test_coordset__replace_dim_preserves_multicoord_behavior():
     assert_coord_almost_equal(updated.x["_2"], x2)
 
 
+def test_coordset__drop_dims_preserves_remaining_multicoord_state(
+    coord0, coord1, coord2
+):
+    coords = CoordSet(coord2, [coord0, coord0.copy()], coord1)
+    coords.y.select(2)
+
+    updated = coords._drop_dims(["z", "u"], missing="ignore")
+
+    assert updated.names == ["x", "y"]
+    assert updated.y.is_same_dim
+    assert updated.y.default == updated.y._2
+    assert_coord_almost_equal(updated.y._1, coords.y._1, decimal=1)
+    assert_coord_almost_equal(updated.y._2, coords.y._2, decimal=1)
+    assert updated.x == coords.x
+
+
 def test_coordset_arithmetics():
     # typical use case
     ds = NDDataset([0.0, 1.0, 2.0])

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -505,11 +505,11 @@ def test_coordset_deepcopy_isolation(coord0, coord1):
     assert "x" not in coords_copy.names
 
 
-def test_coordset_slice_dims_preserves_multicoord_default(coord0, coord1, coord2):
+def test_coordset__slice_dims_preserves_multicoord_default(coord0, coord1, coord2):
     coords = CoordSet(coord2, [coord0, coord0.copy()], coord1)
     coords.y.select(2)
 
-    sliced = coords.slice_dims(["z", "y", "x"], (slice(1, 4), slice(2, 5)))
+    sliced = coords._slice_dims(["z", "y", "x"], (slice(1, 4), slice(2, 5)))
 
     assert sliced.z.size == 2
     assert sliced.y.is_same_dim
@@ -517,6 +517,19 @@ def test_coordset_slice_dims_preserves_multicoord_default(coord0, coord1, coord2
     assert_coord_almost_equal(sliced.y._1, coord0[2:5], decimal=1)
     assert_coord_almost_equal(sliced.y._2, coord0[2:5], decimal=1)
     assert sliced.x == coords.x
+
+
+def test_coordset__replace_dim_preserves_multicoord_behavior():
+    coords = CoordSet(x=Coord([0.0, 1.0, 2.0]))
+    x2 = Coord(np.array([0.5, 0.8, 9.0]))
+    x1 = Coord(np.array([1.5, 5.8, -9.0]))
+
+    updated = coords._replace_dim("x", CoordSet(Coord(x2), Coord(x1)))
+
+    assert isinstance(updated.x, CoordSet)
+    assert updated.x.is_same_dim
+    assert_coord_almost_equal(updated.x["_1"], x1)
+    assert_coord_almost_equal(updated.x["_2"], x2)
 
 
 def test_coordset_arithmetics():

--- a/tests/test_core/test_dataset/test_dataset_coords_behavior.py
+++ b/tests/test_core/test_dataset/test_dataset_coords_behavior.py
@@ -17,6 +17,7 @@ from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.units import ur
 from spectrochempy.utils.testing import assert_array_equal
+from spectrochempy.utils.testing import assert_coord_almost_equal
 from spectrochempy.utils.testing import assert_units_equal
 
 # ==============================================================================
@@ -146,6 +147,55 @@ class TestNDDatasetCoordReplacement:
         ds.coordset.set_units(x="cm^-1", force=True)
         units = ds.coordset.units
         assert any(u is not None for u in units)
+
+    def test_replace_coord_via_dimension_attribute_preserves_metadata(self):
+        c = Coord([1, 2, 3], name="x", title="Old", units="cm^-1")
+        ds = NDDataset([10, 20, 30], coordset=CoordSet(c))
+        replacement = Coord(
+            [100, 200, 300],
+            name="wavelength",
+            title="Wavenumber",
+            units="nm",
+            labels=["a", "b", "c"],
+        )
+
+        ds.x = replacement
+
+        assert ds.shape == (3,)
+        assert_array_equal(ds.x.data, [100, 200, 300])
+        assert ds.x.name == "x"
+        assert ds.x.title == "Wavenumber"
+        assert_units_equal(ds.x.units, ur.nm)
+        assert_array_equal(ds.x.labels, ["a", "b", "c"])
+
+    def test_replace_coord_via_dimension_attribute_with_matching_length(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0], name="x")
+        ds = NDDataset(np.ones((3, 2)), coordset=[coord_y, coord_x])
+
+        ds.x = [100.0, 200.0]
+
+        assert ds.shape == (3, 2)
+        assert_array_equal(ds.x.data, [100.0, 200.0])
+
+    def test_replace_coord_via_dimension_attribute_rejects_wrong_length(self):
+        c = Coord([1, 2, 3], name="x")
+        ds = NDDataset([10, 20, 30], coordset=CoordSet(c))
+
+        with pytest.raises(ValueError, match="coordinate size=2 != data shape"):
+            ds.x = Coord([100, 200], name="wrong")
+
+    def test_replace_coord_via_dimension_attribute_preserves_multicoord_behavior(self):
+        ds = NDDataset([0.0, 1.0, 2.0])
+        x2 = Coord(np.array([0.5, 0.8, 9.0]))
+        x1 = Coord(np.array([1.5, 5.8, -9.0]))
+
+        ds.x = CoordSet(Coord(x2), Coord(x1))
+
+        assert isinstance(ds.x, CoordSet)
+        assert ds.x.is_same_dim
+        assert_coord_almost_equal(ds.x["_1"], x1)
+        assert_coord_almost_equal(ds.x["_2"], x2)
 
 
 # ==============================================================================

--- a/tests/test_core/test_dataset/test_dataset_squeeze.py
+++ b/tests/test_core/test_dataset/test_dataset_squeeze.py
@@ -65,5 +65,27 @@ def test_squeeze_named_dims_coord_consistency():
     assert squeezed.x.title == "temperature"
 
 
+def test_squeeze_preserves_remaining_multicoord_dimension():
+    """Squeeze keeps same-dimension multi-coordinates on surviving dims."""
+    coord_y = scp.Coord(np.array([0.0]), title="row")
+    coord_x_primary = scp.Coord(np.array([10.0, 20.0, 30.0]), title="wavelength")
+    coord_x_secondary = scp.Coord(np.array([1.0, 2.0, 3.0]), title="index")
+    ds = scp.NDDataset(np.ones((1, 3)), coordset=[coord_y, coord_x_primary])
+    ds.x = scp.CoordSet(coord_x_secondary.copy(), coord_x_primary.copy())
+    ds.x.select(2)
+
+    squeezed = ds.squeeze()
+
+    assert squeezed.shape == (3,)
+    assert squeezed.dims == ["x"]
+    assert isinstance(squeezed.x, scp.CoordSet)
+    assert squeezed.x.is_same_dim
+    assert squeezed.x.default == squeezed.x._2
+    assert_array_equal(squeezed.x._1.data, np.array([10.0, 20.0, 30.0]))
+    assert_array_equal(squeezed.x._2.data, np.array([1.0, 2.0, 3.0]))
+    assert squeezed.x._1.title == "wavelength"
+    assert squeezed.x._2.title == "index"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Superseded by #1047, which carries the same PR3 change on a clean branch from `upstream/master` for a one-commit review diff.

Please review #1047 instead.