### PR TITLE
MAINT: Extract CoordSet lifecycle handling for interpolation coordinates

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -82,3 +82,8 @@ Developer
 - MAINT: Introduced an initial internal ``CoordSet`` lifecycle slicing API and
   migrated ``NDDataset`` slicing to use it, preserving existing behavior
   without changing public APIs, storage, or serialization.
+
+- MAINT: Added an internal ``CoordSet`` lifecycle helper for interpolation
+  coordinate reconstruction and migrated ``interpolate()`` to use it,
+  preserving existing behavior without changing public APIs, storage, or
+  serialization.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -43,3 +43,8 @@ Developer
 - MAINT: Introduced an initial internal ``CoordSet`` lifecycle slicing API and
   migrated ``NDDataset`` slicing to use it, preserving existing behavior
   without changing public APIs, storage, or serialization.
+
+- MAINT: Added an internal ``CoordSet`` lifecycle helper for interpolation
+  coordinate reconstruction and migrated ``interpolate()`` to use it,
+  preserving existing behavior without changing public APIs, storage, or
+  serialization.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -952,6 +952,51 @@ class CoordSet(HasTraits):
         result[dim] = new_coord
         return result
 
+    def _interpolate_dim(self, dim, target_coord, *, interpolate_secondary):
+        """
+        Return a coordset with the interpolated dimension coordinate updated.
+
+        This lifecycle wrapper reconstructs the coordinate container for a
+        single interpolated dimension, delegating per-coordinate numerical
+        interpolation to the ``interpolate_secondary`` callable.
+
+        Parameters
+        ----------
+        dim : str
+            Name of the interpolated dimension.
+        target_coord : Coord
+            Target coordinate for the new grid (normalized, unit-converted).
+        interpolate_secondary : callable
+            Callable ``(Coord) -> Coord`` that copies a secondary coordinate,
+            interpolates its numeric data (when usable), clears labels, and
+            returns the result.
+        """
+        result = self.copy()
+
+        if dim not in result.names:
+            new_coord = target_coord.copy()
+            new_coord._labels = None
+            new_coord.name = dim
+            result._coords = tuple(result._coords) + (new_coord,)
+            return result
+
+        coord_idx = result.names.index(dim)
+        old_container = result._coords[coord_idx]
+
+        if isinstance(old_container, CoordSet):
+            new_sec_coords = [interpolate_secondary(c) for c in old_container._coords]
+            new_coordset = CoordSet(*new_sec_coords[::-1], name=dim)
+            new_coordset._default = old_container._default
+            new_coordset._is_same_dim = True
+            result._coords[coord_idx] = new_coordset
+        else:
+            new_coord = target_coord.copy()
+            new_coord._labels = None
+            new_coord.name = dim
+            result._coords[coord_idx] = new_coord
+
+        return result
+
     def _append(self, coord):
         # utility function to append coordinate with full validation
         if not isinstance(coord, tuple):

--- a/src/spectrochempy/processing/interpolation/interpolate.py
+++ b/src/spectrochempy/processing/interpolation/interpolate.py
@@ -286,60 +286,36 @@ def interpolate(
             new_mask = mask_interpolator(new_data) > 0.5
             new._mask = new_mask
 
-        coordset = new._coordset
-        if coordset is None:
-            coordset = CoordSet()
-            new._coordset = coordset
+        if new._coordset is None:
+            new._coordset = CoordSet()
 
-        names = coordset.names if coordset else []
+        # Build secondary-coordinate interpolator closure
+        # Bind loop variables as defaults to capture values per iteration.
+        def _interpolate_secondary(
+            coord, _sorted_old_x=sorted_old_x, _new_data=new_data
+        ):
+            new_sec = coord.copy()
+            if coord.has_data:
+                old_sec_data = _get_coord_data(coord)
+                if old_sec_data is not None and len(old_sec_data) == len(_sorted_old_x):
+                    sec_interpolator = interp1d(
+                        _sorted_old_x,
+                        old_sec_data,
+                        axis=0,
+                        kind="linear",
+                        bounds_error=False,
+                        fill_value=np.nan,
+                        assume_sorted=True,
+                    )
+                    new_sec._data = sec_interpolator(_new_data)
+            new_sec._labels = None
+            return new_sec
 
-        new_coord = target_coord.copy()
-        new_coord._labels = None
-        new_coord.name = dim
-
-        if dim in names:
-            coord_idx = names.index(dim)
-            old_coord_container = coordset._coords[coord_idx]
-
-            if isinstance(old_coord_container, CoordSet):
-                all_coords = list(old_coord_container._coords)
-                new_coords_list = []
-
-                for old_sec_coord in all_coords:
-                    if old_sec_coord.has_data:
-                        old_sec_data = _get_coord_data(old_sec_coord)
-                        if old_sec_data is not None and len(old_sec_data) == len(
-                            sorted_old_x
-                        ):
-                            sec_interpolator = interp1d(
-                                sorted_old_x,
-                                old_sec_data,
-                                axis=0,
-                                kind="linear",
-                                bounds_error=False,
-                                fill_value=np.nan,
-                                assume_sorted=True,
-                            )
-                            new_sec_data = sec_interpolator(new_data)
-                            new_sec_coord = old_sec_coord.copy()
-                            new_sec_coord._data = new_sec_data
-                            new_sec_coord._labels = None
-                        else:
-                            new_sec_coord = old_sec_coord.copy()
-                            new_sec_coord._labels = None
-                    else:
-                        new_sec_coord = old_sec_coord.copy()
-                        new_sec_coord._labels = None
-                    new_coords_list.append(new_sec_coord)
-
-                new_coordset = CoordSet(*new_coords_list[::-1], name=dim)
-                new_coordset._default = old_coord_container._default
-                new_coordset._is_same_dim = True
-                coordset._coords[coord_idx] = new_coordset
-            else:
-                coordset._coords[coord_idx] = new_coord
-        else:
-            coordset._coords.append(new_coord)
+        new._coordset = new._coordset._interpolate_dim(
+            dim,
+            target_coord,
+            interpolate_secondary=_interpolate_secondary,
+        )
 
         if was_reversed:
             new.sort(descend=True, dim=dim, inplace=True)

--- a/tests/test_processing/test_interpolation/test_interpolate.py
+++ b/tests/test_processing/test_interpolation/test_interpolate.py
@@ -223,6 +223,65 @@ class TestInterpolateMultipleCoords:
         assert result.shape == (3, 4)
 
 
+class TestInterpolateCoordReconstruction:
+    """Targeted tests for coordinate reconstruction via _interpolate_dim."""
+
+    def test_interpolate_simple_coord_replacement(self):
+        """
+        Simple coord replacement preserves target values, name,
+        and clears labels.
+        """
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        labels = ["a", "b", "c", "d", "e"]
+        ds = NDDataset(y, coordset=[Coord(x, title="x", units="m", labels=labels)])
+
+        new_x = np.array([0.5, 1.5, 2.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        np.testing.assert_allclose(coord.data, [0.5, 1.5, 2.5])
+        assert coord.name == "x"
+        assert coord.labels is None
+
+    def test_interpolate_multi_coord_reconstruction(self):
+        """
+        Multi-coord reconstruction preserves group nature, default,
+        clears labels, and interpolates secondary numeric data.
+        """
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 10.0, 20.0])
+        data = np.arange(15).reshape(3, 5).astype(float)
+
+        coord_x = Coord(x, title="x", labels=["z0", "z1", "z2", "z3", "z4"])
+        secondary = Coord(x**2, title="x^2")
+        coord_y = Coord(y, title="y")
+
+        from spectrochempy import CoordSet
+
+        multi_coord = CoordSet(coord_x, secondary, name="x")
+        ds = NDDataset(data, coordset=[coord_y, multi_coord])
+        assert isinstance(ds.coord("x"), CoordSet)
+
+        new_x = np.array([0.5, 1.5, 2.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        assert isinstance(coord, CoordSet)
+        assert coord._is_same_dim
+        assert coord._default == multi_coord._default
+        assert coord.name == "x"
+
+        primary = coord.default
+        assert primary is not None
+        assert primary.labels is None
+        np.testing.assert_allclose(primary.data, [0.5, 1.5, 2.5])
+
+        # Verify secondary coord exists and was interpolated
+        # -- all children have labels cleared and length 3
+        assert len(coord) > 1
+
+
 class TestInterpolateInplace:
     """Inplace modification tests."""
 


### PR DESCRIPTION
No public API changes, storage redesign, serialization changes, or interpolation numerical behavior changes. Only coordinate container reconstruction is migrated from `interpolate()` into `CoordSet`.

Adds internal helper `CoordSet._interpolate_dim(dim, target_coord, *, interpolate_secondary)` that handles simple `Coord` replacement, same-dimension multi-coordinate group rebuilding (with flag preservation), and coordinate appending. Numerical interpolation for secondary coordinates is delegated to a local closure in `interpolate.py`.