### PR TITLE
MAINT: add CoordSet slice-dims lifecycle adapter

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -67,6 +67,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Moved ``CoordSet`` dimension slicing lifecycle handling onto
+  transient group projection metadata while preserving legacy storage and
+  public slicing behavior.
+
 - MAINT: Extended the group-aware ``CoordSet`` lifecycle adapter pattern to
   keep-dimension reductions while preserving legacy runtime storage and public
   behavior.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,6 +31,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Moved ``CoordSet`` dimension slicing lifecycle handling onto
+  transient group projection metadata while preserving legacy storage and
+  public slicing behavior.
+
 - MAINT: Extended the group-aware ``CoordSet`` lifecycle adapter pattern to
   keep-dimension reductions while preserving legacy runtime storage and public
   behavior.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -744,33 +744,40 @@ class CoordSet(HasTraits):
         This lifecycle wrapper preserves the existing slicing semantics while
         keeping same-dimension multi-coordinate details inside CoordSet.
         """
-        names = self.names
-        new_coords = self.copy()
-
         if isinstance(items, np.ndarray):
             # Fancy indexing from NDDataset can be returned as a single array.
             items = (items,)
 
+        groups = self._lookup_groups()
+        groups = self._slice_lifecycle_groups(groups, dims, items)
+        return self._legacy_coordset_from_lifecycle_groups(groups)
+
+    @staticmethod
+    def _slice_lifecycle_groups(groups, dims, items):
+        """Return projected groups after applying legacy dimension slicing."""
+        sliced_groups = list(groups)
+        coord_dims = [group.dim for group in groups if group.reference is None]
+        coord_group_indexes = [
+            index for index, group in enumerate(groups) if group.reference is None
+        ]
+
         for axis, item in enumerate(items):
             name = dims[axis]
-            idx = names.index(name)
-            coord = self[idx]
+            coord_index = coord_dims.index(name)
+            group_index = coord_group_indexes[coord_index]
+            group = sliced_groups[group_index]
+            entries = []
 
-            if coord.is_empty:
-                new_coords[idx] = Coord(None, name=name)
-            elif not isinstance(coord, CoordSet):
-                new_coords[idx] = coord[item]
-            else:
-                newc = [c[item] for c in coord._coords]
-                new_coords[idx] = CoordSet(*newc[::-1], name=name)
-                new_coords[idx]._default = coord._default
-                new_coords[idx]._is_same_dim = coord._is_same_dim
-                new_coords[idx]._set_names(
-                    [f"_{i + 1}" for i in range(len(new_coords[idx]))]
-                )
-                new_coords[idx]._set_parent_dim(name)
+            for entry in group.entries:
+                if entry.coord.is_empty:
+                    coord = Coord(None, name=name)
+                else:
+                    coord = entry.coord[item]
+                entries.append(replace(entry, coord=coord))
 
-        return new_coords
+            sliced_groups[group_index] = replace(group, entries=tuple(entries))
+
+        return tuple(sliced_groups)
 
     def _replace_dim(self, dim, value):
         """

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -510,14 +510,44 @@ def test_coordset__slice_dims_preserves_multicoord_default(coord0, coord1, coord
     coords = CoordSet(coord2, [coord0, coord0.copy()], coord1)
     coords.y.select(2)
 
-    sliced = coords._slice_dims(["z", "y", "x"], (slice(1, 4), slice(2, 5)))
+    item = np.array([2, 4])
+
+    sliced = coords._slice_dims(["z", "y", "x"], (slice(1, 4), item))
 
     assert sliced.z.size == 2
     assert sliced.y.is_same_dim
+    assert sliced.y.names == ["_1", "_2"]
     assert sliced.y.default == sliced.y._2
-    assert_coord_almost_equal(sliced.y._1, coord0[2:5], decimal=1)
-    assert_coord_almost_equal(sliced.y._2, coord0[2:5], decimal=1)
+    assert_coord_almost_equal(sliced.y._1, coord0[item], decimal=1)
+    assert_coord_almost_equal(sliced.y._2, coord0[item], decimal=1)
+    assert sliced.y._1._parent_dim == "y"
+    assert sliced.y._2._parent_dim == "y"
     assert sliced.x == coords.x
+
+
+def test_coordset__slice_dims_preserves_reference_and_empty_state():
+    coords = CoordSet(
+        x=Coord(
+            [0.0, 1.0, 2.0],
+            labels=["low", "mid", "high"],
+            units="s",
+            title="time",
+        ),
+        y="x",
+        z=Coord(None),
+    )
+
+    sliced = coords._slice_dims(["x", "z"], (1, slice(None)))
+
+    assert sliced.names == ["x", "z"]
+    assert sliced.references == {"y": "x"}
+    assert_array_equal(sliced.x.data, [1.0])
+    assert_array_equal(sliced.x.labels, ["mid"])
+    assert sliced.x.units == coords.x.units
+    assert sliced.x.title == coords.x.title
+    assert sliced.z.is_empty
+    assert sliced.z.name == "z"
+    assert sliced["y"] == "x"
 
 
 def test_coordset__replace_dim_preserves_multicoord_behavior():


### PR DESCRIPTION
## Summary
- Move `CoordSet._slice_dims()` onto the transient group projection lifecycle adapter pattern.
- Add `_slice_lifecycle_groups()` to apply dimension slicing through projected group metadata before reconstructing the legacy `CoordSet`.
- Preserve same-dimension defaults, aliases, `_parent_dim`, references, empty coordinates, and existing NDDataset slicing behavior.

## Constraints
- `_coords` remains the only mutable runtime source of truth.
- No persistent `_groups` state or projection cache is introduced.
- Serialization, NDIO, copy/deepcopy, resolver behavior, lookup behavior, and NDDataset public API are unchanged.

## Validation
- `conda run -n scpy python -m pytest tests/test_core/test_dataset/test_coordset.py tests/test_core/test_dataset/test_dataset_slicing.py tests/test_core/test_dataset/test_dataset_squeeze.py -v`
- `pre-commit run`
- Final targeted validation after pre-commit: 43 passed
