### PR TITLE
MAINT: switch CoordSet runtime storage from trait-based _coords to _s…

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -127,6 +127,16 @@ Developer
    ``default_id`` semantics, label metadata, reference pass-through, and
    coordinate metadata are preserved throughout.
 
+- MAINT: Switched ``CoordSet`` internal storage from the ``_coords``
+  ``traitlets.List`` trait (with its ``@validate`` hook) to a plain Python
+  ``_storage`` list, completing the migration away from trait-based
+  coercion.  The ``_coords`` trait and ``_coords_validate`` method have been
+  removed; ``_finalize_child_coordset`` now handles nested ``CoordSet``
+  setup explicitly in ``_append`` and mutation paths.  Sorting, copying,
+  and name-validation logic that was previously in the validator are now
+  performed in ``__init__``, ``_append``, and ``set``.  The internal
+  observer ``_coords_update`` was renamed to ``_child_name_changed``.
+
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -101,6 +101,16 @@ Developer
    ``default_id`` semantics, label metadata, reference pass-through, and
    coordinate metadata are preserved throughout.
 
+- MAINT: Switched ``CoordSet`` internal storage from the ``_coords``
+  ``traitlets.List`` trait (with its ``@validate`` hook) to a plain Python
+  ``_storage`` list, completing the migration away from trait-based
+  coercion.  The ``_coords`` trait and ``_coords_validate`` method have been
+  removed; ``_finalize_child_coordset`` now handles nested ``CoordSet``
+  setup explicitly in ``_append`` and mutation paths.  Sorting, copying,
+  and name-validation logic that was previously in the validator are now
+  performed in ``__init__``, ``_append``, and ``set``.  The internal
+  observer ``_coords_update`` was renamed to ``_child_name_changed``.
+
 - MAINT: Removed stale commented ``docrep`` residue and the unused commented
   ``numpydoc`` pre-commit hook block.
 

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -19,12 +19,10 @@ from traitlets import Bool
 from traitlets import Dict
 from traitlets import HasTraits
 from traitlets import Int
-from traitlets import List
 from traitlets import Unicode
 from traitlets import default
 from traitlets import observe
 from traitlets import signature_has_traits
-from traitlets import validate
 
 from spectrochempy.core.dataset._coordgroup import _CoordinateEntry
 from spectrochempy.core.dataset._coordgroup import _coordset_to_groups
@@ -124,7 +122,6 @@ class CoordSet(HasTraits):
     """
 
     # Hidden attributes containing the collection of objects
-    _coords = List()
     _references = Dict()
     _updated = Bool(False)
 
@@ -157,7 +154,7 @@ class CoordSet(HasTraits):
         self.name = kwargs.pop("name", None)
 
         # initialise the coordinate list
-        self._coords = []
+        self._storage = []
 
         # First evaluate passed args
         # --------------------------
@@ -189,7 +186,7 @@ class CoordSet(HasTraits):
             else:
                 raise ValueError("Did not understand the inputs")
 
-        # now store the args coordinates in self._coords (validation is fired when this attribute is set)
+        # now store the args coordinates in self._storage (validation is fired when this attribute is set)
         if coords:
             for coord in coords[::-1]:  # we fill from the end of the list
                 # (in reverse order) because by convention when the
@@ -258,7 +255,8 @@ class CoordSet(HasTraits):
                     # replace it
                     idx = self.names.index(key)
                     coord.name = key
-                    self._coords[idx] = coord
+                    self._finalize_child_coordset(coord)
+                    self._storage.__setitem__(idx, coord)
 
                 else:
                     raise KeyError(
@@ -272,15 +270,27 @@ class CoordSet(HasTraits):
                 )
 
         # store the item (validation will be performed)
-        # self._coords = _coords
+        # self._storage = _coords
+
+        # Validate and sort
+        for coord in self._storage:
+            if coord is None:
+                continue
+            if not coord.has_defined_name:
+                raise ValueError(
+                    "At this point all passed coordinates should have a valid name!",
+                )
+
+        if self._storage and self._sorted:
+            self._storage.sort(key=lambda coord: coord.name)
 
         # inform the parent about the update
         self._updated = True
 
         # set a notifier on the name traits name of each coordinates
-        for coord in self._coords:
+        for coord in self._storage:
             if coord is not None:
-                HasTraits.observe(coord, self._coords_update, "_name")
+                HasTraits.observe(coord, self._child_name_changed, "_name")
 
         # initialize the base class with the eventual remaining arguments
         super().__init__(**kwargs)
@@ -358,61 +368,20 @@ class CoordSet(HasTraits):
     # ----------------------------------------------------------------------------------
     # Validation methods
     # ----------------------------------------------------------------------------------
-    @validate("_coords")
-    def _coords_validate(self, proposal):
-        coords = proposal["value"]
-        if not coords:
-            return []
-
-        for id, coord in enumerate(coords):
-            if coord and not isinstance(coord, Coord | CoordSet):
-                raise TypeError(
-                    "At this point all passed coordinates should be of type Coord or CoordSet!",
-                )  # coord =  #
-                # Coord(coord)
-            if self._copy:
-                coords[id] = coord.copy()
-            else:
-                coords[id] = coord
-
-        for coord in coords:
-            if isinstance(coord, CoordSet):
-                # it must be a single dimension axis
-                # in this case we must have same length for all coordinates
-                coord._is_same_dim = True
-
-                # check this is valid in term of size
-                try:
-                    _ = coord.sizes
-                except ValueError:
-                    raise
-
-                # change the internal names
-                n = len(coord)
-                coord._set_names(
-                    [f"_{i + 1}" for i in range(n)],
-                )  # we must have  _1 for the first coordinates,
-                # _2 the second, etc...
-                coord._set_parent_dim(coord.name)
-
-        # last check and sorting
-        names = []
-        for coord in coords:
-            if coord.has_defined_name:
-                names.append(coord.name)
-            else:
-                raise ValueError(
-                    "At this point all passed coordinates should have a valid name!",
-                )
-
-        if coords:
-            if self._sorted:
-                _sortedtuples = sorted(
-                    (coord.name, coord) for coord in coords
-                )  # Final sort
-                coords = list(zip(*_sortedtuples, strict=False))[1]
-            return list(coords)  # be sure its a list not a tuple
-        return []
+    def _finalize_child_coordset(self, coord):
+        """Set up cross-coord metadata for a nested same-dim CoordSet."""
+        if isinstance(coord, CoordSet):
+            coord._is_same_dim = True
+            try:
+                _ = coord.sizes
+            except ValueError:
+                raise
+            coord._storage.sort(key=lambda c: c.name)
+            n = len(coord)
+            coord._set_names(
+                [f"_{i + 1}" for i in range(n)],
+            )
+            coord._set_parent_dim(coord.name)
 
     @default("_id")
     def _id_default(self):
@@ -438,7 +407,7 @@ class CoordSet(HasTraits):
     @property
     def coords(self):
         """Coordinates in the coordset (list)."""
-        return self._coords
+        return self._storage
 
     @property
     def has_defined_name(self):
@@ -453,7 +422,7 @@ class CoordSet(HasTraits):
     @property
     def is_empty(self):
         """True if there is no coords defined (bool)."""
-        return not self._coords
+        return not self._storage
 
     @property
     def is_same_dim(self):
@@ -472,10 +441,10 @@ class CoordSet(HasTraits):
         (readonly property). If the set is for a single dimension return a
         single size as all coordinates must have the same.
         """
-        if not self._coords:
+        if not self._storage:
             return []
         _sizes = []
-        for _i, item in enumerate(self._coords):
+        for _i, item in enumerate(self._storage):
             _sizes.append(item.size)  # recurrence if item is a CoordSet
 
         if self.is_same_dim:
@@ -497,14 +466,14 @@ class CoordSet(HasTraits):
     #     list - list of the Coord objects in the current coords (readonly
     #     property).
     #     """
-    #     return self._coords
+    #     return self._storage
 
     @property
     def names(self):
         """Names of the coords in the current coords (list - read only property)."""
         _names = []
-        if self._coords:
-            for item in self._coords:
+        if self._storage:
+            for item in self._storage:
                 if item.has_defined_name:
                     _names.append(item.name)
         return _names
@@ -515,14 +484,14 @@ class CoordSet(HasTraits):
     @property
     def default(self):
         """Default coordinates (Coord), or None if empty."""
-        if not self._coords:
+        if not self._storage:
             return None
-        return self._coords[self._default]
+        return self._storage[self._default]
 
     @property
     def default_index(self):
         """Selected default coordinate index (int), or None if empty."""
-        if not self._coords:
+        if not self._storage:
             return None
         return self._default
 
@@ -530,7 +499,7 @@ class CoordSet(HasTraits):
     def data(self):
         # in case data is called on a coordset for dimension with multiple coordinates
         # return the default coordinates data
-        if not self._coords:
+        if not self._storage:
             return None
         return self.default.data
 
@@ -548,15 +517,15 @@ class CoordSet(HasTraits):
     @property
     def titles(self):
         """Titles of the coords in the current coords (list)."""
-        if not self._coords:
+        if not self._storage:
             return []
         _titles = []
-        for item in self._coords:
+        for item in self._storage:
             if isinstance(item, Coord):
                 _titles.append(item.title if item.title else item.name)  # TODO:name
             elif isinstance(item, CoordSet):
                 _titles.append(
-                    [el.title if el.title else el.name for el in item._coords],
+                    [el.title if el.title else el.name for el in item._storage],
                 )  # TODO:name
             else:
                 raise ValueError("Something wrong with the titles!")
@@ -565,23 +534,23 @@ class CoordSet(HasTraits):
     @property
     def labels(self):
         """Labels of the coordinates in the current coordset (list)."""
-        if not self._coords:
+        if not self._storage:
             return []
-        return [item.labels for item in self._coords]
+        return [item.labels for item in self._storage]
 
     @property
     def is_labeled(self):
         """Returns True if one of the coords is labeled."""
-        if not self._coords:
+        if not self._storage:
             return False
-        return any(item.is_labeled for item in self._coords)
+        return any(item.is_labeled for item in self._storage)
 
     @property
     def units(self):
         """Units of the coords in the current coords (list)."""
-        if not self._coords:
+        if not self._storage:
             return []
-        return [item.units for item in self._coords]
+        return [item.units for item in self._storage]
 
     # ----------------------------------------------------------------------------------
     # Public methods
@@ -632,7 +601,7 @@ class CoordSet(HasTraits):
             args = ()
 
         if args:
-            self._coords = []  # reset
+            self._storage = []  # reset
 
         for _i, item in enumerate(args[::-1]):
             item.name = self.available_names.pop()
@@ -643,6 +612,9 @@ class CoordSet(HasTraits):
                 # try to keep this parameter to True!
                 item._is_same_dim = True
             self[k] = item
+
+        if self._storage and self._sorted:
+            self._storage.sort(key=lambda coord: coord.name)
 
     def set_titles(self, *args, **kwargs):
         """
@@ -671,10 +643,10 @@ class CoordSet(HasTraits):
             args = args[0]
 
         for i, item in enumerate(args):
-            if not isinstance(self._coords[i], CoordSet):
-                self._coords[i].title = item
+            if not isinstance(self._storage[i], CoordSet):
+                self._storage[i].title = item
             elif is_sequence(item):
-                for j, v in enumerate(self._coords[i]._coords):
+                for j, v in enumerate(self._storage[i]._storage):
                     v.title = item[j]
 
         for k, item in kwargs.items():
@@ -711,10 +683,10 @@ class CoordSet(HasTraits):
             args = args[0]
 
         for i, item in enumerate(args):
-            if not isinstance(self._coords[i], CoordSet):
-                self._coords[i].to(item, force=force, inplace=True)
+            if not isinstance(self._storage[i], CoordSet):
+                self._storage[i].to(item, force=force, inplace=True)
             elif is_sequence(item):
-                for j, v in enumerate(self._coords[i]._coords):
+                for j, v in enumerate(self._storage[i]._storage):
                     v.to(item[j], force=force, inplace=True)
 
         for k, item in kwargs.items():
@@ -731,7 +703,7 @@ class CoordSet(HasTraits):
             the coordinates themselves.
 
         """
-        return dict(zip(self.names, self._coords, strict=False))
+        return dict(zip(self.names, self._storage, strict=False))
 
     def update(self, **kwargs):
         """
@@ -1097,8 +1069,8 @@ class CoordSet(HasTraits):
             per_coord_labels = []
             for cs in coordsets:
                 legacy = cs[dim]
-                if isinstance(legacy, CoordSet) and i < len(legacy._coords):
-                    lbl = legacy._coords[i].labels
+                if isinstance(legacy, CoordSet) and i < len(legacy._storage):
+                    lbl = legacy._storage[i].labels
                 elif i == 0:
                     lbl = legacy.labels
                 else:
@@ -1194,17 +1166,13 @@ class CoordSet(HasTraits):
         return tuple(result_groups)
 
     def _append(self, coord):
-        # utility function to append coordinate with full validation
+        # utility function to prepend coordinate
+        if self._copy and not isinstance(coord, tuple):
+            coord = coord.copy()
+        self._finalize_child_coordset(coord)
         if not isinstance(coord, tuple):
             coord = (coord,)
-        if self._coords:
-            # some coordinates already present, prepend the new one
-            self._coords = (*coord,) + tuple(
-                self._coords,
-            )  # instead of append, fire the validation process
-        else:
-            # no coordinates yet, start a new tuple of coordinate
-            self._coords = (*coord,)
+        self._storage[:0] = coord
 
     def _loc2index(self, loc):
         # Return the index of a location
@@ -1219,12 +1187,12 @@ class CoordSet(HasTraits):
     def _set_names(self, names):
         # utility function to change names of coordinates (in batch)
         # useful when a coordinate is a CoordSet itself
-        for coord, name in zip(self._coords, names, strict=False):
+        for coord, name in zip(self._storage, names, strict=False):
             coord.name = name
 
     def _set_parent_dim(self, name):
         # utility function to set the paretn name for sub coordset
-        for coord in self._coords:
+        for coord in self._storage:
             coord._parent_dim = name
 
     # ----------------------------------------------------------------------------------
@@ -1247,17 +1215,17 @@ class CoordSet(HasTraits):
             for i in axis:
                 coords.append(self[i])
         else:
-            coords = self._coords
+            coords = self._storage
         if len(coords) == 1:
             return coords[0]
         return CoordSet(*coords)
 
     def __hash__(self):
         # all instance of this class has same hash, so they can be compared
-        return hash(tuple(self._coords))
+        return hash(tuple(self._storage))
 
     def __len__(self):
-        return len(self._coords)
+        return len(self._storage)
 
     def __delattr__(self, item):
         if "notify_change" in item:
@@ -1395,7 +1363,7 @@ class CoordSet(HasTraits):
         if idx is None:
             return None
 
-        coord = self._coords.__getitem__(idx)
+        coord = self._storage.__getitem__(idx)
         entry_id = (
             entry.id if entry is not None else self._lookup_default_entry_id(group)
         )
@@ -1459,7 +1427,7 @@ class CoordSet(HasTraits):
             warnings.warn(warning_message, stacklevel=2)
 
         idx, group, entry = matches[0]
-        coord = self._coords.__getitem__(idx)
+        coord = self._storage.__getitem__(idx)
         entry_id = (
             entry.id if entry is not None else self._lookup_default_entry_id(group)
         )
@@ -1480,14 +1448,14 @@ class CoordSet(HasTraits):
 
     def _lookup_child_title_match(self, index, coord_groups):
         """Resolve nested child title lookup using projected group entries."""
-        for item, group in zip(self._coords, coord_groups, strict=False):
+        for item, group in zip(self._storage, coord_groups, strict=False):
             if isinstance(item, CoordSet):
                 idx, entry = self._lookup_entry_by_title(group, index)
             else:
                 idx, entry = None, None
 
             if idx is not None:
-                coord = item._coords.__getitem__(idx)
+                coord = item._storage.__getitem__(idx)
                 return _CoordLookupResult(
                     coord,
                     "child_title",
@@ -1504,14 +1472,14 @@ class CoordSet(HasTraits):
 
     def _lookup_child_alias_match(self, index, coord_groups):
         """Resolve global nested child alias lookup using projected group entries."""
-        for item, group in zip(self._coords, coord_groups, strict=False):
+        for item, group in zip(self._storage, coord_groups, strict=False):
             if isinstance(item, CoordSet):
                 idx, entry = self._lookup_entry_by_alias(group, index)
             else:
                 idx, entry = None, None
 
             if idx is not None:
-                coord = item._coords.__getitem__(idx)
+                coord = item._storage.__getitem__(idx)
                 return _CoordLookupResult(
                     coord,
                     "child_name",
@@ -1529,7 +1497,7 @@ class CoordSet(HasTraits):
             if idx is None:
                 return None
 
-            coord = self._coords.__getitem__(idx)
+            coord = self._storage.__getitem__(idx)
             owner_dim = group.dim if group is not None else getattr(coord, "name", None)
             if len(index) > 1 and index[1] == "_":
                 if isinstance(coord, CoordSet):
@@ -1595,7 +1563,7 @@ class CoordSet(HasTraits):
         coord_groups = self._coordinate_lookup_groups()
 
         if not multi:
-            coord = self._coords.__getitem__(index)
+            coord = self._storage.__getitem__(index)
             group = self._lookup_group_for_legacy_index(coord_groups, index)
             owner_dim = group.dim if group is not None else getattr(coord, "name", None)
             return _CoordLookupResult(
@@ -1607,7 +1575,7 @@ class CoordSet(HasTraits):
             )
 
         res = []
-        for c in self._coords:
+        for c in self._storage:
             res.append(c.__getitem__(index))
         coords = self.__class__(*res, keepnames=True)
         coords.name = self.name
@@ -1647,7 +1615,7 @@ class CoordSet(HasTraits):
 
     def _sync_from_coordset(self, other):
         """Replace legacy runtime state from a reconstructed CoordSet."""
-        self._coords = other._coords
+        self._storage = other._storage
         self._default = other._default
         self._is_same_dim = other._is_same_dim
         self._references = other._references
@@ -1657,9 +1625,9 @@ class CoordSet(HasTraits):
         group = groups[0]
         # Use in-place list mutation to avoid triggering _coords_validate,
         # which would convert empty list to None or raise on unnamed coords.
-        del self._coords[:]
+        del self._storage[:]
         for entry in group.entries:
-            self._coords.append(entry.coord)
+            self._storage.append(entry.coord)
         self._default = 0
         if group.default_id:
             for i, entry in enumerate(group.entries):
@@ -2057,7 +2025,7 @@ class CoordSet(HasTraits):
             and index[1] == "_"
             and index[0] in self.names
             and isinstance(
-                c := self._coords.__getitem__(self.names.index(index[0])), CoordSet
+                c := self._storage.__getitem__(self.names.index(index[0])), CoordSet
             )
         ):
             c.__setitem__(index[1:], coord)
@@ -2087,31 +2055,34 @@ class CoordSet(HasTraits):
 
         # 1. numeric index replacement
         if not isinstance(index, str):
-            self._coords[index] = coord
+            self._finalize_child_coordset(coord)
+            self._storage[index] = coord
             return
 
         # 1. top-level name replacement
         if index in self.names:
             idx = self.names.index(index)
             coord.name = index
-            self._coords.__setitem__(idx, coord)
+            self._finalize_child_coordset(coord)
+            self._storage.__setitem__(idx, coord)
             return
 
         # 2. top-level title replacement
         if index in self.titles:
             idx = self.titles.index(index)
             coord.name = index
-            self._coords.__setitem__(idx, coord)
+            self._finalize_child_coordset(coord)
+            self._storage.__setitem__(idx, coord)
             return
 
         # 3. nested child title replacement
-        for item in self._coords:
+        for item in self._storage:
             if isinstance(item, CoordSet) and index in item.titles:
                 item.__setitem__(index, coord)
                 return
 
         # 4. nested child name replacement
-        for item in self._coords:
+        for item in self._storage:
             if isinstance(item, CoordSet) and index in item.names:
                 item.__setitem__(index, coord)
                 return
@@ -2119,7 +2090,7 @@ class CoordSet(HasTraits):
         # 5. canonical synthetic alias (append case only; replacement is
         #    handled above before the group-backed path)
         if index[0] in self.names:
-            c = self._coords.__getitem__(self.names.index(index[0]))
+            c = self._storage.__getitem__(self.names.index(index[0]))
             if len(index) > 1 and index[1] == "_" and isinstance(c, CoordSet):
                 c.__setitem__(index[1:], coord)
                 return
@@ -2134,7 +2105,8 @@ class CoordSet(HasTraits):
             )
         ):
             coord.name = index
-            self._coords.append(coord)
+            self._finalize_child_coordset(coord)
+            self._storage.append(coord)
             return
 
         raise KeyError(f"Could not find `{index}` in coordinates names or titles")
@@ -2160,7 +2132,7 @@ class CoordSet(HasTraits):
             and index[1] == "_"
             and index[0] in self.names
             and isinstance(
-                c := self._coords.__getitem__(self.names.index(index[0])), CoordSet
+                c := self._storage.__getitem__(self.names.index(index[0])), CoordSet
             )
         ):
             c.__delitem__(index[1:])
@@ -2183,7 +2155,7 @@ class CoordSet(HasTraits):
                 # Use in-place mutation (del [:] ) to avoid triggering the
                 # _coords_validate validator, which would convert empty list
                 # to None and break __len__().
-                del self._coords[:]
+                del self._storage[:]
                 self._default = 0
                 self._is_same_dim = False
                 self._references = {}
@@ -2201,24 +2173,24 @@ class CoordSet(HasTraits):
         # 1. top-level name deletion
         if index in self.names:
             idx = self.names.index(index)
-            del self._coords[idx]
+            del self._storage[idx]
             return
 
         # 2. top-level title deletion
         if index in self.titles:
             idx = self.titles.index(index)
-            self._coords.__delitem__(idx)
+            self._storage.__delitem__(idx)
             return
 
         # 3. nested child title deletion
-        for item in self._coords:
+        for item in self._storage:
             if isinstance(item, CoordSet) and index in item.titles:
                 item.__delitem__(index)
                 return
 
         # 4. canonical synthetic alias deletion
         if index[0] in self.names:
-            c = self._coords.__getitem__(self.names.index(index[0]))
+            c = self._storage.__getitem__(self.names.index(index[0]))
             if len(index) > 1 and index[1] == "_" and isinstance(c, CoordSet):
                 c.__delitem__(index[1:])
                 return
@@ -2261,13 +2233,13 @@ class CoordSet(HasTraits):
             super().__setattr__(key, value)
 
     # def __iter__(self):
-    #    for item in self._coords:
+    #    for item in self._storage:
     #        yield item
 
     def __repr__(self):
-        out = "CoordSet: [" + ", ".join(["{}"] * len(self._coords)) + "]"
+        out = "CoordSet: [" + ", ".join(["{}"] * len(self._storage)) + "]"
         s = []
-        for item in self._coords:
+        for item in self._storage:
             if isinstance(item, CoordSet):
                 s.append(f"{item.name}:" + repr(item).replace("CoordSet: ", ""))
             else:
@@ -2294,7 +2266,7 @@ class CoordSet(HasTraits):
                     # txt += '        index: {}\n'.format(idx)
                     if not coord.is_empty:
                         if print_size:
-                            txt += f"{coord._coords[0]._str_shape().rstrip()}\n"
+                            txt += f"{coord._storage[0]._str_shape().rstrip()}\n"
 
                         coord._html_output = self._html_output
                         for _idx_s, dim_s in enumerate(coord.names):
@@ -2324,7 +2296,7 @@ class CoordSet(HasTraits):
 
     def __deepcopy__(self, memo):
         coords = self.__class__(
-            tuple(cpy.deepcopy(ax, memo=memo) for ax in self._coords),
+            tuple(cpy.deepcopy(ax, memo=memo) for ax in self._storage),
             keepnames=True,
         )
         coords.name = self.name
@@ -2335,7 +2307,7 @@ class CoordSet(HasTraits):
 
     def __copy__(self):
         coords = self.__class__(
-            tuple(cpy.copy(ax) for ax in self._coords),
+            tuple(cpy.copy(ax) for ax in self._storage),
             keepnames=True,
         )
         # name must be changed
@@ -2350,7 +2322,7 @@ class CoordSet(HasTraits):
         if other is None:
             return False
         try:
-            return self._coords == other._coords
+            return self._storage == other._storage
         except Exception:
             return False
 
@@ -2360,7 +2332,7 @@ class CoordSet(HasTraits):
     # ----------------------------------------------------------------------------------
     # Events
     # ----------------------------------------------------------------------------------
-    def _coords_update(self, change):
+    def _child_name_changed(self, change):
         # when notified that a coord name have been updated
         self._updated = True
 

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -432,7 +432,7 @@ class TestCoordSetMutation:
         cs = CoordSet([c1, c2])
         del cs["x_2"]
         x = cs["x"]
-        for child in x._coords:
+        for child in x.coords:
             assert not isinstance(
                 child, CoordSet
             ), f"double-wrap: {type(child).__name__}"
@@ -910,7 +910,7 @@ class TestCoordSetSameDimMutation:
         inner = cs["x"]
         inner["_3"] = Coord([7, 8, 9])
         x = cs["x"]
-        for child in x._coords:
+        for child in x.coords:
             assert not isinstance(
                 child, CoordSet
             ), f"double-wrap: {type(child).__name__}"
@@ -958,7 +958,7 @@ class TestCoordSetSameDimMutation:
         inner = cs["x"]
         inner["_3"] = Coord([7, 8, 9])
         x = cs["x"]
-        for child in x._coords:
+        for child in x.coords:
             assert not isinstance(
                 child, CoordSet
             ), f"double-wrap: {type(child).__name__}"

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -209,7 +209,7 @@ def test_concatenate_preserves_multi_coord_labels():
     assert len(x_coords) == 2
 
     # Collect labels from sub-coords without assuming _coords order.
-    all_label_sets = {tuple(c.labels.tolist()) for c in x_coords._coords}
+    all_label_sets = {tuple(c.labels.tolist()) for c in x_coords.coords}
     assert ("a", "b", "c", "g", "h", "i") in all_label_sets
     assert ("d", "e", "f", "j", "k", "l") in all_label_sets
 
@@ -235,7 +235,7 @@ def test_concatenate_multi_coord_default_data_is_not_concatenated():
 
     result = concatenate(ds1, ds2, dims="x")
     # Each sub-coord data length is unchanged (concatenation not applied).
-    for c in result.coordset["x"]._coords:
+    for c in result.coordset["x"].coords:
         assert len(c.data) == 3
 
 


### PR DESCRIPTION
## Summary

Complete the CoordSet runtime storage migration by replacing the legacy trait-based `_coords` storage with `_storage`, a plain Python runtime container.

This PR finalizes the storage redesign effort by removing the remaining runtime dependency on:

* `_coords`
* `traitlets.List`
* `_coords_validate`

while preserving public APIs, serialization behavior, same-dim semantics, alias handling, and mutation behavior.

The group-based architecture introduced in previous PRs remains the semantic foundation of CoordSet operations.

## Changes

### Runtime storage switch

Replace the legacy runtime container:

```python
_coords = List(...)
```

with:

```python
_storage = []
```

as the internal runtime representation used by CoordSet.

Read-side APIs now operate on `_storage` rather than `_coords`.

### Validator removal

Remove `_coords_validate()` entirely.

Its previous responsibilities have been redistributed:

* copy handling moved to insertion paths;
* nested CoordSet initialization centralized;
* name validation performed during construction;
* sorting performed during construction and mutation where required.

This removes the last dependency on trait-based storage validation.

### Nested CoordSet finalization

Introduce `_finalize_child_coordset()` to centralize compatibility handling for nested CoordSets:

* same-dim initialization;
* size validation;
* compatibility alias assignment;
* parent-dimension propagation;
* ordering behavior consistent with the legacy implementation.

### Synchronization migration

Update runtime synchronization helpers to operate on `_storage`:

* `_sync_from_coordset()`
* `_sync_same_dim_from_groups()`

while preserving existing group-backed mutation behavior.

### Read-side migration

Migrate CoordSet runtime reads away from `_coords`, including:

* coordinates access;
* names;
* titles;
* labels;
* units;
* sizes;
* default handling;
* representation;
* equality and hashing;
* copy and deepcopy behavior.

### Empty CoordSet compatibility

Build on PR24 by preserving explicit empty CoordSet semantics:

```python
len(cs) == 0
cs.default is None
cs.default_index is None
```

without relying on `_coords is None`.

## Compatibility

The following behaviors are preserved:

* same-dim CoordSet semantics;
* alias generation and lookup;
* default coordinate selection;
* copy and deepcopy behavior;
* serialization and deserialization;
* group conversion logic;
* mutation behavior introduced in PR19, PR20 and PR22.

Serialization continues to expose the historical public state shape:

```text
coords
references
is_same_dim
default_index
name
```

ensuring backward compatibility.

## Validation

Validated with focused CoordSet, CoordGroup, Dataset coordinate, and I/O test suites, including:

* CoordSet behavior tests;
* CoordSet conversion tests;
* serialization roundtrips;
* dataset coordinate behavior tests;
* default preservation tests;
* reference preservation tests.

Additional review confirmed that the explicit child ordering performed during nested CoordSet finalization preserves the effective behavior of the legacy `_coords_validate()` path.

## Architectural impact

This PR completes the runtime storage switch.

CoordSet no longer relies on trait-based runtime storage and validation.

The remaining work is limited to cleanup and simplification of legacy compatibility paths that are no longer required by the new architecture.
