### PR TITLE
MAINT: add private CoordSet serializer adapter helpers

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -63,6 +63,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Added private CoordSet serializer adapter helpers for converting
+  legacy serialized coordset state to and from the private group model,
+  without changing runtime storage or native I/O behavior.
+
 - MAINT: Added a private `CoordSet` lookup-result context object for internal
   read-lookup resolution, preserving all existing public lookup behavior while
   preparing future storage-migration work.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Added private CoordSet serializer adapter helpers for converting
+  legacy serialized coordset state to and from the private group model,
+  without changing runtime storage or native I/O behavior.
+
 - MAINT: Added a private `CoordSet` lookup-result context object for internal
   read-lookup resolution, preserving all existing public lookup behavior while
   preparing future storage-migration work.

--- a/src/spectrochempy/core/dataset/_coordgroup.py
+++ b/src/spectrochempy/core/dataset/_coordgroup.py
@@ -7,11 +7,14 @@
 
 from __future__ import annotations
 
+import copy as cpy
 from dataclasses import dataclass
 from dataclasses import field
 from typing import TYPE_CHECKING
 
 from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.utils.jsonutils import json_decoder
+from spectrochempy.utils.jsonutils import json_encoder
 
 if TYPE_CHECKING:
     from spectrochempy.core.dataset.coordset import CoordSet
@@ -194,3 +197,195 @@ def _groups_to_coordset(
         coordset.name = name
     coordset._references = references
     return coordset
+
+
+def _coord_from_legacy_state(state: dict) -> Coord:
+    """Rebuild one Coord from legacy serialized state."""
+    coord = Coord()
+    for key, value in state.items():
+        if key == "__class__":
+            continue
+        decoded = (
+            json_decoder(cpy.deepcopy(value)) if isinstance(value, dict) else value
+        )
+        setattr(coord, key if key == "name" else f"_{key}", decoded)
+    return coord
+
+
+def _coord_to_legacy_state(coord: Coord) -> dict:
+    """Serialize one Coord to the legacy coord-state shape."""
+    return json_encoder(coord, encoding="base64")
+
+
+def _legacy_group_state_to_dimension(state: dict) -> _DimensionCoordinates:
+    """Convert one legacy same-dimension serialized state to a private group."""
+    used_ids: set[str] = set()
+    aliases: dict[str, str] = {}
+    entries: list[_CoordinateEntry] = []
+
+    for index, coord_state in enumerate(state.get("coords", ()), start=1):
+        coord = _coord_from_legacy_state(coord_state)
+        alias = coord_state.get("name", f"_{index}")
+        entry_id = _make_entry_id(coord, alias, used_ids)
+        entries.append(
+            _CoordinateEntry(
+                id=entry_id,
+                coord=coord,
+                aliases=(alias,),
+            )
+        )
+        aliases[alias] = entry_id
+
+    default_index = state.get("default_index")
+    if default_index is None and isinstance(state.get("default"), int):
+        default_index = state["default"]
+
+    default_id = None
+    if entries:
+        index = min(max(0, int(default_index or 0)), len(entries) - 1)
+        default_id = entries[index].id
+
+    reference = None
+    references = state.get("references", {})
+    if references:
+        ref_dim, target_dim = next(iter(references.items()))
+        reference = _CoordReference(dim=ref_dim, target_dim=target_dim)
+
+    return _DimensionCoordinates(
+        dim=state["name"],
+        entries=tuple(entries),
+        default_id=default_id,
+        aliases=aliases,
+        reference=reference,
+    )
+
+
+def _legacy_state_to_groups(state: dict) -> tuple[_DimensionCoordinates, ...]:
+    """Convert legacy serialized CoordSet state to private groups."""
+    if state.get("is_same_dim"):
+        return (_legacy_group_state_to_dimension(state),)
+
+    groups: list[_DimensionCoordinates] = []
+
+    for item in state.get("coords", ()):
+        if "coords" in item:
+            groups.append(_legacy_group_state_to_dimension(item))
+            continue
+
+        coord = _coord_from_legacy_state(item)
+        entry = _CoordinateEntry(
+            id=_make_entry_id(coord, item["name"], set()),
+            coord=coord,
+        )
+        groups.append(
+            _DimensionCoordinates(
+                dim=item["name"],
+                entries=(entry,),
+                default_id=entry.id,
+            )
+        )
+
+    for dim, target_dim in state.get("references", {}).items():
+        groups.append(
+            _DimensionCoordinates(
+                dim=dim,
+                entries=(),
+                reference=_CoordReference(dim=dim, target_dim=target_dim),
+            )
+        )
+
+    return tuple(groups)
+
+
+def _groups_to_legacy_state(
+    groups: tuple[_DimensionCoordinates, ...] | list[_DimensionCoordinates],
+    *,
+    name: str,
+    is_same_dim: bool = False,
+) -> dict:
+    """Convert private groups back to the legacy serialized CoordSet state."""
+    if is_same_dim:
+        if len(groups) != 1:
+            raise ValueError("Same-dimension legacy state expects exactly one group")
+        group = groups[0]
+        child_states = []
+        for index, entry in enumerate(group.entries, start=1):
+            coord_state = _coord_to_legacy_state(entry.coord)
+            alias = next(
+                (item for item in entry.aliases if group.aliases.get(item) == entry.id),
+                None,
+            )
+            coord_state["name"] = alias or f"_{index}"
+            child_states.append(coord_state)
+
+        default_index = 0
+        if group.entries:
+            default_index = next(
+                (
+                    index
+                    for index, entry in enumerate(group.entries)
+                    if entry.id == group.default_id
+                ),
+                0,
+            )
+
+        return {
+            "coords": child_states,
+            "references": {},
+            "is_same_dim": True,
+            "default_index": default_index,
+            "name": name,
+        }
+
+    references: dict[str, str] = {}
+    coords: list[dict] = []
+
+    for group in groups:
+        if group.reference is not None:
+            references[group.reference.dim] = group.reference.target_dim
+            continue
+
+        if len(group.entries) == 1 and not group.aliases and not is_same_dim:
+            coord_state = _coord_to_legacy_state(group.entries[0].coord)
+            coord_state["name"] = group.dim
+            coords.append(coord_state)
+            continue
+
+        child_states = []
+        for index, entry in enumerate(group.entries, start=1):
+            coord_state = _coord_to_legacy_state(entry.coord)
+            alias = next(
+                (item for item in entry.aliases if group.aliases.get(item) == entry.id),
+                None,
+            )
+            coord_state["name"] = alias or f"_{index}"
+            child_states.append(coord_state)
+
+        default_index = 0
+        if group.entries:
+            default_index = next(
+                (
+                    index
+                    for index, entry in enumerate(group.entries)
+                    if entry.id == group.default_id
+                ),
+                0,
+            )
+
+        coords.append(
+            {
+                "coords": child_states,
+                "references": {},
+                "is_same_dim": True,
+                "default_index": default_index,
+                "name": group.dim,
+            }
+        )
+
+    return {
+        "coords": coords,
+        "references": references,
+        "is_same_dim": is_same_dim,
+        "default_index": 0,
+        "name": name,
+    }

--- a/tests/test_core/test_dataset/test_coordgroup_serialization.py
+++ b/tests/test_core/test_dataset/test_coordgroup_serialization.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# (see LICENSE.txt for details)
+
+"""Focused tests for private CoordSet serializer adapter helpers."""
+
+from spectrochempy.core.dataset._coordgroup import _groups_to_legacy_state
+from spectrochempy.core.dataset._coordgroup import _legacy_state_to_groups
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
+from spectrochempy.utils.jsonutils import json_encoder
+
+
+def _legacy_state(coordset):
+    return json_encoder(coordset, encoding="base64")
+
+
+def test_legacy_state_roundtrip_for_simple_coord_dimension():
+    coordset = CoordSet(
+        x=Coord([1.0, 2.0, 3.0], name="x", title="distance", units="cm"),
+    )
+    state = _legacy_state(coordset)
+
+    groups = _legacy_state_to_groups(state)
+    rebuilt = _groups_to_legacy_state(
+        groups,
+        name=state["name"],
+        is_same_dim=state["is_same_dim"],
+    )
+
+    assert rebuilt == state
+
+
+def test_legacy_state_roundtrip_for_multi_coordinate_dimension():
+    coord_a = Coord([1.0, 2.0, 3.0], name="a", title="alpha", units="cm^-1")
+    coord_b = Coord([4.0, 5.0, 6.0], name="b", title="beta", units="s")
+    coordset = CoordSet([coord_a, coord_b])
+    coordset["x"].select(2)
+    state = _legacy_state(coordset)
+
+    groups = _legacy_state_to_groups(state)
+    rebuilt = _groups_to_legacy_state(
+        groups,
+        name=state["name"],
+        is_same_dim=state["is_same_dim"],
+    )
+
+    assert rebuilt == state
+    assert rebuilt["coords"][0]["default_index"] == 1
+    assert rebuilt["coords"][0]["coords"][0]["name"] == "_1"
+    assert rebuilt["coords"][0]["coords"][1]["name"] == "_2"
+
+
+def test_legacy_state_roundtrip_for_reference_dimension():
+    coordset = CoordSet(
+        x=Coord([1.0, 2.0, 3.0], name="x", title="distance", units="cm"),
+        y="x",
+    )
+    state = _legacy_state(coordset)
+
+    groups = _legacy_state_to_groups(state)
+    rebuilt = _groups_to_legacy_state(
+        groups,
+        name=state["name"],
+        is_same_dim=state["is_same_dim"],
+    )
+
+    assert rebuilt == state
+    assert rebuilt["references"] == {"y": "x"}
+
+
+def test_legacy_state_without_default_index_uses_legacy_fallback():
+    coord_a = Coord([1.0, 2.0, 3.0], name="a", title="alpha", units="cm^-1")
+    coord_b = Coord([4.0, 5.0, 6.0], name="b", title="beta", units="s")
+    coordset = CoordSet([coord_a, coord_b])
+    coordset["x"].select(2)
+    state = _legacy_state(coordset)
+    state["coords"][0].pop("default_index", None)
+
+    groups = _legacy_state_to_groups(state)
+    rebuilt = _groups_to_legacy_state(
+        groups,
+        name=state["name"],
+        is_same_dim=state["is_same_dim"],
+    )
+
+    assert groups[0].default_id == groups[0].entries[0].id
+    assert rebuilt["coords"][0]["default_index"] == 0


### PR DESCRIPTION
## Summary

This PR adds private serializer adapter helpers for converting between the legacy serialized `CoordSet` state and the private group model introduced for the storage redesign preparation work.

## Changes

- Added private legacy-state adapter helpers in `_coordgroup.py`
- Added focused conversion tests for:
  - simple coordinate dimensions
  - same-dimension multi-coordinate groups
  - reference dimensions
  - backward-compatible legacy states without `default_index`
- Updated the storage migration audit and changelog

## Compatibility

- No runtime storage changes
- No lookup behavior changes
- No resolver changes
- No native I/O behavior changes
- No v2 serialization
- No public API changes

## Testing

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordgroup_serialization.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordgroup_conversion.py -v`
- `pre-commit run --all-files`