### PR TITLE
FIX: tolerate malformed OPUS acquisition sub-second field (#1036)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,10 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``read_opus`` no longer fails when an OPUS file stores a malformed
+  acquisition sub-second field (e.g. ``10:31:19.-70``); the timestamp now
+  falls back to whole-second precision instead of returning ``None`` (#1036).
+
 - Fixed native round-trip preservation of selected non-first default
   coordinates in same-dimension multi-coordinate datasets.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,10 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- ``read_opus`` no longer fails when an OPUS file stores a malformed
+  acquisition sub-second field (e.g. ``10:31:19.-70``); the timestamp now
+  falls back to whole-second precision instead of returning ``None`` (#1036).
+
 - Fixed native round-trip preservation of selected non-first default
   coordinates in same-dimension multi-coordinate datasets.
 

--- a/src/spectrochempy/core/readers/read_opus.py
+++ b/src/spectrochempy/core/readers/read_opus.py
@@ -318,10 +318,14 @@ def _get_timestamp_from(params):
     acqtime = params.tim
     gmt_offset_hour = float(acqtime.split("GMT")[1].split(")")[0])
     if len(acqdate.split("/")[0]) == 2:
-        date_time = datetime.strptime(
-            acqdate + "_" + acqtime.split()[0],
-            "%d/%m/%Y_%H:%M:%S.%f",
-        )
+        dt_str = acqdate + "_" + acqtime.split()[0]
+        try:
+            date_time = datetime.strptime(dt_str, "%d/%m/%Y_%H:%M:%S.%f")
+        except ValueError:
+            # Some OPUS files store a malformed sub-second field, e.g.
+            # "10:31:19.-70"; fall back to whole-second precision instead of
+            # failing the whole read (#1036).
+            date_time = datetime.strptime(dt_str.split(".")[0], "%d/%m/%Y_%H:%M:%S")
     elif len(acqdate.split("/")[0]) == 4:
         date_time = datetime.strptime(
             acqdate + "_" + acqtime.split()[0],

--- a/tests/test_core/test_readers/test_read_opus_timestamp.py
+++ b/tests/test_core/test_readers/test_read_opus_timestamp.py
@@ -1,0 +1,41 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Unit tests for OPUS acquisition-timestamp parsing (no test data required)."""
+
+from types import SimpleNamespace
+
+from spectrochempy.core.readers.read_opus import _get_timestamp_from
+
+
+def test_timestamp_malformed_subsecond():
+    """
+    A malformed sub-second field must not break the read (#1036).
+
+    Some OPUS files store a garbage fractional-seconds value such as
+    ``10:31:19.-70``; ``_get_timestamp_from`` should fall back to whole-second
+    precision instead of raising ``ValueError``.
+    """
+    params = SimpleNamespace(dat="25/03/2020", tim="10:31:19.-70 (GMT+1)")
+    dt, timestamp = _get_timestamp_from(params)
+    # GMT+1 -> UTC shifts 10:31:19 to 09:31:19, sub-second dropped
+    assert (dt.year, dt.month, dt.day) == (2020, 3, 25)
+    assert (dt.hour, dt.minute, dt.second) == (9, 31, 19)
+    assert dt.microsecond == 0
+    assert isinstance(timestamp, float)
+
+
+def test_timestamp_valid_subsecond_preserved():
+    """A well-formed sub-second field keeps microsecond precision."""
+    params = SimpleNamespace(dat="25/03/2020", tim="10:31:19.123 (GMT+1)")
+    dt, _ = _get_timestamp_from(params)
+    assert (dt.hour, dt.second, dt.microsecond) == (9, 19, 123000)
+
+
+def test_timestamp_iso_date_form():
+    """The ``YYYY/MM/DD`` second-precision form is unaffected."""
+    params = SimpleNamespace(dat="2020/03/25", tim="10:31:19 (GMT+1)")
+    dt, _ = _get_timestamp_from(params)
+    assert (dt.year, dt.hour, dt.second) == (2020, 9, 19)


### PR DESCRIPTION
Closes #1036.

## Problem

`read_opus` returns `None` (after a `UserWarning`) for OPUS files whose acquisition time has a malformed sub-second field. The reporter's files carry timestamps like:

```
time data '25/03/2020_10:31:19.-70' does not match format '%d/%m/%Y_%H:%M:%S.%f'
```

The `.-70` is a garbage fractional-seconds value: `%f` only accepts digits, so `datetime.strptime` raises `ValueError` and the whole file fails to load.

## Cause

`_get_timestamp_from` (`read_opus.py`) parses the `DD/MM/YYYY` form strictly with `"%d/%m/%Y_%H:%M:%S.%f"`. Any sub-second text that isn't a plain unsigned integer (here `-70`) makes the parse fail.

## Fix

When the sub-second parse fails, fall back to whole-second precision (`"%d/%m/%Y_%H:%M:%S"`) by dropping the fractional part, instead of failing the read. Sub-second precision is irrelevant for acquisition timestamps, so this preserves the date/time and lets the file load. Well-formed sub-second values are unchanged (still parsed at microsecond precision), as is the `YYYY/MM/DD` second-precision form.

## Tests

Added `tests/test_core/test_readers/test_read_opus_timestamp.py` — pure unit tests of `_get_timestamp_from` (no OPUS test data required): the malformed `.-70` case (fails on `master`, passes here), plus a well-formed sub-second case (microseconds preserved) and the `YYYY/MM/DD` form. Ran `ruff` clean.
