### PR TITLE
MAINT: Add CoordSet group-model conversion helpers

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,14 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Added private ``CoordSet`` group-model conversion helpers to prepare
+  storage migration without changing runtime storage, lookup, serialization, or
+  lifecycle behavior.
+
+- TEST: Added focused round-trip tests covering simple, multi-coordinate,
+  selected-default, and reference ``CoordSet`` conversion through the private
+  group model.
+
 - MAINT: Added an internal ``CoordSet`` lifecycle helper for reduction-related
   dimension cleanup and migrated ``ndmath._reduce_dims()`` to use it,
   preserving existing behavior without changing public APIs, storage, or

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,14 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
+- MAINT: Added private ``CoordSet`` group-model conversion helpers to prepare
+  storage migration without changing runtime storage, lookup, serialization, or
+  lifecycle behavior.
+
+- TEST: Added focused round-trip tests covering simple, multi-coordinate,
+  selected-default, and reference ``CoordSet`` conversion through the private
+  group model.
+
 - MAINT: Added an internal ``CoordSet`` lifecycle helper for reduction-related
   dimension cleanup and migrated ``ndmath._reduce_dims()`` to use it,
   preserving existing behavior without changing public APIs, storage, or

--- a/src/spectrochempy/core/dataset/__init__.pyi
+++ b/src/spectrochempy/core/dataset/__init__.pyi
@@ -7,6 +7,7 @@
 # ruff: noqa
 
 __all__ = [
+    "_coordgroup",
     "arraymixins",
     "basearrays",
     "coord",
@@ -14,6 +15,7 @@ __all__ = [
     "nddataset",
 ]
 
+from . import _coordgroup
 from . import arraymixins
 from . import basearrays
 from . import coord

--- a/src/spectrochempy/core/dataset/_coordgroup.py
+++ b/src/spectrochempy/core/dataset/_coordgroup.py
@@ -1,0 +1,196 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Private CoordSet group-model helpers used to prepare storage migration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import TYPE_CHECKING
+
+from spectrochempy.core.dataset.coord import Coord
+
+if TYPE_CHECKING:
+    from spectrochempy.core.dataset.coordset import CoordSet
+
+
+@dataclass(frozen=True)
+class _CoordinateEntry:
+    """One coordinate entry inside a future dimension-coordinate group."""
+
+    id: str
+    coord: Coord
+    aliases: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _CoordReference:
+    """Reference from one dimension name to another."""
+
+    dim: str
+    target_dim: str
+
+
+@dataclass(frozen=True)
+class _DimensionCoordinates:
+    """Future internal representation for all coordinates of one dimension."""
+
+    dim: str
+    entries: tuple[_CoordinateEntry, ...]
+    default_id: str | None = None
+    aliases: dict[str, str] = field(default_factory=dict)
+    reference: _CoordReference | None = None
+
+
+def _make_entry_id(coord: Coord, fallback: str, used_ids: set[str]) -> str:
+    """Create a deterministic private entry id for one coordinate."""
+    base = coord.title or coord.name or fallback
+    entry_id = base
+    suffix = 2
+
+    while entry_id in used_ids:
+        entry_id = f"{base}#{suffix}"
+        suffix += 1
+
+    used_ids.add(entry_id)
+    return entry_id
+
+
+def _coordset_group_to_dimension(coordset: CoordSet) -> _DimensionCoordinates:
+    """Convert a same-dimension CoordSet compatibility group to one private group."""
+    used_ids: set[str] = set()
+    aliases: dict[str, str] = {}
+    entries: list[_CoordinateEntry] = []
+
+    for index, coord in enumerate(coordset.coords, start=1):
+        alias = coordset.names[index - 1] if index - 1 < len(coordset.names) else f"_{index}"
+        entry_id = _make_entry_id(coord, alias, used_ids)
+        entries.append(
+            _CoordinateEntry(
+                id=entry_id,
+                coord=coord.copy(keepname=True),
+                aliases=(alias,),
+            )
+        )
+        aliases[alias] = entry_id
+
+    default_id = None
+    if entries:
+        default_index = min(max(0, coordset._default), len(entries) - 1)
+        default_id = entries[default_index].id
+
+    reference = None
+    if coordset.references:
+        ref_dim, target_dim = next(iter(coordset.references.items()))
+        reference = _CoordReference(dim=ref_dim, target_dim=target_dim)
+
+    return _DimensionCoordinates(
+        dim=coordset.name,
+        entries=tuple(entries),
+        default_id=default_id,
+        aliases=aliases,
+        reference=reference,
+    )
+
+
+def _coordset_to_groups(coordset: CoordSet) -> tuple[_DimensionCoordinates, ...]:
+    """Convert a legacy CoordSet into private dimension-coordinate groups."""
+    if coordset.is_same_dim:
+        return (_coordset_group_to_dimension(coordset),)
+
+    groups: list[_DimensionCoordinates] = []
+
+    for coord in coordset.coords:
+        if coord is None:
+            continue
+
+        if coord._implements("CoordSet"):
+            groups.append(_coordset_group_to_dimension(coord))
+            continue
+
+        entry = _CoordinateEntry(
+            id=_make_entry_id(coord, coord.name, set()),
+            coord=coord.copy(keepname=True),
+        )
+        groups.append(
+            _DimensionCoordinates(
+                dim=coord.name,
+                entries=(entry,),
+                default_id=entry.id,
+            )
+        )
+
+    for dim, target_dim in coordset.references.items():
+        groups.append(
+            _DimensionCoordinates(
+                dim=dim,
+                entries=(),
+                reference=_CoordReference(dim=dim, target_dim=target_dim),
+            )
+        )
+
+    return tuple(groups)
+
+
+def _groups_to_coordset(
+    groups: tuple[_DimensionCoordinates, ...] | list[_DimensionCoordinates],
+    *,
+    name: str | None = None,
+) -> CoordSet:
+    """Convert private dimension-coordinate groups back to the legacy CoordSet model."""
+    from spectrochempy.core.dataset.coordset import CoordSet
+
+    coords = []
+    references = {}
+
+    for group in groups:
+        if group.reference is not None:
+            references[group.reference.dim] = group.reference.target_dim
+            continue
+
+        if len(group.entries) == 1 and not group.aliases:
+            coord = group.entries[0].coord.copy(keepname=True)
+            coord.name = group.dim
+            coords.append(coord)
+            continue
+
+        children = [entry.coord.copy(keepname=True) for entry in group.entries]
+        nested = CoordSet(*children, name=group.dim, sorted=False)
+        nested._is_same_dim = True
+
+        alias_names = []
+        for index, entry in enumerate(group.entries, start=1):
+            alias = next(
+                (
+                    item
+                    for item in entry.aliases
+                    if group.aliases.get(item) == entry.id
+                ),
+                None,
+            )
+            alias_names.append(alias or f"_{index}")
+
+        nested._set_names(alias_names)
+        nested._set_parent_dim(group.dim)
+
+        if group.entries:
+            default_index = next(
+                (
+                    index
+                    for index, entry in enumerate(group.entries)
+                    if entry.id == group.default_id
+                ),
+                0,
+            )
+            nested._default = default_index
+
+        coords.append(nested)
+
+    coordset = CoordSet(*coords, keepnames=True, sorted=False)
+    if name is not None:
+        coordset.name = name
+    coordset._references = references
+    return coordset

--- a/src/spectrochempy/core/dataset/_coordgroup.py
+++ b/src/spectrochempy/core/dataset/_coordgroup.py
@@ -66,7 +66,11 @@ def _coordset_group_to_dimension(coordset: CoordSet) -> _DimensionCoordinates:
     entries: list[_CoordinateEntry] = []
 
     for index, coord in enumerate(coordset.coords, start=1):
-        alias = coordset.names[index - 1] if index - 1 < len(coordset.names) else f"_{index}"
+        alias = (
+            coordset.names[index - 1]
+            if index - 1 < len(coordset.names)
+            else f"_{index}"
+        )
         entry_id = _make_entry_id(coord, alias, used_ids)
         entries.append(
             _CoordinateEntry(
@@ -164,11 +168,7 @@ def _groups_to_coordset(
         alias_names = []
         for index, entry in enumerate(group.entries, start=1):
             alias = next(
-                (
-                    item
-                    for item in entry.aliases
-                    if group.aliases.get(item) == entry.id
-                ),
+                (item for item in entry.aliases if group.aliases.get(item) == entry.id),
                 None,
             )
             alias_names.append(alias or f"_{index}")

--- a/tests/test_core/test_dataset/test_coordgroup_conversion.py
+++ b/tests/test_core/test_dataset/test_coordgroup_conversion.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (see LICENSE.txt for details)
+
+"""Focused tests for private CoordSet group-model conversion helpers."""
+
+from spectrochempy.core.dataset._coordgroup import _coordset_to_groups
+from spectrochempy.core.dataset._coordgroup import _groups_to_coordset
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
+from spectrochempy.utils.testing import assert_array_equal
+
+
+def _assert_public_coord_equal(left, right):
+    assert left.name == right.name
+    assert left.title == right.title
+    assert left.units == right.units
+    assert_array_equal(left.data, right.data)
+    if left.labels is None:
+        assert right.labels is None
+    else:
+        assert_array_equal(left.labels, right.labels)
+
+
+def _assert_public_coordset_equal(left, right):
+    assert left.names == right.names
+    assert left.keys() == right.keys()
+    assert left.titles == right.titles
+    assert left.units == right.units
+    assert_array_equal(left.data, right.data)
+
+
+def test_simple_coordset_group_roundtrip_preserves_public_behavior():
+    coord = Coord(
+        [1.0, 2.0, 3.0],
+        name="x",
+        title="distance",
+        units="cm",
+        labels=["a", "b", "c"],
+    )
+    coordset = CoordSet(x=coord)
+
+    groups = _coordset_to_groups(coordset)
+    rebuilt = _groups_to_coordset(groups, name=coordset.name)
+
+    assert len(groups) == 1
+    assert groups[0].dim == "x"
+    assert len(groups[0].entries) == 1
+    _assert_public_coordset_equal(coordset, rebuilt)
+    _assert_public_coord_equal(coordset["x"], rebuilt["x"])
+
+
+def test_multi_coordinate_group_conversion_preserves_aliases_and_metadata():
+    coord_a = Coord(
+        [1.0, 2.0, 3.0],
+        name="a",
+        title="alpha",
+        units="cm^-1",
+        labels=["u", "v", "w"],
+    )
+    coord_b = Coord([4.0, 5.0, 6.0], name="b", title="beta", units="s")
+    coordset = CoordSet([coord_a, coord_b])
+
+    groups = _coordset_to_groups(coordset)
+    rebuilt = _groups_to_coordset(groups, name=coordset.name)
+
+    assert len(groups) == 1
+    group = groups[0]
+    assert group.dim == "x"
+    assert len(group.entries) == 2
+    assert group.aliases["_1"] == group.entries[0].id
+    assert group.aliases["_2"] == group.entries[1].id
+    _assert_public_coord_equal(group.entries[0].coord, coordset["x"]["_1"])
+    _assert_public_coord_equal(group.entries[1].coord, coordset["x"]["_2"])
+
+    _assert_public_coordset_equal(coordset, rebuilt)
+    _assert_public_coord_equal(coordset["x"]["_1"], rebuilt["x"]["_1"])
+    _assert_public_coord_equal(coordset["x"]["_2"], rebuilt["x"]["_2"])
+    _assert_public_coord_equal(coordset["x_1"], rebuilt["x_1"])
+    _assert_public_coord_equal(coordset["_1"], rebuilt["_1"])
+
+
+def test_non_first_default_roundtrip_preserves_selected_coordinate():
+    coord_a = Coord([1.0, 2.0, 3.0], name="a", title="alpha", units="cm^-1")
+    coord_b = Coord([4.0, 5.0, 6.0], name="b", title="beta", units="s")
+    coordset = CoordSet([coord_a, coord_b])
+    coordset["x"].select(2)
+
+    groups = _coordset_to_groups(coordset)
+    rebuilt = _groups_to_coordset(groups, name=coordset.name)
+
+    assert groups[0].default_id == groups[0].entries[1].id
+    _assert_public_coord_equal(coordset["x"].default, rebuilt["x"].default)
+    assert_array_equal(coordset["x"].data, rebuilt["x"].data)
+
+
+def test_reference_roundtrip_preserves_reference_key_and_lookup_behavior():
+    coord = Coord([1.0, 2.0, 3.0], name="x", title="distance", units="cm")
+    coordset = CoordSet(x=coord, y="x")
+
+    groups = _coordset_to_groups(coordset)
+    rebuilt = _groups_to_coordset(groups, name=coordset.name)
+
+    assert len(groups) == 2
+    assert groups[1].reference is not None
+    assert groups[1].reference.dim == "y"
+    assert groups[1].reference.target_dim == "x"
+    assert rebuilt.references == coordset.references
+    assert rebuilt["y"] == coordset["y"] == "x"
+    _assert_public_coord_equal(coordset["x"], rebuilt["x"])
+
+
+def test_public_roundtrip_equivalence_for_mixed_coordset_cases():
+    coord_x = Coord([1.0, 2.0, 3.0], name="x", title="distance", units="cm")
+    coord_a = Coord([10.0, 20.0, 30.0], name="a", title="alpha", units="s")
+    coord_b = Coord([11.0, 21.0, 31.0], name="b", title="beta", units="ms")
+    coordset = CoordSet(x=CoordSet(coord_a, coord_b), y=coord_x, z="y")
+    coordset["x"].select(2)
+
+    rebuilt = _groups_to_coordset(_coordset_to_groups(coordset), name=coordset.name)
+
+    _assert_public_coordset_equal(coordset, rebuilt)
+    _assert_public_coord_equal(coordset["x"].default, rebuilt["x"].default)
+    _assert_public_coord_equal(coordset["x_1"], rebuilt["x_1"])
+    _assert_public_coord_equal(coordset["_1"], rebuilt["_1"])
+    _assert_public_coord_equal(coordset["y"], rebuilt["y"])
+    assert rebuilt["z"] == coordset["z"] == "y"


### PR DESCRIPTION
## Summary

- Introduce private group-model dataclasses for future `CoordSet` storage migration.
- Add lossless conversion helpers between legacy `CoordSet` storage and the private group representation.
- Preserve runtime behavior by keeping legacy storage as the source of truth.
- Add focused conversion round-trip tests covering:
  - multi-coordinate dimensions;
  - aliases;
  - references;
  - selected default coordinates.
- No lookup, serialization, lifecycle, or `NDDataset` behavior changes.

## Changes

- Added private module `spectrochempy.core.dataset._coordgroup`.
- Added private dataclasses:
  - `_CoordinateEntry`
  - `_DimensionCoordinates`
  - `_CoordReference`
- Added private conversion helpers:
  - `_coordset_to_groups(...)`
  - `_groups_to_coordset(...)`
- Added focused round-trip tests for simple, multi-coordinate, labeled, referenced, and non-first-default cases.
- Updated developer changelog entry.

## Compatibility

- Runtime storage unchanged.
- Lookup behavior unchanged.
- Serialization behavior unchanged.
- `NDDataset` behavior unchanged.
- Lifecycle behavior unchanged.

## Testing

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordgroup_conversion.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset_behavior.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_dataset_coords_behavior.py -v`
- `pre-commit run --all-files`

## Notes

This PR is intentionally preparatory only. The private group model is not yet used as runtime storage and is introduced solely to support the next storage-migration steps with explicit, testable conversion boundaries.