### PR TITLE
BUG: disallow NDDataset arithmetic with Coord operands

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -99,6 +99,13 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
 
+- Mixed arithmetic between ``NDDataset`` and ``Coord`` is now rejected
+  (e.g. ``dataset + coord`` or ``coord * dataset``).  ``Coord`` is treated as
+  axis support, not as a signal-bearing operand.  Workflows needing correction
+  vectors, weighting profiles, response curves, or other signal-like 1D
+  operands should represent them as 1D ``NDDataset`` objects instead.  This
+  clarifies the math semantics under the broader ``#1103`` arithmetic and
+  metadata characterization work.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -81,6 +81,17 @@ Dependency Updates
 
 - pint >= 0.24 is now required
 
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- Mixed arithmetic between ``NDDataset`` and ``Coord`` is now rejected
+  (e.g. ``dataset + coord`` or ``coord * dataset``).  ``Coord`` is treated as
+  axis support, not as a signal-bearing operand.  Workflows needing correction
+  vectors, weighting profiles, response curves, or other signal-like 1D
+  operands should represent them as 1D ``NDDataset`` objects instead.  This
+  clarifies the math semantics under the broader ``#1103`` arithmetic and
+  metadata characterization work.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -2772,6 +2772,13 @@ class NDMath:
         """
         from spectrochempy.core.units import Quantity  # noqa: PLC0415
 
+        if {objtype, othertype} == {"NDDataset", "Coord"}:
+            raise TypeError(
+                "Arithmetic between NDDataset and Coord is not supported. "
+                "Coord represents an axis, not signal data. Use a 1D "
+                "NDDataset for correction vectors or signal-like operands."
+            )
+
         def reduce_(magnitude):
             if hasattr(magnitude, "dtype"):
                 if magnitude.dtype in TYPE_COMPLEX:

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -1485,13 +1485,28 @@ def test_operator_quantity_operand():
     assert r.units == ds.units
 
 
-def test_operator_coord_operand():
-    """Arithmetic with a Coord operand works."""
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda ds, coord: ds + coord,
+        lambda ds, coord: ds - coord,
+        lambda ds, coord: ds * coord,
+        lambda ds, coord: ds / coord,
+        lambda ds, coord: coord + ds,
+        lambda ds, coord: coord - ds,
+        lambda ds, coord: coord * ds,
+        lambda ds, coord: coord / ds,
+    ],
+)
+def test_operator_coord_operand_rejected(operation):
+    """Mixed NDDataset/Coord arithmetic is rejected."""
     ds = NDDataset(np.ones((3,)), units="m")
     coord = Coord(np.array([0.1, 0.2, 0.3]), units="m")
-    r = ds + coord
-    assert_array_equal(r.data, np.array([1.1, 1.2, 1.3]))
-    assert isinstance(r, NDDataset)
+    with pytest.raises(
+        TypeError,
+        match="Arithmetic between NDDataset and Coord is not supported",
+    ):
+        operation(ds, coord)
 
 
 def test_mask_propagation():
@@ -2173,12 +2188,37 @@ def test_operation_matching_coordinates_succeeds():
     assert isinstance(r, NDDataset)
 
 
-def test_operation_coord_vs_dataset_no_check():
-    """Operation with a Coord and a Dataset skips coord check."""
+def test_operation_coord_vs_dataset_scalar_still_allowed():
+    """The Coord-specific restriction does not affect dataset-scalar arithmetic."""
     x = Coord.linspace(0, 9, 10)
     ds = NDDataset(np.ones(10), coordset=CoordSet(x=x))
     r = ds + 1.0
     assert isinstance(r, NDDataset)
+
+
+@pytest.mark.parametrize(
+    ("ufunc", "label"),
+    [
+        (np.add, "add"),
+        (np.subtract, "subtract"),
+        (np.multiply, "multiply"),
+        (np.divide, "divide"),
+    ],
+)
+def test_coord_dataset_ufunc_operand_rejected(ufunc, label):
+    """NumPy ufuncs also reject mixed NDDataset/Coord arithmetic."""
+    ds = NDDataset(np.ones((3,)), units="m")
+    coord = Coord(np.array([0.1, 0.2, 0.3]), units="m")
+    with pytest.raises(
+        TypeError,
+        match="Arithmetic between NDDataset and Coord is not supported",
+    ):
+        ufunc(ds, coord)
+    with pytest.raises(
+        TypeError,
+        match="Arithmetic between NDDataset and Coord is not supported",
+    ):
+        ufunc(coord, ds)
 
 
 # ===============================================================================


### PR DESCRIPTION
## Summary

Disallow mixed arithmetic between `NDDataset` and `Coord`.

This PR treats that behavior as a semantic bug, not as a supported scientific
feature. In the SpectroChemPy object model, `Coord` represents axis support and
coordinate positions, while `NDDataset` represents measured or derived
signal-bearing values.

Because of that distinction, mixed arithmetic such as `dataset + coord`,
`dataset - coord`, `dataset * coord`, `dataset / coord`, and the symmetric
`coord + dataset`, `coord - dataset`, `coord * dataset`, `coord / dataset` is
no longer accepted.

The new behavior raises a clear exception explaining that `Coord` is an axis,
not signal data, and that signal-like 1D operands should be represented as
`NDDataset`.

## Why this is disallowed

Although `Coord` is numeric and unit-aware, its semantic role in
SpectroChemPy is to describe where the data lives, not to behave as a signal
operand.

Allowing mixed `NDDataset` / `Coord` arithmetic blurred an important model
boundary:

- `Coord` = axis / support / coordinate information
- `NDDataset` = measured or derived values

That permissive behavior came from shared NDMath machinery, but it does not
express a clear spectroscopy-first scientific meaning in the general case.

## What to use instead

If a workflow needs a 1D operand such as a correction vector, weighting
profile, response curve, calibration profile, or baseline-like signal, that
operand should be represented as a **1D `NDDataset`**, not as a `Coord`.

In other words, this PR does not remove legitimate arithmetic use cases. It
makes the object model explicit by requiring signal-like operands to use the
signal-bearing object type.

## In scope

- reject mixed `NDDataset` / `Coord` arithmetic in both operator and NumPy
  ufunc forms;
- add focused regression tests for rejected and still-allowed cases.

## Out of scope

- NDMath redesign;
- coordinate arithmetic redesign between datasets;
- metadata behavior;
- result assembly changes;
- Coord or CoordSet redesign.

## Related

- #1103