### PR TITLE
TEST: characterize metadata propagation paths

### DIFF
--- a/tests/test_core/test_dataset/test_metadata_characterization.py
+++ b/tests/test_core/test_dataset/test_metadata_characterization.py
@@ -198,7 +198,9 @@ def test_integrate_preserves_metadata_with_operation_overrides(metadata_dataset)
     assert result.coordset is not None
     np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
     assert len(result.history) == 1
-    assert "Dataset resulting from application of `trapezoid` method" in result.history[0]
+    assert (
+        "Dataset resulting from application of `trapezoid` method" in result.history[0]
+    )
 
 
 def test_interpolate_preserves_metadata_and_replaces_interpolated_coord(
@@ -223,8 +225,9 @@ def test_interpolate_preserves_metadata_and_replaces_interpolated_coord(
     np.testing.assert_allclose(result.x.data, new_x)
     assert len(result.history) == 2
     assert "Initial history marker" in result.history[0]
-    assert "Interpolated along dims ['x'] to 4 points using linear method" in (
-        result.history[1]
+    assert (
+        "Interpolated along dims ['x'] to 4 points using linear method"
+        in (result.history[1])
     )
 
 

--- a/tests/test_core/test_dataset/test_metadata_characterization.py
+++ b/tests/test_core/test_dataset/test_metadata_characterization.py
@@ -1,0 +1,278 @@
+# ======================================================================================
+# Copyright (c) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Characterization tests for current NDDataset metadata propagation."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+
+
+@pytest.fixture
+def metadata_dataset():
+    y = scp.Coord(np.arange(4.0), title="sample", units="s")
+    x = scp.Coord(np.linspace(0.0, 4.0, 9), title="wavelength", units="cm^-1")
+    xx, yy = np.meshgrid(x.data, y.data)
+    dataset = scp.NDDataset(
+        xx**2 + 2.0 * yy,
+        coordset=[y, x],
+        units="absorbance",
+        title="test_title",
+    )
+
+    dataset.name = "sample_001"
+    dataset.meta.project = "metadata_contract"
+    dataset.meta.instrument = "test_instrument"
+    dataset.author = "test_author"
+    dataset.description = "test_description"
+    dataset.origin = "test_origin"
+    dataset.filename = Path("test_filename.spc")
+    dataset.history = "initial history marker"
+
+    return dataset
+
+
+@pytest.fixture
+def metadata_peak_dataset():
+    x = scp.Coord(np.linspace(0.0, 4.0, 9), title="wavelength", units="cm^-1")
+    dataset = scp.NDDataset(
+        np.array([0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 1.0, 0.0]),
+        coordset=[x],
+        units="absorbance",
+        title="test_title",
+    )
+
+    dataset.name = "sample_001"
+    dataset.meta.project = "metadata_contract"
+    dataset.meta.instrument = "test_instrument"
+    dataset.author = "test_author"
+    dataset.description = "test_description"
+    dataset.origin = "test_origin"
+    dataset.filename = Path("test_filename.spc")
+    dataset.history = "initial history marker"
+
+    return dataset
+
+
+def test_copy_based_add_preserves_metadata(metadata_dataset):
+    result = metadata_dataset + 1
+
+    assert result.name == metadata_dataset.name
+    assert result.title == metadata_dataset.title
+    assert result.meta.project == metadata_dataset.meta.project
+    assert result.meta.instrument == metadata_dataset.meta.instrument
+    assert result.author == metadata_dataset.author
+    assert result.description == metadata_dataset.description
+    assert result.origin == metadata_dataset.origin
+    assert result.filename == metadata_dataset.filename
+    assert result.units == metadata_dataset.units
+    assert result.dims == ["y", "x"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert len(result.history) == 2
+    assert "Initial history marker" in result.history[0]
+    assert "Binary operation add" in result.history[1]
+
+
+def test_copy_based_multiply_preserves_metadata(metadata_dataset):
+    result = metadata_dataset * 2
+
+    assert result.name == metadata_dataset.name
+    assert result.title == metadata_dataset.title
+    assert result.meta.project == metadata_dataset.meta.project
+    assert result.meta.instrument == metadata_dataset.meta.instrument
+    assert result.author == metadata_dataset.author
+    assert result.description == metadata_dataset.description
+    assert result.origin == metadata_dataset.origin
+    assert result.filename == metadata_dataset.filename
+    assert result.units == metadata_dataset.units
+    assert result.dims == ["y", "x"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert len(result.history) == 2
+    assert "Initial history marker" in result.history[0]
+    assert "Binary operation mul" in result.history[1]
+
+
+def test_copy_based_abs_preserves_metadata(metadata_dataset):
+    result = abs(metadata_dataset)
+
+    assert result.name == metadata_dataset.name
+    assert result.title == metadata_dataset.title
+    assert result.meta.project == metadata_dataset.meta.project
+    assert result.meta.instrument == metadata_dataset.meta.instrument
+    assert result.author == metadata_dataset.author
+    assert result.description == metadata_dataset.description
+    assert result.origin == metadata_dataset.origin
+    assert result.filename == metadata_dataset.filename
+    assert result.units == metadata_dataset.units
+    assert result.dims == ["y", "x"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert len(result.history) == 2
+    assert "Initial history marker" in result.history[0]
+    assert "Unary operation abs" in result.history[1]
+
+
+def test_mean_without_dimension_returns_quantity_without_dataset_metadata(
+    metadata_dataset,
+):
+    result = metadata_dataset.mean()
+
+    assert result.units == metadata_dataset.units
+    assert not hasattr(result, "name")
+    assert not hasattr(result, "title")
+    assert not hasattr(result, "meta")
+    assert not hasattr(result, "author")
+    assert not hasattr(result, "description")
+    assert not hasattr(result, "origin")
+    assert not hasattr(result, "filename")
+    assert not hasattr(result, "coordset")
+    assert not hasattr(result, "history")
+
+
+def test_mean_along_dimension_preserves_metadata_and_drops_reduced_coord(
+    metadata_dataset,
+):
+    result = metadata_dataset.mean(dim="x")
+
+    assert result.name == metadata_dataset.name
+    assert result.title == metadata_dataset.title
+    assert result.meta.project == metadata_dataset.meta.project
+    assert result.meta.instrument == metadata_dataset.meta.instrument
+    assert result.author == metadata_dataset.author
+    assert result.description == metadata_dataset.description
+    assert result.origin == metadata_dataset.origin
+    assert result.filename == metadata_dataset.filename
+    assert result.units == metadata_dataset.units
+    assert result.dims == ["y"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    assert "Initial history marker" in result.history[0]
+
+
+def test_wrapper_based_filter_drops_meta_and_source_provenance(
+    metadata_dataset,
+):
+    result = scp.Filter(method="savgol", size=5, order=2).transform(metadata_dataset)
+
+    assert result.name == "sample_001_Filter.transform"
+    assert result.title == metadata_dataset.title
+    assert result.meta.project is None
+    assert result.meta.instrument is None
+    assert result.author != metadata_dataset.author
+    assert result.description == ""
+    assert result.origin == ""
+    assert result.filename != metadata_dataset.filename
+    assert result.filename.name == "sample_001_Filter.scp"
+    assert result.units == metadata_dataset.units
+    assert result.dims == ["y", "x"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert len(result.history) == 1
+    assert "Created using method Filter.transform" in result.history[0]
+
+
+def test_integrate_preserves_metadata_with_operation_overrides(metadata_dataset):
+    result = metadata_dataset.trapezoid(dim="x")
+
+    assert result.name == metadata_dataset.name
+    assert result.title == "area"
+    assert result.meta.project == metadata_dataset.meta.project
+    assert result.meta.instrument == metadata_dataset.meta.instrument
+    assert result.author == metadata_dataset.author
+    assert result.description == "Integration of NDDataset 'sample_001' along dim: 'x'."
+    assert result.origin == metadata_dataset.origin
+    assert result.filename == metadata_dataset.filename
+    assert result.units == metadata_dataset.units * metadata_dataset.x.units
+    assert result.dims == ["y"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    assert len(result.history) == 1
+    assert "Dataset resulting from application of `trapezoid` method" in result.history[0]
+
+
+def test_interpolate_preserves_metadata_and_replaces_interpolated_coord(
+    metadata_dataset,
+):
+    new_x = np.linspace(0.5, 3.5, 4)
+
+    result = metadata_dataset.interpolate(dim="x", coord=new_x)
+
+    assert result.name == metadata_dataset.name
+    assert result.title == metadata_dataset.title
+    assert result.meta.project == metadata_dataset.meta.project
+    assert result.meta.instrument == metadata_dataset.meta.instrument
+    assert result.author == metadata_dataset.author
+    assert result.description == metadata_dataset.description
+    assert result.origin == metadata_dataset.origin
+    assert result.filename == metadata_dataset.filename
+    assert result.units == metadata_dataset.units
+    assert result.dims == ["y", "x"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    np.testing.assert_allclose(result.x.data, new_x)
+    assert len(result.history) == 2
+    assert "Initial history marker" in result.history[0]
+    assert "Interpolated along dims ['x'] to 4 points using linear method" in (
+        result.history[1]
+    )
+
+
+def test_dot_drops_meta_and_source_provenance(metadata_dataset):
+    right = metadata_dataset.T
+    right.name = "sample_002"
+    right.title = "right_title"
+
+    result = scp.dot(metadata_dataset, right)
+
+    assert result.name != metadata_dataset.name
+    assert result.name.startswith("NDDataset_")
+    assert result.title == "test_title.right_title"
+    assert result.meta.project is None
+    assert result.meta.instrument is None
+    assert result.author != metadata_dataset.author
+    assert result.description == ""
+    assert result.origin == ""
+    assert result.filename != metadata_dataset.filename
+    assert result.filename.suffix == ".scp"
+    assert result.units == metadata_dataset.units * right.units
+    assert result.dims == ["y", "x"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    np.testing.assert_allclose(result.x.data, metadata_dataset.y.data)
+    assert len(result.history) == 1
+    assert "Dot product between sample_001 and sample_002" in result.history[0]
+
+
+def test_find_peaks_preserves_metadata_with_name_and_history_overrides(
+    metadata_peak_dataset,
+):
+    result, properties = scp.find_peaks(metadata_peak_dataset, height=0.5)
+
+    assert properties is not None
+    assert result.name == "peaks of sample_001"
+    assert result.title == metadata_peak_dataset.title
+    assert result.meta.project == metadata_peak_dataset.meta.project
+    assert result.meta.instrument == metadata_peak_dataset.meta.instrument
+    assert result.author == metadata_peak_dataset.author
+    assert result.description == metadata_peak_dataset.description
+    assert result.origin == metadata_peak_dataset.origin
+    assert result.filename == metadata_peak_dataset.filename
+    assert result.units == metadata_peak_dataset.units
+    assert result.dims == ["x"]
+    assert result.coordset is not None
+    np.testing.assert_allclose(result.x.data, [0.5, 1.5, 2.5, 3.5])
+    assert len(result.history) == 3
+    assert "Initial history marker" in result.history[0]
+    assert "Slice extracted" in result.history[1]
+    assert "Find_peaks(): 4 peak(s) found" in result.history[2]


### PR DESCRIPTION
## Summary

Adds characterization tests documenting current `NDDataset` metadata propagation across representative operation families:

- copy-based NDMath operations;
- wrapper-based transform output;
- geometry-changing copy paths;
- manual result assembly;
- slice-derived results.

The tests document current behavior only, including inconsistent metadata preservation between construction paths.

## Out of Scope

This PR intentionally does not:

- change production code;
- modify metadata behavior;
- introduce a Metadata Contract;
- introduce a Result Assembly Contract;
- redesign coordinate arithmetic;
- update the changelog.

## Related Issue

Related to #1103.

This PR provides characterization coverage for the metadata propagation behavior discussed in that issue before any semantic or architectural changes are attempted.

## Validation

```bash
conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_metadata_characterization.py
conda run -n scpy-core ruff check tests/test_core/test_dataset/test_metadata_characterization.py