### PR TITLE
MAINT: Migrate _concatenate_dim to lifecycle adapter pattern

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -51,6 +51,10 @@ Bug Fixes
 - Fixed preservation of reference-based coordinates when copying
   ``CoordSet`` and ``NDDataset`` objects.
 
+- Fixed a crash when concatenating datasets along a dimension where one
+  dataset has labels and another does not.  Previously, a ``TypeError``
+  was raised on mixed labeled/unlabeled coordinates.
+
 
 .. section
 
@@ -89,7 +93,10 @@ Developer
 - MAINT: Advanced the internal ``CoordSet`` storage migration by consolidating
   lookup, serializer adapters, group conversion, and lifecycle helpers around
   transient group metadata while preserving legacy runtime storage,
-  serialization, and public behavior.
+  serialization, and public behavior.  Migrated ``_concatenate_dim`` to the
+  lifecycle adapter pattern, completing the migration of all dimension
+  manipulation methods.  Same-dimension multi-coordinate labels, alias metadata,
+  empty coordinate handling, and non-first default selection are preserved.
 
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -43,6 +43,10 @@ Bug Fixes
 - Fixed preservation of reference-based coordinates when copying
   ``CoordSet`` and ``NDDataset`` objects.
 
+- Fixed a crash when concatenating datasets along a dimension where one
+  dataset has labels and another does not.  Previously, a ``TypeError``
+  was raised on mixed labeled/unlabeled coordinates.
+
 Dependency Updates
 ~~~~~~~~~~~~~~~~~~
 
@@ -63,7 +67,10 @@ Developer
 - MAINT: Advanced the internal ``CoordSet`` storage migration by consolidating
   lookup, serializer adapters, group conversion, and lifecycle helpers around
   transient group metadata while preserving legacy runtime storage,
-  serialization, and public behavior.
+  serialization, and public behavior.  Migrated ``_concatenate_dim`` to the
+  lifecycle adapter pattern, completing the migration of all dimension
+  manipulation methods.  Same-dimension multi-coordinate labels, alias metadata,
+  empty coordinate handling, and non-first default selection are preserved.
 
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -1035,47 +1035,76 @@ class CoordSet(HasTraits):
         coordsets for the specified dimension coordinate, preserving the
         existing concatenation-time coordinate semantics.
         """
-        result = self.copy()
-        coord = result[dim]
-
-        if coord.is_empty:
-            return result
-
-        labels = []
-        if coord.is_labeled:
-            for cs in coordsets:
-                labels.append(cs[dim].labels)
-
-        if coord._implements() in ["Coord"]:
-            new_coord = Coord(coord)
-            if labels:
-                new_coord._labels = np.concatenate(labels)
-        elif coord._implements("CoordSet"):
-            new_coord = cpy.deepcopy(coord)
-            if labels:
-                labels_arr = np.array(labels, dtype=object)
-                for i, c in enumerate(new_coord._coords):
-                    try:
-                        labels_not_none = np.all(
-                            labels_arr[:, i] != [None] * len(labels_arr[:, i]),
-                        )
-                    except ValueError:
-                        labels_not_none = True
-                    if labels_not_none:
-                        c._labels = np.concatenate(list(labels_arr[:, i]))
+        groups = self._lookup_groups()
+        groups = self._concatenate_lifecycle_groups(groups, dim, coordsets)
+        result = self._legacy_coordset_from_lifecycle_groups(groups)
 
         data_tuple = tuple(cs[dim].data for cs in coordsets)
         none_coord = any(x is None for x in data_tuple)
         if not none_coord:
-            new_coord._data = np.concatenate(data_tuple)
+            result[dim]._data = np.concatenate(data_tuple)
         else:
             warnings.warn(
                 f"Some dataset(s) coordinates in the {dim} dimension are None.",
                 stacklevel=2,
             )
 
-        result[dim] = new_coord
         return result
+
+    @staticmethod
+    def _concatenate_lifecycle_groups(groups, dim, coordsets):
+        """
+        Return projected groups after concatenating dimension coordinate labels.
+
+        This helper applies the per-entry label concatenation logic on the
+        transient group projection.  Data concatenation is handled by the
+        caller since it applies to the reconstructed container (Coord or
+        CoordSet) rather than individual group entries.
+        """
+        coord_dims = [g.dim for g in groups if g.reference is None]
+        if dim not in coord_dims:
+            return tuple(groups)
+
+        coord_indices = [i for i, g in enumerate(groups) if g.reference is None]
+        idx = coord_dims.index(dim)
+        group_idx = coord_indices[idx]
+        group = groups[group_idx]
+
+        if not group.entries or group.entries[0].coord.is_empty:
+            return tuple(groups)
+
+        new_entries = []
+        for i, entry in enumerate(group.entries):
+            new_coord = entry.coord.copy(keepname=True)
+
+            per_coord_labels = []
+            for cs in coordsets:
+                legacy = cs[dim]
+                if isinstance(legacy, CoordSet) and i < len(legacy._coords):
+                    lbl = legacy._coords[i].labels
+                elif i == 0:
+                    lbl = legacy.labels
+                else:
+                    lbl = None
+                if lbl is not None:
+                    per_coord_labels.append(lbl)
+
+            if per_coord_labels:
+                try:
+                    has_labels = np.all(
+                        np.array(per_coord_labels)
+                        != [None] * len(per_coord_labels),
+                    )
+                except ValueError:
+                    has_labels = True
+                if has_labels:
+                    new_coord._labels = np.concatenate(per_coord_labels)
+
+            new_entries.append(replace(entry, coord=new_coord))
+
+        result_groups = list(groups)
+        result_groups[group_idx] = replace(group, entries=tuple(new_entries))
+        return tuple(result_groups)
 
     def _interpolate_dim(self, dim, target_coord, *, interpolate_secondary):
         """

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -1092,8 +1092,7 @@ class CoordSet(HasTraits):
             if per_coord_labels:
                 try:
                     has_labels = np.all(
-                        np.array(per_coord_labels)
-                        != [None] * len(per_coord_labels),
+                        np.array(per_coord_labels) != [None] * len(per_coord_labels),
                     )
                 except ValueError:
                     has_labels = True

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -204,10 +204,78 @@ def test_concatenate_preserves_multi_coord_labels():
 
     result = concatenate(ds1, ds2, dims="x")
     # The x dim has two sub-coords; each should have concatenated labels.
-    # CoordSet processes coords in reverse order, so sub-coord order is reversed.
     x_coords = result.coordset["x"]
     assert isinstance(x_coords, scp.CoordSet)
     assert len(x_coords) == 2
+
+    # Collect labels from sub-coords without assuming _coords order.
+    all_label_sets = {
+        tuple(c.labels.tolist()) for c in x_coords._coords
+    }
+    assert ("a", "b", "c", "g", "h", "i") in all_label_sets
+    assert ("d", "e", "f", "j", "k", "l") in all_label_sets
+
+
+def test_concatenate_multi_coord_default_data_is_not_concatenated():
+    """Multi-coord data is not concatenated through ``CoordSet.data``.
+
+    ``CoordSet.data`` delegates to ``self.default.data``, and the old code
+    only sets a dead ``_data`` dynamic attribute on the CoordSet that is
+    never read.  Behavior is preserved.
+    """
+    y = scp.Coord(np.arange(2.0), title="rows")
+    inner1 = scp.CoordSet(
+        scp.Coord(np.arange(3.0)),
+        scp.Coord(np.arange(3.0, 6.0)),
+    )
+    inner2 = scp.CoordSet(
+        scp.Coord(np.arange(3.0, 6.0)),
+        scp.Coord(np.arange(6.0, 9.0)),
+    )
+    ds1 = scp.NDDataset(np.ones((2, 3)), coordset=[y, inner1])
+    ds2 = scp.NDDataset(np.ones((2, 3)), coordset=[y, inner2])
+
+    result = concatenate(ds1, ds2, dims="x")
+    # Each sub-coord data length is unchanged (concatenation not applied).
+    for c in result.coordset["x"]._coords:
+        assert len(c.data) == 3
+
+
+def test_concatenate_with_empty_coord_returns_coordset_unchanged():
+    """Concatenate on an empty dimension coordinate returns the coordset unchanged."""
+    x_empty = scp.Coord(None, size=3)
+    y1 = scp.Coord(np.arange(2.0))
+    y2 = scp.Coord(np.arange(2.0, 4.0))
+    ds1 = scp.NDDataset(np.ones((2, 3)), coordset=[y1, x_empty])
+    ds2 = scp.NDDataset(np.ones((2, 3)), coordset=[y2, x_empty])
+
+    result = concatenate(ds1, ds2, dims="x")
+    # The x coord is empty in both; the result should still have an empty x coord.
+    assert result.x.is_empty
+
+
+def test_concatenate_preserves_non_first_default():
+    """Concatenate preserves the selected non-first default for multi-coord dims."""
+    y = scp.Coord(np.arange(2.0), title="rows")
+    inner1 = scp.CoordSet(
+        scp.Coord(np.arange(3.0), title="first"),
+        scp.Coord(np.arange(3.0, 6.0), title="second"),
+    )
+    # select uses 1-indexed ints: select(2) makes the second sub-coord default.
+    inner1.select(2)
+    inner2 = scp.CoordSet(
+        scp.Coord(np.arange(3.0, 6.0), title="first"),
+        scp.Coord(np.arange(6.0, 9.0), title="second"),
+    )
+    ds1 = scp.NDDataset(np.ones((2, 3)), coordset=[y, inner1])
+    ds2 = scp.NDDataset(np.ones((2, 3)), coordset=[y, inner2])
+
+    result = concatenate(ds1, ds2, dims="x")
+    # The default index should be preserved from the first coordset.
+    assert result.coordset["x"]._default == 1
+
+
+
 
 
 def test_concatenate_none_coord_warns():

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -209,9 +209,7 @@ def test_concatenate_preserves_multi_coord_labels():
     assert len(x_coords) == 2
 
     # Collect labels from sub-coords without assuming _coords order.
-    all_label_sets = {
-        tuple(c.labels.tolist()) for c in x_coords._coords
-    }
+    all_label_sets = {tuple(c.labels.tolist()) for c in x_coords._coords}
     assert ("a", "b", "c", "g", "h", "i") in all_label_sets
     assert ("d", "e", "f", "j", "k", "l") in all_label_sets
 
@@ -273,9 +271,6 @@ def test_concatenate_preserves_non_first_default():
     result = concatenate(ds1, ds2, dims="x")
     # The default index should be preserved from the first coordset.
     assert result.coordset["x"]._default == 1
-
-
-
 
 
 def test_concatenate_none_coord_warns():


### PR DESCRIPTION
Migrate `CoordSet._concatenate_dim()` to the established lifecycle adapter pattern (projection → lifecycle reasoning → legacy reconstruction) used by `_drop_dims`, `_reduce_dim`, `_slice_dims`, `_reshape_dims`, `_replace_dim`.

**What changed:**
- New static method `_concatenate_lifecycle_groups` handles per-entry label concatenation on projected groups for both `Coord` (single-entry) and `CoordSet` (multi-entry) dimension coordinates.
- Data concatenation remains in the wrapper after reconstruction to preserve existing semantics — including the dead `_data` attribute on CoordSet (set but never read by `CoordSet.data`).
- **Minor behavioral fix**: `None`/partial labels from a coordset are now filtered instead of causing a `TypeError` during `np.concatenate`. This fixes a pre-existing crash when concatenating datasets with mixed labeled/unlabeled coords.

**Preserved:**
- Single-coord and multi-coord label concatenation
- Empty coordinate early return
- None-coord warning
- Non-first default index selection
- Same-dimension multi-coordinate semantics
- Reference coordinate pass-through
- `_parent_dim` consistency
- All existing alias/name ordering (pre-existing CoordSet constructor behavior)
