### PR TITLE
MAINT: remove stale docrep residue and add source docstring guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,9 +48,3 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
-
-  # This is not working correctly because the use of docrep for some docstrings
-  # - repo: https://github.com/numpy/numpydoc
-  #   rev: v1.8.0
-  #   hooks:
-  #     - id: numpydoc-validation

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,12 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Removed stale commented ``docrep`` residue and the unused commented
+  ``numpydoc`` pre-commit hook block.
+
+- TEST: Added a project-wide source-docstring guard to detect stale
+  ``docrep``-style placeholders in ``spectrochempy`` source docstrings.
+
 - MAINT: Added private ``CoordSet`` group-model conversion helpers to prepare
   storage migration without changing runtime storage, lookup, serialization, or
   lifecycle behavior.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,12 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
+- MAINT: Removed stale commented ``docrep`` residue and the unused commented
+  ``numpydoc`` pre-commit hook block.
+
+- TEST: Added a project-wide source-docstring guard to detect stale
+  ``docrep``-style placeholders in ``spectrochempy`` source docstrings.
+
 - MAINT: Added private ``CoordSet`` group-model conversion helpers to prepare
   storage migration without changing runtime storage, lookup, serialization, or
   lifecycle behavior.

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -398,7 +398,6 @@ class DecompositionAnalysis(AnalysisConfigurable):
 
         return self._inverse_transform(X_transform)
 
-    # _docstring.keep_params("analysis_inverse_transform.parameters", "X_transform")
     def fit_transform(self, X, Y=None, **kwargs):
         r"""
         Fit the model with `X` and apply the dimensionality reduction on `X`.
@@ -799,7 +798,6 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
         X, Y = self._inverse_transform(X_transform, X_transform)
         return X, Y
 
-    # _docstring.keep_params("analysis_inverse_transform.parameters", "X_transform")
     def fit_transform(self, X, Y, both=False):
         r"""
         Fit the model with `X` and `Y` and apply the dimensionality reduction on `X` and optionally on `Y`.

--- a/src/spectrochempy/ci/analyse_utils.py
+++ b/src/spectrochempy/ci/analyse_utils.py
@@ -30,7 +30,7 @@ def analyze_methods():
                     print(f"- Line: {node.lineno}")
                     print(f"- Args: `{', '.join(args)}`")
                     if docstring:
-                        print(f"- Doc: {docstring.split('\n')[0]}")
+                        print(f"- Doc: {docstring.splitlines()[0]}")
 
                     # Register method for duplicate checking
                     method_registry[node.name].append(

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -500,51 +500,6 @@ def read_dir(directory=None, **kwargs):
     return importer(directory, **kwargs)
 
 
-# _docstring.delete_params("Importer.see_also", "read_remote")
-# @_docstring.dedent
-# def read_remote(file_or_dir, **kwargs):
-#     """
-#     Download and read files or an entire directory from any url
-#
-#     The first usage in spectrochempy is the loading of test files in the
-#     `spectrochempy_data repository <https://github.com/spectrochempy/spectrochempy_data>`__.
-#     This is done only if the data are not yet
-#     downloaded and present in the `~spectrochempy.preferences.datadir` directory.
-#
-#     It can also be used to download and read file or directory from any url.
-#
-#     Parameters
-#     ----------
-#     path : `str`, `~pathlib.Path` object or an url.
-#         When a file or folder is specified, it must be written as if it were present
-#         locally exactly as for the `read` function. The correponding file or directory
-#         is downloaded from the ``github spectrochemp_data`` repository.
-#         Otherwise it should be a full and valid url.
-#     %(kwargs)s
-#
-#     Returns
-#     --------
-#     %(Importer.returns)s
-#
-#     Other Parameters
-#     ----------------
-#     %(Importer.other_parameters)s
-#
-#     See Also
-#     --------
-#     %(Importer.see_also.no_read_remote)s
-#
-#     Examples
-#     --------
-#
-#     >>> A = scp.read_remote('irdata/subdir')
-#     """
-#     kwargs["remote"] = True
-#     importer = Importer()
-#     return importer(file_or_dir, **kwargs)
-#
-
-
 # ======================================================================================
 # Private read functions
 # ======================================================================================

--- a/tests/test_utils/test_docstrings_projectwide.py
+++ b/tests/test_utils/test_docstrings_projectwide.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-
 SOURCE_ROOT = Path(__file__).resolve().parents[2] / "src" / "spectrochempy"
 DOCREP_DOCSTRING_MARKERS = ("%(", "_docstring.", "@_docstring")
 

--- a/tests/test_utils/test_docstrings_projectwide.py
+++ b/tests/test_utils/test_docstrings_projectwide.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (see LICENSE.txt for details)
+
+"""Project-wide guards against stale docrep-style source docstrings."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[2] / "src" / "spectrochempy"
+DOCREP_DOCSTRING_MARKERS = ("%(", "_docstring.", "@_docstring")
+
+
+def _iter_source_docstrings():
+    for path in SOURCE_ROOT.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=str(path))
+
+        for node in ast.walk(tree):
+            if not isinstance(
+                node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                continue
+
+            doc = ast.get_docstring(node, clean=False)
+            if doc is None:
+                continue
+
+            yield path.relative_to(SOURCE_ROOT.parent), node, doc
+
+
+def test_source_docstrings_contain_no_docrep_placeholders():
+    offenders = []
+
+    for path, node, doc in _iter_source_docstrings():
+        if any(marker in doc for marker in DOCREP_DOCSTRING_MARKERS):
+            name = getattr(node, "name", "<module>")
+            offenders.append(f"{path}:{getattr(node, 'lineno', 1)}:{name}")
+
+    assert offenders == []


### PR DESCRIPTION
## Summary

- Remove stale commented `docrep` residue from the codebase.
- Remove the unused commented `numpydoc` pre-commit hook block.
- Add a project-wide AST-based guard to ensure source docstrings contain no stale templated placeholders.

## Changes

- Removed the dead commented `docrep`-era block from `core/readers/importer.py`.
- Removed stale commented `_docstring.keep_params(...)` lines from `analysis/_base/_analysisbase.py`.
- Removed the commented `numpydoc` hook block from `.pre-commit-config.yaml`.
- Added `tests/test_utils/test_docstrings_projectwide.py` to scan `src/spectrochempy/**/*.py` docstrings for stale placeholder markers.
- Updated changelog entries, including generated `latest.rst` via pre-commit.

## Motivation

The repository no longer uses `docrep`, but a few commented residues and an old commented pre-commit block still suggested otherwise. This PR removes that stale residue and adds a broader guard than the existing plotting-only docstring check.

## Compatibility

- No runtime behavior changes.
- No API changes.
- No docstring content changes in active source objects were needed.
- No pre-commit hook was enabled; only dead commented config was removed.

## Testing

- `conda run -n scpy-core python -m pytest tests/test_utils/test_docstrings_projectwide.py -v`
- `pre-commit run --all-files`

## Notes

If the team wants to evaluate the official `numpydoc` pre-commit hook later, that can now happen as a fresh proposal rather than by reviving stale commented configuration.