### PR TITLE
MAINT: Add internal CoordSet lifecycle API for reshape coordinates

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,11 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Added an internal ``CoordSet`` lifecycle helper for reshape-related
+  coordinate handling and migrated ``NDDataset.reshape()`` to use it,
+  preserving existing behavior without changing public APIs, storage, or
+  serialization.
+
 - MAINT: Added an internal ``CoordSet`` lifecycle API for dimension dropping
   and migrated ``NDDataset.squeeze()`` to use it, preserving existing behavior
   without changing public APIs, storage, or serialization.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,11 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
+- MAINT: Added an internal ``CoordSet`` lifecycle helper for reshape-related
+  coordinate handling and migrated ``NDDataset.reshape()`` to use it,
+  preserving existing behavior without changing public APIs, storage, or
+  serialization.
+
 - MAINT: Added an internal ``CoordSet`` lifecycle API for dimension dropping
   and migrated ``NDDataset.squeeze()`` to use it, preserving existing behavior
   without changing public APIs, storage, or serialization.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -804,6 +804,79 @@ class CoordSet(HasTraits):
 
         return new_coords
 
+    def _reshape_dims(
+        self,
+        old_dims,
+        old_shape,
+        new_dims,
+        new_shape,
+        *,
+        coord_policy,
+        coords=None,
+    ):
+        """
+        Return a coordset rebuilt for a reshape operation.
+
+        This lifecycle wrapper preserves the existing reshape-time coordinate
+        handling while keeping coordinate reconstruction policy inside
+        ``CoordSet``.
+        """
+        if coord_policy == "drop":
+            return None
+
+        if coords is not None:
+            for dim_name, coord in coords.items():
+                if dim_name not in new_dims:
+                    raise ValueError(
+                        f"Coordinate dim '{dim_name}' not found in new dims {new_dims}."
+                    )
+                if len(coord) != new_shape[new_dims.index(dim_name)]:
+                    raise ValueError(
+                        f"Coordinate for '{dim_name}' has length {len(coord)}, "
+                        f"expected {new_shape[new_dims.index(dim_name)]}."
+                    )
+
+        new_coords = []
+        for new_idx, new_dim in enumerate(new_dims):
+            new_size = new_shape[new_idx]
+
+            if coords is not None and new_dim in coords:
+                new_coords.append(coords[new_dim])
+                continue
+
+            if coord_policy == "strict":
+                for old_idx_s, old_dim_s in enumerate(old_dims):
+                    old_size_s = old_shape[old_idx_s]
+                    matches = [
+                        i for i, size in enumerate(new_shape) if size == old_size_s
+                    ]
+                    if len(matches) != 1:
+                        raise ValueError(
+                            f"strict mode: cannot unambiguously map dim "
+                            f"'{old_dim_s}' (size {old_size_s}) to the new "
+                            f"shape {new_shape}."
+                        )
+                    if new_dims[matches[0]] != old_dim_s:
+                        raise ValueError(
+                            f"strict mode: dim '{old_dim_s}' maps to new dim "
+                            f"'{new_dims[matches[0]]}' but name changed."
+                        )
+                if new_dim in self.names:
+                    new_coords.append(self[new_dim].copy())
+                else:
+                    new_coords.append(None)
+            else:  # "safe"
+                if (
+                    new_dim in old_dims
+                    and old_shape[old_dims.index(new_dim)] == new_size
+                    and new_dim in self.names
+                ):
+                    new_coords.append(self[new_dim].copy())
+                else:
+                    new_coords.append(None)
+
+        return CoordSet(*new_coords, dims=new_dims.copy())
+
     def _append(self, coord):
         # utility function to append coordinate with full validation
         if not isinstance(coord, tuple):

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -1554,7 +1554,8 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         # --- Coordinate handling --------------------------------------------
         old_coordset = self.coordset
 
-        # Validate explicit coords early
+        # Explicit coordinate overrides are validated even when the source
+        # dataset has no coordset to preserve.
         if coords is not None:
             for dim_name, coord in coords.items():
                 if dim_name not in new_dims:
@@ -1567,54 +1568,17 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
                         f"expected {shape[new_dims.index(dim_name)]}."
                     )
 
-        if coord_policy == "drop" or old_coordset is None:
+        if old_coordset is None:
             new._coordset = None
         else:
-            # Build the list of coords for all new dimensions
-            new_coords = []
-            for new_idx, new_dim in enumerate(new_dims):
-                new_size = shape[new_idx]
-
-                # 1. Explicit user coords take precedence
-                if coords is not None and new_dim in coords:
-                    new_coords.append(coords[new_dim])
-                    continue
-
-                # 2. Policy-based coord preservation
-                if coord_policy == "strict":
-                    # Validate that every old dim maps unambiguously
-                    for old_idx_s, old_dim_s in enumerate(old_dims):
-                        old_size_s = old_shape[old_idx_s]
-                        matches = [i for i, s in enumerate(shape) if s == old_size_s]
-                        if len(matches) != 1:
-                            raise ValueError(
-                                f"strict mode: cannot unambiguously map dim "
-                                f"'{old_dim_s}' (size {old_size_s}) to the new "
-                                f"shape {shape}."
-                            )
-                        if new_dims[matches[0]] != old_dim_s:
-                            raise ValueError(
-                                f"strict mode: dim '{old_dim_s}' maps to new dim "
-                                f"'{new_dims[matches[0]]}' but name changed."
-                            )
-                    # All valid — copy preserved coord if present
-                    if old_coordset is not None and new_dim in old_coordset.names:
-                        new_coords.append(old_coordset[new_dim].copy())
-                    else:
-                        new_coords.append(None)
-
-                else:  # "safe"
-                    if (
-                        new_dim in old_dims
-                        and old_shape[old_dims.index(new_dim)] == new_size
-                        and old_coordset is not None
-                        and new_dim in old_coordset.names
-                    ):
-                        new_coords.append(old_coordset[new_dim].copy())
-                    else:
-                        new_coords.append(None)
-
-            new._coordset = CoordSet(*new_coords, dims=new_dims.copy())
+            new._coordset = old_coordset._reshape_dims(
+                old_dims,
+                old_shape,
+                new_dims,
+                shape,
+                coord_policy=coord_policy,
+                coords=coords,
+            )
 
         new.history = f"Data reshaped from {old_shape} to {shape}"
         return new

--- a/tests/test_core/test_dataset/test_dataset_reshape.py
+++ b/tests/test_core/test_dataset/test_dataset_reshape.py
@@ -1,0 +1,98 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.utils.testing import assert_array_equal
+
+
+def test_reshape_noop_preserves_coordinates():
+    coord_y = scp.Coord(np.array([1.0, 2.0, 3.0]), title="time")
+    coord_x = scp.Coord(np.array([10.0, 20.0]), title="wavelength")
+    ds = scp.NDDataset(np.arange(6.0).reshape(3, 2), coordset=[coord_y, coord_x])
+
+    reshaped = ds.reshape((3, 2))
+
+    assert reshaped.shape == (3, 2)
+    assert reshaped.dims == ["y", "x"]
+    assert_array_equal(reshaped.y.data, coord_y.data)
+    assert_array_equal(reshaped.x.data, coord_x.data)
+    assert reshaped.y.title == "time"
+    assert reshaped.x.title == "wavelength"
+
+
+def test_reshape_drop_policy_clears_coordset():
+    coord_y = scp.Coord(np.array([1.0, 2.0, 3.0]), title="time")
+    coord_x = scp.Coord(np.array([10.0, 20.0]), title="wavelength")
+    ds = scp.NDDataset(np.arange(6.0).reshape(3, 2), coordset=[coord_y, coord_x])
+
+    reshaped = ds.reshape((6,), coord_policy="drop")
+
+    assert reshaped.shape == (6,)
+    assert reshaped.coordset is None
+
+
+def test_reshape_with_explicit_dims_and_coords_override():
+    coord_y = scp.Coord(np.array([1.0, 2.0, 3.0]), title="time")
+    coord_x = scp.Coord(np.array([10.0, 20.0]), title="wavelength")
+    ds = scp.NDDataset(np.arange(6.0).reshape(3, 2), coordset=[coord_y, coord_x])
+    cycle = scp.Coord(np.array([1.0]), title="cycle index")
+
+    reshaped = ds.reshape(
+        (1, 3, 2),
+        dims=("cycle", "y", "x"),
+        coords={"cycle": cycle},
+    )
+
+    assert reshaped.shape == (1, 3, 2)
+    assert reshaped.dims == ["cycle", "y", "x"]
+    assert_array_equal(reshaped.coordset["cycle"].data, [1.0])
+    assert reshaped.coordset["cycle"].title == "cycle index"
+    assert_array_equal(reshaped.y.data, coord_y.data)
+    assert_array_equal(reshaped.x.data, coord_x.data)
+
+
+def test_reshape_without_source_coordset_keeps_coordset_none():
+    ds = scp.NDDataset(np.arange(6.0).reshape(3, 2))
+
+    reshaped = ds.reshape((1, 3, 2), dims=("u", "y", "x"))
+
+    assert reshaped.shape == (1, 3, 2)
+    assert reshaped.coordset is None
+
+
+def test_reshape_strict_preserves_current_ambiguity_error():
+    coord_y = scp.Coord(np.array([1.0, 2.0]), title="rows")
+    coord_x = scp.Coord(np.array([10.0, 20.0]), title="cols")
+    ds = scp.NDDataset(np.arange(4.0).reshape(2, 2), coordset=[coord_y, coord_x])
+
+    with pytest.raises(
+        ValueError,
+        match="strict mode: cannot unambiguously map dim",
+    ):
+        ds.reshape((2, 2), coord_policy="strict")
+
+
+def test_reshape_preserves_same_dimension_multicoord_when_dim_survives():
+    coord_y = scp.Coord(np.array([1.0, 2.0, 3.0]), title="time")
+    coord_x_primary = scp.Coord(np.array([10.0, 20.0]), title="wavelength")
+    coord_x_secondary = scp.Coord(np.array([100.0, 200.0]), title="index")
+    ds = scp.NDDataset(
+        np.arange(6.0).reshape(3, 2), coordset=[coord_y, coord_x_primary]
+    )
+    ds.x = scp.CoordSet(coord_x_secondary.copy(), coord_x_primary.copy())
+    ds.x.select(2)
+
+    reshaped = ds.reshape((1, 3, 2), dims=("u", "y", "x"))
+
+    assert reshaped.shape == (1, 3, 2)
+    assert isinstance(reshaped.x, scp.CoordSet)
+    assert reshaped.x.is_same_dim
+    assert reshaped.x.default == reshaped.x._2
+    assert_array_equal(reshaped.x._1.data, coord_x_primary.data)
+    assert_array_equal(reshaped.x._2.data, coord_x_secondary.data)


### PR DESCRIPTION
## Summary

This PR introduces an internal `CoordSet` lifecycle helper for reshape-related coordinate handling and migrates `NDDataset.reshape()` to use it.

## Motivation

The previous lifecycle PRs moved slicing, coordinate assignment/replacement, and dimension dropping into internal `CoordSet` lifecycle helpers. Reshape is the next coordinate lifecycle hotspot where `NDDataset` still owns `CoordSet`-specific coordinate reconstruction logic.

## Changes

- Added an internal `CoordSet` lifecycle helper for reshape coordinate handling.
- Migrated `NDDataset.reshape()` to use it.
- Added focused behavioral tests.
- Updated the changelog.

## Compatibility

- No public API changes.
- No `CoordSet` storage redesign.
- No serialization changes.
- Existing behavior is intended to be preserved.

## Testing

```bash
conda run -n scpy-core python -m pytest \
  tests/test_core/test_dataset/test_dataset_reshape.py \
  tests/test_core/test_dataset/test_dataset_slicing.py \
  -q -k "reshape"
```

Result: `6 passed, 14 deselected`

```bash
pre-commit run --files \
  docs/sources/whatsnew/changelog.rst \
  docs/sources/whatsnew/latest.rst \
  src/spectrochempy/core/dataset/coordset.py \
  src/spectrochempy/core/dataset/nddataset.py \
  tests/test_core/test_dataset/test_dataset_reshape.py
```

Result: passed

## Follow-up work

Potential future lifecycle PRs:

- ndmath reduction lifecycle handling
- concatenate lifecycle handling
- interpolation lifecycle handling
- serialization lifecycle boundary
