### PR TITLE
TEST: characterize unit propagation in numerical integration

### DIFF
--- a/tests/test_analysis/test_integration/test_integrate.py
+++ b/tests/test_analysis/test_integration/test_integrate.py
@@ -50,3 +50,65 @@ def test_integrate():
     expected_trap_y = 3.0 * x.data**2 + 9.0
     assert_allclose(area_trap_y.data, expected_trap_y)
     assert area_trap_y.units == dataset.units * dataset.y.units
+
+
+# ==============================================================================
+# Unit propagation (issue #1102)
+# ==============================================================================
+
+
+def test_integrate_units_propagation():
+    """Integration multiplies data units by the integrated coordinate units."""
+    # conventional descending wavenumber axis -> positive area
+    x = scp.Coord([2.0, 1.0, 0.0], title="wavenumbers", units="cm^-1")
+    dataset = scp.NDDataset(
+        [1.0, 1.0, 1.0], coordset=[x], units="absorbance", title="absorbance"
+    )
+
+    for area in (dataset.trapezoid(), dataset.simpson()):
+        assert area.units == dataset.units * x.units
+        assert area.title == "area"
+        assert_allclose(area.data, 2.0)
+
+
+def test_integrate_units_with_unitless_coord_or_data():
+    """Integration keeps the only available units when data or coord is unitless."""
+    # unitless coordinate -> data units kept
+    dataset = scp.NDDataset(
+        [1.0, 1.0, 1.0],
+        coordset=[scp.Coord([0.0, 1.0, 2.0], title="index")],
+        units="V",
+    )
+    area = dataset.trapezoid()
+    assert area.units == dataset.units
+    assert_allclose(area.data, 2.0)
+
+    # unitless data -> coordinate units kept
+    dataset2 = scp.NDDataset(
+        [1.0, 1.0, 1.0],
+        coordset=[scp.Coord([0.0, 1.0, 2.0], title="time", units="s")],
+    )
+    area2 = dataset2.trapezoid()
+    assert area2.units == dataset2.x.units
+    assert_allclose(area2.data, 2.0)
+
+    # no units at all -> result stays unitless
+    dataset3 = scp.NDDataset(
+        [1.0, 1.0, 1.0], coordset=[scp.Coord([0.0, 1.0, 2.0], title="index")]
+    )
+    assert dataset3.trapezoid().units is None
+
+
+def test_integrate_preserves_remaining_coord_units():
+    """Integration preserves units and titles of the non-integrated coordinates."""
+    y = scp.Coord([10.0, 20.0], title="temperature", units="K")
+    x = scp.Coord([2.0, 1.0, 0.0], title="wavenumbers", units="cm^-1")
+    dataset = scp.NDDataset(np.ones((2, 3)), coordset=[y, x], units="absorbance")
+
+    area = dataset.trapezoid(dim="x")
+
+    assert area.dims == ["y"]
+    assert area.y.units == y.units
+    assert area.y.title == "temperature"
+    assert area.units == dataset.units * x.units
+    assert_allclose(area.data, [2.0, 2.0])


### PR DESCRIPTION
Adds regression coverage for #1102.

I audited `_integrate_method` (`analysis/integration/integrate.py`): unit propagation is already correct — result units are `data.units * coord.units`, single-sided units are kept when the other operand is unitless, and the non-integrated coordinates keep their units and titles. None of this was covered by tests, so this PR adds synthetic regression tests pinning that behavior for trapezoid and simpson (including the common absorbance-vs-descending-wavenumbers case → positive `a.u.·cm⁻¹` area). No code changes; existing numerical behavior is untouched.

Follow-up notes for the semantics review rather than this PR:
- The post-integration sign flip uses `coord.reversed`, which is a *display-convention* flag (cm⁻¹ non-Raman, ppm), not the actual data ordering — so a spectrum stored with *ascending* wavenumbers integrates to a **negative** area (the existing `test_integrate` asserts this). If the intent is "positive area regardless of storage order", the flip should key on `x[0] > x[-1]` (a commented-out line in `Coord.reversed` suggests this was once considered). Behavior-changing, so left as documented.
- `dataset.trapezoid()` raises `AttributeError` when the integrated dim has no coordinate (`dataset.coord(dim).data` on `None`) instead of integrating with unit spacing or giving a clear error.
- Integration uses `dataset.data`, ignoring the mask.
