### PR TITLE
FIX: harden empty CoordSet invariants

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -66,6 +66,14 @@ Bug Fixes
   related case of setting a child coordinate by synthetic alias
   (e.g. ``cs["x_2"] = coord``).
 
+- Fixed ``CoordSet`` empty-state invariants: ``CoordSet()`` now correctly
+  creates a valid empty coordinate set instead of raising ``TypeError``.
+  Properties ``default``, ``default_index``, ``data`` return ``None`` and
+  ``titles``, ``labels``, ``units``, ``sizes`` return ``[]`` when the
+  coordinate set is empty, instead of raising ``IndexError`` or
+  ``TypeError``.  The internal ``_coords`` list is never set to ``None``,
+  eliminating fragile None-guards in read-side properties.
+
 - Stabilized 1D CSV round-trip support: ``read_csv`` now tolerates header rows
   (e.g., column titles) written by ``write_csv``, and correctly handles both
   single-column (data-only) and multi-column (coordinate + data) CSV files.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -58,6 +58,14 @@ Bug Fixes
   related case of setting a child coordinate by synthetic alias
   (e.g. ``cs["x_2"] = coord``).
 
+- Fixed ``CoordSet`` empty-state invariants: ``CoordSet()`` now correctly
+  creates a valid empty coordinate set instead of raising ``TypeError``.
+  Properties ``default``, ``default_index``, ``data`` return ``None`` and
+  ``titles``, ``labels``, ``units``, ``sizes`` return ``[]`` when the
+  coordinate set is empty, instead of raising ``IndexError`` or
+  ``TypeError``.  The internal ``_coords`` list is never set to ``None``,
+  eliminating fragile None-guards in read-side properties.
+
 - Stabilized 1D CSV round-trip support: ``read_csv`` now tolerates header rows
   (e.g., column titles) written by ``write_csv``, and correctly handles both
   single-column (data-only) and multi-column (coordinate + data) CSV files.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -124,7 +124,7 @@ class CoordSet(HasTraits):
     """
 
     # Hidden attributes containing the collection of objects
-    _coords = List(allow_none=True)
+    _coords = List()
     _references = Dict()
     _updated = Bool(False)
 
@@ -362,7 +362,7 @@ class CoordSet(HasTraits):
     def _coords_validate(self, proposal):
         coords = proposal["value"]
         if not coords:
-            return None
+            return []
 
         for id, coord in enumerate(coords):
             if coord and not isinstance(coord, Coord | CoordSet):
@@ -412,7 +412,7 @@ class CoordSet(HasTraits):
                 )  # Final sort
                 coords = list(zip(*_sortedtuples, strict=False))[1]
             return list(coords)  # be sure its a list not a tuple
-        return None
+        return []
 
     @default("_id")
     def _id_default(self):
@@ -453,9 +453,7 @@ class CoordSet(HasTraits):
     @property
     def is_empty(self):
         """True if there is no coords defined (bool)."""
-        if self._coords:
-            return len(self._coords) == 0
-        return False
+        return not self._coords
 
     @property
     def is_same_dim(self):
@@ -474,6 +472,8 @@ class CoordSet(HasTraits):
         (readonly property). If the set is for a single dimension return a
         single size as all coordinates must have the same.
         """
+        if not self._coords:
+            return []
         _sizes = []
         for _i, item in enumerate(self._coords):
             _sizes.append(item.size)  # recurrence if item is a CoordSet
@@ -514,18 +514,24 @@ class CoordSet(HasTraits):
     # ----------------------------------------------------------------------------------
     @property
     def default(self):
-        """Default coordinates (Coord)."""
+        """Default coordinates (Coord), or None if empty."""
+        if not self._coords:
+            return None
         return self._coords[self._default]
 
     @property
     def default_index(self):
-        """Selected default coordinate index (int)."""
+        """Selected default coordinate index (int), or None if empty."""
+        if not self._coords:
+            return None
         return self._default
 
     @property
     def data(self):
         # in case data is called on a coordset for dimension with multiple coordinates
         # return the default coordinates data
+        if not self._coords:
+            return None
         return self.default.data
 
     @property
@@ -542,6 +548,8 @@ class CoordSet(HasTraits):
     @property
     def titles(self):
         """Titles of the coords in the current coords (list)."""
+        if not self._coords:
+            return []
         _titles = []
         for item in self._coords:
             if isinstance(item, Coord):
@@ -557,16 +565,22 @@ class CoordSet(HasTraits):
     @property
     def labels(self):
         """Labels of the coordinates in the current coordset (list)."""
+        if not self._coords:
+            return []
         return [item.labels for item in self._coords]
 
     @property
     def is_labeled(self):
         """Returns True if one of the coords is labeled."""
+        if not self._coords:
+            return False
         return any(item.is_labeled for item in self._coords)
 
     @property
     def units(self):
         """Units of the coords in the current coords (list)."""
+        if not self._coords:
+            return []
         return [item.units for item in self._coords]
 
     # ----------------------------------------------------------------------------------

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -74,9 +74,59 @@ class TestCoordSetConstruction:
             assert len(name) > 0
 
     def test_construction_without_args(self):
-        # CoordSet() currently raises TypeError (existing bug in _coords validator)
-        with pytest.raises(TypeError):
-            CoordSet()
+        cs = CoordSet()
+        assert len(cs) == 0
+        assert cs.is_empty
+
+
+# ==============================================================================
+# Empty CoordSet
+# ==============================================================================
+
+
+class TestCoordSetEmpty:
+    """Empty CoordSet invariants."""
+
+    def test_empty_coordset_invariants(self):
+        cs = CoordSet()
+        assert len(cs) == 0
+        assert cs.is_empty
+        assert cs.names == []
+        assert cs.titles == []
+        assert cs.labels == []
+        assert cs.units == []
+        assert cs.sizes == []
+        assert not cs.is_labeled
+        assert cs.default is None
+        assert cs.default_index is None
+        assert repr(cs) == "CoordSet: []"
+        assert cs == CoordSet()
+        assert cs.coords == []
+
+    def test_empty_after_delete_last(self):
+        c1 = Coord([1, 2, 3], name="x", title="test")
+        cs = CoordSet(c1, keepnames=True)
+        assert not cs.is_empty
+        del cs["x"]
+        assert len(cs) == 0
+        assert cs.is_empty
+        assert cs.names == []
+        assert cs.titles == []
+        assert cs.default is None
+        assert cs.default_index is None
+
+    def test_empty_after_delete_last_by_title(self):
+        c1 = Coord([1, 2, 3], name="x", title="wavelength")
+        cs = CoordSet(c1, keepnames=True)
+        del cs["wavelength"]
+        assert len(cs) == 0
+        assert cs.is_empty
+
+    def test_two_empty_coordsets_are_equal(self):
+        assert CoordSet() == CoordSet()
+
+    def test_empty_coordset_hash(self):
+        hash(CoordSet())  # does not raise
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

Harden empty CoordSet behavior before the runtime storage switch.

This PR eliminates the fragile `_coords is None` state by ensuring empty
CoordSets are represented as an empty list instead of `None`.

## Changes

- Change `_coords` from `List(allow_none=True)` to `List()`.
- Update `_coords_validate()` to preserve empty lists.
- Make empty CoordSets safe for:
  - `sizes`
  - `default`
  - `default_index`
  - `data`
  - `titles`
  - `labels`
  - `units`
  - `is_labeled`
- Add focused empty CoordSet invariant tests.

## Validation

- `128 passed` in `test_coordset_behavior.py`
- `27 passed` in `test_coordset.py`
- `8 passed` in `test_dataset_reshape.py`

## Notes

No runtime storage switch is performed in this PR.
This prepares the codebase for the upcoming storage switch by making
empty CoordSet a valid first-class state.