### PR TITLE
MAINT: add has_defined_name to Project, exclude auto-generated names from HTML headings (#843)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -155,6 +155,15 @@ Developer
   headings may differ from terminal display.  This is PR4 of the Display /
   Representation Architecture (#843).
 
+- MAINT: Added ``has_defined_name`` to ``Project`` — a boolean trait signal
+  distinguishing user-provided names from auto-generated fallbacks.  The name
+  setter now sets ``_explicit_name = True`` only when ``name is not None``;
+  the auto-generated fallback assigns directly to ``_name`` (no recursive
+  call) to preserve the distinction.  ``_html_heading()`` now handles Project
+  via the ``has_defined_name`` property, so auto-generated names no longer
+  appear in notebook headings.  This is PR4.5 of the Display / Representation
+  Architecture (#843).
+
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -133,6 +133,15 @@ Developer
   headings may differ from terminal display.  This is PR4 of the Display /
   Representation Architecture (#843).
 
+- MAINT: Added ``has_defined_name`` to ``Project`` — a boolean trait signal
+  distinguishing user-provided names from auto-generated fallbacks.  The name
+  setter now sets ``_explicit_name = True`` only when ``name is not None``;
+  the auto-generated fallback assigns directly to ``_name`` (no recursive
+  call) to preserve the distinction.  ``_html_heading()`` now handles Project
+  via the ``has_defined_name`` property, so auto-generated names no longer
+  appear in notebook headings.  This is PR4.5 of the Display / Representation
+  Architecture (#843).
+
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.
 

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -76,6 +76,7 @@ class Project(AbstractProject, NDIO):
 
     _id = tr.Unicode()
     _name = tr.Unicode(allow_none=True)
+    _explicit_name = tr.Bool(False)
 
     _parent = tr.This()
     _projects = tr.Dict(tr.This())
@@ -315,11 +316,16 @@ class Project(AbstractProject, NDIO):
 
     @name.setter
     def name(self, name):
-        # property.setter for name
         if name is not None:
             self._name = name
+            self._explicit_name = True
         else:
-            self.name = "Project-" + self.id.split("-")[0]
+            self._name = "Project-" + self.id.split("-")[0]
+
+    @property
+    def has_defined_name(self):
+        """True if the name was explicitly provided by the user (bool)."""
+        return self._explicit_name
 
     @property
     def parent(self):

--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -32,13 +32,13 @@ def _html_heading(obj):
     (i.e. when the name was auto-generated rather than user-provided).
     """
     type_name = type(obj).__name__
-    # Use has_defined_name when available (NDArray, Coord, NDDataset, CoordSet)
-    # to distinguish user-provided names from auto-generated internal IDs.
+    # Use has_defined_name when available (NDArray, Coord, NDDataset, CoordSet,
+    # Project) to distinguish user-provided names from auto-generated IDs.
     if hasattr(obj, "has_defined_name"):
         if obj.has_defined_name:
             return f"{type_name} [{obj.name}]"
         return type_name
-    # For types without has_defined_name (e.g. Project), check _name directly.
+    # Fallback for types without has_defined_name.
     name = getattr(obj, "_name", None)
     if name:
         return f"{type_name} [{name}]"

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -462,6 +462,43 @@ class TestProjectCurrentBehavior:
         assert "Test description" in detailed
 
 
+class TestProjectNameModel:
+    """Tests for Project's explicit-name signal (has_defined_name)."""
+
+    def test_project_named_has_defined_name(self):
+        """Project with explicit name has has_defined_name == True."""
+        proj = Project(name="my_project")
+        assert proj.has_defined_name is True
+
+    def test_project_default_has_no_defined_name(self):
+        """Project with no name argument has has_defined_name == False."""
+        proj = Project()
+        assert proj.has_defined_name is False
+
+    def test_project_none_has_no_defined_name(self):
+        """Project(name=None) has has_defined_name == False."""
+        proj = Project(name=None)
+        assert proj.has_defined_name is False
+
+    def test_project_auto_name_not_in_html_heading(self):
+        """Default Project should not show generated name in HTML heading."""
+        proj = Project()
+        html = proj._repr_html_()
+        # Extract the outer summary line (the heading)
+        import re
+
+        summary = re.search(r"<summary>(.*?)</summary>", html)
+        assert summary is not None
+        assert "Project-Project_" not in summary.group(0)
+
+    def test_project_explicit_name_in_html_heading(self):
+        """Named Project should show name in HTML heading."""
+        proj = Project(name="myproj")
+        html = proj._repr_html_()
+        assert "myproj" in html
+        assert "Project" in html
+
+
 # ======================================================================================
 # HTML HEADING TESTS
 # ======================================================================================


### PR DESCRIPTION
## Summary

Adds `has_defined_name` to `Project` so auto-generated fallback names are hidden from notebook HTML headings, consistent with NDArray/CoordSet.

## Changes

- **`project.py`** — Added `_explicit_name = tr.Bool(False)` trait; name setter sets it `True` only for non-`None` input; auto-generated fallback assigns directly to `_name` (no recursive call); added `has_defined_name` property
- **`utils/print.py`** — Updated comment to include Project in `has_defined_name` types
- **`test_display_characterization.py`** — Added `TestProjectNameModel` (5 tests)
- **Changelog** — PR4.5 entry

## Verification

139 tests pass.