### PR TITLE
MAINT: enrich HTML headings with dtype/shape/units for array-like objects (#843)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -155,28 +155,16 @@ Developer
 
 - MAINT: Harmonized notebook HTML headings — replaced the ad-hoc
   ``obj.__str__() + [obj.name]`` summary line in ``convert_to_html()`` with
-  a dedicated ``_html_heading()`` helper.  Headings now follow the pattern
-  ``TypeName [name]`` (user-provided name) or just ``TypeName``
-  (auto-generated ID), eliminating duplicated project names and exposing no
-  internal UUIDs.  ``_repr_html_()`` headings are now decoupled from
-  terminal ``__str__()``, aligning with the RFC decision that notebook
-  headings may differ from terminal display.  This is PR4 of the Display /
+  a dedicated ``_html_heading()`` helper.  Headings now follow a
+  type-specific format: ``TypeName [name] — dtype, shape, units`` for
+  array-like objects (Coord, NDDataset), ``CoordSet — x, y`` for coordinate
+  sets, and ``Project [name]`` for projects.  Auto-generated internal IDs
+  (UUIDs) are never shown in headings, and ``Project.__str__()`` hierarchy
+  is preserved in HTML through block-level rendering of indented lines.
+  ``_repr_html_()`` headings are now decoupled from terminal ``__str__()``,
+  aligning with the RFC decision that notebook headings may differ from
+  terminal display.  This consolidates PR4 through PR7 of the Display /
   Representation Architecture (#843).
-
-- MAINT: Added ``has_defined_name`` to ``Project`` — a boolean trait signal
-  distinguishing user-provided names from auto-generated fallbacks.  The name
-  setter now sets ``_explicit_name = True`` only when ``name is not None``;
-  the auto-generated fallback assigns directly to ``_name`` (no recursive
-  call) to preserve the distinction.  ``_html_heading()`` now handles Project
-  via the ``has_defined_name`` property, so auto-generated names no longer
-  appear in notebook headings.  This is PR4.5 of the Display / Representation
-  Architecture (#843).
-
-- MAINT: Preserved Project hierarchy in HTML display — ``_process_section()``
-  now wraps indented hierarchy lines (prefixed by ``⤷``) in ``<div>`` elements,
-  preventing HTML whitespace collapsing from flattening nested sub-projects and
-  datasets into a single line.  This is PR6 of the Display / Representation
-  Architecture (#843).
 
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.

--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -27,22 +27,53 @@ def _html_heading(obj):
     """
     Build a compact HTML heading identifying *obj*.
 
-    Returns a string like ``"Coord [mycoord]"`` or ``"Project [my_project]"``.
-    Falls back to the bare type name when the object has no meaningful name
-    (i.e. when the name was auto-generated rather than user-provided).
+    For array-like objects (Coord, NDDataset, NDArray) the heading includes
+    dtype, shape/size, and units when available::
+
+        Coord [x] — float64, size: 50, m
+
+    For unnamed objects the bracketed name is omitted::
+
+        NDDataset — float64, shape: (y:10, x:20)
+
+    For CoordSet the child coordinate names are shown::
+
+        CoordSet — x, y
+
+    For Project the bare type name with optional bracketed name is used::
+
+        Project [my_project]
     """
     type_name = type(obj).__name__
-    # Use has_defined_name when available (NDArray, Coord, NDDataset, CoordSet,
-    # Project) to distinguish user-provided names from auto-generated IDs.
+
+    # --- name part ---
     if hasattr(obj, "has_defined_name"):
-        if obj.has_defined_name:
-            return f"{type_name} [{obj.name}]"
-        return type_name
-    # Fallback for types without has_defined_name.
-    name = getattr(obj, "_name", None)
-    if name:
-        return f"{type_name} [{name}]"
-    return type_name
+        name_part = f" [{obj.name}]" if obj.has_defined_name else ""
+    else:
+        name_part = ""
+
+    # --- scientific identity part ---
+    extras = ""
+
+    # Array-like objects (Coord, NDArray, NDDataset)
+    if hasattr(obj, "_repr_shape"):
+        parts = []
+        if hasattr(obj, "dtype") and obj.dtype is not None:
+            parts.append(str(obj.dtype))
+        parts.append(obj._repr_shape())
+        units = obj._repr_units() if hasattr(obj, "_repr_units") else ""
+        if units and units != "unitless":
+            parts.append(units)
+        if parts:
+            extras = " — " + ", ".join(parts)
+
+    # CoordSet: show child coordinate names
+    elif type_name == "CoordSet":
+        names = obj.names
+        if names:
+            extras = f" — {', '.join(names)}"
+
+    return f"{type_name}{name_part}{extras}"
 
 
 # ======================================================================================

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -580,12 +580,32 @@ class TestHTMLHeading:
         html = coord._repr_html_()
         assert "[]" not in html
 
+    def test_coord_heading_scientific_identity(self):
+        """Coord heading includes dtype, size/shape, and units when present."""
+        coord = Coord([1.0, 2.0, 3.0], name="x", units="m")
+        html = coord._repr_html_()
+        assert "Coord" in html
+        assert "x" in html
+        assert "float" in html.lower()
+        assert "size" in html.lower() or "shape" in html.lower()
+        assert "m" in html
+
     def test_coordset_heading_contains_type(self):
         """CoordSet HTML heading contains the type name."""
         x = Coord([1.0, 2.0])
         cs = CoordSet(x=x)
         html = cs._repr_html_()
         assert "CoordSet" in html
+
+    def test_coordset_heading_shows_coord_names(self):
+        """CoordSet heading lists child coordinate names."""
+        x = Coord([1.0, 2.0], name="x")
+        y = Coord([3.0, 4.0], name="y")
+        cs = CoordSet(x=x, y=y)
+        html = cs._repr_html_()
+        assert "CoordSet" in html
+        assert "x" in html
+        assert "y" in html
 
     def test_nddataset_heading_contains_type(self):
         """NDDataset HTML heading contains the type name."""
@@ -598,6 +618,23 @@ class TestHTMLHeading:
         ds = NDDataset([1.0, 2.0], name="myds")
         html = ds._repr_html_()
         assert "myds" in html
+
+    def test_nddataset_heading_scientific_identity(self):
+        """NDDataset heading includes dtype, shape/size, and units when present."""
+        ds = NDDataset([[1, 2], [3, 4]], units="cm⁻¹", name="spec")
+        html = ds._repr_html_()
+        assert "NDDataset" in html
+        assert "spec" in html
+        assert "float" in html.lower()
+        assert "shape" in html.lower() or "size" in html.lower()
+        assert "cm" in html
+
+    def test_nddataset_heading_no_auto_id(self):
+        """Unnamed NDDataset should not show auto-generated ID in heading."""
+        ds = NDDataset([1.0, 2.0])
+        html = ds._repr_html_()
+        # The auto-generated name is the id (starts with NDDataset_)
+        assert "NDDataset_NDDataset_" not in html
 
     def test_project_heading_no_duplicate_name(self):
         """Project HTML heading should not duplicate the project name."""


### PR DESCRIPTION
## Summary

HTML headings for array-like objects now include dtype, shape/size, and units, restoring the scientific identity that was lost in the initial heading harmonization.  Changelog entries for PR4–PR7 have been consolidated into a single entry.

## Changes

**`_html_heading()`** in `utils/print.py` now produces type-specific enriched headings:

| Object | Heading |
|--------|---------|
| `Coord(name="x", units="m")` | `Coord [x] — float64, size: 50, m` |
| `Coord(units="m")` (no name) | `Coord — float64, size: 50, m` |
| `NDDataset(name="ds", units="a.u.")` | `NDDataset [ds] — float64, size: 10, a.u.` |
| `NDDataset(units="cm⁻¹")` (no name) | `NDDataset — float64, shape: (y:10, x:20), cm⁻¹` |
| `CoordSet(x=..., y=...)` | `CoordSet — x, y` |
| `Project(name="proj")` | `Project [proj]` (unchanged) |

- dtype, shape/size, and units are shown when available
- auto-generated UUIDs remain hidden
- Project headings unchanged
- Changelog consolidated: PR4, PR4.5, PR6, PR7 merged into one entry

## Tests

4 new tests added covering scientific identity content for Coord, NDDataset, CoordSet, and auto-ID suppression.  All 351 related tests pass.

## Audit

Updated `~display-pr4-html-headings.md` with v2 heading table and implementation notes.  Updated `~display-representation-model-rfc.md` to reflect enriched heading decision.