### PR TITLE
MAINT: add CoordSet drop-dims lifecycle adapter

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -67,6 +67,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Established the first group-aware ``CoordSet`` lifecycle adapter
+  pattern for dimension dropping while preserving legacy runtime storage and
+  public behavior.
+
 - MAINT: Moved additional ``CoordSet`` read-lookup branch decisions onto
   transient group projection metadata while preserving legacy runtime storage
   and public lookup behavior.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,6 +31,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Established the first group-aware ``CoordSet`` lifecycle adapter
+  pattern for dimension dropping while preserving legacy runtime storage and
+  public behavior.
+
 - MAINT: Moved additional ``CoordSet`` read-lookup branch decisions onto
   transient group projection metadata while preserving legacy runtime storage
   and public lookup behavior.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -26,6 +26,7 @@ from traitlets import signature_has_traits
 from traitlets import validate
 
 from spectrochempy.core.dataset._coordgroup import _coordset_to_groups
+from spectrochempy.core.dataset._coordgroup import _groups_to_coordset
 from spectrochempy.core.dataset.basearrays.ndarray import DEFAULT_DIM_NAME
 from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 from spectrochempy.core.dataset.coord import Coord
@@ -816,14 +817,32 @@ class CoordSet(HasTraits):
         if isinstance(dims, str):
             dims = (dims,)
 
-        new_coords = self.copy()
+        groups = self._lookup_groups()
+        groups = self._drop_lifecycle_groups(groups, dims, missing=missing)
+        return self._legacy_coordset_from_lifecycle_groups(groups)
+
+    @staticmethod
+    def _drop_lifecycle_groups(groups, dims, *, missing):
+        """Return projected groups after applying legacy dimension dropping."""
+        coord_dims = {group.dim for group in groups if group.reference is None}
+        drop_dims = set()
+
         for dim in dims:
-            if dim in new_coords.names:
-                del new_coords[dim]
-            elif missing == "raise":
+            if dim in coord_dims:
+                drop_dims.add(dim)
+                continue
+            if missing == "raise":
                 raise KeyError(dim)
 
-        return new_coords
+        return tuple(
+            group
+            for group in groups
+            if group.reference is not None or group.dim not in drop_dims
+        )
+
+    def _legacy_coordset_from_lifecycle_groups(self, groups):
+        """Reconstruct the current legacy CoordSet shape from lifecycle groups."""
+        return _groups_to_coordset(groups, name=self.name)
 
     def _reshape_dims(
         self,

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -546,7 +546,29 @@ def test_coordset__drop_dims_preserves_remaining_multicoord_state(
     assert updated.y.default == updated.y._2
     assert_coord_almost_equal(updated.y._1, coords.y._1, decimal=1)
     assert_coord_almost_equal(updated.y._2, coords.y._2, decimal=1)
+    assert updated.y._1._parent_dim == "y"
+    assert updated.y._2._parent_dim == "y"
     assert updated.x == coords.x
+
+
+def test_coordset__drop_dims_preserves_reference_state():
+    coords = CoordSet(
+        x=Coord([1.0, 2.0, 3.0]),
+        y="x",
+        z=Coord([10.0, 20.0, 30.0]),
+    )
+
+    updated = coords._drop_dims("z")
+
+    assert updated.names == ["x"]
+    assert updated.references == {"y": "x"}
+    assert updated["y"] == "x"
+
+    dangling = coords._drop_dims("x")
+
+    assert dangling.names == ["z"]
+    assert dangling.references == {"y": "x"}
+    assert dangling["y"] == "x"
 
 
 def test_coordset__reduce_dim_drops_target_coordinate(coord0, coord1, coord2):


### PR DESCRIPTION
## Summary

- Establish the first group-aware CoordSet lifecycle adapter pattern using `_drop_dims()`.
- Route dimension-drop decisions through transient group projections, then reconstruct the same legacy CoordSet shape with `_groups_to_coordset()`.
- Preserve legacy runtime storage (`_coords`), references, aliases, selected defaults, and parent-dim compatibility; no persistent `_groups`, cache, serialization, NDIO, resolver, copy/deepcopy, or NDDataset API changes.

## Validation

- `pre-commit run`
- `conda run -n scpy python -m pytest tests/test_core/test_dataset/test_coordset.py::test_coordset__drop_dims_preserves_remaining_multicoord_state tests/test_core/test_dataset/test_coordset.py::test_coordset__drop_dims_preserves_reference_state -v` (`2 passed`)
- `conda run -n scpy python -m pytest tests/test_core/test_dataset/test_coordset.py tests/test_core/test_dataset/test_dataset_squeeze.py -v` (`27 passed`)

## Notes

- `docs/sources/whatsnew/latest.rst` was updated by the release-notes pre-commit hook and included per repository policy.
- Local audit notes were written to `audit/~coordset-storage-pr12-notes.md` and remain untracked.