### PR TITLE
MAINT: use CoordSet group metadata in lookup context

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -63,6 +63,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Started consuming private CoordSet group-model metadata inside read
+  lookup context generation while preserving legacy storage and public lookup
+  behavior.
+
 - MAINT: Added private CoordSet serializer adapter helpers for converting
   legacy serialized coordset state to and from the private group model,
   without changing runtime storage or native I/O behavior.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Started consuming private CoordSet group-model metadata inside read
+  lookup context generation while preserving legacy storage and public lookup
+  behavior.
+
 - MAINT: Added private CoordSet serializer adapter helpers for converting
   legacy serialized coordset state to and from the private group model,
   without changing runtime storage or native I/O behavior.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -25,6 +25,7 @@ from traitlets import observe
 from traitlets import signature_has_traits
 from traitlets import validate
 
+from spectrochempy.core.dataset._coordgroup import _coordset_to_groups
 from spectrochempy.core.dataset.basearrays.ndarray import DEFAULT_DIM_NAME
 from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 from spectrochempy.core.dataset.coord import Coord
@@ -45,6 +46,9 @@ class _CoordLookupResult:
     owner_dim: str | None = None
     compat_key: str | int | None = None
     warning_message: str | None = None
+    entry_id: str | None = None
+    alias: str | None = None
+    reference_target: str | None = None
 
 
 @signature_has_traits
@@ -1103,6 +1107,47 @@ class CoordSet(HasTraits):
     # Private resolver helpers (read-lookup only)
     # ------------------------------------------------------------------
 
+    def _lookup_groups(self):
+        """Project current legacy storage to private lookup groups."""
+        return _coordset_to_groups(self)
+
+    def _coordinate_lookup_groups(self):
+        """Private groups that correspond positionally to legacy ``_coords``."""
+        return tuple(
+            group for group in self._lookup_groups() if group.reference is None
+        )
+
+    def _lookup_group_for_legacy_index(self, coord_groups, index):
+        """Return the projected group corresponding to one legacy coord index."""
+        if self.is_same_dim:
+            return coord_groups[0] if coord_groups else None
+        return coord_groups[index] if index < len(coord_groups) else None
+
+    @staticmethod
+    def _lookup_entry(group, index):
+        """Return one private group entry by position if available."""
+        if group is None or index < 0 or index >= len(group.entries):
+            return None
+        return group.entries[index]
+
+    @staticmethod
+    def _lookup_alias(group, entry_id):
+        """Return the first compatibility alias for *entry_id* in one group."""
+        if group is None:
+            return None
+        for alias, candidate_id in group.aliases.items():
+            if candidate_id == entry_id:
+                return alias
+        return None
+
+    @staticmethod
+    def _lookup_reference_group(groups, dim):
+        """Return the private reference group for *dim* if present."""
+        for group in groups:
+            if group.reference is not None and group.reference.dim == dim:
+                return group
+        return None
+
     def _resolve_string_lookup_result(self, index):
         """
         Resolve a string key using current lookup precedence.
@@ -1115,20 +1160,44 @@ class CoordSet(HasTraits):
         5. nested child name
         6. canonical synthetic alias (e.g. ``x_1``)
         """
+        groups = self._lookup_groups()
+        coord_groups = tuple(group for group in groups if group.reference is None)
+
         # find by name
         if index in self.names:
             idx = self.names.index(index)
             coord = self._coords.__getitem__(idx)
-            owner_dim = getattr(coord, "name", None)
-            return _CoordLookupResult(coord, "dimension", owner_dim, index)
+            group = self._lookup_group_for_legacy_index(coord_groups, idx)
+            entry = self._lookup_entry(group, idx) if self.is_same_dim else None
+            entry_id = entry.id if entry is not None else None
+            if group is not None and entry_id is None:
+                entry_id = group.default_id
+                if len(group.entries) == 1:
+                    entry_id = group.entries[0].id
+            owner_dim = group.dim if group is not None else getattr(coord, "name", None)
+            return _CoordLookupResult(
+                coord,
+                "dimension",
+                owner_dim,
+                index,
+                entry_id=entry_id,
+                alias=index if self.is_same_dim else None,
+            )
 
         # try in references
         if index in self._references:
+            group = self._lookup_reference_group(groups, index)
+            target_dim = (
+                group.reference.target_dim
+                if group is not None and group.reference is not None
+                else self._references[index]
+            )
             return _CoordLookupResult(
                 self._references[index],
                 "reference",
                 index,
                 index,
+                reference_target=target_dim,
             )
 
         # try in the title
@@ -1143,47 +1212,95 @@ class CoordSet(HasTraits):
                 warnings.warn(warning_message, stacklevel=2)
             idx = self.titles.index(index)
             coord = self._coords.__getitem__(idx)
-            owner_dim = getattr(coord, "name", None)
+            group = self._lookup_group_for_legacy_index(coord_groups, idx)
+            entry = self._lookup_entry(group, idx) if self.is_same_dim else None
+            entry_id = entry.id if entry is not None else None
+            if group is not None and entry_id is None:
+                entry_id = group.default_id
+                if len(group.entries) == 1:
+                    entry_id = group.entries[0].id
+            owner_dim = group.dim if group is not None else getattr(coord, "name", None)
             return _CoordLookupResult(
                 coord,
                 "title",
                 owner_dim,
                 index,
                 warning_message,
+                entry_id=entry_id,
+                alias=(
+                    self._lookup_alias(group, entry.id)
+                    if self.is_same_dim and entry is not None
+                    else None
+                ),
             )
 
         # may be it is a title or a name in a sub-coords
-        for item in self._coords:
+        for item, group in zip(self._coords, coord_groups, strict=False):
             if isinstance(item, CoordSet) and index in item.titles:
                 # selection by subcoord title
                 idx = item.titles.index(index)
                 coord = item._coords.__getitem__(idx)
-                return _CoordLookupResult(coord, "child_title", item.name, index)
+                entry = self._lookup_entry(group, idx)
+                return _CoordLookupResult(
+                    coord,
+                    "child_title",
+                    group.dim,
+                    index,
+                    entry_id=entry.id if entry is not None else None,
+                    alias=(
+                        self._lookup_alias(group, entry.id)
+                        if entry is not None
+                        else None
+                    ),
+                )
 
-        for item in self._coords:
+        for item, group in zip(self._coords, coord_groups, strict=False):
             if isinstance(item, CoordSet) and index in item.names:
                 # selection by subcoord name
                 idx = item.names.index(index)
                 coord = item._coords.__getitem__(idx)
-                return _CoordLookupResult(coord, "child_name", item.name, index)
+                entry = self._lookup_entry(group, idx)
+                return _CoordLookupResult(
+                    coord,
+                    "child_name",
+                    group.dim,
+                    index,
+                    entry_id=entry.id if entry is not None else None,
+                    alias=index,
+                )
 
         try:
             # let try with the canonical dimension names
             if index[0] in self.names:
-                c = self._coords.__getitem__(self.names.index(index[0]))
-                owner_dim = getattr(c, "name", None)
+                idx = self.names.index(index[0])
+                c = self._coords.__getitem__(idx)
+                group = coord_groups[idx] if idx < len(coord_groups) else None
+                owner_dim = group.dim if group is not None else getattr(c, "name", None)
                 if len(index) > 1 and index[1] == "_":
                     if isinstance(c, CoordSet):
                         result = c._resolve_get_result(index[1:])
                         return _CoordLookupResult(
                             result.value,
                             "synthetic_alias",
-                            c.name,
+                            owner_dim,
                             index,
                             result.warning_message,
+                            entry_id=result.entry_id,
+                            alias=result.alias,
                         )
                     c = c.__getitem__(index[2:])  # try on labels
-                return _CoordLookupResult(c, "dimension", owner_dim, index)
+                entry_id = None
+                if group is not None:
+                    entry_id = group.default_id
+                    if len(group.entries) == 1:
+                        entry_id = group.entries[0].id
+                return _CoordLookupResult(
+                    c,
+                    "dimension",
+                    owner_dim,
+                    index,
+                    entry_id=entry_id,
+                )
         except IndexError:
             pass
 
@@ -1197,11 +1314,24 @@ class CoordSet(HasTraits):
         For same-dimension multi-coordinate groups this slices every child.
         """
         multi = bool(self.is_same_dim)
+        coord_groups = self._coordinate_lookup_groups()
 
         if not multi:
             coord = self._coords.__getitem__(index)
-            owner_dim = getattr(coord, "name", None)
-            return _CoordLookupResult(coord, "numeric", owner_dim, index)
+            group = self._lookup_group_for_legacy_index(coord_groups, index)
+            owner_dim = group.dim if group is not None else getattr(coord, "name", None)
+            entry_id = None
+            if group is not None:
+                entry_id = group.default_id
+                if len(group.entries) == 1:
+                    entry_id = group.entries[0].id
+            return _CoordLookupResult(
+                coord,
+                "numeric",
+                owner_dim,
+                index,
+                entry_id=entry_id,
+            )
 
         res = []
         for c in self._coords:
@@ -1210,7 +1340,14 @@ class CoordSet(HasTraits):
         coords.name = self.name
         coords._is_same_dim = self._is_same_dim
         coords._default = self._default
-        return _CoordLookupResult(coords, "numeric", self.name, index)
+        group = coord_groups[0] if coord_groups else None
+        return _CoordLookupResult(
+            coords,
+            "numeric",
+            group.dim if group is not None else self.name,
+            index,
+            entry_id=group.default_id if group is not None else None,
+        )
 
     def _resolve_get_result(self, index):
         """

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -1121,6 +1121,8 @@ class CoordSet(HasTraits):
         """Return the projected group corresponding to one legacy coord index."""
         if self.is_same_dim:
             return coord_groups[0] if coord_groups else None
+        if not isinstance(index, int):
+            return None
         return coord_groups[index] if index < len(coord_groups) else None
 
     @staticmethod

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -464,6 +464,7 @@ class TestCoordSetLookupContext:
         assert result.lookup_kind == "reference"
         assert result.owner_dim == "y"
         assert result.compat_key == "y"
+        assert result.reference_target == "x"
 
     def test_resolve_get_result_reports_child_name_owner_dim(self):
         cs = CoordSet(
@@ -474,16 +475,29 @@ class TestCoordSetLookupContext:
         assert result.lookup_kind == "child_name"
         assert result.owner_dim == "x"
         assert result.compat_key == "_1"
+        assert result.entry_id is not None
+        assert result.alias == "_1"
 
     def test_resolve_get_result_reports_synthetic_alias_context(self):
         cs = CoordSet(
             x=CoordSet(Coord([1, 2, 3], name="a"), Coord([4, 5, 6], name="b"))
         )
         result = cs._resolve_get_result("x_1")
+        nested = cs["x"]._resolve_get_result("_1")
         assert result.value == cs["x_1"]
         assert result.lookup_kind == "synthetic_alias"
         assert result.owner_dim == "x"
         assert result.compat_key == "x_1"
+        assert result.entry_id == nested.entry_id
+        assert result.alias == "_1"
+
+    def test_resolve_get_result_reports_title_entry_context(self):
+        cs = CoordSet(x=Coord([1, 2, 3], title="distance"))
+        result = cs._resolve_get_result("distance")
+        assert result.value == cs["distance"]
+        assert result.lookup_kind == "title"
+        assert result.owner_dim == "x"
+        assert result.entry_id is not None
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

This PR starts consuming the private CoordSet group model inside read lookup internals while keeping legacy `_coords` storage as the sole runtime source of truth.

It enriches private lookup context metadata without changing public lookup return values or lookup precedence.

## Changes

- Project legacy CoordSet storage through `_coordset_to_groups(self)` during read lookup resolution.
- Populate private `_CoordLookupResult` metadata from group projections, including entry id, alias, and reference target context.
- Preserve legacy return values from `CoordSet.__getitem__()` and `_resolve_get()`.
- Add focused tests for the new internal lookup metadata.
- Update changelog and storage migration audit notes.

## Compatibility

- `_coords` remains the runtime source of truth.
- No `_groups` runtime state is introduced.
- No lookup precedence changes.
- No public API changes.
- No serialization changes.
- No lifecycle helper changes.
- No NDDataset behavior changes.

## Testing

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset_behavior.py -v`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_dataset_coords_behavior.py -v`
- `conda run -n scpy-core ruff check src/spectrochempy/core/dataset/coordset.py tests/test_core/test_dataset/test_coordset_behavior.py`
- `pre-commit run --all-files`