### PR TITLE
MAINT: add private CoordSet lookup result context

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -63,6 +63,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Added a private `CoordSet` lookup-result context object for internal
+  read-lookup resolution, preserving all existing public lookup behavior while
+  preparing future storage-migration work.
+
 - TEST: Added focused native serialization round-trip tests for selected
   defaults, reference lookup, and backward-compatible loading without a
   serialized default field.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Added a private `CoordSet` lookup-result context object for internal
+  read-lookup resolution, preserving all existing public lookup behavior while
+  preparing future storage-migration work.
+
 - TEST: Added focused native serialization round-trip tests for selected
   defaults, reference lookup, and backward-compatible loading without a
   serialized default field.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -10,6 +10,7 @@ __all__ = ["CoordSet"]
 import copy as cpy
 import uuid
 import warnings
+from dataclasses import dataclass
 
 import numpy as np
 from traitlets import All
@@ -35,6 +36,17 @@ from spectrochempy.utils.typeutils import is_sequence
 # ======================================================================================
 # CoordSet
 # ======================================================================================
+@dataclass(frozen=True)
+class _CoordLookupResult:
+    """Private lookup result carrying legacy value plus resolver context."""
+
+    value: object
+    lookup_kind: str
+    owner_dim: str | None = None
+    compat_key: str | int | None = None
+    warning_message: str | None = None
+
+
 @signature_has_traits
 class CoordSet(HasTraits):
     r"""
@@ -1091,7 +1103,7 @@ class CoordSet(HasTraits):
     # Private resolver helpers (read-lookup only)
     # ------------------------------------------------------------------
 
-    def _resolve_string_lookup(self, index):
+    def _resolve_string_lookup_result(self, index):
         """
         Resolve a string key using current lookup precedence.
 
@@ -1106,51 +1118,78 @@ class CoordSet(HasTraits):
         # find by name
         if index in self.names:
             idx = self.names.index(index)
-            return self._coords.__getitem__(idx)
+            coord = self._coords.__getitem__(idx)
+            owner_dim = getattr(coord, "name", None)
+            return _CoordLookupResult(coord, "dimension", owner_dim, index)
 
         # try in references
         if index in self._references:
-            return self._references[index]
+            return _CoordLookupResult(
+                self._references[index],
+                "reference",
+                index,
+                index,
+            )
 
         # try in the title
         if index in self.titles:
             # selection by coord titles
+            warning_message = None
             if self.titles.count(index) > 1:
-                warnings.warn(
+                warning_message = (
                     f"Getting a coordinate from its title. However `{index}` occurs "
-                    f"several time. Only"
-                    f" the first occurrence is returned!",
-                    stacklevel=2,
+                    f"several time. Only the first occurrence is returned!"
                 )
-            return self._coords.__getitem__(self.titles.index(index))
+                warnings.warn(warning_message, stacklevel=2)
+            idx = self.titles.index(index)
+            coord = self._coords.__getitem__(idx)
+            owner_dim = getattr(coord, "name", None)
+            return _CoordLookupResult(
+                coord,
+                "title",
+                owner_dim,
+                index,
+                warning_message,
+            )
 
         # may be it is a title or a name in a sub-coords
         for item in self._coords:
             if isinstance(item, CoordSet) and index in item.titles:
                 # selection by subcoord title
-                return item._coords.__getitem__(item.titles.index(index))
+                idx = item.titles.index(index)
+                coord = item._coords.__getitem__(idx)
+                return _CoordLookupResult(coord, "child_title", item.name, index)
 
         for item in self._coords:
             if isinstance(item, CoordSet) and index in item.names:
                 # selection by subcoord name
-                return item._coords.__getitem__(item.names.index(index))
+                idx = item.names.index(index)
+                coord = item._coords.__getitem__(idx)
+                return _CoordLookupResult(coord, "child_name", item.name, index)
 
         try:
             # let try with the canonical dimension names
             if index[0] in self.names:
                 c = self._coords.__getitem__(self.names.index(index[0]))
+                owner_dim = getattr(c, "name", None)
                 if len(index) > 1 and index[1] == "_":
                     if isinstance(c, CoordSet):
-                        c = c.__getitem__(index[1:])
-                    else:
-                        c = c.__getitem__(index[2:])  # try on labels
-                return c
+                        result = c._resolve_get_result(index[1:])
+                        return _CoordLookupResult(
+                            result.value,
+                            "synthetic_alias",
+                            c.name,
+                            index,
+                            result.warning_message,
+                        )
+                    c = c.__getitem__(index[2:])  # try on labels
+                return _CoordLookupResult(c, "dimension", owner_dim, index)
         except IndexError:
             pass
 
         raise KeyError(f"Could not find `{index}` in coordinates names or titles")
 
-    def _resolve_numeric_lookup(self, index):
+    def _resolve_numeric_lookup_result(self, index):
         """
         Resolve a numeric key.
 
@@ -1160,7 +1199,9 @@ class CoordSet(HasTraits):
         multi = bool(self.is_same_dim)
 
         if not multi:
-            return self._coords.__getitem__(index)
+            coord = self._coords.__getitem__(index)
+            owner_dim = getattr(coord, "name", None)
+            return _CoordLookupResult(coord, "numeric", owner_dim, index)
 
         res = []
         for c in self._coords:
@@ -1169,7 +1210,18 @@ class CoordSet(HasTraits):
         coords.name = self.name
         coords._is_same_dim = self._is_same_dim
         coords._default = self._default
-        return coords
+        return _CoordLookupResult(coords, "numeric", self.name, index)
+
+    def _resolve_get_result(self, index):
+        """
+        Resolve *index* and return the matching private lookup result.
+
+        Public callers should continue to use ``__getitem__`` or
+        ``_resolve_get()``, which unwrap the legacy value.
+        """
+        if isinstance(index, str):
+            return self._resolve_string_lookup_result(index)
+        return self._resolve_numeric_lookup_result(index)
 
     def _resolve_get(self, index):
         """
@@ -1177,9 +1229,7 @@ class CoordSet(HasTraits):
 
         Dispatches to ``_resolve_string_lookup`` or ``_resolve_numeric_lookup``.
         """
-        if isinstance(index, str):
-            return self._resolve_string_lookup(index)
-        return self._resolve_numeric_lookup(index)
+        return self._resolve_get_result(index).value
 
     # ------------------------------------------------------------------
     # Private resolver helpers (write/delete lookup)

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -449,6 +449,44 @@ class TestCoordSetLookupAmbiguities:
 
 
 # ==============================================================================
+# Private lookup context
+# ==============================================================================
+
+
+class TestCoordSetLookupContext:
+    """Private lookup context used to prepare storage migration work."""
+
+    def test_resolve_get_result_reports_reference_context(self):
+        c = Coord([1.0, 2.0, 3.0], name="x")
+        cs = CoordSet(x=c, y="x")
+        result = cs._resolve_get_result("y")
+        assert result.value == "x"
+        assert result.lookup_kind == "reference"
+        assert result.owner_dim == "y"
+        assert result.compat_key == "y"
+
+    def test_resolve_get_result_reports_child_name_owner_dim(self):
+        cs = CoordSet(
+            x=CoordSet(Coord([1, 2, 3], name="a"), Coord([4, 5, 6], name="b"))
+        )
+        result = cs._resolve_get_result("_1")
+        assert result.value == cs["_1"]
+        assert result.lookup_kind == "child_name"
+        assert result.owner_dim == "x"
+        assert result.compat_key == "_1"
+
+    def test_resolve_get_result_reports_synthetic_alias_context(self):
+        cs = CoordSet(
+            x=CoordSet(Coord([1, 2, 3], name="a"), Coord([4, 5, 6], name="b"))
+        )
+        result = cs._resolve_get_result("x_1")
+        assert result.value == cs["x_1"]
+        assert result.lookup_kind == "synthetic_alias"
+        assert result.owner_dim == "x"
+        assert result.compat_key == "x_1"
+
+
+# ==============================================================================
 # Call syntax
 # ==============================================================================
 


### PR DESCRIPTION
## Summary

This PR adds a small private lookup-result context object for `CoordSet` read lookup resolution.

## Changes

- introduce a private `_CoordLookupResult` dataclass in `coordset.py`
- add `_resolve_get_result()` as the internal read-lookup entry point
- have string and numeric read lookup paths produce private context metadata
- keep `_resolve_get()` and `__getitem__()` returning the exact same legacy public values as before
- add focused tests for private lookup context on:
  - reference lookup
  - child alias lookup
  - synthetic alias lookup
- update the changelog

## Compatibility

- no runtime storage migration
- no lookup precedence changes
- no serialization changes
- no lifecycle changes
- write/delete resolvers intentionally unchanged in this PR

## Testing

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset_behavior.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_dataset_coords_behavior.py -v`
- `pre-commit run --all-files`

## Follow-up

This prepares future `NDDataset` owner-context work and later storage migration without making the private lookup context a runtime source of truth.