### PR TITLE
FIX: respect fill_value in PCHIP interpolation (#1093)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -35,6 +35,12 @@ Bug Fixes
   (became ``<untitled>``); the array values are assumed to be expressed in the
   source coordinate's units, so the units are attached rather than converted.
 
+- PCHIP interpolation (``method="pchip"``) now honours the ``fill_value``
+  argument, consistently with the linear method (#1093).  Out-of-range points
+  are filled with the requested constant (e.g. ``fill_value=0.0``), and
+  ``fill_value="extrapolate"`` extrapolates, while the default
+  ``fill_value=np.nan`` still returns NaN outside the original range.
+
 - ``interpolate`` now returns the result in the order of the requested target
   coordinate.  Interpolating a dataset stored with decreasing coordinates (e.g.
   wavenumbers from 4000 to 400 cm⁻¹) onto an increasing target previously

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,12 @@ Bug Fixes
   (became ``<untitled>``); the array values are assumed to be expressed in the
   source coordinate's units, so the units are attached rather than converted.
 
+- PCHIP interpolation (``method="pchip"``) now honours the ``fill_value``
+  argument, consistently with the linear method (#1093).  Out-of-range points
+  are filled with the requested constant (e.g. ``fill_value=0.0``), and
+  ``fill_value="extrapolate"`` extrapolates, while the default
+  ``fill_value=np.nan`` still returns NaN outside the original range.
+
 - ``interpolate`` now returns the result in the order of the requested target
   coordinate.  Interpolating a dataset stored with decreasing coordinates (e.g.
   wavenumbers from 4000 to 400 cm⁻¹) onto an increasing target previously

--- a/src/spectrochempy/processing/interpolation/interpolate.py
+++ b/src/spectrochempy/processing/interpolation/interpolate.py
@@ -189,8 +189,11 @@ def interpolate(
         For multiple dims: dict {dim: coord} or sequential application.
     method : str, optional, default='linear'
         Interpolation method: 'linear' or 'pchip'.
-    fill_value : any, optional, default=np.nan
-        Value for points outside the original range.
+    fill_value : float or str, optional, default=np.nan
+        Value used for points outside the original range. This applies to both
+        the ``'linear'`` and ``'pchip'`` methods: a finite value fills
+        out-of-range points with that constant, the default ``np.nan`` returns
+        NaN outside the range, and ``"extrapolate"`` extrapolates instead.
     assume_sorted : bool, optional, default=False
         If True, skip monotonicity checks.
     inplace : bool, optional, default=False
@@ -305,6 +308,13 @@ def interpolate(
         else:
             sorted_data = new._data
 
+        # ``fill_value`` may be NaN (the default), a finite constant or the
+        # string ``"extrapolate"``. ``interp1d`` (linear) handles all three
+        # natively; ``PchipInterpolator`` only knows ``extrapolate`` True/False,
+        # so the finite-constant case is applied by hand below so that
+        # ``fill_value`` behaves consistently for both methods (#1093).
+        extrapolate = isinstance(fill_value, str) and fill_value == "extrapolate"
+
         if method == "linear":
             interpolator = interp1d(
                 sorted_old_x,
@@ -325,12 +335,30 @@ def interpolate(
                 sorted_old_x,
                 sorted_data,
                 axis=ax,
-                extrapolate=False,
+                extrapolate=extrapolate,
             )
         else:
             raise ValueError(f"Unknown method: {method}")
 
         interpolated_data = interpolator(new_data)
+
+        if (
+            method == "pchip"
+            and not extrapolate
+            and not (isinstance(fill_value, float) and np.isnan(fill_value))
+        ):
+            # PCHIP leaves out-of-range points as NaN (``extrapolate=False``);
+            # replace them with the requested constant so ``fill_value`` matches
+            # the linear method. ``sorted_old_x`` is ascending, so this mask is
+            # independent of the target-coordinate direction.
+            out_of_range = (new_data < sorted_old_x[0]) | (new_data > sorted_old_x[-1])
+            if out_of_range.any():
+                interpolated_data[
+                    tuple(
+                        out_of_range if i == ax else slice(None)
+                        for i in range(interpolated_data.ndim)
+                    )
+                ] = fill_value
 
         if sort_idx is not None and len(sort_idx) > 0:
             new._data = interpolated_data

--- a/tests/test_processing/test_interpolation/test_interpolate.py
+++ b/tests/test_processing/test_interpolation/test_interpolate.py
@@ -190,6 +190,48 @@ class TestInterpolateMultidimensional:
         assert result.shape == (2, 3)
 
 
+class TestInterpolateFillValue:
+    """``fill_value`` handling, consistent between linear and PCHIP (#1093)."""
+
+    @staticmethod
+    def _dataset():
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = x**2
+        return NDDataset(y, coordset=[Coord(x, title="x")])
+
+    # -1.0 and 5.0 fall outside the original [0, 4] range; 0.5 and 2.5 are inside.
+    new_x = np.array([-1.0, 0.5, 2.5, 5.0])
+
+    @pytest.mark.parametrize("method", ["linear", "pchip"])
+    def test_default_fill_value_is_nan_outside_range(self, method):
+        """Both methods leave out-of-range points as NaN by default."""
+        result = self._dataset().interpolate(dim="x", coord=self.new_x, method=method)
+        assert np.isnan(result.data[0])
+        assert np.isnan(result.data[-1])
+        assert not np.isnan(result.data[1])
+        assert not np.isnan(result.data[2])
+
+    @pytest.mark.parametrize("method", ["linear", "pchip"])
+    def test_constant_fill_value_outside_range(self, method):
+        """A finite ``fill_value`` fills out-of-range points for both methods."""
+        result = self._dataset().interpolate(
+            dim="x", coord=self.new_x, method=method, fill_value=0.0
+        )
+        assert result.data[0] == 0.0
+        assert result.data[-1] == 0.0
+
+    def test_pchip_fill_value_leaves_in_range_unchanged(self):
+        """Changing ``fill_value`` only affects out-of-range points for PCHIP."""
+        ds = self._dataset()
+        ref = ds.interpolate(dim="x", coord=self.new_x, method="pchip")
+        filled = ds.interpolate(
+            dim="x", coord=self.new_x, method="pchip", fill_value=0.0
+        )
+        np.testing.assert_allclose(filled.data[1:3], ref.data[1:3], rtol=1e-10)
+        assert filled.data[0] == 0.0
+        assert filled.data[-1] == 0.0
+
+
 class TestInterpolateErrorCases:
     """Error handling tests."""
 


### PR DESCRIPTION
Fixes #1093.

## Problem

`interpolate()` exposes a `fill_value` parameter for points outside the original coordinate range. For `method="linear"` it is forwarded to scipy's `interp1d`, but `method="pchip"` hard-coded `PchipInterpolator(..., extrapolate=False)`, so `fill_value` was **ignored** for PCHIP — out-of-range points always came back as `NaN` regardless of the requested value, inconsistent with the linear method.

```python
ds = NDDataset(x**2, coordset=[Coord(x, title="x")])   # x = 0..4
new_x = np.array([-1.0, 0.5, 2.5, 5.0])                # -1 and 5 are out of range

ds.interpolate(coord=new_x, method="linear", fill_value=0.0).data  # [0, 0.5, 6.5, 0]   ✓
ds.interpolate(coord=new_x, method="pchip",  fill_value=0.0).data  # [nan, .., .., nan] ✗  (was)
```

## Fix

Map `fill_value` onto `PchipInterpolator`'s capabilities so both methods behave the same:

- `fill_value=np.nan` (default) → `NaN` outside the range (**unchanged**);
- a finite constant (e.g. `0.0`) → out-of-range points filled with it (PCHIP returns `NaN` there with `extrapolate=False`, then those points are set to the constant — `sorted_old_x` is ascending, so the out-of-range mask is independent of the target-coordinate direction, and it composes correctly with the decreasing-source handling from #1100);
- `fill_value="extrapolate"` → `PchipInterpolator(extrapolate=True)`.

In-range interpolated values are untouched. After the fix:

```python
ds.interpolate(coord=new_x, method="pchip", fill_value=0.0).data          # [0, 0.3125, 6.24, 0]
ds.interpolate(coord=new_x, method="pchip", fill_value="extrapolate").data # [2, 0.3125, 6.24, 24.67]
```

## Tests

Added `TestInterpolateFillValue` (synthetic data only): default-`NaN` and constant-fill cases parametrized over both `linear` and `pchip`, plus a PCHIP check that `fill_value` changes only out-of-range points. The two PCHIP-fill tests fail on `master` and pass with the fix; the full interpolation + alignment suite (36 tests) stays green.

### Acceptance criteria
- [x] `method="pchip", fill_value=np.nan` keeps returning `NaN` outside the original range;
- [x] `method="pchip", fill_value=0.0` fills out-of-range values with `0.0`;
- [x] existing interpolation tests still pass;
- [x] synthetic tests only, no external datasets.

---
*Authored with AI assistance under my direction; I verified the diagnosis and tests empirically.*
