### PR TITLE
MAINT: complete group-backed assignment mutation migration

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -56,13 +56,15 @@ Bug Fixes
   was raised on mixed labeled/unlabeled coordinates.
 
 - Fixed structural corruption of same-dimension ``CoordSet`` when setting
-  coordinates by name.  The group-backed resolution path left stale child
-  aliases on the dimension group after replacing multiple entries with a
-  single incoming ``CoordSet`` (e.g. ``cs["x"] = CoordSet(...)``), causing
-  ``_groups_to_coordset`` to double-wrap the inner coordinates under an
-  extra ``CoordSet`` layer.  This affected concatenation of multi-coordinate
-  datasets.  Also fixed the related case of setting a child coordinate by
-  synthetic alias (e.g. ``cs["x_2"] = coord``).
+  coordinates by name, numeric index, or title.  The group-backed resolution
+  path left stale child aliases on the dimension group after replacing
+  multiple entries with a single incoming ``CoordSet`` (e.g.
+  ``cs["x"] = CoordSet(...)``, ``cs[0] = CoordSet(...)``,
+  ``cs["wavenumber"] = CoordSet(...)``), causing ``_groups_to_coordset``
+  to double-wrap the inner coordinates under an extra ``CoordSet`` layer.
+  This affected concatenation of multi-coordinate datasets.  Also fixed the
+  related case of setting a child coordinate by synthetic alias
+  (e.g. ``cs["x_2"] = coord``).
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -48,13 +48,15 @@ Bug Fixes
   was raised on mixed labeled/unlabeled coordinates.
 
 - Fixed structural corruption of same-dimension ``CoordSet`` when setting
-  coordinates by name.  The group-backed resolution path left stale child
-  aliases on the dimension group after replacing multiple entries with a
-  single incoming ``CoordSet`` (e.g. ``cs["x"] = CoordSet(...)``), causing
-  ``_groups_to_coordset`` to double-wrap the inner coordinates under an
-  extra ``CoordSet`` layer.  This affected concatenation of multi-coordinate
-  datasets.  Also fixed the related case of setting a child coordinate by
-  synthetic alias (e.g. ``cs["x_2"] = coord``).
+  coordinates by name, numeric index, or title.  The group-backed resolution
+  path left stale child aliases on the dimension group after replacing
+  multiple entries with a single incoming ``CoordSet`` (e.g.
+  ``cs["x"] = CoordSet(...)``, ``cs[0] = CoordSet(...)``,
+  ``cs["wavenumber"] = CoordSet(...)``), causing ``_groups_to_coordset``
+  to double-wrap the inner coordinates under an extra ``CoordSet`` layer.
+  This affected concatenation of multi-coordinate datasets.  Also fixed the
+  related case of setting a child coordinate by synthetic alias
+  (e.g. ``cs["x_2"] = coord``).
 
 Dependency Updates
 ~~~~~~~~~~~~~~~~~~

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -1666,7 +1666,9 @@ class CoordSet(HasTraits):
                 group = coord_groups[index]
                 new_entry = replace(group.entries[0], coord=coord.copy(keepname=True))
                 return self._replace_group_in_groups(
-                    groups, group, replace(group, entries=(new_entry,))
+                    groups,
+                    group,
+                    replace(group, entries=(new_entry,), aliases={}),
                 )
 
         return None
@@ -1715,7 +1717,9 @@ class CoordSet(HasTraits):
         coord.name = group.dim
         new_entry = replace(group.entries[0], coord=coord)
         return self._replace_group_in_groups(
-            groups, group, replace(group, entries=(new_entry,))
+            groups,
+            group,
+            replace(group, entries=(new_entry,), aliases={}),
         )
 
     def _resolve_set_child_title_groups(self, groups, coord_groups, index, coord):


### PR DESCRIPTION
This PR completes migration of non-structural assignment branches of
CoordSet._resolve_set onto the group projection architecture.

The runtime storage model remains unchanged.

Key fixes include:
- alias cleanup when collapsing multi-entry groups;
- prevention of double-wrapped CoordSet reconstruction;
- preservation of same-dimension compatibility behavior;
- validation of repeated replacement and reconstruction scenarios.

Append and delete mutations remain out of scope and will be addressed
in subsequent PRs.