### PR TITLE
MAINT: add CoordSet reduce-dim lifecycle adapter

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -67,6 +67,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Extended the group-aware ``CoordSet`` lifecycle adapter pattern to
+  keep-dimension reductions while preserving legacy runtime storage and public
+  behavior.
+
 - MAINT: Established the first group-aware ``CoordSet`` lifecycle adapter
   pattern for dimension dropping while preserving legacy runtime storage and
   public behavior.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,6 +31,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Extended the group-aware ``CoordSet`` lifecycle adapter pattern to
+  keep-dimension reductions while preserving legacy runtime storage and public
+  behavior.
+
 - MAINT: Established the first group-aware ``CoordSet`` lifecycle adapter
   pattern for dimension dropping while preserving legacy runtime storage and
   public behavior.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -11,6 +11,7 @@ import copy as cpy
 import uuid
 import warnings
 from dataclasses import dataclass
+from dataclasses import replace
 
 import numpy as np
 from traitlets import All
@@ -930,17 +931,32 @@ class CoordSet(HasTraits):
         if not keepdims:
             return self._drop_dims(dim, missing="raise")
 
-        new_coords = self.copy()
-        idx = new_coords.names.index(dim)
-        coord = new_coords[idx]
+        groups = self._lookup_groups()
+        groups = self._reduce_lifecycle_groups(groups, dim)
+        return self._legacy_coordset_from_lifecycle_groups(groups)
 
-        if isinstance(coord, CoordSet):
-            for child in coord._coords:
-                child.data = [0]
-        else:
-            coord.data = [0]
+    @staticmethod
+    def _reduce_lifecycle_groups(groups, dim):
+        """Return projected groups after applying legacy keepdims reduction."""
+        coord_dims = [group.dim for group in groups if group.reference is None]
+        if dim not in coord_dims:
+            raise ValueError(f"{dim!r} is not in list")
 
-        return new_coords
+        reduced_groups = []
+        for group in groups:
+            if group.reference is not None or group.dim != dim:
+                reduced_groups.append(group)
+                continue
+
+            reduced_entries = []
+            for entry in group.entries:
+                coord = entry.coord.copy(keepname=True)
+                coord.data = [0]
+                reduced_entries.append(replace(entry, coord=coord))
+
+            reduced_groups.append(replace(group, entries=tuple(reduced_entries)))
+
+        return tuple(reduced_groups)
 
     def _concatenate_dim(self, dim, coordsets):
         """

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -591,10 +591,35 @@ def test_coordset__reduce_dim_keepdims_preserves_multicoord_group(coord0, coord1
 
     assert updated.names == ["x", "z"]
     assert updated.x.is_same_dim
+    assert updated.x.names == ["_1", "_2"]
     assert updated.x.default == updated.x._2
     assert_array_equal(updated.x._1.data, [0])
     assert_array_equal(updated.x._2.data, [0])
+    assert_array_equal(updated.x._1.labels, coords.x._1.labels)
+    assert_array_equal(updated.x._2.labels, coords.x._2.labels)
+    assert updated.x._1.title == coords.x._1.title
+    assert updated.x._2.title == coords.x._2.title
+    assert updated.x._1.units == coords.x._1.units
+    assert updated.x._2.units == coords.x._2.units
+    assert updated.x._1._parent_dim == "x"
+    assert updated.x._2._parent_dim == "x"
     assert updated.z == coords.z
+
+
+def test_coordset__reduce_dim_keepdims_preserves_reference_state():
+    coords = CoordSet(
+        x=Coord([0.0, 1.0, 2.0]),
+        y="x",
+        z=Coord([1.0, 2.0, 3.0]),
+    )
+
+    updated = coords._reduce_dim("x", keepdims=True)
+
+    assert updated.names == ["x", "z"]
+    assert updated.references == {"y": "x"}
+    assert_array_equal(updated.x.data, [0])
+    assert updated.z == coords.z
+    assert updated["y"] == "x"
 
 
 def test_coordset_arithmetics():


### PR DESCRIPTION
## Summary
- Move the `_reduce_dim(..., keepdims=True)` path onto the transient group projection lifecycle adapter pattern.
- Keep `keepdims=False` delegated to the PR12 `_drop_dims(..., missing="raise")` adapter path.
- Preserve legacy CoordSet reconstruction, same-dimension aliases/defaults/parent dims, references, and public behavior.

## Constraints
- `_coords` remains the only mutable runtime source of truth.
- No persistent `_groups` state or projection cache is introduced.
- Serialization, NDIO, copy/deepcopy, resolver behavior, lookup precedence, and NDDataset public behavior are unchanged.

## Validation
- `conda run -n scpy python -m pytest tests/test_core/test_dataset/test_coordset.py -v`
- `conda run -n scpy python -m pytest tests/test_core/test_dataset/test_mixins/test_ndmath.py::test_amax_dim_reduces_coordset tests/test_core/test_dataset/test_mixins/test_ndmath.py::test_amin_dim_reduces_coordset tests/test_core/test_dataset/test_mixins/test_ndmath.py::test_amax_keepdims_preserves_coord tests/test_core/test_dataset/test_mixins/test_ndmath.py::test_amin_keepdims_preserves_coord tests/test_core/test_dataset/test_mixins/test_ndmath.py::test_mean_dim_reduction_preserves_surviving_coordinate tests/test_core/test_dataset/test_mixins/test_ndmath.py::test_mean_keepdims_preserves_reduced_coordinate_as_singleton tests/test_core/test_dataset/test_mixins/test_ndmath.py::test_sum_keepdims_preserves_surviving_multicoord_group -v`
- `pre-commit run`
- Final combined targeted validation after pre-commit: 30 passed
