### PR TITLE
FIX: preserve metadata in wrapper outputs

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -80,6 +80,10 @@ Bug Fixes
   Synthetic tests for CSV reading/writing have been added, removing the dependency
   on external test data for these functionalities (#1077).
 
+- Preserved scientific-context metadata (``meta``, ``author``,
+  ``description``, ``origin``, and ``filename``) in wrapper-based processing
+  and analysis outputs such as ``Filter(...).transform(...)`` (#1103).
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -72,6 +72,10 @@ Bug Fixes
   Synthetic tests for CSV reading/writing have been added, removing the dependency
   on external test data for these functionalities (#1077).
 
+- Preserved scientific-context metadata (``meta``, ``author``,
+  ``description``, ``origin``, and ``filename``) in wrapper-based processing
+  and analysis outputs such as ``Filter(...).transform(...)`` (#1103).
+
 Dependency Updates
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -428,6 +428,12 @@ class _set_output:
         if args and type(args[0]) is type(obj):
             args = args[1:]
 
+        original_X = None
+        if args and isinstance(args[0], NDDataset):
+            original_X = args[0]
+        elif isinstance(kwargs.get("dataset"), NDDataset):
+            original_X = kwargs["dataset"]
+
         # get the method output - one or two arrays depending on the method and *args
         output = self.method(obj, *args, **kwargs)
 
@@ -460,7 +466,15 @@ class _set_output:
 
             # determine the input X dataset
             X = getattr(obj, meta_from)
+            metadata_source = (
+                original_X if meta_from == "_X" and original_X is not None else X
+            )
 
+            X_transf.meta = copy.deepcopy(metadata_source.meta)
+            X_transf.author = copy.copy(metadata_source.author)
+            X_transf.description = copy.copy(metadata_source.description)
+            X_transf.origin = copy.copy(metadata_source.origin)
+            X_transf.filename = copy.copy(metadata_source.filename)
             if self.units is not None:
                 if self.units == "keep":
                     X_transf.units = X.units

--- a/tests/test_core/test_dataset/test_metadata_characterization.py
+++ b/tests/test_core/test_dataset/test_metadata_characterization.py
@@ -28,6 +28,7 @@ def metadata_dataset():
     dataset.name = "sample_001"
     dataset.meta.project = "metadata_contract"
     dataset.meta.instrument = "test_instrument"
+    dataset.meta.processing = ["source"]
     dataset.author = "test_author"
     dataset.description = "test_description"
     dataset.origin = "test_origin"
@@ -159,20 +160,25 @@ def test_mean_along_dimension_preserves_metadata_and_drops_reduced_coord(
     assert "Initial history marker" in result.history[0]
 
 
-def test_wrapper_based_filter_drops_meta_and_source_provenance(
+def test_wrapper_based_filter_preserves_scientific_context_metadata(
     metadata_dataset,
 ):
     result = scp.Filter(method="savgol", size=5, order=2).transform(metadata_dataset)
 
     assert result.name == "sample_001_Filter.transform"
     assert result.title == metadata_dataset.title
-    assert result.meta.project is None
-    assert result.meta.instrument is None
-    assert result.author != metadata_dataset.author
-    assert result.description == ""
-    assert result.origin == ""
-    assert result.filename != metadata_dataset.filename
-    assert result.filename.name == "sample_001_Filter.scp"
+    assert result.meta == metadata_dataset.meta
+    assert result.meta is not metadata_dataset.meta
+    assert result.meta.project == metadata_dataset.meta.project
+    assert result.meta.instrument == metadata_dataset.meta.instrument
+    assert result.meta.processing == metadata_dataset.meta.processing
+    assert result.meta.processing is not metadata_dataset.meta.processing
+    result.meta.processing.append("result")
+    assert metadata_dataset.meta.processing == ["source"]
+    assert result.author == metadata_dataset.author
+    assert result.description == metadata_dataset.description
+    assert result.origin == metadata_dataset.origin
+    assert result.filename == metadata_dataset.filename
     assert result.units == metadata_dataset.units
     assert result.dims == ["y", "x"]
     assert result.coordset is not None


### PR DESCRIPTION
## Summary

Preserves scientific-context metadata when wrapper-based result construction creates transformed `NDDataset` outputs.

Specifically, `_set_output` now preserves:

- `meta`
- `author`
- `description`
- `origin`
- `filename`

This aligns wrapper-based outputs such as `Filter(...).transform(...)` with the dominant copy-based metadata behavior already present in NDMath.

## Related Issue

Related to #1103.

## Out of Scope

This PR intentionally does not change:

- history behavior;
- name generation;
- title behavior;
- coordset reconstruction;
- unit propagation;
- mask behavior;
- `dot()` or other manual assembly paths;
- integration, interpolation, or NDMath behavior;
- broader Metadata Contract or Result Assembly Contract design.

## Validation

```bash
conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_metadata_characterization.py tests/test_processing/test_filter/test_filter_shape.py