### PR TITLE
FIX: preserve reference-based coordinates across copy paths

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,9 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fixed preservation of reference-based coordinates when copying
+  ``CoordSet`` and ``NDDataset`` objects.
+
 
 .. section
 
@@ -53,6 +56,9 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- TEST: Added focused behavioral tests covering reference preservation through
+  ``CoordSet.copy()``, ``copy.deepcopy(CoordSet)``, and ``NDDataset.copy()``.
 
 - TEST: Added CoordSet public-contract edge tests covering duplicate-title
   lookup, title/name collisions, synthetic alias collisions, reference lookup,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,8 +12,17 @@ What's New in Revision 0.9.4.dev
 These are the changes in SpectroChemPy-0.9.4.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+Bug Fixes
+~~~~~~~~~
+
+- Fixed preservation of reference-based coordinates when copying
+  ``CoordSet`` and ``NDDataset`` objects.
+
 Developer
 ~~~~~~~~~
+
+- TEST: Added focused behavioral tests covering reference preservation through
+  ``CoordSet.copy()``, ``copy.deepcopy(CoordSet)``, and ``NDDataset.copy()``.
 
 - TEST: Added CoordSet public-contract edge tests covering duplicate-title
   lookup, title/name collisions, synthetic alias collisions, reference lookup,

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -1406,6 +1406,7 @@ class CoordSet(HasTraits):
         coords.name = self.name
         coords._is_same_dim = self._is_same_dim
         coords._default = self._default
+        coords._references = cpy.deepcopy(self._references, memo=memo)
         return coords
 
     def __copy__(self):
@@ -1418,6 +1419,7 @@ class CoordSet(HasTraits):
         # and is_same_dim and default for coordset
         coords._is_same_dim = self._is_same_dim
         coords._default = self._default
+        coords._references = cpy.copy(self._references)
         return coords
 
     def __eq__(self, other):

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -524,6 +524,22 @@ class TestCoordSetCopy:
         assert cs2["x"].default == cs2["x"]["_2"]
         assert_array_equal(cs2["x"].data, [4.0, 5.0, 6.0])
 
+    def test_copy_preserves_reference_lookup(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        cs = CoordSet(x=c, y="x")
+        cs2 = cs.copy()
+        assert cs2.references == {"y": "x"}
+        assert cs2["y"] == "x"
+        assert_array_equal(cs2["x"].data, [1.0, 2.0, 3.0])
+
+    def test_deepcopy_preserves_reference_lookup(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        cs = CoordSet(x=c, y="x")
+        cs2 = deepcopy(cs)
+        assert cs2.references == {"y": "x"}
+        assert cs2["y"] == "x"
+        assert_array_equal(cs2["x"].data, [1.0, 2.0, 3.0])
+
 
 # ==============================================================================
 # Arithmetic

--- a/tests/test_core/test_dataset/test_dataset_coords_behavior.py
+++ b/tests/test_core/test_dataset/test_dataset_coords_behavior.py
@@ -382,6 +382,14 @@ class TestNDDatasetDimAttributeAccess:
         assert ds.coordset.references == {"y": "x"}
         assert_coord_almost_equal(ds.y, ds.x)
 
+    def test_reference_dimension_attribute_preserves_after_copy(self):
+        c = Coord([100.0, 200.0, 300.0], name="x")
+        ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(x=c, y="x"))
+        ds2 = ds.copy()
+        assert ds2.coordset.references == {"y": "x"}
+        assert ds2.coordset["y"] == "x"
+        assert_coord_almost_equal(ds2.y, ds2.x)
+
 
 # ==============================================================================
 # Multi-coord dimension


### PR DESCRIPTION
## Summary

This PR fixes preservation of reference-based coordinates when copying `CoordSet` and `NDDataset` objects.

## Changes

- preserve `CoordSet._references` in `CoordSet.__copy__()`
- preserve `CoordSet._references` in `CoordSet.__deepcopy__()`
- add focused behavioral tests for:
  - `CoordSet.copy()`
  - `copy.deepcopy(CoordSet)`
  - `NDDataset.copy()`
- update the changelog

## Compatibility

- no runtime storage redesign
- no lookup precedence changes
- no serialization changes
- no lifecycle changes

## Testing

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset_behavior.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_dataset_coords_behavior.py -v`
- `pre-commit run --all-files`

## Follow-up

Native serialization preservation remains separate follow-up work for the PR6b half of the preservation fixes.