### PR TITLE
TEST: ensure baseline correction preserves masked values (#1097)

### DIFF
--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -220,3 +220,60 @@ def test_baseline_ms_profile(synthetic_ms_like_dataset):
     assert baseline.shape == dataset.shape
     assert np.all(np.isfinite(baseline.data))
     assert np.all(np.isfinite(corrected.data))
+
+
+def test_baseline_preserves_mask_2d(synthetic_2d_baseline_dataset):
+    # #1097: masking a spectral region must survive baseline correction unchanged.
+    # The existing masked-baseline tests only check shape and finiteness; none assert
+    # that the mask locations themselves are preserved on the baseline/corrected output.
+    dataset, _, _ = synthetic_2d_baseline_dataset
+
+    dataset[:, 3000.0:2000.0] = scp.MASKED
+    expected_mask = np.asarray(dataset.mask).copy()
+    assert expected_mask.any()
+
+    blc = Baseline()
+    blc.model = "polynomial"
+    blc.order = 3
+    blc.fit(dataset)
+    baseline = blc.baseline
+    corrected = blc.transform()
+
+    # mask locations remain unchanged on both the baseline and the corrected dataset
+    assert np.array_equal(np.asarray(baseline.mask), expected_mask)
+    assert np.array_equal(np.asarray(corrected.mask), expected_mask)
+
+    # units, dimensions and shape are preserved
+    assert corrected.shape == dataset.shape
+    assert corrected.units == dataset.units
+    assert baseline.units == dataset.units
+    assert corrected.dims == dataset.dims
+
+    # no values are introduced into the masked region: unmasked data stays finite
+    unmasked = ~np.asarray(corrected.mask)
+    assert np.all(np.isfinite(corrected.data[unmasked]))
+    assert np.all(np.isfinite(baseline.data[unmasked]))
+
+
+def test_baseline_preserves_mask_1d(synthetic_1d_baseline_dataset):
+    # #1097, 1D case: a masked region in a 1D spectrum survives baseline correction.
+    # The dataset is processed as a single-row 2D internally, but the mask is restored
+    # at the same coordinate positions.
+    dataset, _, _ = synthetic_1d_baseline_dataset
+
+    dataset[3000.0:2000.0] = scp.MASKED
+    expected_positions = np.flatnonzero(np.asarray(dataset.mask).ravel())
+    assert expected_positions.size
+
+    blc = Baseline()
+    blc.model = "polynomial"
+    blc.order = 3
+    blc.fit(dataset)
+    corrected = blc.transform()
+
+    out_positions = np.flatnonzero(np.asarray(corrected.mask).ravel())
+    assert np.array_equal(out_positions, expected_positions)
+    assert corrected.units == dataset.units
+
+    unmasked = ~np.asarray(corrected.mask).ravel()
+    assert np.all(np.isfinite(corrected.data.ravel()[unmasked]))


### PR DESCRIPTION
## Summary

Adds regression tests for #1097: baseline correction should preserve mask locations on masked datasets.

The existing masked-baseline tests (`test_baseline_masked_data`, `test_baseline_sequential_asls`, `test_preprocessing_nddataset_methods`) exercise masked input but only assert output **shape** and **finiteness** — none check that the mask itself is preserved. These tests close that gap.

## What the tests pin

- `test_baseline_preserves_mask_2d`: masking a spectral region (`ds[:, 3000.:2000.] = MASKED`) on a 2D dataset, then `Baseline(model="polynomial").fit()` / `transform()`, leaves the mask **unchanged** on both the `baseline` and the `corrected` dataset (same locations), preserves units/dims/shape, and introduces no values outside the mask (unmasked data stays finite).
- `test_baseline_preserves_mask_1d`: the same for a 1D spectrum (processed as a single-row 2D internally; the mask is restored at the same coordinate positions).

Both use the existing synthetic fixtures — no external data. Tests-only, so no changelog entry.

## Audit notes (left out of scope; flagging for your call)

While auditing I confirmed the supported case — entire masked rows/columns — round-trips correctly. Two cases are **not** handled, and I left them untouched to keep this tests-only:

- Individual masked points (not whole rows/columns) are unsupported by design — `baseconfigurable._remove_masked_data` notes this explicitly.
- A fully-masked input raises a cryptic `TypeError: 'NoneType' object is not subscriptable` at `baseconfigurable.py:199` (`Xc = X[:, ~masked_columns]` becomes `None` when every column is masked). Happy to turn that into a clear error message in a small follow-up if you'd like.

Written with AI assistance, under my direction and review.
