### PR TITLE
MAINT: add CoordSet reshape-dims lifecycle adapter

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -67,6 +67,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Moved ``CoordSet`` reshape lifecycle coordinate survival decisions
+  onto transient group projection metadata while preserving legacy storage and
+  public reshape behavior.
+
 - MAINT: Moved ``CoordSet`` dimension slicing lifecycle handling onto
   transient group projection metadata while preserving legacy storage and
   public slicing behavior.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,6 +31,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Moved ``CoordSet`` reshape lifecycle coordinate survival decisions
+  onto transient group projection metadata while preserving legacy storage and
+  public reshape behavior.
+
 - MAINT: Moved ``CoordSet`` dimension slicing lifecycle handling onto
   transient group projection metadata while preserving legacy storage and
   public slicing behavior.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -872,6 +872,30 @@ class CoordSet(HasTraits):
         if coord_policy == "drop":
             return None
 
+        groups = self._lookup_groups()
+        groups = self._reshape_lifecycle_groups(
+            groups,
+            old_dims,
+            old_shape,
+            new_dims,
+            new_shape,
+            coord_policy=coord_policy,
+            coords=coords,
+        )
+        return _groups_to_coordset(groups)
+
+    @staticmethod
+    def _reshape_lifecycle_groups(
+        groups,
+        old_dims,
+        old_shape,
+        new_dims,
+        new_shape,
+        *,
+        coord_policy,
+        coords=None,
+    ):
+        """Return projected groups after applying legacy reshape policies."""
         if coords is not None:
             for dim_name, coord in coords.items():
                 if dim_name not in new_dims:
@@ -884,7 +908,25 @@ class CoordSet(HasTraits):
                         f"expected {new_shape[new_dims.index(dim_name)]}."
                     )
 
+        coord_groups = {group.dim: group for group in groups if group.reference is None}
         new_coords = []
+
+        if coord_policy == "strict":
+            for old_idx_s, old_dim_s in enumerate(old_dims):
+                old_size_s = old_shape[old_idx_s]
+                matches = [i for i, size in enumerate(new_shape) if size == old_size_s]
+                if len(matches) != 1:
+                    raise ValueError(
+                        f"strict mode: cannot unambiguously map dim "
+                        f"'{old_dim_s}' (size {old_size_s}) to the new "
+                        f"shape {new_shape}."
+                    )
+                if new_dims[matches[0]] != old_dim_s:
+                    raise ValueError(
+                        f"strict mode: dim '{old_dim_s}' maps to new dim "
+                        f"'{new_dims[matches[0]]}' but name changed."
+                    )
+
         for new_idx, new_dim in enumerate(new_dims):
             new_size = new_shape[new_idx]
 
@@ -893,37 +935,31 @@ class CoordSet(HasTraits):
                 continue
 
             if coord_policy == "strict":
-                for old_idx_s, old_dim_s in enumerate(old_dims):
-                    old_size_s = old_shape[old_idx_s]
-                    matches = [
-                        i for i, size in enumerate(new_shape) if size == old_size_s
-                    ]
-                    if len(matches) != 1:
-                        raise ValueError(
-                            f"strict mode: cannot unambiguously map dim "
-                            f"'{old_dim_s}' (size {old_size_s}) to the new "
-                            f"shape {new_shape}."
-                        )
-                    if new_dims[matches[0]] != old_dim_s:
-                        raise ValueError(
-                            f"strict mode: dim '{old_dim_s}' maps to new dim "
-                            f"'{new_dims[matches[0]]}' but name changed."
-                        )
-                if new_dim in self.names:
-                    new_coords.append(self[new_dim].copy())
+                if new_dim in coord_groups:
+                    new_coords.append(
+                        CoordSet._reshape_lifecycle_coord(coord_groups[new_dim])
+                    )
                 else:
                     new_coords.append(None)
             else:  # "safe"
                 if (
                     new_dim in old_dims
                     and old_shape[old_dims.index(new_dim)] == new_size
-                    and new_dim in self.names
+                    and new_dim in coord_groups
                 ):
-                    new_coords.append(self[new_dim].copy())
+                    new_coords.append(
+                        CoordSet._reshape_lifecycle_coord(coord_groups[new_dim])
+                    )
                 else:
                     new_coords.append(None)
 
-        return CoordSet(*new_coords, dims=new_dims.copy())
+        return _coordset_to_groups(CoordSet(*new_coords, dims=new_dims.copy()))
+
+    @staticmethod
+    def _reshape_lifecycle_coord(group):
+        """Rebuild one legacy coordinate container from one projected group."""
+        coordset = _groups_to_coordset((group,))
+        return coordset[group.dim].copy()
 
     def _reduce_dim(self, dim, *, keepdims=False):
         """

--- a/tests/test_core/test_dataset/test_dataset_reshape.py
+++ b/tests/test_core/test_dataset/test_dataset_reshape.py
@@ -78,6 +78,18 @@ def test_reshape_strict_preserves_current_ambiguity_error():
         ds.reshape((2, 2), coord_policy="strict")
 
 
+def test_reshape_strict_preserves_unambiguous_coordinates():
+    coord_y = scp.Coord(np.array([1.0, 2.0, 3.0]), title="rows")
+    coord_x = scp.Coord(np.array([10.0, 20.0]), title="cols")
+    ds = scp.NDDataset(np.arange(6.0).reshape(3, 2), coordset=[coord_y, coord_x])
+
+    reshaped = ds.reshape((3, 2), coord_policy="strict")
+
+    assert reshaped.shape == (3, 2)
+    assert_array_equal(reshaped.y.data, coord_y.data)
+    assert_array_equal(reshaped.x.data, coord_x.data)
+
+
 def test_reshape_preserves_same_dimension_multicoord_when_dim_survives():
     coord_y = scp.Coord(np.array([1.0, 2.0, 3.0]), title="time")
     coord_x_primary = scp.Coord(np.array([10.0, 20.0]), title="wavelength")
@@ -93,6 +105,25 @@ def test_reshape_preserves_same_dimension_multicoord_when_dim_survives():
     assert reshaped.shape == (1, 3, 2)
     assert isinstance(reshaped.x, scp.CoordSet)
     assert reshaped.x.is_same_dim
+    assert reshaped.x.names == ["_1", "_2"]
     assert reshaped.x.default == reshaped.x._2
     assert_array_equal(reshaped.x._1.data, coord_x_primary.data)
     assert_array_equal(reshaped.x._2.data, coord_x_secondary.data)
+    assert reshaped.x._1.title == coord_x_primary.title
+    assert reshaped.x._2.title == coord_x_secondary.title
+    assert reshaped.x._1._parent_dim == "x"
+    assert reshaped.x._2._parent_dim == "x"
+
+
+def test_reshape_preserves_current_reference_removal_behavior():
+    coord_x = scp.Coord(np.array([1.0, 2.0, 3.0]), title="time")
+    ds = scp.NDDataset(
+        np.arange(3.0),
+        coordset=scp.CoordSet(x=coord_x, y="x"),
+    )
+
+    reshaped = ds.reshape((3,))
+
+    assert reshaped.shape == (3,)
+    assert reshaped.coordset.references == {}
+    assert_array_equal(reshaped.x.data, coord_x.data)


### PR DESCRIPTION
## Summary
- Move `CoordSet._reshape_dims()` coordinate survival decisions onto transient group projection metadata.
- Add `_reshape_lifecycle_groups()` and `_reshape_lifecycle_coord()` for policy-specific reshape reasoning.
- Preserve legacy reshape behavior, including safe/drop/strict policy decisions, same-dimension metadata, empty coordinate placeholders, current reference removal behavior, and generated CoordSet naming.

## Constraints
- `_coords` remains the only mutable runtime source of truth.
- No persistent `_groups` state or projection cache is introduced.
- Serialization, NDIO, copy/deepcopy, resolver behavior, lookup behavior, and NDDataset public APIs are unchanged.

## Validation
- `conda run -n scpy python -m pytest tests/test_core/test_dataset/test_dataset_reshape.py -v`
- `conda run -n scpy python -m pytest tests/test_core/test_dataset/test_dataset_reshape.py tests/test_core/test_dataset/test_coordset.py -v`
- `pre-commit run`
- Final targeted validation after pre-commit: 32 passed
