### PR TITLE
TEST: add public-contract behavioral tests for CoordSet and NDDataset+CoordSet

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -87,3 +87,11 @@ Developer
   coordinate reconstruction and migrated ``interpolate()`` to use it,
   preserving existing behavior without changing public APIs, storage, or
   serialization.
+
+- TEST: Added public-contract behavioral tests for ``CoordSet`` multi-coord
+  construction, attribute access, iteration, keepnames, and additional
+  properties (``name``, ``coords``).
+
+- TEST: Added public-contract behavioral tests for ``NDDataset`` ``coord()``,
+  ``set_coordset()``, dim attribute access, multi-coord dimensions, and
+  ``None``/size-only coordinate entries.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -48,3 +48,11 @@ Developer
   coordinate reconstruction and migrated ``interpolate()`` to use it,
   preserving existing behavior without changing public APIs, storage, or
   serialization.
+
+- TEST: Added public-contract behavioral tests for ``CoordSet`` multi-coord
+  construction, attribute access, iteration, keepnames, and additional
+  properties (``name``, ``coords``).
+
+- TEST: Added public-contract behavioral tests for ``NDDataset`` ``coord()``,
+  ``set_coordset()``, dim attribute access, multi-coord dimensions, and
+  ``None``/size-only coordinate entries.

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -427,6 +427,149 @@ class TestCoordSetEdgeCases:
 
 
 # ==============================================================================
+# Multi-coord (same-dimension)
+# ==============================================================================
+
+
+class TestCoordSetMultiCoord:
+    """CoordSet with multiple coords sharing a dimension."""
+
+    def test_list_arg_exposes_child_coords(self):
+        """Passing a list of Coords exposes both through compatibility aliases."""
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        assert cs["x"]["_1"] == c1
+        assert cs["x"]["_2"] == c2
+
+    def test_child_coord_metadata_preserved(self):
+        c1 = Coord([1, 2, 3], name="a", units="cm^-1", title="alpha")
+        c2 = Coord([4, 5, 6], name="b", units="s", title="beta")
+        cs = CoordSet([c1, c2])
+        assert cs["x"]["_1"].units is not None
+        assert cs["x"]["_2"].title == "beta"
+
+    def test_explicit_multi_coord_via_kwargs(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet(x=CoordSet(c1, c2))
+        # Both coordinates are accessible through compatibility aliases
+        assert len(cs["x"]) == 2
+
+
+# ==============================================================================
+# Attribute access
+# ==============================================================================
+
+
+class TestCoordSetAttributeAccess:
+    """CoordSet __getattr__ behavior."""
+
+    def test_getattr_by_name(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"), Coord([10, 20], name="y"))
+        assert cs.x is not None
+        assert cs.y is not None
+
+    def test_getattr_returns_coord(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        assert isinstance(cs.x, Coord)
+
+    def test_getattr_subcoord_by_index(self):
+        c1 = Coord([1, 2, 3])
+        c2 = Coord([4, 5, 6])
+        cs = CoordSet([c1, c2])
+        sub = cs["x"]
+        assert sub._1 == c1
+        assert sub._2 == c2
+
+    def test_getattr_missing_raises(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        with pytest.raises(AttributeError):
+            _ = cs.nonexistent
+
+
+# ==============================================================================
+# Additional properties
+# ==============================================================================
+
+
+class TestCoordSetAdditionalProperties:
+    """Additional CoordSet public properties."""
+
+    def test_name_default_is_id_string(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        name = cs.name
+        assert isinstance(name, str)
+        assert len(name) > 0
+
+    def test_name_can_be_set(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        cs.name = "mycoords"
+        assert cs.name == "mycoords"
+
+    def test_coords_returns_list(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"), Coord([10, 20], name="y"))
+        coords = cs.coords
+        assert isinstance(coords, list)
+        assert len(coords) == 2
+
+    def test_coords_contains_coord_objects(self):
+        c = Coord([1, 2, 3], name="x")
+        cs = CoordSet(c)
+        assert isinstance(cs.coords[0], Coord)
+
+
+# ==============================================================================
+# Iteration
+# ==============================================================================
+
+
+class TestCoordSetIteration:
+    """CoordSet iteration behavior."""
+
+    def test_iter_yields_all_items(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        items = list(cs)
+        assert len(items) == 2
+
+    def test_iter_contains_all_items(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([10, 20], name="b")
+        cs = CoordSet(c1, c2, keepnames=True)
+        items = list(cs)
+        assert c1 in items
+        assert c2 in items
+
+
+# ==============================================================================
+# Keepnames
+# ==============================================================================
+
+
+class TestCoordSetKeepnames:
+    """CoordSet keepnames behavior."""
+
+    def test_keepnames_true_preserves_coord_names(self):
+        c = Coord([1, 2, 3], name="wavelength")
+        cs = CoordSet(c, keepnames=True)
+        assert cs.names == ["wavelength"]
+
+    def test_keepnames_false_auto_renames(self):
+        c = Coord([1, 2, 3], name="wavelength")
+        cs = CoordSet(c, keepnames=False)
+        # When keepnames=False, coord names may be reassigned
+        assert cs.names is not None
+
+    def test_default_keepnames_false(self):
+        c = Coord([1, 2, 3], name="wavelength")
+        cs = CoordSet(c)
+        # Default is keepnames=False, so name may be auto-assigned
+        assert cs.names is not None
+
+
+# ==============================================================================
 # Equality
 # ==============================================================================
 

--- a/tests/test_core/test_dataset/test_dataset_coords_behavior.py
+++ b/tests/test_core/test_dataset/test_dataset_coords_behavior.py
@@ -280,6 +280,159 @@ class TestCoordMetadataAfterSlice:
 
 
 # ==============================================================================
+# coord() method
+# ==============================================================================
+
+
+class TestNDDatasetCoordMethod:
+    """NDDataset.coord() public method."""
+
+    def test_coord_by_dim_name(self):
+        c = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(c))
+        retrieved = ds.coord("x")
+        assert isinstance(retrieved, Coord)
+        assert_array_equal(retrieved.data, [100.0, 200.0, 300.0])
+
+    def test_coord_by_dim_index(self):
+        c = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(c))
+        retrieved = ds.coord(0)
+        assert isinstance(retrieved, Coord)
+        assert_array_equal(retrieved.data, [100.0, 200.0, 300.0])
+
+    def test_coord_returns_none_when_no_coordset(self):
+        ds = NDDataset([1.0, 2.0, 3.0])
+        assert ds.coord("x") is None
+
+    def test_coord_with_custom_dim_name(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0], name="x")
+        ds = NDDataset(np.ones((3, 2)), coordset=[coord_y, coord_x])
+        assert_array_equal(ds.coord("y").data, [1.0, 2.0, 3.0])
+        assert_array_equal(ds.coord("x").data, [10.0, 20.0])
+
+
+# ==============================================================================
+# set_coordset() method
+# ==============================================================================
+
+
+class TestNDDatasetSetCoordset:
+    """NDDataset.set_coordset() public method."""
+
+    def test_set_coordset_with_kwargs(self):
+        c_x = Coord([10.0, 20.0, 30.0], name="x")
+        c_y = Coord([1.0, 2.0], name="y")
+        ds = NDDataset(np.ones((2, 3)))
+        ds.set_coordset(x=c_x, y=c_y)
+        assert ds.coordset is not None
+        assert "x" in ds.coordset.names
+        assert "y" in ds.coordset.names
+
+    def test_set_coordset_matches_shape(self):
+        c_x = Coord([10.0, 20.0, 30.0], name="x")
+        c_y = Coord([1.0, 2.0], name="y")
+        ds = NDDataset(np.ones((2, 3)))
+        ds.set_coordset(x=c_x, y=c_y)
+        assert ds.shape == (2, 3)
+        assert ds.coordset["x"].size == 3
+        assert ds.coordset["y"].size == 2
+
+    def test_set_coordset_replaces_previous(self):
+        c1 = Coord([1.0, 2.0, 3.0], name="x")
+        ds = NDDataset([10, 20, 30], coordset=CoordSet(c1))
+        c2 = Coord([100.0, 200.0, 300.0], name="x")
+        ds.set_coordset(x=c2)
+        assert_array_equal(ds.coordset["x"].data, [100.0, 200.0, 300.0])
+
+
+# ==============================================================================
+# Dim attribute access
+# ==============================================================================
+
+
+class TestNDDatasetDimAttributeAccess:
+    """Accessing coordinates via dataset dimension attributes."""
+
+    def test_1d_dim_attribute(self):
+        c = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(c))
+        assert isinstance(ds.x, Coord)
+        assert_array_equal(ds.x.data, [100.0, 200.0, 300.0])
+
+    def test_2d_dim_attributes(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0], name="x")
+        ds = NDDataset(np.ones((3, 2)), coordset=[coord_y, coord_x])
+        assert_array_equal(ds.y.data, [1.0, 2.0, 3.0])
+        assert_array_equal(ds.x.data, [10.0, 20.0])
+
+    def test_dim_attribute_preserves_after_copy(self):
+        c = Coord([100.0, 200.0, 300.0], name="x", units="cm^-1")
+        ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(c))
+        ds2 = ds.copy()
+        assert_array_equal(ds2.x.data, [100.0, 200.0, 300.0])
+        assert_units_equal(ds2.x.units, ur("cm^-1"))
+
+
+# ==============================================================================
+# Multi-coord dimension
+# ==============================================================================
+
+
+class TestNDDatasetMultiCoordDim:
+    """Dataset dimension with multiple coordinates (CoordSet per dim)."""
+
+    def test_assign_multi_coord_to_dim(self):
+        ds = NDDataset([0.0, 1.0, 2.0])
+        x1 = Coord(np.array([1.5, 5.8, -9.0]))
+        x2 = Coord(np.array([0.5, 0.8, 9.0]))
+        ds.x = CoordSet(Coord(x2), Coord(x1))
+        assert len(ds.x) == 2
+
+    def test_multi_coord_preserves_sub_coords(self):
+        ds = NDDataset([0.0, 1.0, 2.0])
+        x1 = Coord(np.array([1.5, 5.8, -9.0]))
+        x2 = Coord(np.array([0.5, 0.8, 9.0]))
+        ds.x = CoordSet(Coord(x2), Coord(x1))
+        assert_array_equal(ds.x["_2"].data, [0.5, 0.8, 9.0])
+        assert_array_equal(ds.x["_1"].data, [1.5, 5.8, -9.0])
+
+    def test_multi_coord_dim_attribute_after_slice(self):
+        coord_y = Coord([1.0, 2.0, 3.0], name="y")
+        coord_x = Coord([10.0, 20.0, 30.0], name="x")
+        ds = NDDataset(np.ones((3, 3)), coordset=[coord_y, coord_x])
+        ds.x = CoordSet(Coord([11.0, 21.0, 31.0]), Coord([12.0, 22.0, 32.0]))
+        sliced = ds[0:2, 0:2]
+        assert len(sliced.x) == 2
+
+
+# ==============================================================================
+# Coord with None data / size only
+# ==============================================================================
+
+
+class TestNDDatasetNoneCoord:
+    """Dataset with None-valued or size-only coordinate entries."""
+
+    def test_coord_none_size_creates_default(self):
+        c = Coord(None, size=5)
+        ds = NDDataset(np.ones(5), coordset=CoordSet(c))
+        assert ds.shape == (5,)
+
+    def test_none_coord_in_list(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        ds = NDDataset(np.ones((3, 1)), coordset=[c, None])
+        assert ds.shape == (3, 1)
+
+    def test_none_coord_keeps_dim_count(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        ds = NDDataset(np.ones((3, 1)), coordset=[c, None])
+        assert len(ds.dims) == 2
+
+
+# ==============================================================================
 # Edge cases
 # ==============================================================================
 


### PR DESCRIPTION
## Summary

Add public-contract behavioral tests for CoordSet and NDDataset+CoordSet integration as a safety net for the upcoming storage redesign (Storage PR1).

No production code is modified. Tests use only public API and deterministic synthetic data.

### test_coordset_behavior.py (+16 tests)

- Multi-coord: list construction exposes child coords via _1/_2 aliases, metadata preserved, kwargs
- Attribute access: cs.x, cs.y, cs._1, cs._2, AttributeError for missing
- Properties: name (get/set), coords (list)
- Iteration: yields all items
- Keepnames: keepnames=True preserves names, default is False

### test_dataset_coords_behavior.py (+17 tests)

- coord(): by dim name, by index, returns None without coordset, custom names
- set_coordset(): kwargs, shape match, replacement
- Dim attribute access: ds.x, ds.y, preserved through copy()
- Multi-coord: assignment, sub-coord access via _1/_2, after slice
- None/size: Coord(None, size=N), None in coord list, dim count

### Design constraints

- No assertions on _coords, _default, _is_same_dim, _parent_dim or nested CoordSet storage structure
- is_same_dim is intentionally not tested (it reflects the old storage model being removed)
- Compatibility aliases _1/_2 are tested as public behavior