### PR TITLE
MAINT: preserve Project hierarchy in HTML display (#843)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -164,6 +164,12 @@ Developer
   appear in notebook headings.  This is PR4.5 of the Display / Representation
   Architecture (#843).
 
+- MAINT: Preserved Project hierarchy in HTML display — ``_process_section()``
+  now wraps indented hierarchy lines (prefixed by ``⤷``) in ``<div>`` elements,
+  preventing HTML whitespace collapsing from flattening nested sub-projects and
+  datasets into a single line.  This is PR6 of the Display / Representation
+  Architecture (#843).
+
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -142,6 +142,12 @@ Developer
   appear in notebook headings.  This is PR4.5 of the Display / Representation
   Architecture (#843).
 
+- MAINT: Preserved Project hierarchy in HTML display — ``_process_section()``
+  now wraps indented hierarchy lines (prefixed by ``⤷``) in ``<div>`` elements,
+  preventing HTML whitespace collapsing from flattening nested sub-projects and
+  datasets into a single line.  This is PR6 of the Display / Representation
+  Architecture (#843).
+
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.
 

--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -182,7 +182,19 @@ def _process_section(section):
     out = re.sub(regex, subst, out, count=0, flags=re.MULTILINE)
 
     regex = r"\.{3}\s+\n"
-    return re.sub(regex, "", out, count=0, flags=re.MULTILINE)
+    out = re.sub(regex, "", out, count=0, flags=re.MULTILINE)
+
+    # Preserve hierarchy lines (prefixed by ⤷ or containing "empty project")
+    # as block elements so that whitespace collapsing in HTML does not flatten
+    # Project nesting.
+    regex = r"^(\s*(?:⤷\s*.*|\(empty project\)))$"
+
+    def subst(match):
+        line = match.group(1)
+        n_spaces = len(line) - len(line.lstrip())
+        return f"<div>{'&nbsp;' * n_spaces}{line.lstrip()}</div>"
+
+    return re.sub(regex, subst, out, count=0, flags=re.MULTILINE)
 
 
 def convert_to_html(obj, open=False, id=None):

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -499,6 +499,57 @@ class TestProjectNameModel:
         assert "Project" in html
 
 
+class TestProjectHTMLHierarchy:
+    """Tests for Project HTML hierarchy rendering."""
+
+    def test_project_html_contains_hierarchy(self):
+        """Project HTML contains sub-project and dataset names."""
+        top = Project(name="top")
+        sub = Project(name="subproj")
+        top.add_project(sub)
+        sub.add_dataset(NDDataset([1, 2, 3], name="ds1"))
+        html = top._repr_html_()
+        assert "subproj" in html
+        assert "ds1" in html
+        assert "sub-project" in html
+        assert "dataset" in html
+
+    def test_project_hierarchy_nesting_preserved(self):
+        """Nested projects preserve structure in HTML."""
+        top = Project(name="top")
+        mid = Project(name="mid")
+        bot = Project(name="bot")
+        top.add_project(mid)
+        mid.add_project(bot)
+        bot.add_dataset(NDDataset([1], name="leaf"))
+        html = top._repr_html_()
+        assert "top" in html
+        assert "mid" in html
+        assert "bot" in html
+        assert "leaf" in html
+        # Hierarchy lines are wrapped in <div> tags
+        assert "<div>" in html
+        assert "⤷" in html
+
+    def test_project_empty_html_shows_empty(self):
+        """Empty project HTML shows empty indicator."""
+        proj = Project(name="empty")
+        html = proj._repr_html_()
+        assert "empty project" in html
+
+    def test_project_mixed_items_in_html(self):
+        """Project with sub-projects, datasets, and scripts shows all."""
+        proj = Project(name="mixed")
+        proj.add_dataset(NDDataset([1], name="ds1"))
+        sub = Project(name="sub")
+        proj.add_project(sub)
+        sub.add_dataset(NDDataset([2], name="sub_ds"))
+        html = proj._repr_html_()
+        assert "ds1" in html
+        assert "sub" in html
+        assert "sub_ds" in html
+
+
 # ======================================================================================
 # HTML HEADING TESTS
 # ======================================================================================


### PR DESCRIPTION
## Summary

Project HTML display was flattening nested hierarchy into a single line because `_process_section()` left hierarchy lines (prefixed by `⤷`) as bare text. HTML whitespace collapsing turned:

    ⤷ A350 (sub-project)
        ⤷ IR (dataset)
        ⤷ TG (dataset)

into a flat:

    ⤷ A350 (sub-project) ⤷ IR (dataset) ⤷ TG (dataset)

## Fix

One regex added at the end of `_process_section()` in `utils/print.py`:

    r"^(\s*(?:⤷\s*.*|\(empty project\)))$"

Each matching line is wrapped in a `<div>` with leading whitespace converted to `&nbsp;`, preserving both line separation and visual indentation.

## Changes

- **`utils/print.py`** — hierarchy preservation regex in `_process_section()`
- **`test_display_characterization.py`** — `TestProjectHTMLHierarchy` with 4 semantic tests
- **`maintainers/project-html-hierarchy-note.md`** — root cause and solution documentation
- **Changelog** — PR6 entry

## Verification

143 tests pass. Other objects (Coord, CoordSet, NDDataset) unaffected.