### PR TITLE
MAINT: integrate Project into common representation model

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,13 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fixed ``Project.__str__()`` tree formatting when a project contains both
+  sub-projects and sibling datasets or scripts at the same level.  The
+  recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which
+  stripped the trailing newline from the entire accumulated string, causing
+  sibling entries to appear on the same line as the last child of the
+  preceding sub-project.
+
 - ``concatenate`` now converts coordinate values expressed in compatible but
   different units to the units of the first dataset instead of silently
   concatenating raw magnitudes, and raises a ``UnitsCompatibilityError`` when
@@ -128,6 +135,15 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- MAINT: Integrated ``Project`` into the common display/representation model:
+  added a custom compact ``__repr__`` (``Project: <name>``), a ``_cstr()``
+  detailed representation (name, author, description, hierarchy), and migrated
+  ``_repr_html_()`` from ad-hoc string replacement to the shared
+  ``convert_to_html()`` pipeline.  ``pstr(project)`` now returns the detailed
+  ``_cstr()`` output.  Observable behavior is preserved for Coord, CoordSet,
+  and NDDataset.  This is PR3 of the Display / Representation Architecture
+  (#843).
 
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed ``Project.__str__()`` tree formatting when a project contains both
+  sub-projects and sibling datasets or scripts at the same level.  The
+  recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which
+  stripped the trailing newline from the entire accumulated string, causing
+  sibling entries to appear on the same line as the last child of the
+  preceding sub-project.
+
 - ``concatenate`` now converts coordinate values expressed in compatible but
   different units to the units of the first dataset instead of silently
   concatenating raw magnitudes, and raises a ``UnitsCompatibilityError`` when
@@ -106,6 +113,15 @@ Deprecations
 
 Developer
 ~~~~~~~~~
+
+- MAINT: Integrated ``Project`` into the common display/representation model:
+  added a custom compact ``__repr__`` (``Project: <name>``), a ``_cstr()``
+  detailed representation (name, author, description, hierarchy), and migrated
+  ``_repr_html_()`` from ad-hoc string replacement to the shared
+  ``convert_to_html()`` pipeline.  ``pstr(project)`` now returns the detailed
+  ``_cstr()`` output.  Observable behavior is preserved for Coord, CoordSet,
+  and NDDataset.  This is PR3 of the Display / Representation Architecture
+  (#843).
 
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -7,6 +7,7 @@ __all__ = ["Project"]
 
 import copy as cpy
 import pathlib
+import textwrap
 import uuid
 import warnings
 from functools import wraps
@@ -18,6 +19,8 @@ from spectrochempy.core.dataset.nddataset import NDIO
 from spectrochempy.core.project.abstractproject import AbstractProject
 from spectrochempy.core.script import Script
 from spectrochempy.utils.meta import Meta
+from spectrochempy.utils.print import colored_output
+from spectrochempy.utils.print import convert_to_html
 from spectrochempy.utils.traits import NDDatasetType
 
 # from collections import OrderedDict
@@ -83,6 +86,7 @@ class Project(AbstractProject, NDIO):
 
     _filename = tr.Instance(pathlib.Path, allow_none=True)
     _directory = tr.Instance(pathlib.Path, allow_none=True)
+    _html_output = tr.Bool(False)
 
     def __init__(self, *args, argnames=None, name=None, **meta):
         super().__init__()
@@ -129,9 +133,51 @@ class Project(AbstractProject, NDIO):
         pass  # TODO: ???
 
     def _repr_html_(self):
-        h = self.__str__()
-        h = h.replace("\n", "<br/>\n")
-        return h.replace(" ", "&nbsp;")
+        return convert_to_html(self)
+
+    def __repr__(self):
+        return f"Project: {self.name}"
+
+    def _cstr(self):
+        out = ""
+        out += f"         name: {self.name}\n"
+
+        author = self.meta.get("author", None)
+        if author:
+            out += f"       author: {author}\n"
+
+        description = self.meta.get("description", None)
+        if description:
+            wrapper = textwrap.TextWrapper(
+                initial_indent="",
+                subsequent_indent=" " * 15,
+                replace_whitespace=True,
+                width=80,
+            )
+            pars = description.strip().splitlines()
+            desc = ""
+            if pars:
+                desc += f"{wrapper.fill(pars[0])}\n"
+            for par in pars[1:]:
+                desc += "{}\n".format(textwrap.indent(par, " " * 15))
+            desc = f"\0\0\0{desc.rstrip()}\0\0\0\n"
+            out += "  description: "
+            out += desc
+
+        out += "DATA\n"
+
+        str_output = self.__str__()
+        lines = str_output.split("\n")
+        hier_lines = lines[1:] if len(lines) > 1 else []
+        out += "\n".join(hier_lines)
+
+        if not out.endswith("\n"):
+            out += "\n"
+        out += "\n"
+
+        if not self._html_output:
+            return colored_output(out.rstrip())
+        return out.rstrip()
 
     # ----------------------------------------------------------------------------------
     # Special methods
@@ -223,9 +269,9 @@ class Project(AbstractProject, NDIO):
                 # nothing has been found in the project
                 s += f"{sep} (empty project)\n"
 
-            return s.strip("\n")
+            return s
 
-        return _listproj(s, self, 0)
+        return _listproj(s, self, 0).rstrip("\n")
 
     def _attributes_(self):
         return [

--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -17,6 +17,7 @@ def pstr(object, **kwargs):
         "NDDataset",
         "Coord",
         "CoordSet",
+        "Project",
     ]:
         return object._cstr(**kwargs).strip()
     return str(object).strip()

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -205,6 +205,20 @@ class TestProjectObservedDisplay:
         proj = Project(name="test_project")
         assert len(str(proj)) > 0
 
+    def test_repr_is_compact(self):
+        """Project repr should be compact and contain type and name."""
+        proj = Project(name="test_project")
+        repr_str = repr(proj)
+        assert "Project" in repr_str
+        assert "test_project" in repr_str
+        assert "\n" not in repr_str.strip()
+
+    def test_repr_differs_from_default_object_repr(self):
+        """Project repr should not be the default Python object repr."""
+        proj = Project(name="test_project")
+        repr_str = repr(proj)
+        assert "object at 0x" not in repr_str
+
     def test_repr_html_exists(self):
         """Project should have a _repr_html_ method that produces output."""
         proj = Project(name="test_project")
@@ -241,6 +255,28 @@ class TestProjectObservedDisplay:
         proj._datasets["my_dataset"] = ds
         str_output = str(proj)
         assert "my_dataset" in str_output
+
+    def test_cstr_contains_metadata_when_present(self):
+        """Project _cstr should include metadata fields when present."""
+        proj = Project(name="test_project", author="test_author")
+        proj.meta.description = "Test description"
+        detailed = pstr(proj)
+        assert "test_project" in detailed
+        assert "test_author" in detailed
+        assert "Test description" in detailed
+
+    def test_cstr_contains_hierarchy(self):
+        """Project _cstr should include hierarchy information."""
+        proj = Project(name="parent")
+        subproj = Project(name="child")
+        proj._projects["child"] = subproj
+        ds = NDDataset([1.0, 2.0, 3.0], name="my_dataset")
+        proj._datasets["my_dataset"] = ds
+        detailed = pstr(proj)
+        assert "child" in detailed
+        assert "(sub-project)" in detailed
+        assert "my_dataset" in detailed
+        assert "(dataset)" in detailed
 
 
 # ======================================================================================
@@ -409,14 +445,21 @@ class TestProjectCurrentBehavior:
         str_output = str(proj)
         assert "(script)" in str_output
 
-    def test_project_does_not_show_metadata(self):
-        """Project currently does not show metadata in str output."""
-        proj = Project(name="test_project")
-        proj.author = "test_author"
-        proj.description = "Test description"
+    def test_project_does_not_show_metadata_in_str(self):
+        """Project __str__ does not show metadata (metadata belongs in _cstr)."""
+        proj = Project(name="test_project", author="test_author")
+        proj.meta.description = "Test description"
         str_output = str(proj)
         assert "test_author" not in str_output
         assert "Test description" not in str_output
+
+    def test_project_metadata_appears_in_cstr(self):
+        """Project metadata does appear in _cstr / detailed display."""
+        proj = Project(name="test_project", author="test_author")
+        proj.meta.description = "Test description"
+        detailed = pstr(proj)
+        assert "test_author" in detailed
+        assert "Test description" in detailed
 
 
 # ======================================================================================

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -323,8 +323,8 @@ class TestRepr:
     def test_repr_html(self):
         proj = Project(name="test")
         html = proj._repr_html_()
-        assert "<br/>" in html
-        assert "&nbsp;" in html
+        assert "<div class='scp-output'>" in html
+        assert "test" in html
 
     def test_str_empty_project(self):
         proj = Project(name="root")


### PR DESCRIPTION
## PR3 of Display / Representation Architecture (#843)

### Changes

- **Project.__repr__()** — returns Project: <name> (compact, single-line)
- **Project._cstr()** — detailed representation with name, author, description, and hierarchy tree in DATA section
- **Project._repr_html_() — migrated from ad-hoc string replacement to shared convert_to_html() pipeline
- **pstr(project)** — dispatches to _cstr() via registry in print.py
- **Bugfix** — Project.__str__() no longer collapses sibling entries onto the same line after a recursive sub-project listing (pre-existing issue, s.strip("\n"))

### What is preserved

- Coord.__repr__(), CoordSet.__repr__(), Coord._cstr(), CoordSet._cstr() — unchanged
- NDDataset.__repr__(), NDDataset._cstr() — unchanged
- convert_to_html() signature and dispatch — unchanged
- All 123 display characterization + project tests pass