### PR TITLE
FIX: preserve CoordSet defaults and references in native I/O

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fixed native round-trip preservation of selected non-first default
+  coordinates in same-dimension multi-coordinate datasets.
+
+- Fixed restoration of reference-based coordinates after native
+  save/load round-trips.
+
 - Fixed preservation of reference-based coordinates when copying
   ``CoordSet`` and ``NDDataset`` objects.
 
@@ -56,6 +62,10 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- TEST: Added focused native serialization round-trip tests for selected
+  defaults, reference lookup, and backward-compatible loading without a
+  serialized default field.
 
 - TEST: Added focused behavioral tests covering reference preservation through
   ``CoordSet.copy()``, ``copy.deepcopy(CoordSet)``, and ``NDDataset.copy()``.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,11 +15,21 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed native round-trip preservation of selected non-first default
+  coordinates in same-dimension multi-coordinate datasets.
+
+- Fixed restoration of reference-based coordinates after native
+  save/load round-trips.
+
 - Fixed preservation of reference-based coordinates when copying
   ``CoordSet`` and ``NDDataset`` objects.
 
 Developer
 ~~~~~~~~~
+
+- TEST: Added focused native serialization round-trip tests for selected
+  defaults, reference lookup, and backward-compatible loading without a
+  serialized default field.
 
 - TEST: Added focused behavioral tests covering reference preservation through
   ``CoordSet.copy()``, ``copy.deepcopy(CoordSet)``, and ``NDDataset.copy()``.

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -380,6 +380,15 @@ class NDIO(tr.HasTraits):
         from spectrochempy.core.script import Script
 
         # .........................
+        def restore_coordset_state(coordset: CoordSet, val: dict[str, Any]) -> CoordSet:
+            default_index = val.get("default_index")
+            if default_index is None and isinstance(val.get("default"), int):
+                default_index = val["default"]
+            if default_index is not None:
+                coordset._default = default_index
+            coordset._references = val.get("references", {})
+            return coordset
+
         def item_to_attr(obj: Any, dic: dict[str, Any]) -> Any:
             for key, val in dic.items():
                 try:
@@ -411,14 +420,15 @@ class NDIO(tr.HasTraits):
                                         _mcoords.append(item_to_attr(Coord(), mv))
 
                                     cs = CoordSet(*_mcoords[::-1], name=v["name"])
+                                    restore_coordset_state(cs, v)
                                     _coords.append(cs)
                                 else:
                                     raise ValueError("Invalid : not a multicoordinate")
 
                         coords = {c.name: c for c in _coords}
                         obj.set_coordset(coords)
-                        obj._name = val["name"]
-                        obj._references = val["references"]
+                        restore_coordset_state(obj._coordset, val)
+                        obj._coordset._name = val["name"]
 
                     elif key in ["_datasets"]:
                         # datasets = [item_to_attr(NDDataset(name=k),

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -497,6 +497,11 @@ class CoordSet(HasTraits):
         return self._coords[self._default]
 
     @property
+    def default_index(self):
+        """Selected default coordinate index (int)."""
+        return self._default
+
+    @property
     def data(self):
         # in case data is called on a coordset for dimension with multiple coordinates
         # return the default coordinates data
@@ -1036,7 +1041,7 @@ class CoordSet(HasTraits):
     # ----------------------------------------------------------------------------------
     # @staticmethod
     def _attributes_(self):
-        return ["coords", "references", "is_same_dim", "name"]
+        return ["coords", "references", "is_same_dim", "default_index", "name"]
 
     def __call__(self, *args, **kwargs):
         # allow the following syntax: coords(), coords(0,2) or

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -7,8 +7,13 @@
 
 """Tests for the ndplugin module"""
 
+import json
+import zipfile
+
 import pytest
 
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.utils.testing import assert_array_equal, assert_dataset_equal
 
@@ -70,6 +75,55 @@ def test_ndio_2D(ndataset_2d, tmp_path):
     nd = NDDataset.load(tmp_path / "essai2D")
     assert nd.directory == tmp_path
     f.unlink()
+
+
+def test_ndio_roundtrip_preserves_selected_non_first_default(tmp_path):
+    ds = NDDataset([0.0, 1.0, 2.0])
+    ds.x = CoordSet(Coord([10.0, 20.0, 30.0]), Coord([100.0, 200.0, 300.0]))
+    ds.x.select(2)
+    selected_data = ds.x.data.copy()
+    filename = ds.save_as(tmp_path / "multicoord_default", confirm=False)
+
+    loaded = NDDataset.load(filename)
+
+    assert loaded.x.default == loaded.x["_2"]
+    assert_array_equal(loaded.x.default.data, selected_data)
+    assert_array_equal(loaded.x.data, selected_data)
+
+
+def test_ndio_roundtrip_preserves_reference_lookup(tmp_path):
+    c = Coord([100.0, 200.0, 300.0], name="x")
+    ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(x=c, y="x"))
+    filename = ds.save_as(tmp_path / "reference_coords", confirm=False)
+
+    loaded = NDDataset.load(filename)
+
+    assert loaded.coordset.references == ds.coordset.references
+    assert loaded.coordset["y"] == "x"
+    assert_array_equal(loaded.y.data, loaded.x.data)
+    assert_array_equal(loaded.x.data, [100.0, 200.0, 300.0])
+
+
+def test_ndio_load_without_default_field_keeps_legacy_behavior(tmp_path):
+    ds = NDDataset([0.0, 1.0, 2.0])
+    ds.x = CoordSet(Coord([10.0, 20.0, 30.0]), Coord([100.0, 200.0, 300.0]))
+    ds.x.select(2)
+    legacy_default_data = ds.x["_1"].data.copy()
+    filename = ds.save_as(tmp_path / "legacy_default", confirm=False)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    js["coordset"]["coords"][0].pop("default_index", None)
+
+    with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(member, json.dumps(js, indent=2))
+
+    loaded = NDDataset.load(filename)
+
+    assert loaded.x.default == loaded.x["_1"]
+    assert_array_equal(loaded.x.data, legacy_default_data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR preserves selected default coordinates and reference lookup behavior across native SpectroChemPy save/load round-trips.

## Changes

- serialize an explicit private `CoordSet.default_index` state for native I/O
- restore selected default coordinates during native deserialization
- restore `CoordSet` references on the reconstructed `coordset` owner
- add focused native round-trip tests for:
  - selected non-first defaults
  - reference lookup
  - backward-compatible loading when the default index field is absent
- update the changelog

## Compatibility

- no runtime storage migration
- no lookup precedence changes
- no v2 serialization
- no lifecycle changes
- legacy loading remains backward compatible when the new field is absent

## Testing

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_mixins/test_ndio.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset_behavior.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_dataset_coords_behavior.py -v`
- `pre-commit run --all-files`

## Follow-up

This stays within the legacy native format and runtime storage model. Resolver-context and storage-migration work remain separate follow-up PRs.