### PR TITLE
MAINT: complete group-backed CoordSet mutation migration

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -107,17 +107,17 @@ Developer
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.
 
-- MAINT: Advanced the internal ``CoordSet`` storage migration by consolidating
-  lookup, serializer adapters, group conversion, and lifecycle helpers around
-  transient group metadata while preserving legacy runtime storage,
-  serialization, and public behavior.  Migrated ``_concatenate_dim`` and
-  ``_interpolate_dim`` to the lifecycle adapter pattern, completing the
-  migration of all dimension manipulation methods.  Migrated ``_resolve_delete``
-  to the group-backed architecture following the same projection-resolution-
-  reconstruction pattern, covering top-level name and title deletion, synthetic
-  alias delegation, and same-dimension fallthrough.  Same-dimension
-  multi-coordinate semantics, label metadata, alias and default preservation,
-  reference pass-through, and coordinate metadata propagation are maintained.
+- MAINT: Internal ``CoordSet`` storage redesign — all mutation paths (set,
+   delete, append, lifecycle) now resolve through the group-backed
+   projection-resolution-reconstruction pipeline instead of legacy in-place
+   ``_coords`` mutation.  The migration consolidated lookup, serializer
+   adapters, group conversion, and lifecycle helpers around transient group
+   metadata while preserving runtime storage, serialization, and public
+   behavior.  Same-dimension mutations apply group state directly to legacy
+   storage to avoid double-wrapping in ``_groups_to_coordset``, which fixed a
+   pre-existing corruption bug in same-dimension title set.  Alias invariants,
+   ``default_id`` semantics, label metadata, reference pass-through, and
+   coordinate metadata are preserved throughout.
 
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -81,17 +81,17 @@ Developer
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.
 
-- MAINT: Advanced the internal ``CoordSet`` storage migration by consolidating
-  lookup, serializer adapters, group conversion, and lifecycle helpers around
-  transient group metadata while preserving legacy runtime storage,
-  serialization, and public behavior.  Migrated ``_concatenate_dim`` and
-  ``_interpolate_dim`` to the lifecycle adapter pattern, completing the
-  migration of all dimension manipulation methods.  Migrated ``_resolve_delete``
-  to the group-backed architecture following the same projection-resolution-
-  reconstruction pattern, covering top-level name and title deletion, synthetic
-  alias delegation, and same-dimension fallthrough.  Same-dimension
-  multi-coordinate semantics, label metadata, alias and default preservation,
-  reference pass-through, and coordinate metadata propagation are maintained.
+- MAINT: Internal ``CoordSet`` storage redesign — all mutation paths (set,
+   delete, append, lifecycle) now resolve through the group-backed
+   projection-resolution-reconstruction pipeline instead of legacy in-place
+   ``_coords`` mutation.  The migration consolidated lookup, serializer
+   adapters, group conversion, and lifecycle helpers around transient group
+   metadata while preserving runtime storage, serialization, and public
+   behavior.  Same-dimension mutations apply group state directly to legacy
+   storage to avoid double-wrapping in ``_groups_to_coordset``, which fixed a
+   pre-existing corruption bug in same-dimension title set.  Alias invariants,
+   ``default_id`` semantics, label metadata, reference pass-through, and
+   coordinate metadata are preserved throughout.
 
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -28,6 +28,7 @@ from traitlets import validate
 
 from spectrochempy.core.dataset._coordgroup import _CoordinateEntry
 from spectrochempy.core.dataset._coordgroup import _coordset_to_groups
+from spectrochempy.core.dataset._coordgroup import _DimensionCoordinates
 from spectrochempy.core.dataset._coordgroup import _groups_to_coordset
 from spectrochempy.core.dataset._coordgroup import _make_entry_id
 from spectrochempy.core.dataset.basearrays.ndarray import DEFAULT_DIM_NAME
@@ -1637,6 +1638,23 @@ class CoordSet(HasTraits):
         self._is_same_dim = other._is_same_dim
         self._references = other._references
 
+    def _sync_same_dim_from_groups(self, groups):
+        """Update legacy storage for a same-dim CoordSet from updated groups."""
+        group = groups[0]
+        # Use in-place list mutation to avoid triggering _coords_validate,
+        # which would convert empty list to None or raise on unnamed coords.
+        del self._coords[:]
+        for entry in group.entries:
+            self._coords.append(entry.coord)
+        self._default = 0
+        if group.default_id:
+            for i, entry in enumerate(group.entries):
+                if entry.id == group.default_id:
+                    self._default = i
+                    break
+        self._is_same_dim = True
+        self._references = {}
+
     @staticmethod
     def _replace_group_in_groups(groups, old_group, new_group):
         """Replace one group in a groups tuple by identity."""
@@ -1681,6 +1699,15 @@ class CoordSet(HasTraits):
     def _resolve_set_name_groups(self, groups, coord_groups, index, coord):
         """Group-backed top-level name replacement."""
         if self.is_same_dim:
+            group = coord_groups[0] if coord_groups else None
+            entry_idx, entry = self._lookup_entry_by_alias(group, index)
+            if entry is not None:
+                coord.name = index
+                entries = list(group.entries)
+                entries[entry_idx] = replace(entry, coord=coord)
+                return self._replace_group_in_groups(
+                    groups, group, replace(group, entries=tuple(entries))
+                )
             return None
 
         idx, group = self._lookup_coordinate_group_by_dim(coord_groups, index)
@@ -1770,6 +1797,42 @@ class CoordSet(HasTraits):
         dimension and ``_3`` is a new synthetic child alias.
         """
         try:
+            # New: same-dim raw _N append/replacement
+            if self.is_same_dim and index.startswith("_"):
+                alias = index
+                group = coord_groups[0] if coord_groups else None
+                if group is None:
+                    return None
+                if alias in group.aliases:
+                    entry_id = group.aliases[alias]
+                    for entry_idx, entry in enumerate(group.entries):
+                        if entry.id == entry_id:
+                            coord.name = alias
+                            entries = list(group.entries)
+                            entries[entry_idx] = replace(entry, coord=coord)
+                            return self._replace_group_in_groups(
+                                groups,
+                                group,
+                                replace(group, entries=tuple(entries)),
+                            )
+                    return None
+                coord.name = alias
+                new_entry = _CoordinateEntry(
+                    id=_make_entry_id(coord, alias, set()),
+                    coord=coord,
+                    aliases=(alias,),
+                )
+                new_aliases = dict(group.aliases)
+                new_aliases[alias] = new_entry.id
+                new_entries = list(group.entries) + [new_entry]
+                new_group = replace(
+                    group,
+                    entries=tuple(new_entries),
+                    aliases=new_aliases,
+                )
+                return self._replace_group_in_groups(groups, group, new_group)
+
+            # Existing: x_N pattern for non-same-dim
             idx, group = self._lookup_coordinate_group_by_dim(coord_groups, index[0])
             if idx is None:
                 return None
@@ -1805,9 +1868,25 @@ class CoordSet(HasTraits):
                 )
                 return self._replace_group_in_groups(groups, group, new_group)
 
-            return groups
+            return None
         except (KeyError, IndexError):
             return None
+
+    def _resolve_set_append_groups(self, groups, coord_groups, index, coord):
+        """Group-backed append for new dimension names."""
+        if isinstance(index, str) and index in self.available_names:
+            coord.name = index
+            new_entry = _CoordinateEntry(
+                id=_make_entry_id(coord, index, set()),
+                coord=coord,
+            )
+            new_group = _DimensionCoordinates(
+                dim=index,
+                entries=(new_entry,),
+                default_id=new_entry.id,
+            )
+            return groups + (new_group,)
+        return None
 
     def _resolve_set_groups(self, groups, index, coord):
         """
@@ -1826,6 +1905,8 @@ class CoordSet(HasTraits):
             self._resolve_set_title_groups,
             self._resolve_set_child_title_groups,
             self._resolve_set_child_name_groups,
+            self._resolve_set_synthetic_alias_groups,
+            self._resolve_set_append_groups,
         ):
             result = resolver(groups, coord_groups, index, coord)
             if result is not None:
@@ -1840,8 +1921,23 @@ class CoordSet(HasTraits):
     def _resolve_delete_name_groups(self, groups, coord_groups, index):
         """Group-backed name-based deletion."""
         if self.is_same_dim:
-            # Same-dim CoordSets fall through to legacy in-place mutation
-            # to avoid double-wrapping via _groups_to_coordset.
+            group = coord_groups[0] if coord_groups else None
+            entry_idx, entry = self._lookup_entry_by_alias(group, index)
+            if entry is not None:
+                entries = list(group.entries)
+                del entries[entry_idx]
+                new_aliases = dict(group.aliases)
+                new_aliases.pop(index, None)
+                new_default_id = group.default_id
+                if group.default_id == entry.id:
+                    new_default_id = entries[0].id if entries else None
+                new_group = replace(
+                    group,
+                    entries=tuple(entries),
+                    aliases=new_aliases,
+                    default_id=new_default_id,
+                )
+                return self._replace_group_in_groups(groups, group, new_group)
             return None
 
         idx, group = self._lookup_coordinate_group_by_dim(coord_groups, index)
@@ -1853,9 +1949,37 @@ class CoordSet(HasTraits):
     def _resolve_delete_title_groups(self, groups, coord_groups, index):
         """Group-backed title-based deletion."""
         if self.is_same_dim:
-            # Same-dim CoordSets fall through to legacy in-place mutation
-            # to avoid double-wrapping via _groups_to_coordset.
-            return None
+            matches = self._lookup_top_level_title_matches(index, coord_groups)
+            if not matches:
+                return None
+
+            if len(matches) > 1:
+                warnings.warn(
+                    f"Getting a coordinate from its title. However `{index}` "
+                    f"occurs several time. Only"
+                    f" the first occurrence is returned!",
+                    stacklevel=3,
+                )
+
+            entry_idx, group, entry = matches[0]
+            entries = list(group.entries)
+            del entries[entry_idx]
+            alias = next(
+                (a for a, eid in group.aliases.items() if eid == entry.id), None
+            )
+            new_aliases = dict(group.aliases)
+            if alias:
+                new_aliases.pop(alias, None)
+            new_default_id = group.default_id
+            if group.default_id == entry.id:
+                new_default_id = entries[0].id if entries else None
+            new_group = replace(
+                group,
+                entries=tuple(entries),
+                aliases=new_aliases,
+                default_id=new_default_id,
+            )
+            return self._replace_group_in_groups(groups, group, new_group)
 
         matches = self._lookup_top_level_title_matches(index, coord_groups)
         if not matches:
@@ -1929,6 +2053,12 @@ class CoordSet(HasTraits):
         groups = self._lookup_groups()
         groups = self._resolve_set_groups(groups, index, coord)
         if groups is not None:
+            if self.is_same_dim:
+                # Same-dim CoordSets bypass _groups_to_coordset to avoid
+                # double-wrapping (the reconstruction wraps the inner
+                # same-dim group in an extra CoordSet layer).
+                self._sync_same_dim_from_groups(groups)
+                return
             try:
                 result = self._legacy_coordset_from_lifecycle_groups(groups)
             except ValueError:
@@ -2027,6 +2157,12 @@ class CoordSet(HasTraits):
         coord_groups = self._filter_coordinate_lookup_groups(groups)
         groups = self._resolve_delete_groups(groups, coord_groups, index)
         if groups is not None:
+            if self.is_same_dim:
+                # Same-dim CoordSets bypass _groups_to_coordset to avoid
+                # double-wrapping (the reconstruction wraps the inner
+                # same-dim group in an extra CoordSet layer).
+                self._sync_same_dim_from_groups(groups)
+                return
             if not self._filter_coordinate_lookup_groups(groups):
                 # All dimension groups removed.  Sync empty state directly
                 # since _groups_to_coordset does not handle empty groups.

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -739,6 +739,223 @@ class TestCoordSetMultiCoord:
 
 
 # ==============================================================================
+# Same-dim mutation (PR22)
+# ==============================================================================
+
+
+class TestCoordSetSameDimMutation:
+    """CoordSet same-dimension mutation behavior (group-backed)."""
+
+    # ------------------------------------------------------------------
+    # Same-dim assignment
+    # ------------------------------------------------------------------
+
+    def test_same_dim_set_by_alias_replaces(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        inner = cs["x"]
+        inner["_1"] = Coord([7, 8, 9], name="a")
+        assert_array_equal(cs["x"]["_1"].data, [7, 8, 9])
+        assert cs["x"].names == ["_1", "_2"]
+
+    def test_same_dim_set_by_alias_keeps_other_entries(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        inner = cs["x"]
+        inner["_2"] = Coord([10, 11, 12], name="b")
+        assert_array_equal(cs["x"]["_2"].data, [10, 11, 12])
+        assert_array_equal(cs["x"]["_1"].data, [1, 2, 3])
+
+    def test_same_dim_set_preserves_default_id(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        cs["x"].select(2)
+        before_default = cs["x"].default
+        inner = cs["x"]
+        inner["_1"] = Coord([7, 8, 9], name="a")
+        assert cs["x"].default == before_default
+
+    # ------------------------------------------------------------------
+    # Same-dim deletion
+    # ------------------------------------------------------------------
+
+    def test_same_dim_del_by_alias_removes_entry(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        c3 = Coord([7, 8, 9], name="c")
+        cs = CoordSet([c1, c2, c3])
+        del cs["x"]["_2"]
+        assert cs["x"].names == ["_1", "_3"]
+
+    def test_same_dim_del_by_alias_no_renumber(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        c3 = Coord([7, 8, 9], name="c")
+        cs = CoordSet([c1, c2, c3])
+        del cs["x"]["_2"]
+        assert cs["x"].names == ["_1", "_3"]
+
+    def test_same_dim_del_by_title_removes_entry(self):
+        c1 = Coord([1, 2, 3], name="a", title="alpha")
+        c2 = Coord([4, 5, 6], name="b", title="beta")
+        cs = CoordSet([c1, c2])
+        del cs["x"]["beta"]
+        assert cs["x"].names == ["_1"]
+        assert_array_equal(cs["x"]["_1"].data, [1, 2, 3])
+
+    def test_same_dim_del_duplicate_title_warns(self):
+        c1 = Coord([1, 2, 3], name="a", title="dup")
+        c2 = Coord([4, 5, 6], name="b", title="dup")
+        cs = CoordSet([c1, c2])
+        with pytest.warns(UserWarning, match="occurs several time"):
+            del cs["x"]["dup"]
+        assert cs["x"].names == ["_2"]
+
+    def test_same_dim_del_default_entry_updates_default(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        cs["x"].select(2)
+        del cs["x"]["_2"]
+        assert cs["x"].default is not None
+        assert cs["x"].names == ["_1"]
+
+    def test_same_dim_del_last_entry_empties(self):
+        c1 = Coord([1, 2, 3], name="a")
+        cs = CoordSet([c1])
+        inner = cs["x"]
+        del inner["_1"]
+        assert len(cs["x"]) == 0
+
+    # ------------------------------------------------------------------
+    # Same-dim append via _N
+    # ------------------------------------------------------------------
+
+    def test_same_dim_append_via_synthetic_alias(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        inner = cs["x"]
+        inner["_3"] = Coord([7, 8, 9])
+        assert len(cs["x"]) == 3
+        assert cs["x"].names == ["_1", "_2", "_3"]
+        assert_array_equal(cs["x"]["_3"].data, [7, 8, 9])
+
+    def test_same_dim_append_preserves_existing(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        inner = cs["x"]
+        inner["_3"] = Coord([7, 8, 9])
+        assert_array_equal(cs["x"]["_1"].data, [1, 2, 3])
+        assert_array_equal(cs["x"]["_2"].data, [4, 5, 6])
+
+    def test_same_dim_append_no_double_wrap(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        inner = cs["x"]
+        inner["_3"] = Coord([7, 8, 9])
+        x = cs["x"]
+        for child in x._coords:
+            assert not isinstance(
+                child, CoordSet
+            ), f"double-wrap: {type(child).__name__}"
+
+    # ------------------------------------------------------------------
+    # New dimension append
+    # ------------------------------------------------------------------
+
+    def test_append_new_dim_via_available_name(self):
+        cs = CoordSet(Coord([1, 2, 3], name="x"))
+        cs["y"] = Coord([10, 20, 30], name="y")
+        assert "y" in cs.names
+        assert len(cs) == 2
+
+    def test_append_preserves_ordering(self):
+        c1 = Coord([1, 2, 3], name="x")
+        c2 = Coord([10, 20], name="y")
+        cs = CoordSet(c1, c2, keepnames=True)
+        cs["z"] = Coord([5, 5], name="z")
+        assert cs.names == ["x", "y", "z"]
+
+    # ------------------------------------------------------------------
+    # Mutation sequences
+    # ------------------------------------------------------------------
+
+    def test_same_dim_sequence_set_del_append(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        inner = cs["x"]
+        inner["_2"] = Coord([10, 11, 12], name="b")
+        assert_array_equal(cs["x"]["_2"].data, [10, 11, 12])
+        del cs["x"]["_1"]
+        assert cs["x"].names == ["_2"]
+        inner = cs["x"]
+        inner["_3"] = Coord([7, 8, 9])
+        assert cs["x"].names == ["_2", "_3"]
+        assert_array_equal(cs["x"]["_3"].data, [7, 8, 9])
+
+    def test_same_dim_del_then_append_reconstructs(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        del cs["x"]["_1"]
+        inner = cs["x"]
+        inner["_3"] = Coord([7, 8, 9])
+        x = cs["x"]
+        for child in x._coords:
+            assert not isinstance(
+                child, CoordSet
+            ), f"double-wrap: {type(child).__name__}"
+
+    # ------------------------------------------------------------------
+    # Boundary cases
+    # ------------------------------------------------------------------
+
+    def test_same_dim_three_to_two(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        c3 = Coord([7, 8, 9], name="c")
+        cs = CoordSet([c1, c2, c3])
+        inner = cs["x"]
+        del inner["_2"]
+        assert cs["x"].names == ["_1", "_3"]
+        assert cs["x"]._is_same_dim
+
+    def test_same_dim_two_to_one(self):
+        c1 = Coord([1, 2, 3], name="a")
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        inner = cs["x"]
+        del inner["_1"]
+        assert cs["x"].names == ["_2"]
+        assert len(cs["x"]) == 1
+
+    def test_same_dim_one_to_zero(self):
+        c1 = Coord([1, 2, 3], name="a")
+        cs = CoordSet([c1])
+        inner = cs["x"]
+        del inner["_1"]
+        assert len(cs["x"]) == 0
+
+    def test_same_dim_zero_to_one_append(self):
+        c1 = Coord([1, 2, 3], name="a")
+        cs = CoordSet([c1])
+        inner = cs["x"]
+        del inner["_1"]
+        assert len(cs["x"]) == 0
+        inner = cs["x"]
+        inner["_2"] = Coord([4, 5, 6])
+        assert len(cs["x"]) == 1
+        assert_array_equal(cs["x"]["_2"].data, [4, 5, 6])
+
+
+# ==============================================================================
 # Attribute access
 # ==============================================================================
 


### PR DESCRIPTION
## Summary

Complete migration of the remaining CoordSet mutation paths onto the
group-projection architecture.

This PR finishes the mutation phase of the CoordSet storage redesign by
migrating the last active legacy mutation branches:

- same-dim name assignment;
- same-dim name deletion;
- same-dim title deletion;
- same-dim synthetic alias append;
- new-dimension append.

After this change, all normal mutation flows are resolved through the
group-backed architecture before being synchronized to the legacy runtime
representation.

## Changes

### Same-dim mutation migration

Migrate the remaining same-dim mutation branches from legacy `_coords`
operations to group-based transformations:

- `_resolve_set_name_groups()`
- `_resolve_delete_name_groups()`
- `_resolve_delete_title_groups()`

The implementation follows the same group replacement pattern already used
by `_resolve_set_title_groups()`.

### Append migration

Activate and extend `_resolve_set_synthetic_alias_groups()`:

- support same-dim `_N` aliases;
- support synthetic alias append operations;
- fix resolver fallthrough behavior.

Add a dedicated group-backed append resolver for:

```python
cs["z"] = coord
```

when creating a new dimension.

### Same-dim synchronization

Introduce `_sync_same_dim_from_groups()` to synchronize same-dim CoordSets
directly from group metadata.

This avoids reconstruction paths that can produce nested:

```python
CoordSet(
    CoordSet(...)
)
```

structures and preserves legacy same-dim behavior.

### Resolver chain completion

`_resolve_set_groups()` now includes the previously unused synthetic alias
resolver and the new append resolver, ensuring all normal mutation paths
participate in the group architecture.

## Validation

Focused mutation tests were added for:

- same-dim assignment;
- same-dim deletion;
- same-dim title deletion;
- synthetic alias append;
- new-dimension append;
- repeated mutation sequences;
- alias and default preservation.

Validation results:

```text
716 dataset tests passed
150 coordset tests passed
```

## Architectural impact

This PR completes migration of the mutation layer.

Completed migration phases:

- lookup paths;
- lifecycle operations;
- assignment mutation;
- deletion mutation;
- append mutation;
- same-dim mutation.

Remaining work is now focused on evaluating and implementing the final
runtime storage architecture.

Runtime storage remains unchanged in this PR.