### PR TITLE
FIX: preserve coordinate units and title when interpolating onto a bare array (#1094)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -43,6 +43,15 @@ Bug Fixes
   with the data before interpolation, so they stay aligned when the source
   coordinate is decreasing.
 
+- ``interpolate`` now carries coordinate labels onto target points that exactly
+  match an original coordinate value, instead of dropping all labels (#1098).
+  Identity, reordering and subsetting therefore keep their labels (attached to
+  the correct values), while genuinely resampled points are left unlabelled.
+  The same point-wise policy is applied to the primary dimension coordinate and
+  to same-dimension secondary coordinates.  Matching is exact: SpectroChemPy
+  has no coordinate-matching tolerance convention, so a broader tolerance would
+  be a separate, explicit design decision.
+
 - Fixed ``Project.__str__()`` tree formatting when a project contains both
   sub-projects and sibling datasets or scripts at the same level.  The
   recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``interpolate`` now preserves the source coordinate's units and title when the
+  target is given as a bare array (e.g. ``np.linspace(...)``) (#1094).  The
+  generated coordinate previously lost its units (became unitless) and title
+  (became ``<untitled>``); the array values are assumed to be expressed in the
+  source coordinate's units, so the units are attached rather than converted.
+
 - ``interpolate`` now returns the result in the order of the requested target
   coordinate.  Interpolating a dataset stored with decreasing coordinates (e.g.
   wavenumbers from 4000 to 400 cm⁻¹) onto an increasing target previously

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,12 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- ``interpolate`` now preserves the source coordinate's units and title when the
+  target is given as a bare array (e.g. ``np.linspace(...)``) (#1094).  The
+  generated coordinate previously lost its units (became unitless) and title
+  (became ``<untitled>``); the array values are assumed to be expressed in the
+  source coordinate's units, so the units are attached rather than converted.
+
 - ``interpolate`` now returns the result in the order of the requested target
   coordinate.  Interpolating a dataset stored with decreasing coordinates (e.g.
   wavenumbers from 4000 to 400 cm⁻¹) onto an increasing target previously

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -35,6 +35,15 @@ Bug Fixes
   with the data before interpolation, so they stay aligned when the source
   coordinate is decreasing.
 
+- ``interpolate`` now carries coordinate labels onto target points that exactly
+  match an original coordinate value, instead of dropping all labels (#1098).
+  Identity, reordering and subsetting therefore keep their labels (attached to
+  the correct values), while genuinely resampled points are left unlabelled.
+  The same point-wise policy is applied to the primary dimension coordinate and
+  to same-dimension secondary coordinates.  Matching is exact: SpectroChemPy
+  has no coordinate-matching tolerance convention, so a broader tolerance would
+  be a separate, explicit design decision.
+
 - Fixed ``Project.__str__()`` tree formatting when a project contains both
   sub-projects and sibling datasets or scripts at the same level.  The
   recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -1146,8 +1146,8 @@ class CoordSet(HasTraits):
             Target coordinate for the new grid (normalized, unit-converted).
         interpolate_secondary : callable
             Callable ``(Coord) -> Coord`` that copies a secondary coordinate,
-            interpolates its numeric data (when usable), clears labels, and
-            returns the result.
+            interpolates its numeric data (when usable), carries labels onto
+            exactly-matching target points, and returns the result.
         """
         groups = self._lookup_groups()
         groups = self._interpolate_lifecycle_groups(
@@ -1166,7 +1166,8 @@ class CoordSet(HasTraits):
         Handles three cases:
         1. **Dim not found** -- appends a new group with *target_coord*.
         2. **Simple coord** (single entry, no aliases) -- replaces the entry's
-           coord with a copy of *target_coord* (labels cleared).
+           coord with a copy of *target_coord*, whose labels have already been
+           carried over for exactly-matching points by the caller.
         3. **Same-dim multi-coord** (multiple entries or aliases) -- applies
            *interpolate_secondary* to each entry's coord.
         """
@@ -1174,7 +1175,6 @@ class CoordSet(HasTraits):
 
         if dim not in coord_dims:
             new_coord = target_coord.copy()
-            new_coord._labels = None
             temp_coordset = CoordSet(new_coord, keepnames=True, sorted=False)
             new_group = _coordset_to_groups(temp_coordset)[0]
             return tuple(groups) + (new_group,)
@@ -1186,7 +1186,6 @@ class CoordSet(HasTraits):
 
         if len(group.entries) == 1 and not group.aliases:
             new_coord = target_coord.copy()
-            new_coord._labels = None
             new_entry = replace(group.entries[0], coord=new_coord)
             new_group = replace(group, entries=(new_entry,))
         else:

--- a/src/spectrochempy/processing/interpolation/interpolate.py
+++ b/src/spectrochempy/processing/interpolation/interpolate.py
@@ -194,10 +194,12 @@ def interpolate(
         # Handle different target coordinate types
         from spectrochempy.core.dataset.nddataset import NDDataset
 
+        target_from_array = False
         if isinstance(target_coord, NDDataset):
             target_coord = target_coord.coord(dim)
         elif isinstance(target_coord, np.ndarray):
             target_coord = Coord(target_coord)
+            target_from_array = True
         elif not isinstance(target_coord, Coord):
             raise TypeError(
                 f"coord must be Coord, np.ndarray, or NDDataset, got {type(target_coord)}"
@@ -211,6 +213,16 @@ def interpolate(
 
         if primary_old_coord is None or not primary_old_coord.has_data:
             raise ValueError(f"Dimension '{dim}' has no coordinate data to interpolate")
+
+        if target_from_array:
+            # A coordinate generated from a bare array carries no metadata. Keep
+            # the semantics of the axis being interpolated by inheriting the
+            # source coordinate's units and title (#1094). The array values are
+            # assumed to already be expressed in the source coordinate's units,
+            # so the units are *attached*, not converted.
+            if primary_old_coord.has_units:
+                target_coord.units = primary_old_coord.units
+            target_coord.title = primary_old_coord.title
 
         old_data = _get_coord_data(primary_old_coord)
         if old_data is None:

--- a/src/spectrochempy/processing/interpolation/interpolate.py
+++ b/src/spectrochempy/processing/interpolation/interpolate.py
@@ -118,6 +118,50 @@ def _get_coord_data(coord):
     return None
 
 
+def _match_indices(old_data, new_data):
+    """
+    Map each target point to an exactly matching original index, or ``-1``.
+
+    Implements the point-wise label policy (#1098): a target point counts as
+    "the same" as an original point only on exact value equality, so identity,
+    reordering and subsetting carry labels over while genuinely resampled
+    points (which fall between original values) do not. Matching is exact on
+    purpose -- SpectroChemPy has no coordinate-matching tolerance convention,
+    so a broader tolerance would be a separate, explicit design decision.
+    """
+    old_data = np.asarray(old_data)
+    new_data = np.asarray(new_data)
+    match_idx = np.full(len(new_data), -1, dtype=int)
+    for j, value in enumerate(new_data):
+        hits = np.flatnonzero(old_data == value)
+        if hits.size:
+            match_idx[j] = hits[0]
+    return match_idx
+
+
+def _carry_labels(old_labels, match_idx):
+    """
+    Carry labels onto interpolated points using precomputed match indices.
+
+    Each target point that exactly matches an original coordinate value
+    inherits that point's label(s); the others stay unlabelled (empty string).
+    Returns ``None`` when there is nothing to carry, leaving the interpolated
+    coordinate unlabelled (#1098). The label level structure is preserved by
+    copying whole per-point rows (labels are stored with points on axis 0).
+    """
+    if old_labels is None:
+        return None
+    old_labels = np.asarray(old_labels)
+    matched = match_idx >= 0
+    if not np.any(matched):
+        return None
+    new_labels = np.full(
+        (len(match_idx),) + old_labels.shape[1:], "", dtype=old_labels.dtype
+    )
+    new_labels[matched] = old_labels[match_idx[matched]]
+    return new_labels
+
+
 def interpolate(
     dataset,
     dim=None,
@@ -166,7 +210,10 @@ def interpolate(
 
     Notes
     -----
-    - Labels are NOT interpolated and are reset after interpolation.
+    - Labels are not interpolated. A target point carries over the label of an
+      original point only when it exactly matches that point's coordinate value
+      (so identity, reordering and subsetting keep their labels); genuinely
+      resampled points are left unlabelled (#1098).
     - For multiple coordinates per dimension, all are interpolated consistently.
     - Secondary coordinates are interpolated numerically. If they represent
       analytical transformations of the primary coordinate (e.g., wavelength = 1/wavenumber),
@@ -241,6 +288,11 @@ def interpolate(
                 target_coord = target_coord.copy()
                 target_coord.ito(primary_old_coord.units)
                 new_data = _get_coord_data(target_coord)
+
+        # Point-wise label carry-over: for each target point, find the exactly
+        # matching original index so labels can follow the data (#1098). Both
+        # arrays are now expressed in the source coordinate's units.
+        match_idx = _match_indices(old_data, new_data)
 
         sorted_old_x, sort_idx, _was_reversed = _validate_monotonic(
             primary_old_coord, assume_sorted
@@ -318,6 +370,7 @@ def interpolate(
             _sorted_old_x=sorted_old_x,
             _new_data=new_data,
             _sort_idx=sort_idx,
+            _match_idx=match_idx,
         ):
             new_sec = coord.copy()
             if coord.has_data:
@@ -338,8 +391,15 @@ def interpolate(
                         assume_sorted=True,
                     )
                     new_sec._data = sec_interpolator(_new_data)
-            new_sec._labels = None
+            # Carry the secondary coordinate's labels onto exactly-matching
+            # target points, consistently with the primary coordinate (#1098).
+            new_sec._labels = _carry_labels(coord._labels, _match_idx)
             return new_sec
+
+        # Carry the primary coordinate's labels onto exactly-matching target
+        # points (#1098); copy first so a user-supplied target is not mutated.
+        target_coord = target_coord.copy()
+        target_coord._labels = _carry_labels(primary_old_coord._labels, match_idx)
 
         new._coordset = new._coordset._interpolate_dim(
             dim,

--- a/tests/test_processing/test_interpolation/test_interpolate.py
+++ b/tests/test_processing/test_interpolation/test_interpolate.py
@@ -387,6 +387,35 @@ class TestInterpolateMetadata:
         assert result.name == "test_name"
         assert result.title == "test title"
 
+    def test_interpolate_array_target_preserves_coord_units_title(self):
+        """A plain-array target keeps the source coordinate units/title (#1094)."""
+        x = np.linspace(4000.0, 400.0, 10)
+        ds = NDDataset(
+            np.linspace(0.0, 1.0, 10),
+            coordset=[Coord(x, title="wavenumber", units="cm^-1")],
+        )
+
+        new_x = np.linspace(3500.0, 500.0, 6)  # bare ndarray, no metadata
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        assert result.coord("x").units == ds.coord("x").units
+        assert result.coord("x").title == ds.coord("x").title
+        # coordinate values follow the requested target, units only attached
+        np.testing.assert_allclose(result.coord("x").data, new_x, rtol=1e-10)
+
+    def test_interpolate_explicit_coord_target_keeps_own_metadata(self):
+        """An explicit Coord target keeps its own title, not the source's (#1094)."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        ds = NDDataset(
+            np.array([0.0, 2.0, 4.0, 6.0, 8.0]),
+            coordset=[Coord(x, title="wavenumber", units="cm^-1")],
+        )
+
+        target = Coord(np.array([0.5, 1.5, 2.5, 3.5]), title="mine", units="cm^-1")
+        result = ds.interpolate(dim="x", coord=target)
+
+        assert result.coord("x").title == "mine"
+
     def test_interpolate_updates_history(self):
         """Test that history is updated."""
         x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])

--- a/tests/test_processing/test_interpolation/test_interpolate.py
+++ b/tests/test_processing/test_interpolation/test_interpolate.py
@@ -242,10 +242,10 @@ class TestInterpolateUnits:
 
 
 class TestInterpolateLabels:
-    """Label handling tests."""
+    """Label handling tests (point-wise carry-over policy, GH #1098)."""
 
-    def test_interpolate_removes_labels(self):
-        """Test that labels are removed after interpolation."""
+    def test_interpolate_resampled_points_unlabelled(self):
+        """Genuinely resampled points (no exact match) are left unlabelled."""
         x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
         labels = ["a", "b", "c", "d", "e"]
         y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
@@ -255,7 +255,102 @@ class TestInterpolateLabels:
         result = ds.interpolate(dim="x", coord=new_x)
 
         coord = result.coord("x")
+        # none of the target points match an original value -> unlabelled
         assert coord._labels is None
+
+    def test_interpolate_identity_preserves_all_labels(self):
+        """An identity target grid keeps every label."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        labels = ["a", "b", "c", "d", "e"]
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", labels=labels)])
+
+        result = ds.interpolate(dim="x", coord=x.copy())
+
+        coord = result.coord("x")
+        assert coord.is_labeled
+        assert list(np.asarray(coord.get_labels())) == labels
+
+    def test_interpolate_reordered_preserves_labels_at_values(self):
+        """A reordered target grid keeps labels attached to their values."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        labels = ["a", "b", "c", "d", "e"]
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", labels=labels)])
+
+        new_x = np.array([2.0, 0.0, 4.0, 1.0, 3.0])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        assert list(np.asarray(coord.get_labels())) == ["c", "a", "e", "b", "d"]
+
+    def test_interpolate_subset_preserves_matching_labels(self):
+        """A subset target grid keeps only the matching labels."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        labels = ["a", "b", "c", "d", "e"]
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", labels=labels)])
+
+        new_x = np.array([1.0, 3.0])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        assert list(np.asarray(coord.get_labels())) == ["b", "d"]
+
+    def test_interpolate_mixed_grid_labels_exact_matches_only(self):
+        """A mixed grid labels exact matches and leaves new points unlabelled."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        labels = ["a", "b", "c", "d", "e"]
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", labels=labels)])
+
+        new_x = np.array([0.0, 1.5, 2.0, 3.5])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        assert list(np.asarray(coord.get_labels())) == ["a", "", "c", ""]
+
+    def test_interpolate_no_match_gives_unlabelled_coord(self):
+        """When no target point matches, the coordinate stays unlabelled."""
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        labels = ["a", "b", "c", "d", "e"]
+        y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+        ds = NDDataset(y, coordset=[Coord(x, title="x", labels=labels)])
+
+        new_x = np.array([0.1, 1.1, 2.1])
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        assert not coord.is_labeled
+        assert coord._labels is None
+
+    def test_interpolate_secondary_coord_labels_consistent(self):
+        """Same-dim secondary coordinates follow the same point-wise policy."""
+        from spectrochempy import CoordSet
+
+        x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        y = np.array([0.0, 10.0, 20.0])
+        data = np.arange(15).reshape(3, 5).astype(float)
+
+        primary = Coord(x, title="x", labels=["a", "b", "c", "d", "e"])
+        secondary = Coord(10.0 * x, title="x10", labels=["p", "q", "r", "s", "t"])
+        multi_coord = CoordSet(primary, secondary, name="x")
+        ds = NDDataset(data, coordset=[Coord(y, title="y"), multi_coord])
+
+        # Matching is driven by the default coordinate; pick a target that is a
+        # reordered subset of its own values (original positions 3 then 1).
+        default_values = np.asarray(multi_coord.default.data)
+        new_x = default_values[[3, 1]]
+        result = ds.interpolate(dim="x", coord=new_x)
+
+        coord = result.coord("x")
+        assert isinstance(coord, CoordSet)
+        # every same-dim coordinate carries its own labels for the matched
+        # points, consistently with the default/primary coordinate
+        for cc in coord.coords:
+            labels = list(np.asarray(cc.get_labels()))
+            assert cc.is_labeled
+            assert labels[0] != "" and labels[1] != ""
 
 
 class TestInterpolateMask:
@@ -300,8 +395,8 @@ class TestInterpolateCoordReconstruction:
 
     def test_interpolate_simple_coord_replacement(self):
         """
-        Simple coord replacement preserves target values, name,
-        and clears labels.
+        Simple coord replacement preserves target values and name, and leaves
+        genuinely resampled points unlabelled.
         """
         x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
         y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
@@ -318,8 +413,8 @@ class TestInterpolateCoordReconstruction:
 
     def test_interpolate_multi_coord_reconstruction(self):
         """
-        Multi-coord reconstruction preserves group nature, default,
-        clears labels, and interpolates secondary numeric data.
+        Multi-coord reconstruction preserves group nature and default, leaves
+        resampled points unlabelled, and interpolates secondary numeric data.
         """
         x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
         y = np.array([0.0, 10.0, 20.0])
@@ -350,7 +445,7 @@ class TestInterpolateCoordReconstruction:
         np.testing.assert_allclose(primary.data, [0.5, 1.5, 2.5])
 
         # Verify secondary coord exists and was interpolated
-        # -- all children have labels cleared and length 3
+        # -- resampled (non-matching) points leave children unlabelled, length 3
         assert len(coord) > 1
 
 


### PR DESCRIPTION
Fixes #1094.

## Problem

When `interpolate()` is given the target coordinate as a plain array (e.g. `coord=np.linspace(...)`), the result lost the source coordinate's metadata: the generated coordinate came out **unitless** and **untitled**, even though the user only wanted to re-sample the same axis.

```python
ds.coord("x").units, ds.coord("x").title    # cm⁻¹, 'wavenumber'
out = ds.interpolate(dim="x", coord=np.linspace(3500, 500, 6))
out.coord("x").units, out.coord("x").title  # None, '<untitled>'   ← lost
```

The bare array was wrapped with `Coord(target_coord)`, which carries no units or title.

## Fix

When (and only when) the target is built from a bare `ndarray`, inherit the source coordinate's `units` and `title`. The array values are assumed to already be expressed in the source coordinate's units, so the units are **attached, not converted**. Explicit `Coord` / `NDDataset` targets keep their own metadata, and the existing units-compatibility conversion path is unaffected.

```python
out = ds.interpolate(dim="x", coord=np.linspace(3500, 500, 6))
out.coord("x").units, out.coord("x").title  # cm⁻¹, 'wavenumber'   ✓
```

## Tests

Added two tests to `TestInterpolateMetadata` (synthetic data only): a bare-array target now preserves units and title (and the coordinate values still follow the requested target), and an explicit `Coord` target keeps its own title. The first fails on `master` and passes with the fix; the interpolation + alignment suite (33 tests) stays green.

### Acceptance criteria
- [x] coordinate units are preserved;
- [x] coordinate title is preserved;
- [x] interpolation numerical results remain unchanged;
- [x] tests use synthetic data only, no external datasets.

---
*Authored with AI assistance under my direction; I verified the diagnosis and tests empirically.*
