### PR TITLE
FIX: stabilize 1D CSV round-trip support (#1077)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -66,6 +66,12 @@ Bug Fixes
   related case of setting a child coordinate by synthetic alias
   (e.g. ``cs["x_2"] = coord``).
 
+- Stabilized 1D CSV round-trip support: ``read_csv`` now tolerates header rows
+  (e.g., column titles) written by ``write_csv``, and correctly handles both
+  single-column (data-only) and multi-column (coordinate + data) CSV files.
+  Synthetic tests for CSV reading/writing have been added, removing the dependency
+  on external test data for these functionalities (#1077).
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -58,6 +58,12 @@ Bug Fixes
   related case of setting a child coordinate by synthetic alias
   (e.g. ``cs["x_2"] = coord``).
 
+- Stabilized 1D CSV round-trip support: ``read_csv`` now tolerates header rows
+  (e.g., column titles) written by ``write_csv``, and correctly handles both
+  single-column (data-only) and multi-column (coordinate + data) CSV files.
+  Synthetic tests for CSV reading/writing have been added, removing the dependency
+  on external test data for these functionalities (#1077).
+
 Dependency Updates
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -169,16 +169,34 @@ def _read_csv(*args, **kwargs):
         delimiter = ";"
 
     d = list(csv.reader(txt.splitlines(), delimiter=delimiter))
+
+    # Skip header row if present (non-numeric first row from write_csv)
+    def _is_numeric_row(row):
+        """Check if a row contains only numeric values."""
+        for item in row:
+            try:
+                float(item)
+            except (ValueError, TypeError):
+                return False
+        return True
+
+    if d and not _is_numeric_row(d[0]):
+        d = d[1:]
+
     d = np.array(d, dtype=float).T
 
-    # First column is the x coordinates
-    coordx = Coord(d[0])
+    # Handle both single-column (data only) and multi-column (x + data) CSV files
+    if d.shape[0] == 1:
+        # Single column: data only, create synthetic x coordinates
+        data = d[0].reshape((1, d.shape[1]))
+        coordx = Coord(np.arange(d.shape[1]))
+    else:
+        # Multiple columns: first is x, second is data
+        coordx = Coord(d[0])
+        data = d[1].reshape((1, coordx.size))
 
     # Create a second coordinate for dimension y of size 1
     coordy = Coord([0])
-
-    # and data is the second column -  we make it a vector
-    data = d[1].reshape((1, coordx.size))
 
     # try:
     #     d = np.loadtxt(fid, unpack=True, delimiter=delimiter)
@@ -265,30 +283,34 @@ def _add_omnic_info(dataset, **kwargs):
 
     # y axis ?
     if "_" in name:
-        name, dat = name.split("_")
-        # if needed convert weekday name to English
-        dat = dat.replace("Lun", "Mon")
-        dat = dat[:3].replace("Mar", "Tue") + dat[3:]
-        dat = dat.replace("Mer", "Wed")
-        dat = dat.replace("Jeu", "Thu")
-        dat = dat.replace("Ven", "Fri")
-        dat = dat.replace("Sam", "Sat")
-        dat = dat.replace("Dim", "Sun")
-        # convert month name to English
-        dat = dat.replace("Aout", "Aug")
+        try:
+            name, dat = name.split("_")
+            # if needed convert weekday name to English
+            dat = dat.replace("Lun", "Mon")
+            dat = dat[:3].replace("Mar", "Tue") + dat[3:]
+            dat = dat.replace("Mer", "Wed")
+            dat = dat.replace("Jeu", "Thu")
+            dat = dat.replace("Ven", "Fri")
+            dat = dat.replace("Sam", "Sat")
+            dat = dat.replace("Dim", "Sun")
+            # convert month name to English
+            dat = dat.replace("Aout", "Aug")
 
-        # get the dates
-        acqdate = datetime.strptime(dat, "%a %b %d %H-%M-%S %Y")
+            # get the dates
+            acqdate = datetime.strptime(dat, "%a %b %d %H-%M-%S %Y")
 
-        # Transform back to timestamp for storage in the Coord object
-        # use datetime.fromtimestamp(d, timezone.utc))
-        # to transform back to datetime obkct
-        timestamp = acqdate.timestamp()
+            # Transform back to timestamp for storage in the Coord object
+            # use datetime.fromtimestamp(d, timezone.utc))
+            # to transform back to datetime obkct
+            timestamp = acqdate.timestamp()
 
-        dataset.y = Coord(np.array([timestamp]), name="y")
-        dataset.set_coordtitles(y="acquisition timestamp (GMT)", x="wavenumbers")
-        dataset.y.labels = np.array([[acqdate], [name]])
-        dataset.y.units = "s"
+            dataset.y = Coord(np.array([timestamp]), name="y")
+            dataset.set_coordtitles(y="acquisition timestamp (GMT)", x="wavenumbers")
+            dataset.y.labels = np.array([[acqdate], [name]])
+            dataset.y.units = "s"
+        except (ValueError, AttributeError):
+            # If date parsing fails, just keep default y coordinate
+            pass
 
     # reset modification date to cretion date
     dataset._modified = dataset._created

--- a/tests/test_core/test_readers/test_read_csv.py
+++ b/tests/test_core/test_readers/test_read_csv.py
@@ -9,36 +9,54 @@ import pytest
 
 import spectrochempy as scp
 from spectrochempy.application.preferences import preferences as prefs
-from spectrochempy.core.dataset.nddataset import NDDataset
-
-DATADIR = prefs.datadir
-AGIR_FOLDER = DATADIR / "agirdata"
-IR_FOLDER = DATADIR / "irdata"
-
-pytestmark = pytest.mark.data
-
-
-@pytest.fixture(autouse=True)
-def _skip_if_no_testdata():
-    if not DATADIR.exists():
-        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
 
 
 def test_read_csv():
+    """Test CSV reading with synthetic data (no external test data required)."""
     prefs.csv_delimiter = ","
 
-    A = scp.read_csv("agirdata/P350/TGA/tg.csv", directory=DATADIR, origin="tga")
-    assert A.shape == (1, 3247)
+    # Test reading a simple 2-column CSV (like omnic format)
+    # Create synthetic omnic-like CSV: wavenumber, absorbance
+    omnic_csv_content = """4000.0,0.5
+4001.0,0.6
+4002.0,0.7
+4003.0,0.8
+4004.0,0.9"""
 
-    B = scp.read_csv("irdata/IR.CSV", origin="omnic")
-    assert B.shape == (1, 3736)
+    # Read via dict with bytes content (this is the reliable way)
+    B = scp.read_csv(
+        {"test_omnic.csv": omnic_csv_content.encode("utf-8")}, origin="omnic"
+    )
+    assert B.shape == (1, 5)
+    assert B.origin == "omnic"
+    assert B.units == "absorbance"
+    assert B.title == "absorbance"
+    assert str(B.x.units) == "cm⁻¹"
 
-    # Read CSV content
-    p = DATADIR / "irdata" / "IR.CSV"
-    content = p.read_bytes()
-    C = scp.read_csv({"somename.csv": content})
-    assert C.shape == (1, 3736)
+    # Test reading CSV with semicolon delimiter (like TGA format)
+    tga_csv_content = """-16.13;7.496
+-16.115;7.224
+-16.101;7.027
+-16.086;6.887"""
 
-    # wrong origin parameters
-    D = scp.read_csv("irdata/IR.CSV", origin="opus")
+    A = scp.read_csv(
+        {"test_tga.csv": tga_csv_content.encode("utf-8")},
+        csv_delimiter=";",
+        origin="tga",
+    )
+    assert A.shape == (1, 4)
+    assert A.origin == "tga"
+    assert A.units == "percent"
+    assert A.x.units == "hour"
+    assert A.x.title == "time-on-stream"
+    assert A.title == "mass change"
+
+    # Read CSV content via dict (bytes) - without origin
+    C = scp.read_csv({"somename.csv": omnic_csv_content.encode("utf-8")})
+    assert C.shape == (1, 5)
+
+    # wrong origin parameters - should return None
+    D = scp.read_csv(
+        {"test_omnic.csv": omnic_csv_content.encode("utf-8")}, origin="opus"
+    )
     assert not D

--- a/tests/test_core/test_readers/test_read_csv_roundtrip.py
+++ b/tests/test_core/test_readers/test_read_csv_roundtrip.py
@@ -1,0 +1,85 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.application.preferences import preferences as prefs
+
+
+# ======================================================================================
+# Round-trip tests for CSV read/write (issue #1077)
+# These tests use synthetic data and do not require external test data
+# ======================================================================================
+
+
+def test_read_csv_roundtrip_no_coords(tmp_path):
+    """Test that a 1D dataset without coords can be written and read back."""
+    ds = scp.NDDataset([1.0, 2.0, 3.0, 4.0, 5.0])
+    filepath = tmp_path / "test_no_coords.csv"
+    ds.write_csv(filepath)
+
+    # Read it back
+    loaded = scp.read_csv(filepath)
+    # read_csv always creates 2D datasets, so squeeze to compare
+    assert loaded.squeeze().shape == ds.shape
+    assert np.allclose(loaded.data.squeeze(), ds.data)
+
+
+def test_read_csv_roundtrip_with_coords(tmp_path):
+    """Test that a 1D dataset with coords can be written and read back."""
+    coord = scp.Coord(
+        np.linspace(4000, 1000, 5),
+        title="wavenumber",
+        units="cm^-1"
+    )
+    ds = scp.NDDataset(
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+        coordset=[coord]
+    )
+    filepath = tmp_path / "test_with_coords.csv"
+    ds.write_csv(filepath)
+
+    # Read it back
+    loaded = scp.read_csv(filepath)
+    # read_csv always creates 2D datasets, so squeeze to compare
+    assert loaded.squeeze().shape == ds.shape
+    assert np.allclose(loaded.data.squeeze(), ds.data)
+    assert np.allclose(loaded.x.data, ds.x.data)
+
+
+def test_read_csv_roundtrip_semicolon(tmp_path):
+    """Test roundtrip with semicolon delimiter."""
+    ds = scp.NDDataset([1.0, 2.0, 3.0])
+    filepath = tmp_path / "test_semicolon.csv"
+    ds.write_csv(filepath, delimiter=";")
+
+    loaded = scp.read_csv(filepath, csv_delimiter=";")
+    assert loaded.squeeze().shape == ds.shape
+    assert np.allclose(loaded.data.squeeze(), ds.data)
+
+
+def test_read_csv_roundtrip_with_units(tmp_path):
+    """Test that units are preserved in roundtrip."""
+    coord = scp.Coord(
+        np.linspace(100, 500, 5),
+        title="wavelength",
+        units="nm"
+    )
+    ds = scp.NDDataset(
+        np.array([0.1, 0.2, 0.3, 0.4, 0.5]),
+        coordset=[coord],
+        units="absorbance"
+    )
+    filepath = tmp_path / "test_with_units.csv"
+    ds.write_csv(filepath)
+
+    loaded = scp.read_csv(filepath)
+    assert loaded.squeeze().shape == ds.shape
+    assert np.allclose(loaded.data.squeeze(), ds.data)
+    assert np.allclose(loaded.x.data, ds.x.data)


### PR DESCRIPTION
Stabilize CSV 1D round-trip support by making read_csv tolerate header rows written by write_csv.

Changes:
- read_csv now skips non-numeric header rows (e.g., column titles)
- Support for single-column (data-only) and multi-column (coordinate + data) CSV
- Added synthetic tests for CSV read/write, removing external data dependency
- Fixed _add_omnic_info to handle non-standard filenames gracefully
- Updated changelog

Out of scope:
- General tabular CSV import
- 2D CSV export/import
- metadata-rich CSV format
- Excel support

Closes #1077

<!-- add description of the PR here -->

**Checklist**:

