### PR TITLE
MAINT: enrich Coord and CoordSet HTML headings with name:title (#843)

### DIFF
--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -185,7 +185,7 @@ def _html_heading(obj):
     For array-like objects (Coord, NDDataset, NDArray) the heading includes
     dtype, shape/size, and units when available::
 
-        Coord [x] — float64, size: 50, m
+        Coord [x:wavenumbers] — float64, size: 50, m
 
     For unnamed objects the bracketed name is omitted::
 
@@ -210,6 +210,12 @@ def _html_heading(obj):
         name_part = f" [{obj.name}]" if obj.has_defined_name else ""
     else:
         name_part = ""
+
+    # Enrich name with title for Coord when meaningful
+    if name_part and type_name == "Coord" and hasattr(obj, "title"):
+        title = obj.title
+        if title and title != "<untitled>":
+            name_part = f" [{obj.name}:{title}]"
 
     # --- scientific identity part ---
     extras = ""

--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -191,7 +191,11 @@ def _html_heading(obj):
 
         NDDataset — float64, shape: (y:10, x:20)
 
-    For CoordSet the child coordinate names are shown::
+    For CoordSet the child coordinate names and meaningful titles are shown::
+
+        CoordSet — x:wavenumbers, y:acquisition timestamp (GMT)
+
+    For unnamed / untitled child coordinates only the name is shown::
 
         CoordSet — x, y
 
@@ -222,11 +226,25 @@ def _html_heading(obj):
         if parts:
             extras = " — " + ", ".join(parts)
 
-    # CoordSet: show child coordinate names
+    # CoordSet: show child coordinate names and meaningful titles
     elif type_name == "CoordSet":
-        names = obj.names
-        if names:
-            extras = f" — {', '.join(names)}"
+        parts = []
+        if obj._storage:
+            for item in obj._storage:
+                if not item.has_defined_name:
+                    continue
+                name = item.name
+                if type(item).__name__ == "CoordSet":
+                    # Nested CoordSet: name only, no recursion
+                    parts.append(name)
+                else:
+                    title = item.title
+                    if title and title != "<untitled>":
+                        parts.append(f"{name}:{title}")
+                    else:
+                        parts.append(name)
+        if parts:
+            extras = " — " + ", ".join(parts)
 
     return f"{type_name}{name_part}{extras}"
 

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -691,11 +691,42 @@ class TestHTMLHeading:
         assert "empty" in html
         assert "Project" in html
 
-    def test_heading_starts_with_type(self):
+    def test_coord_heading_starts_with_type(self):
         """The outermost summary starts with the type name."""
         coord = Coord([1.0, 2.0, 3.0], name="c")
         html = coord._repr_html_()
         assert "Coord" in html
+
+    def test_coord_heading_with_title(self):
+        """Coord heading shows name:title when title is meaningful."""
+        coord = Coord([1.0, 2.0, 3.0], name="x", title="wavenumbers")
+        html = coord._repr_html_()
+        assert "x:wavenumbers" in html
+
+    def test_coord_heading_without_title(self):
+        """Coord heading shows name only when title is missing or <untitled>."""
+        coord = Coord([1.0, 2.0, 3.0], name="x")
+        html = coord._repr_html_()
+        assert "x" in html
+        summary = html.split("</summary>")[0]
+        assert "<untitled>" not in summary
+        assert "x:" not in summary
+
+    def test_coord_heading_unnamed_with_title(self):
+        """Unnamed Coord with meaningful title keeps bare heading, no bracket noise."""
+        coord = Coord([1.0, 2.0, 3.0], title="wavenumbers")
+        html = coord._repr_html_()
+        summary = html.split("</summary>")[0]
+        assert "<untitled>" not in summary
+        # Title should not appear in heading since there's no explicit name
+        assert ":wavenumbers" not in summary
+
+    def test_coord_heading_title_not_exposed_without_name(self):
+        """Coord heading does not show title when the coord has no defined name."""
+        coord = Coord([1.0, 2.0, 3.0], title="wavenumbers")
+        html = coord._repr_html_()
+        summary = html.split("</summary>")[0]
+        assert "Coord_" not in summary
 
 
 class TestInlineSummary:

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -613,6 +613,36 @@ class TestHTMLHeading:
         assert "x" in html
         assert "y" in html
 
+    def test_coordset_heading_shows_coord_titles(self):
+        """CoordSet heading includes name:title when title is meaningful."""
+        x = Coord([1.0, 2.0], name="x", title="wavenumbers")
+        y = Coord([3.0, 4.0], name="y", title="acquisition timestamp (GMT)")
+        cs = CoordSet(x=x, y=y)
+        html = cs._repr_html_()
+        assert "x:wavenumbers" in html
+        assert "y:acquisition timestamp (GMT)" in html
+
+    def test_coordset_heading_omits_untitled(self):
+        """CoordSet heading does not display '<untitled>'."""
+        x = Coord([1.0, 2.0], name="x")
+        y = Coord([3.0, 4.0], name="y")
+        cs = CoordSet(x=x, y=y)
+        html = cs._repr_html_()
+        summary = html.split("</summary>")[0]
+        assert "<untitled>" not in summary
+
+    def test_coordset_heading_no_auto_id(self):
+        """CoordSet heading does not expose auto-generated internal names."""
+        # Coord assigned without a user-defined name is given
+        # the dimension key (e.g. 'x'), not the auto-generated id.
+        c = Coord([1.0, 2.0])  # auto-generated id like Coord_...
+        cs = CoordSet(x=c)
+        html = cs._repr_html_()
+        summary = html.split("</summary>")[0]
+        assert "Coord_" not in summary
+        # The heading should show the dimension name, not the auto id
+        assert "x" in summary
+
     def test_nddataset_heading_contains_type(self):
         """NDDataset HTML heading contains the type name."""
         ds = NDDataset([1.0, 2.0])


### PR DESCRIPTION
## Description

Restore semantic identity information in HTML headings by including coordinate
titles alongside names for both **Coord** and **CoordSet**.

### Coord heading

| Before | After |
|---|---|
| `Coord [x] — float64, size: 3112, cm⁻¹` | `Coord [x:wavenumbers] — float64, size: 3112, cm⁻¹` |
| `Coord [x] — float64, size: 2` | `Coord [x] — float64, size: 2` (no title, unchanged) |

### CoordSet heading

| Before | After |
|---|---|
| `CoordSet — x, y` | `CoordSet — x:wavenumbers, y:acquisition timestamp (GMT)` |

### Key decisions

- Show `name:title` when the title is meaningful (not `<untitled>`)
- Show bare name when title is missing or equals `<untitled>`
- Never expose auto-generated internal IDs
- Terminal repr/str is not affected
- NDDataset, Project headings are unchanged
- CoordSet stays on the old `convert_to_html()` pipeline (no semantic migration yet)
- Coord heading enrichment is type-specific (`type_name == "Coord"`) to avoid
  affecting other array-like objects

### Tests added

- `test_coord_heading_with_title`
- `test_coord_heading_without_title`
- `test_coord_heading_unnamed_with_title`
- `test_coord_heading_title_not_exposed_without_name`
- `test_coord_heading_starts_with_type`
- `test_coordset_heading_shows_coord_titles`
- `test_coordset_heading_omits_untitled`
- `test_coordset_heading_no_auto_id`