### PR TITLE
FIX: parse dotted unit symbols a.u. and K.M. (#913)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -30,6 +30,10 @@ Bug Fixes
   acquisition sub-second field (e.g. ``10:31:19.-70``); the timestamp now
   falls back to whole-second precision instead of returning ``None`` (#1036).
 
+- Fixed parsing of the ``a.u.`` (absorbance) and ``K.M.`` (Kubelka-Munk) unit
+  symbols from strings, which previously failed because the dots were read as a
+  multiplication.
+
 - Fixed native round-trip preservation of selected non-first default
   coordinates in same-dimension multi-coordinate datasets.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -19,6 +19,10 @@ Bug Fixes
   acquisition sub-second field (e.g. ``10:31:19.-70``); the timestamp now
   falls back to whole-second precision instead of returning ``None`` (#1036).
 
+- Fixed parsing of the ``a.u.`` (absorbance) and ``K.M.`` (Kubelka-Munk) unit
+  symbols from strings, which previously failed because the dots were read as a
+  multiplication.
+
 - Fixed native round-trip preservation of selected non-first default
   coordinates in same-dimension multi-coordinate datasets.
 

--- a/src/spectrochempy/core/units/__init__.py
+++ b/src/spectrochempy/core/units/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "DimensionalityError",
 ]
 
+import re
 import warnings
 
 from pint import __version__
@@ -30,6 +31,40 @@ if pint_version < 24:
         f"Please consider upgrading it to 0.24 or higher (e.g. `> pip install pint --upgrade` or `> conda update pint`)\n",
         stacklevel=2,
     )
+
+
+def _register_dotted_symbols(registry):
+    """
+    Allow parsing custom unit symbols that contain dots (e.g. ``a.u.``).
+
+    pint interprets ``.`` as a multiplication operator, so SpectroChemPy's
+    dotted display symbols (``a.u.`` for absorbance, ``K.M.`` for Kubelka-Munk)
+    round-trip on output but cannot be read back from a string. This installs a
+    registry preprocessor that rewrites those symbols, with or without their
+    trailing dot, to the canonical unit name before parsing. See issue #913.
+    """
+    mapping = {}
+    for name in list(registry):
+        if "." in name:
+            continue
+        try:
+            symbol = registry.get_symbol(name)
+        except Exception:  # noqa: S112 - skip units without a resolvable symbol
+            continue
+        if "." in symbol:
+            mapping[symbol] = name
+            mapping[symbol.rstrip(".")] = name
+    if not mapping:
+        return
+    pattern = re.compile(
+        r"(?<![\w.])("
+        + "|".join(re.escape(s) for s in sorted(mapping, key=len, reverse=True))
+        + r")(?![\w.])",
+    )
+    registry.preprocessors.append(
+        lambda string: pattern.sub(lambda m: mapping[m.group(1)], string),
+    )
+
 
 if pint_version < 24:
     from functools import wraps
@@ -513,6 +548,13 @@ else:  # pint version >= 24
         ur.define("absorbance = 1. = a.u.")
         ur.define("Kubelka_Munk = 1. = K.M.")
         ur.define("ppm = 1. = ppm")
+
+        # pint reads "." as multiplication, so custom display symbols that
+        # contain dots (e.g. "a.u." for absorbance, "K.M." for Kubelka-Munk)
+        # cannot be parsed back from their string form. Register a preprocessor
+        # mapping those symbols (with or without the trailing dot) to their
+        # canonical unit name before parsing. See #913.
+        _register_dotted_symbols(ur)
 
         set_application_registry(ur)
         del UnitRegistry  # to avoid importing it

--- a/tests/test_core/test_units/test_units.py
+++ b/tests/test_core/test_units/test_units.py
@@ -13,6 +13,18 @@ def test_ppm():
     assert x.units == ur.ppm
 
 
+def test_dotted_symbol_parsing():
+    # custom display symbols that contain dots must parse back to the unit
+    # they are the symbol of (pint reads "." as multiplication). See #913.
+    assert ur.Unit("a.u.") == ur.absorbance
+    assert ur.Unit("a.u") == ur.absorbance
+    assert ur.Unit("K.M.") == ur.Kubelka_Munk
+    assert ur.Unit("K.M") == ur.Kubelka_Munk
+    # the full names keep working and ordinary dotted products are untouched
+    assert ur.Unit("absorbance") == ur.absorbance
+    assert ur.Unit("kg.m") == ur.kg * ur.m
+
+
 def test_units():
     assert 10 * ur.km == 10000 * ur.m
     assert ur.km / ur.m == 1000.0


### PR DESCRIPTION
Fixes #913.

`NDDataset(data=[1, 2, 3], units="a.u.")` produced `u.a` instead of `a.u.`, and `to("a.u")`/`ito("a.u")` did not work. The custom unit symbols `a.u.` (absorbance) and `K.M.` (Kubelka-Munk) display correctly, but pint reads `.` as a multiplication operator, so they could not be parsed back from a string. Reading from a file works only because the readers assign the canonical name (`absorbance`), never the dotted symbol.

### Fix
A registry preprocessor rewrites the dotted symbols (with or without their trailing dot) to the canonical unit name before parsing. The mapping is derived from the registered symbols themselves, so any future dotted unit is covered automatically. Ordinary dotted products such as `kg.m` and the astronomical unit `au` are left untouched.

```python
>>> scp.NDDataset(data=[1, 2, 3], units="a.u.").units
a.u.
>>> scp.NDDataset(data=[1, 2, 3], units="a.u").units
a.u.
```

### Notes
- Applied to the active pint (>= 0.24) registry, which is where the bug reproduces (pint 0.25.3).
- Added a regression test in `tests/test_core/test_units/test_units.py` covering `a.u.`/`a.u`/`K.M.`/`K.M` and confirming `kg.m` is unaffected.
- Changelog entry added under Bug Fixes.