### PR TITLE
MAINT: reuse lifecycle reduction handling for extrema

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -58,6 +58,9 @@ Developer
   dimension cleanup and migrated ``ndmath._reduce_dims()`` to use it,
   preserving existing behavior without changing public APIs, storage, or
   serialization.
+- MAINT: Reused the internal ``CoordSet`` reduction lifecycle helper for extrema
+  reduction dimension cleanup, preserving existing behavior without changing
+  public APIs, storage, or serialization.
 
 - MAINT: Added an internal ``CoordSet`` lifecycle helper for reshape-related
   coordinate handling and migrated ``NDDataset.reshape()`` to use it,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -19,6 +19,9 @@ Developer
   dimension cleanup and migrated ``ndmath._reduce_dims()`` to use it,
   preserving existing behavior without changing public APIs, storage, or
   serialization.
+- MAINT: Reused the internal ``CoordSet`` reduction lifecycle helper for extrema
+  reduction dimension cleanup, preserving existing behavior without changing
+  public APIs, storage, or serialization.
 
 - MAINT: Added an internal ``CoordSet`` lifecycle helper for reshape-related
   coordinate handling and migrated ``NDDataset.reshape()`` to use it,

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -787,14 +787,10 @@ class NDMath:
             coordset = cls.coordset
             if coordset is not None:
                 if dim is not None:
-                    idx = coordset.names.index(dim)
+                    new_coordset = coordset._reduce_dim(dim, keepdims=keepdims)
+                    cls._coordset = new_coordset
                     if not keepdims:
-                        del coordset.coords[idx]
                         dims.remove(dim)
-                    else:
-                        coordset.coords[idx].data = [
-                            0,
-                        ]
                 else:
                     # find the coordinates
                     idx = np.ma.argmax(dataset)
@@ -871,14 +867,10 @@ class NDMath:
             coordset = cls.coordset
             if coordset is not None:
                 if dim is not None:
-                    idx = coordset.names.index(dim)
+                    new_coordset = coordset._reduce_dim(dim, keepdims=keepdims)
+                    cls._coordset = new_coordset
                     if not keepdims:
-                        del coordset.coords[idx]
                         dims.remove(dim)
-                    else:
-                        coordset.coords[idx].data = [
-                            0,
-                        ]
                 else:
                     # find the coordinates
                     idx = np.ma.argmin(dataset)

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -736,6 +736,156 @@ def test_max_min_operations(IR_dataset_1D, IR_dataset_2D):
     assert nd2m.shape == (55, 1)
 
 
+# ===============================================================================
+# CoordSet lifecycle — amax / amin dimension cleanup
+# ===============================================================================
+
+
+def test_amax_dim_reduces_coordset():
+    """amax(dim=...) removes the reduced coordinate when keepdims=False."""
+    y = Coord(np.arange(4.0), title="rows")
+    x = Coord(np.arange(5.0), title="cols")
+    ds = NDDataset(
+        np.arange(20.0).reshape(4, 5),
+        coordset=[y, x],
+        title="test",
+        units="m",
+    )
+
+    result = ds.amax(dim="y")
+    assert "y" not in result.dims
+    assert result.coordset is not None
+    assert result.coordset.names == ["x"]
+    assert result.title == "test"
+    assert_units_equal(result.units, ur.m)
+
+    result = ds.amax(dim="x")
+    assert "x" not in result.dims
+    assert result.coordset is not None
+    assert result.coordset.names == ["y"]
+    assert result.title == "test"
+    assert_units_equal(result.units, ur.m)
+
+
+def test_amin_dim_reduces_coordset():
+    """amin(dim=...) removes the reduced coordinate when keepdims=False."""
+    y = Coord(np.arange(4.0), title="rows")
+    x = Coord(np.arange(5.0), title="cols")
+    ds = NDDataset(
+        np.arange(20.0).reshape(4, 5),
+        coordset=[y, x],
+        title="test",
+        units="m",
+    )
+
+    result = ds.amin(dim="y")
+    assert "y" not in result.dims
+    assert result.coordset is not None
+    assert result.coordset.names == ["x"]
+
+    result = ds.amin(dim="x")
+    assert "x" not in result.dims
+    assert result.coordset is not None
+    assert result.coordset.names == ["y"]
+
+
+def test_amax_keepdims_preserves_coord():
+    """amax(dim=..., keepdims=True) keeps dim with singleton coordinate."""
+    x = Coord(np.arange(5.0), title="cols")
+    ds = NDDataset(np.arange(5.0), coordset=CoordSet(x=x))
+
+    result = ds.amax(dim="x", keepdims=True)
+    assert "x" in result.dims
+    assert result.shape == (1,)
+    assert result.coordset is not None
+    assert result.coordset["x"].data == [0]
+
+
+def test_amin_keepdims_preserves_coord():
+    """amin(dim=..., keepdims=True) keeps dim with singleton coordinate."""
+    x = Coord(np.arange(5.0), title="cols")
+    ds = NDDataset(np.arange(5.0), coordset=CoordSet(x=x))
+
+    result = ds.amin(dim="x", keepdims=True)
+    assert "x" in result.dims
+    assert result.shape == (1,)
+    assert result.coordset is not None
+    assert result.coordset["x"].data == [0]
+
+
+def test_amax_preserves_surviving_coords():
+    """amax(dim=...) preserves coordinates of non-reduced dimensions."""
+    y = Coord(np.arange(4.0), title="rows")
+    x = Coord(np.linspace(100, 500, 5), title="wavenumber", units="cm^-1")
+    ds = NDDataset(
+        np.arange(20.0).reshape(4, 5),
+        coordset=[y, x],
+        title="spectrum",
+        units="absorbance",
+    )
+
+    result = ds.amax(dim="y")
+    assert result.coordset is not None
+    assert "x" in result.dims
+    surviving = result.coordset["x"]
+    assert surviving.title == "wavenumber"
+    assert_units_equal(surviving.units, ur.cm**-1)
+
+
+def test_amax_preserves_multi_coord_other_dim():
+    """Amax on one dim preserves multiple coords on the other dim."""
+    y = Coord(np.arange(4.0), title="rows")
+    x1 = Coord(np.linspace(100, 500, 5), title="wavenumber")
+    x2 = Coord(np.arange(5.0), title="second")
+    ds = NDDataset(
+        np.arange(20.0).reshape(4, 5),
+        coordset=[y, CoordSet(x1, x2)],
+        title="test",
+    )
+
+    # Determine which dim name was assigned to the inner CoordSet
+    # (2D datasets have default dims ["y", "x"]; the inner CoordSet
+    # spanning 5 elements gets the second dim)
+    non_reduced_dim = ds.dims[1]
+
+    result = ds.amax(dim="y")
+    assert result.coordset is not None
+    assert "y" not in result.dims
+    # The non-reduced dim survived with both inner coordinates
+    surviving = result.coordset[non_reduced_dim]
+    assert isinstance(surviving, CoordSet)
+    assert len(surviving) == 2
+
+
+def test_global_amax_amin_keepdims_reconstructs_coords():
+    """
+    amax/amin with dim=None, keepdims=True reconstructs coords.
+
+    This exercises the extrema-coordinate path that remains in ndmath.py.
+    """
+    y = Coord(np.array([10.0, 20.0, 30.0, 40.0]), title="y-coord")
+    x = Coord(np.array([1.0, 5.0, 2.0]), title="x-coord")
+    data = np.array(
+        [[1.0, 9.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 2.0], [0.0, 3.0, 1.0]]
+    )
+    ds = NDDataset(data, coordset=[y, x])
+
+    # dim=None + keepdims=True goes through the extrema coord reconstruction path
+    result = ds.amax(dim=None, keepdims=True)
+    assert isinstance(result, NDDataset)
+    assert result.coordset is not None
+    # The global max (9.0) is at (y=0, x=1)
+    assert result.coordset["y"].data[0] == 10.0
+    assert result.coordset["x"].data[0] == 5.0
+
+    result = ds.amin(dim=None, keepdims=True)
+    assert isinstance(result, NDDataset)
+    assert result.coordset is not None
+    # The global min (0.0) is at (y=3, x=0)
+    assert result.coordset["y"].data[0] == 40.0
+    assert result.coordset["x"].data[0] == 1.0
+
+
 def test_clip_operation():
     """Test clip operation."""
     # Create dataset with negative values


### PR DESCRIPTION
## Description

Replaced the inline dimension-cleanup in `amax()`/`amin()` with `CoordSet._reduce_dim(dim, keepdims=keepdims)` for the `dim is not None` branch, preserving the global-extrema coordinate reconstruction path in `ndmath.py`.

## Changes

- `ndmath.py`: Inline coordset mutation replaced by lifecycle helper call + assignment
- `test_ndmath.py`: 7 focused behavioral tests for amax/amin dimension cleanup
- `changelog.rst`: MAINT entry
- `latest.rst`: Auto-synced by pre-commit hook

## Scope

- ✅ amax()/amin() dimension-cleanup only
- ❌ No public API changes
- ❌ No CoordSet storage redesign
- ❌ No serialization changes
- ❌ No argmax/argmin/coordmax/coordmin changes
- ❌ No concatenate/interpolation changes

## Validation

```
228 passed, 3 skipped (IR data-dependent) — all clean
57 CoordSet behavior tests — all clean
ruff check — no new issues
```