### PR TITLE
TEST: Add CoordSet storage migration edge-case contract tests

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- TEST: Added CoordSet public-contract edge tests covering duplicate-title
+  lookup, title/name collisions, synthetic alias collisions, reference lookup,
+  and selected non-first default preservation across copy and slicing.
+
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,10 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
+- TEST: Added CoordSet public-contract edge tests covering duplicate-title
+  lookup, title/name collisions, synthetic alias collisions, reference lookup,
+  and selected non-first default preservation across copy and slicing.
+
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.
 

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -8,6 +8,9 @@ Tests focus on public API behavior, not private implementation details.
 Uses deterministic synthetic data only. No external files, no plotting.
 """
 
+import warnings
+from copy import deepcopy
+
 import pytest
 
 from spectrochempy.core.dataset.coord import Coord
@@ -363,6 +366,89 @@ class TestCoordSetMutation:
 
 
 # ==============================================================================
+# Lookup ambiguities
+# ==============================================================================
+
+
+class TestCoordSetLookupAmbiguities:
+    """Current public lookup behavior for ambiguous CoordSet cases."""
+
+    def test_getitem_duplicate_top_level_title_warns_and_returns_first(self):
+        c1 = Coord([1, 2, 3], name="x", title="dup")
+        c2 = Coord([4, 5], name="y", title="dup")
+        cs = CoordSet(c1, c2, keepnames=True)
+        with pytest.warns(UserWarning, match="occurs several time"):
+            found = cs["dup"]
+        assert found == c1
+
+    def test_getitem_duplicate_child_titles_same_group_returns_first_without_warning(
+        self,
+    ):
+        c1 = Coord([1, 2, 3], name="a", title="dup")
+        c2 = Coord([4, 5, 6], name="b", title="dup")
+        cs = CoordSet([c1, c2])
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            found = cs["dup"]
+        assert recorded == []
+        assert found == cs["x"]["_1"]
+
+    def test_getitem_duplicate_child_titles_across_groups_returns_first_without_warning(
+        self,
+    ):
+        xa = Coord([1, 2, 3], name="a", title="dup")
+        xb = Coord([4, 5, 6], name="b", title="dup")
+        ya = Coord([10, 20], name="c", title="dup")
+        yb = Coord([30, 40], name="d", title="dup")
+        cs = CoordSet(x=CoordSet(xa, xb), y=CoordSet(ya, yb))
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            found = cs["dup"]
+        assert recorded == []
+        assert found == cs["x"]["_1"]
+
+    def test_dimension_name_takes_precedence_over_top_level_title(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([4, 5], name="y", title="x")
+        cs = CoordSet(c1, c2, keepnames=True)
+        found = cs["x"]
+        assert found == c1
+        assert found.title != "x"
+
+    def test_dimension_name_takes_precedence_over_child_title(self):
+        child = Coord([1, 2, 3], name="a", title="y")
+        sibling = Coord([4, 5, 6], name="b")
+        cs = CoordSet(x=CoordSet(child, sibling), y=Coord([10, 20, 30], name="y"))
+        found = cs["y"]
+        assert found.name == "y"
+        assert found.title != "y"
+
+    def test_reference_key_takes_precedence_over_title(self):
+        c1 = Coord([1, 2, 3], name="x", title="y")
+        cs = CoordSet(x=c1, y="x")
+        assert cs["y"] == "x"
+        assert cs["x"].title == "y"
+
+    def test_global_synthetic_alias_collision_returns_first_group_child(self):
+        cs = CoordSet(
+            x=CoordSet(Coord([1, 2, 3], name="a"), Coord([4, 5, 6], name="b")),
+            y=CoordSet(Coord([10, 20, 30], name="c"), Coord([40, 50, 60], name="d")),
+        )
+        assert cs["_1"] == cs["x"]["_1"]
+        assert_array_equal(cs["_1"].data, [4.0, 5.0, 6.0])
+
+    def test_dimension_scoped_synthetic_alias_collision_targets_requested_group(self):
+        cs = CoordSet(
+            x=CoordSet(Coord([1, 2, 3], name="a"), Coord([4, 5, 6], name="b")),
+            y=CoordSet(Coord([10, 20, 30], name="c"), Coord([40, 50, 60], name="d")),
+        )
+        assert cs["x_1"] == cs["x"]["_1"]
+        assert cs["y_1"] == cs["y"]["_1"]
+        assert_array_equal(cs["x_1"].data, [4.0, 5.0, 6.0])
+        assert_array_equal(cs["y_1"].data, [40.0, 50.0, 60.0])
+
+
+# ==============================================================================
 # Call syntax
 # ==============================================================================
 
@@ -419,6 +505,24 @@ class TestCoordSetCopy:
         cs = CoordSet(c)
         cs2 = cs.copy()
         assert_array_equal(cs2["x"].data, cs["x"].data)
+
+    def test_copy_preserves_selected_non_first_default_for_multicoord(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        cs["x"].select(2)
+        cs2 = cs.copy()
+        assert cs2["x"].default == cs2["x"]["_2"]
+        assert_array_equal(cs2["x"].data, [4.0, 5.0, 6.0])
+
+    def test_deepcopy_preserves_selected_non_first_default_for_multicoord(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        cs["x"].select(2)
+        cs2 = deepcopy(cs)
+        assert cs2["x"].default == cs2["x"]["_2"]
+        assert_array_equal(cs2["x"].data, [4.0, 5.0, 6.0])
 
 
 # ==============================================================================

--- a/tests/test_core/test_dataset/test_dataset_coords_behavior.py
+++ b/tests/test_core/test_dataset/test_dataset_coords_behavior.py
@@ -375,6 +375,13 @@ class TestNDDatasetDimAttributeAccess:
         assert_array_equal(ds2.x.data, [100.0, 200.0, 300.0])
         assert_units_equal(ds2.x.units, ur("cm^-1"))
 
+    def test_reference_dimension_attribute_returns_target_coord(self):
+        c = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(x=c, y="x"))
+        assert ds.coordset["y"] == "x"
+        assert ds.coordset.references == {"y": "x"}
+        assert_coord_almost_equal(ds.y, ds.x)
+
 
 # ==============================================================================
 # Multi-coord dimension
@@ -406,6 +413,26 @@ class TestNDDatasetMultiCoordDim:
         ds.x = CoordSet(Coord([11.0, 21.0, 31.0]), Coord([12.0, 22.0, 32.0]))
         sliced = ds[0:2, 0:2]
         assert len(sliced.x) == 2
+
+    def test_copy_preserves_selected_non_first_default_for_multicoord_dim(self):
+        ds = NDDataset([0.0, 1.0, 2.0])
+        x1 = Coord(np.array([1.5, 5.8, -9.0]))
+        x2 = Coord(np.array([0.5, 0.8, 9.0]))
+        ds.x = CoordSet(Coord(x2), Coord(x1))
+        ds.x.select(2)
+        ds2 = ds.copy()
+        assert ds2.x.default == ds2.x["_2"]
+        assert_array_equal(ds2.x.data, [0.5, 0.8, 9.0])
+
+    def test_slice_preserves_selected_non_first_default_for_multicoord_dim(self):
+        ds = NDDataset([0.0, 1.0, 2.0])
+        x1 = Coord(np.array([1.5, 5.8, -9.0]))
+        x2 = Coord(np.array([0.5, 0.8, 9.0]))
+        ds.x = CoordSet(Coord(x2), Coord(x1))
+        ds.x.select(2)
+        ds2 = ds[1:]
+        assert ds2.x.default == ds2.x["_2"]
+        assert_array_equal(ds2.x.data, [0.8, 9.0])
 
 
 # ==============================================================================


### PR DESCRIPTION
This PR strengthens `CoordSet` public-contract coverage ahead of the planned storage migration.

Added coverage includes:

- duplicate title lookup behavior;
- title/name collision behavior;
- synthetic alias collisions across multiple dimensions;
- reference lookup behavior;
- selected non-first default coordinate preservation across copy and slicing operations.

The PR intentionally focuses on documenting and preserving current public behavior.

No `CoordSet` storage changes are introduced.

During test development, several existing preservation issues were identified:

- references are not preserved by copy/deepcopy;
- references are not preserved by serialization;
- selected non-first defaults are not preserved by serialization.

These findings are documented in the migration audit and will be addressed separately.

## Testing

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset_behavior.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_dataset_coords_behavior.py -v`
- `pre-commit run --all-files`