### PR TITLE
FIX: concatenate preserves coordinate units along the concatenation dimension

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``concatenate`` now converts coordinate values expressed in compatible but
+  different units to the units of the first dataset instead of silently
+  concatenating raw magnitudes, and raises a ``UnitsCompatibilityError`` when
+  the coordinate units of the concatenation dimension are incompatible
+  (#1101).
+
 - ``read_opus`` now correctly reads assembled / time-resolved OPUS files
   containing data series blocks such as ``a``, ``sm``, ``igsm``, ``phsm``,
   ``tr``, and exposes the new ``TRACE``, ``GCIG``, ``GCSC`` type selectors

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,12 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- ``concatenate`` now converts coordinate values expressed in compatible but
+  different units to the units of the first dataset instead of silently
+  concatenating raw magnitudes, and raises a ``UnitsCompatibilityError`` when
+  the coordinate units of the concatenation dimension are incompatible
+  (#1101).
+
 - ``read_opus`` now correctly reads assembled / time-resolved OPUS files
   containing data series blocks such as ``a``, ``sm``, ``igsm``, ``phsm``,
   ``tr``, and exposes the new ``TRACE``, ``GCIG``, ``GCSC`` type selectors

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -32,6 +32,7 @@ from spectrochempy.core.dataset._coordgroup import _make_entry_id
 from spectrochempy.core.dataset.basearrays.ndarray import DEFAULT_DIM_NAME
 from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.utils import exceptions
 from spectrochempy.utils.print import colored_output
 from spectrochempy.utils.print import convert_to_html
 from spectrochempy.utils.typeutils import is_sequence
@@ -1027,7 +1028,10 @@ class CoordSet(HasTraits):
         groups = self._concatenate_lifecycle_groups(groups, dim, coordsets)
         result = self._legacy_coordset_from_lifecycle_groups(groups)
 
-        data_tuple = tuple(cs[dim].data for cs in coordsets)
+        base = result[dim]
+        data_tuple = tuple(
+            self._coord_data_in_base_units(cs[dim], base, dim) for cs in coordsets
+        )
         none_coord = any(x is None for x in data_tuple)
         if not none_coord:
             result[dim]._data = np.concatenate(data_tuple)
@@ -1038,6 +1042,38 @@ class CoordSet(HasTraits):
             )
 
         return result
+
+    @staticmethod
+    def _coord_data_in_base_units(coord, base, dim):
+        """
+        Return coord data expressed in the base coordinate units.
+
+        Coordinate values were previously concatenated as raw magnitudes, so
+        compatible but different units (e.g. cm^-1 and um^-1) were silently
+        mixed and incompatible units went undetected (issue #1101).  Multiple
+        coordinates per dimension (CoordSet) keep the previous behavior.
+        """
+        data = getattr(coord, "data", None)
+        if (
+            data is None
+            or not isinstance(coord, Coord)
+            or not isinstance(base, Coord)
+            or coord.units == base.units
+        ):
+            return data
+        if (
+            coord.units is None
+            or base.units is None
+            or coord.units.dimensionality != base.units.dimensionality
+        ):
+            raise exceptions.UnitsCompatibilityError(
+                f"Coordinates of the '{dim}' dimension have incompatible units "
+                f"({coord.units} and {base.units}). The datasets can't be "
+                "concatenated.",
+            )
+        converted = coord.copy()
+        converted.ito(base.units)
+        return converted.data
 
     @staticmethod
     def _concatenate_lifecycle_groups(groups, dim, coordsets):

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -284,6 +284,31 @@ def test_concatenate_none_coord_warns():
         concatenate(ds1, ds2, dims="x")
 
 
+def test_concatenate_converts_compatible_coord_units():
+    """Concatenate converts coordinate values to the first dataset coord units (issue #1101)."""
+    x1 = scp.Coord([100.0, 200.0, 300.0], units="cm^-1", title="wavenumbers")
+    x2 = scp.Coord([0.04, 0.05, 0.06], units="1/um", title="wavenumbers")
+    ds1 = scp.NDDataset([1.0, 2.0, 3.0], coordset=[x1])
+    ds2 = scp.NDDataset([4.0, 5.0, 6.0], coordset=[x2])
+
+    result = concatenate(ds1, ds2)
+
+    assert result.x.units == x1.units
+    assert result.x.title == "wavenumbers"
+    np.testing.assert_allclose(
+        result.x.data, [100.0, 200.0, 300.0, 400.0, 500.0, 600.0]
+    )
+
+
+def test_concatenate_rejects_incompatible_coord_units():
+    """Concatenate raises when dimension coordinate units are incompatible (issue #1101)."""
+    ds1 = scp.NDDataset([1.0, 2.0], coordset=[scp.Coord([1.0, 2.0], units="cm^-1")])
+    ds2 = scp.NDDataset([3.0, 4.0], coordset=[scp.Coord([1.0, 2.0], units="s")])
+
+    with pytest.raises(UnitsCompatibilityError):
+        concatenate(ds1, ds2)
+
+
 def test_stack_regression():
     """Stack creates prepended dimension and delegates to concatenate."""
     y = scp.Coord(np.arange(2.0), title="rows")


### PR DESCRIPTION
Closes #1101 (per the go-ahead there).

`CoordSet._concatenate_dim` concatenated raw coordinate magnitudes, so compatible but different units were silently mixed under the first dataset's units (cm⁻¹ + µm⁻¹ → `[100, 200, 300, 0.04, 0.05, 0.06] cm⁻¹`), and incompatible coordinate units (e.g. cm⁻¹ + s) went undetected. Coordinate data is now converted to the first dataset's coordinate units before concatenation — mirroring how `concatenate` already handles data units — and a `UnitsCompatibilityError` is raised when dimensionalities differ. Coordinate title propagation was audited and already preserves the first dataset's titles; the new test asserts it.

Acceptance criteria from the issue: coordinate units preserved ✔, coordinate titles preserved ✔, synthetic datasets only ✔, no API change ✔.

Follow-up notes (out of scope here, per your guidance):
- multi-coordinate dimensions (`CoordSet` per dim) keep the previous raw-magnitude behavior — conversion only applies to plain `Coord` dims;
- coordinates of the *non*-concatenated dimensions are taken from the last input dataset (`out = dataset.copy()` after the loop) and are not unit-checked against the other inputs — probably one for the broader semantics review.