### PR TITLE
MAINT: clean up CoordSet storage-switch leftovers

### DIFF
--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -270,7 +270,6 @@ class CoordSet(HasTraits):
                 )
 
         # store the item (validation will be performed)
-        # self._storage = _coords
 
         # Validate and sort
         for coord in self._storage:
@@ -1251,11 +1250,11 @@ class CoordSet(HasTraits):
     # ------------------------------------------------------------------
 
     def _lookup_groups(self):
-        """Project current legacy storage to private lookup groups."""
+        """Project current storage to private lookup groups."""
         return _coordset_to_groups(self)
 
     def _coordinate_lookup_groups(self):
-        """Private groups that correspond positionally to legacy ``_coords``."""
+        """Coordinate lookup groups for the current CoordSet."""
         return self._filter_coordinate_lookup_groups(self._lookup_groups())
 
     @staticmethod
@@ -1556,7 +1555,7 @@ class CoordSet(HasTraits):
         """
         Resolve a numeric key.
 
-        For top-level CoordSets this is positional access into ``_coords``.
+        For top-level CoordSets this is positional access into ``_storage``.
         For same-dimension multi-coordinate groups this slices every child.
         """
         multi = bool(self.is_same_dim)
@@ -1614,26 +1613,28 @@ class CoordSet(HasTraits):
     # ------------------------------------------------------------------
 
     def _sync_from_coordset(self, other):
-        """Replace legacy runtime state from a reconstructed CoordSet."""
+        """Replace runtime state from a reconstructed CoordSet."""
         self._storage = other._storage
         self._default = other._default
         self._is_same_dim = other._is_same_dim
         self._references = other._references
 
     def _sync_same_dim_from_groups(self, groups):
-        """Update legacy storage for a same-dim CoordSet from updated groups."""
+        """Update storage for a same-dim CoordSet from updated groups."""
         group = groups[0]
-        # Use in-place list mutation to avoid triggering _coords_validate,
+        # Use in-place list mutation to avoid triggering validation,
         # which would convert empty list to None or raise on unnamed coords.
         del self._storage[:]
         for entry in group.entries:
             self._storage.append(entry.coord)
-        self._default = 0
-        if group.default_id:
-            for i, entry in enumerate(group.entries):
-                if entry.id == group.default_id:
-                    self._default = i
-                    break
+        self._default = next(
+            (
+                i
+                for i, entry in enumerate(group.entries)
+                if entry.id == group.default_id
+            ),
+            0,
+        )
         self._is_same_dim = True
         self._references = {}
 
@@ -2153,7 +2154,7 @@ class CoordSet(HasTraits):
                 # All dimension groups removed.  Sync empty state directly
                 # since _groups_to_coordset does not handle empty groups.
                 # Use in-place mutation (del [:] ) to avoid triggering the
-                # _coords_validate validator, which would convert empty list
+                # validator which would convert empty list
                 # to None and break __len__().
                 del self._storage[:]
                 self._default = 0

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -975,7 +975,7 @@ class TestCoordSetSameDimMutation:
         inner = cs["x"]
         del inner["_2"]
         assert cs["x"].names == ["_1", "_3"]
-        assert cs["x"]._is_same_dim
+        assert cs["x"].is_same_dim
 
     def test_same_dim_two_to_one(self):
         c1 = Coord([1, 2, 3], name="a")

--- a/tests/test_processing/test_interpolation/test_interpolate.py
+++ b/tests/test_processing/test_interpolation/test_interpolate.py
@@ -268,8 +268,8 @@ class TestInterpolateCoordReconstruction:
 
         coord = result.coord("x")
         assert isinstance(coord, CoordSet)
-        assert coord._is_same_dim
-        assert coord._default == multi_coord._default
+        assert coord.is_same_dim
+        assert coord.default_index == multi_coord.default_index
         assert coord.name == "x"
 
         primary = coord.default

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -270,7 +270,7 @@ def test_concatenate_preserves_non_first_default():
 
     result = concatenate(ds1, ds2, dims="x")
     # The default index should be preserved from the first coordset.
-    assert result.coordset["x"]._default == 1
+    assert result.coordset["x"].default_index == 1
 
 
 def test_concatenate_none_coord_warns():


### PR DESCRIPTION
## Summary

Clean up residual comments, docstrings, and test assertions after the CoordSet runtime storage switch.

This PR does not change runtime behavior.

## Changes

- Remove stale `_coords` / trait-validator references from CoordSet comments and docstrings.
- Update wording from legacy storage terminology to current storage terminology.
- Simplify one default lookup expression.
- Replace remaining private test assertions with public API accessors:
  - `_is_same_dim` → `is_same_dim`
  - `_default` → `default_index`

## Notes

- `_resolve_set()` and `_resolve_delete()` fallback branches are intentionally retained as safety nets.
- `_legacy_coordset_from_lifecycle_groups()` is intentionally kept for now because it has many callers.
- No `_storage` assertions were added to tests.

## Validation

Focused CoordSet/storage-switch validation should remain unchanged.