### PR TITLE
MAINT: render summary metadata inline instead of collapsible section (#843)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -161,10 +161,12 @@ Developer
   sets, and ``Project [name]`` for projects.  Auto-generated internal IDs
   (UUIDs) are never shown in headings, and ``Project.__str__()`` hierarchy
   is preserved in HTML through block-level rendering of indented lines.
-  ``_repr_html_()`` headings are now decoupled from terminal ``__str__()``,
-  aligning with the RFC decision that notebook headings may differ from
-  terminal display.  This consolidates PR4 through PR7 of the Display /
-  Representation Architecture (#843).
+  The SUMMARY section metadata is now rendered inline under the main heading
+  instead of inside a collapsible ``<details>`` block, reducing unnecessary
+  nesting.  ``_repr_html_()`` headings are now decoupled from terminal
+  ``__str__()``, aligning with the RFC decision that notebook headings may
+  differ from terminal display.  This consolidates PR4 through PR8 of the
+  Display / Representation Architecture (#843).
 
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -139,10 +139,12 @@ Developer
   sets, and ``Project [name]`` for projects.  Auto-generated internal IDs
   (UUIDs) are never shown in headings, and ``Project.__str__()`` hierarchy
   is preserved in HTML through block-level rendering of indented lines.
-  ``_repr_html_()`` headings are now decoupled from terminal ``__str__()``,
-  aligning with the RFC decision that notebook headings may differ from
-  terminal display.  This consolidates PR4 through PR7 of the Display /
-  Representation Architecture (#843).
+  The SUMMARY section metadata is now rendered inline under the main heading
+  instead of inside a collapsible ``<details>`` block, reducing unnecessary
+  nesting.  ``_repr_html_()`` headings are now decoupled from terminal
+  ``__str__()``, aligning with the RFC decision that notebook headings may
+  differ from terminal display.  This consolidates PR4 through PR8 of the
+  Display / Representation Architecture (#843).
 
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.

--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -246,14 +246,21 @@ def convert_to_html(obj, open=False, id=None):
 
     # Process each section with CSS classes
     html_output = []
-    for section in collapsable_sections.values():
+    for i, section in enumerate(collapsable_sections.values()):
         open = ""  # if section[0] != "SUMMARY" else " open"  # closed by default
         ps = _process_section(section)
         if ps == "<summary>SUMMARY</summary>":
             continue  # summary empty
-        html_output.append(
-            f'<div class="scp-output section"><details{open}>{ps}</details></div>'
-        )
+        if i == 0:
+            # Render summary metadata inline (no collapsible wrapper)
+            # Remove the <summary>SUMMARY</summary> tag from section 0
+            ps = ps.replace("<summary>SUMMARY</summary>\n", "")
+            ps = ps.replace("<summary>SUMMARY</summary>", "")
+            html_output.append(ps)
+        else:
+            html_output.append(
+                f'<div class="scp-output section"><details{open}>{ps}</details></div>'
+            )
 
     obj._html_output = False
 

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -662,6 +662,50 @@ class TestHTMLHeading:
         assert "Coord" in html
 
 
+class TestInlineSummary:
+    """Tests that summary metadata renders inline (no collapsible Summary section)."""
+
+    def test_no_summary_collapsible_in_nddataset(self):
+        """NDDataset HTML should not contain a collapsible Summary section."""
+        ds = NDDataset([1.0, 2.0], name="ds")
+        html = ds._repr_html_()
+        assert "<summary>Summary</summary>" not in html
+
+    def test_metadata_visible_inline_nddataset(self):
+        """NDDataset metadata fields appear directly under heading."""
+        ds = NDDataset([1.0, 2.0], name="ds")
+        html = ds._repr_html_()
+        assert "name" in html
+        assert "ds" in html
+
+    def test_data_section_still_collapsible(self):
+        """Data section should still be wrapped in <details>."""
+        ds = NDDataset([1.0, 2.0])
+        html = ds._repr_html_()
+        # The data section <details> should exist
+        assert "<details>" in html
+
+    def test_no_summary_collapsible_in_project(self):
+        """Project HTML should not contain a collapsible Summary section."""
+        proj = Project(name="proj")
+        html = proj._repr_html_()
+        assert "<summary>Summary" not in html
+        assert "<summary>Data" in html
+
+    def test_project_metadata_inline(self):
+        """Project metadata appears inline under heading."""
+        proj = Project(name="proj", author="test")
+        html = proj._repr_html_()
+        assert "test" in html
+        assert "proj" in html
+
+    def test_coord_no_summary_collapsible(self):
+        """Coord HTML should not contain a collapsible Summary section."""
+        coord = Coord([1.0, 2.0], name="x")
+        html = coord._repr_html_()
+        assert "<summary>Summary</summary>" not in html
+
+
 class TestDisplaySafetyNet:
     """Safety-net tests to catch regressions."""
 


### PR DESCRIPTION
## Summary

The SUMMARY section metadata (name, author, created, etc.) is now rendered inline under the main object heading instead of being wrapped in its own collapsible `<details><summary>Summary</summary>` block, reducing unnecessary nesting in notebook display.

## Before

    ▼ NDDataset
        ▼ Summary
            name: ...
            author: ...
        ▼ Data
            values: ...

## After

    ▼ NDDataset
        name: ...
        author: ...
        ▼ Data
            values: ...

DATA and DIMENSION sections remain collapsible.

## Changes

- **`utils/print.py`** — In `convert_to_html()`, section index 0 (SUMMARY) is detected and rendered without the `<details>` wrapper after stripping the `<summary>SUMMARY</summary>` tag
- **Tests** — `TestInlineSummary` with 6 semantic tests covering NDDataset, Project, Coord
- **Changelog** — Consolidated entry updated to cover PR4–PR8
- **Audit** — `~display-pr4-html-headings.md` updated with PR8 section

## Verification

153 tests pass.