### PR TITLE
FIX: assign transmittance unit when reading JCAMP-DX (#1080)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``read_jcamp`` now assigns the ``transmittance`` unit to datasets imported
+  from JCAMP-DX files declaring ``##YUNITS=TRANSMITTANCE`` (#1080).  The reader
+  previously set only the dataset title and left the units unset (an outdated
+  ``TODO`` noted the unit was missing from the registry); SpectroChemPy now
+  defines ``transmittance``, so it is attached just like ``absorbance``.
+
 - ``write_jcamp`` now exports masked samples as JCAMP-DX missing values (``?``)
   instead of writing their underlying data (#1132).  Masked points are treated
   like NaNs: they are excluded from the ``##MAXY``/``##MINY`` header extrema and

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,12 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- ``read_jcamp`` now assigns the ``transmittance`` unit to datasets imported
+  from JCAMP-DX files declaring ``##YUNITS=TRANSMITTANCE`` (#1080).  The reader
+  previously set only the dataset title and left the units unset (an outdated
+  ``TODO`` noted the unit was missing from the registry); SpectroChemPy now
+  defines ``transmittance``, so it is attached just like ``absorbance``.
+
 - ``write_jcamp`` now exports masked samples as JCAMP-DX missing values (``?``)
   instead of writing their underlying data (#1132).  Masked points are treated
   like NaNs: they are excluded from the ``##MAXY``/``##MINY`` header extrema and

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -352,7 +352,7 @@ def _read_jdx(*args, **kwargs):
         dataset.units = "absorbance"
         dataset.title = "absorbance"
     elif yunits[0].strip() == "TRANSMITTANCE":
-        # TODO: This units not in pint. Add this
+        dataset.units = "transmittance"
         dataset.title = "transmittance"
 
     # now add coordinates

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -25,6 +25,30 @@ def test_read_jcamp(JDX_2D):
     f.unlink()
 
 
+def test_read_jcamp_transmittance_units():
+    # a JCAMP-DX file declaring ##YUNITS=TRANSMITTANCE must come back with the
+    # transmittance unit assigned, not just the title (#1080). Previously the
+    # reader set the title but left units unset.
+    jdx = """##TITLE=transmittance_test
+##JCAMP-DX=5.01
+##DATA TYPE=INFRARED SPECTRUM
+##XUNITS=1/CM
+##YUNITS=TRANSMITTANCE
+##FIRSTX=4000.0
+##LASTX=3996.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 90.0 85.0 80.0 75.0
+##END
+"""
+    ds = read_jcamp({"transmittance_test.jdx": jdx.encode("utf8")})
+    assert ds.title == "transmittance"
+    assert ds.units is not None
+    assert ds.units == "transmittance"
+
+
 def test_write_jcamp_masked_values(tmp_path):
     # masked samples must be exported as JCAMP missing values ("?"), not as
     # their (stale) underlying data, and must be excluded from MAXY/MINY (#1132)


### PR DESCRIPTION
Fixes #1080.

## Problem

The JCAMP-DX reader detects ``##YUNITS=TRANSMITTANCE`` but only sets the dataset title, leaving ``dataset.units`` unset. The branch carried an outdated ``TODO`` noting the transmittance unit was not yet in the registry:

```python
elif yunits[0].strip() == "TRANSMITTANCE":
    # TODO: This units not in pint. Add this
    dataset.title = "transmittance"
```

SpectroChemPy now defines ``transmittance`` (and ``absolute_transmittance``) in its unit system, so the unit can be attached directly.

## Fix

Mirror the ``ABSORBANCE`` branch and assign the unit alongside the title, and drop the stale TODO:

```python
elif yunits[0].strip() == "TRANSMITTANCE":
    dataset.units = "transmittance"
    dataset.title = "transmittance"
```

A transmittance JCAMP-DX file now reads back with ``dataset.units == "transmittance"`` and ``dataset.title == "transmittance"``. The ``ABSORBANCE`` path is unchanged.

## Test

Adds ``test_read_jcamp_transmittance_units``, a synthetic single-block JCAMP-DX string with ``##YUNITS=TRANSMITTANCE``. It fails on the current code (``dataset.units is None``) and passes with the fix.

---
Working with AI assistance under my direction; the change and the red/green test were verified locally against the JCAMP reader.