### PR TITLE
FIX: export masked values as missing in the JCAMP writer (#1132)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``write_jcamp`` now exports masked samples as JCAMP-DX missing values (``?``)
+  instead of writing their underlying data (#1132).  Masked points are treated
+  like NaNs: they are excluded from the ``##MAXY``/``##MINY`` header extrema and
+  written as the ``?`` marker in the ``XYDATA`` block, so masking information is
+  preserved on round-trip instead of leaking stale values.
+
 - ``interpolate`` now preserves the source coordinate's units and title when the
   target is given as a bare array (e.g. ``np.linspace(...)``) (#1094).  The
   generated coordinate previously lost its units (became unitless) and title

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,12 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- ``write_jcamp`` now exports masked samples as JCAMP-DX missing values (``?``)
+  instead of writing their underlying data (#1132).  Masked points are treated
+  like NaNs: they are excluded from the ``##MAXY``/``##MINY`` header extrema and
+  written as the ``?`` marker in the ``XYDATA`` block, so masking information is
+  preserved on round-trip instead of leaking stale values.
+
 - ``interpolate`` now preserves the source coordinate's units and title when the
   target is given as a bare array (e.g. ``np.linspace(...)``) (#1094).  The
   generated coordinate previously lost its units (became unitless) and title

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -90,6 +90,11 @@ def _write_jcamp(*args, **kwargs):
         if timestamp_index is None:
             timestamp = datetime.now(UTC)
 
+        # Masked values are exported as missing values: filling the mask with
+        # NaN lets them flow through the same handling as genuine NaNs below
+        # (excluded from MAXY/MINY and written as the JCAMP "?" marker).
+        ydata = np.ma.filled(dataset.masked_data, np.nan)
+
         for i in range(dataset.shape[0]):
             if dataset.shape[0] > 1:
                 title = (
@@ -122,9 +127,8 @@ def _write_jcamp(*args, **kwargs):
             fid.write(f"##MINX={minx:.6f}\n")
             fid.write(f"##XFACTOR={xfactor}\n")
 
-            firsty, lasty = dataset.data[0, 0], dataset.data[0, -1]
-            # TODO : mask
-            maxy, miny = np.nanmax(dataset.data), np.nanmin(dataset.data)
+            firsty, lasty = ydata[0, 0], ydata[0, -1]
+            maxy, miny = np.nanmax(ydata), np.nanmin(ydata)
             yfactor = 1.0e-8
 
             fid.write(f"##FIRSTY={firsty:.6f}\n")
@@ -141,8 +145,8 @@ def _write_jcamp(*args, **kwargs):
             for j in np.arange(nx):
                 Y = (
                     "? "
-                    if np.isnan(dataset.data[i, j])
-                    else f"{int(dataset.data[i, j] / yfactor):.6f} "
+                    if np.isnan(ydata[i, j])
+                    else f"{int(ydata[i, j] / yfactor):.6f} "
                 )
                 line += Y
                 if len(line) >= 75 or j == nx - 1:

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -5,7 +5,9 @@
 # ======================================================================================
 # ruff: noqa
 
-from spectrochempy import read_jcamp, read
+import numpy as np
+
+from spectrochempy import read_jcamp, read, Coord, NDDataset
 
 
 def test_read_jcamp(JDX_2D):
@@ -21,3 +23,34 @@ def test_read_jcamp(JDX_2D):
     assert Y.name == "IR_2D"
 
     f.unlink()
+
+
+def test_write_jcamp_masked_values(tmp_path):
+    # masked samples must be exported as JCAMP missing values ("?"), not as
+    # their (stale) underlying data, and must be excluded from MAXY/MINY (#1132)
+    nx = 30
+    x = Coord(np.linspace(4000.0, 1000.0, nx), units="1/cm", title="wavenumber")
+    y = Coord([0.0])
+    data = np.linspace(0.1, 0.9, nx).reshape(1, nx)
+    data[0, 10:20] = 999.0  # sentinel hidden under the mask
+    ds = NDDataset(data, coordset=[y, x], units="absorbance", name="masked")
+    mask = np.zeros((1, nx), dtype=bool)
+    mask[0, 10:20] = True
+    ds.mask = mask
+
+    f = ds.write_jcamp(tmp_path / "masked.jdx", confirm=False)
+    text = f.read_text()
+
+    # the masked underlying value never leaks into the file
+    assert "999" not in text
+    # each masked point is written as the JCAMP missing marker
+    assert text.count("? ") == 10
+    # header extrema ignore the masked samples
+    assert "##MAXY=0.900000" in text
+    assert "##MINY=0.100000" in text
+
+    # round-trip: the masked region reads back as NaN, the rest stays finite
+    back = read_jcamp(f)
+    arr = np.asarray(back.data, dtype=float).ravel()
+    assert np.isnan(arr[10:20]).all()
+    assert np.isfinite(np.concatenate([arr[:10], arr[20:]])).all()


### PR DESCRIPTION
Fixes #1132.

## Problem

The JCAMP-DX writer read `dataset.data` directly and ignored the mask (the
code even carried a `# TODO : mask`). For a dataset with masked samples:

```python
ds.mask[10:20] = True
ds.write_jcamp("out.jdx")
```

the masked points were written with their underlying (stale) values, and
those values were also used in the `##MAXY` / `##MINY` header extrema. So a
masked region leaked real-looking numbers into the export and the header
range was wrong.

## Fix

Fill the mask with `NaN` before writing:

```python
ydata = np.ma.filled(dataset.masked_data, np.nan)
```

and use `ydata` for the Y header fields and the `XYDATA` block. Masked
values then flow through the writer's existing NaN handling:

- excluded from `np.nanmax` / `np.nanmin` (so `##MAXY` / `##MINY` reflect
  only real samples), and
- written as the JCAMP `?` missing-value marker in the `XYDATA` block,

which is exactly how genuine NaNs were already represented. Unmasked
datasets are byte-for-byte unaffected (`masked_data` returns the plain data
when there is no mask, and `np.ma.filled` is then a no-op).

This implements the first approach suggested in the issue (export masked
values as missing values, consistent with NaN handling elsewhere).

## Verification

Added `test_write_jcamp_masked_values` (in `test_read_jcamp.py`, where the
write round-trips live): it builds a dataset with a sentinel value hidden
under the mask and asserts the sentinel never reaches the file, that each
masked point is written as `?`, that `##MAXY` / `##MINY` ignore the masked
samples, and that the file round-trips back with the masked region read as
NaN. The test fails against the old writer and passes with the fix; existing
JCAMP read/write tests still pass.
