### PR TITLE
FIX: harden JCAMP-DX reader header parsing (#1150)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,11 +29,13 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
-- ``read_jcamp`` now assigns the ``transmittance`` unit to datasets imported
-  from JCAMP-DX files declaring ``##YUNITS=TRANSMITTANCE`` (#1080).  The reader
-  previously set only the dataset title and left the units unset (an outdated
-  ``TODO`` noted the unit was missing from the registry); SpectroChemPy now
-  defines ``transmittance``, so it is attached just like ``absorbance``.
+- ``read_jcamp`` is more robust and complete when importing JCAMP-DX files
+  (#1080, #1150): datasets declaring ``##YUNITS=TRANSMITTANCE`` now come back with
+  the ``transmittance`` unit assigned instead of only the dataset title; a header
+  value that itself contains ``=`` is split on the first ``=`` only, instead of
+  raising ``too many values to unpack``; the invalid axis-metadata error is a
+  clear formatted message rather than a tuple-style exception; and the deprecated
+  ``read_jdx`` alias now points at the correct ``read_jcamp`` replacement.
 
 - ``write_jcamp`` now exports masked samples as JCAMP-DX missing values (``?``)
   instead of writing their underlying data (#1132).  Masked points are treated

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,11 +21,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
-- ``read_jcamp`` now assigns the ``transmittance`` unit to datasets imported
-  from JCAMP-DX files declaring ``##YUNITS=TRANSMITTANCE`` (#1080).  The reader
-  previously set only the dataset title and left the units unset (an outdated
-  ``TODO`` noted the unit was missing from the registry); SpectroChemPy now
-  defines ``transmittance``, so it is attached just like ``absorbance``.
+- ``read_jcamp`` is more robust and complete when importing JCAMP-DX files
+  (#1080, #1150): datasets declaring ``##YUNITS=TRANSMITTANCE`` now come back with
+  the ``transmittance`` unit assigned instead of only the dataset title; a header
+  value that itself contains ``=`` is split on the first ``=`` only, instead of
+  raising ``too many values to unpack``; the invalid axis-metadata error is a
+  clear formatted message rather than a tuple-style exception; and the deprecated
+  ``read_jdx`` alias now points at the correct ``read_jcamp`` replacement.
 
 - ``write_jcamp`` now exports masked samples as JCAMP-DX missing values (``?``)
   instead of writing their underlying data (#1132).  Masked points are treated

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -130,7 +130,7 @@ def read_jcamp(*paths, **kwargs):
     return importer(*paths, **kwargs)
 
 
-@deprecated(replace="read__jcamp", removed="0.10.0")
+@deprecated(replace="read_jcamp", removed="0.10.0")
 def read_jdx(*args, **kwargs):
     return read_jcamp(*args, **kwargs)
 
@@ -280,8 +280,7 @@ def _read_jdx(*args, **kwargs):
                     )
         else:
             raise ValueError(
-                "##FIRST, ##LASTX or ##NPOINTS are unusable in the spectrum n°",
-                i + 1,
+                f"##FIRSTX, ##LASTX or ##NPOINTS are unusable in spectrum n°{i + 1}"
             )
 
         # Creation of the acquisition date
@@ -410,7 +409,7 @@ def _readl(fid):
             keyword = "##END"
             text = ""
         else:  # keyword + text
-            keyword, text = line.split("=")
+            keyword, text = line.split("=", 1)
     else:
         keyword = ""
         text = line.strip()

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -49,6 +49,28 @@ def test_read_jcamp_transmittance_units():
     assert ds.units == "transmittance"
 
 
+def test_read_jcamp_header_value_with_equals():
+    # A header value containing "=" (e.g. a sample id) must not break the
+    # ``keyword=text`` split (#1150): the parser now splits on the first "="
+    # only, instead of raising "too many values to unpack".
+    jdx = """##TITLE=sample=A/2
+##JCAMP-DX=5.01
+##DATA TYPE=INFRARED SPECTRUM
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 1.0 0.9 0.8 0.7
+##END
+"""
+    ds = read_jcamp({"sample.jdx": jdx.encode("utf8")})
+    assert ds.name == "sample=A/2"
+
+
 def test_write_jcamp_masked_values(tmp_path):
     # masked samples must be exported as JCAMP missing values ("?"), not as
     # their (stale) underlying data, and must be excluded from MAXY/MINY (#1132)


### PR DESCRIPTION
Addresses #1150. Fixes the three clear-cut items and documents the other two with empirical findings, per the acceptance criterion ("fixed or explicitly documented if intentional").

## Fixed

**3. Unrestricted header split.** `keyword, text = line.split("=")` raised `too many values to unpack` whenever a header value contained `=` (e.g. a sample id in `##TITLE`). Now splits on the first `=` only. Regression test `test_read_jcamp_header_value_with_equals` reads `##TITLE=sample=A/2` and asserts the name round-trips (red before, green after).

**4. Poorly-formatted axis-metadata error.** The `ValueError` passed a message and `i + 1` as two positional args, producing a tuple-style exception. It is now a single formatted message (`f"##FIRSTX, ##LASTX or ##NPOINTS are unusable in spectrum n°{i + 1}"`; also corrected `##FIRST` -> `##FIRSTX`).

**5. Typo in deprecated alias.** `read_jdx` was decorated with `replace="read__jcamp"` (double underscore, no such function); corrected to `read_jcamp`, matching the `read_dx` alias.

## Documented (not changed)

**1. `sortbydate` sorts the wrong dimension.** Confirmed: with `sortbydate=True` the reader calls `dataset.sort(dim="x", ...)`, which sorts the wavenumber axis, so multi-spectrum files are **not** actually reordered by date (verified on a 2-block file with out-of-order timestamps: the spectra stay in file order). Switching to `dim="y"` does reorder the spectra chronologically, **but** it also surfaces a separate `sort()` issue: for a `y` coordinate carrying multiple label rows (here `dates` + `titles`), the sort swaps the two label rows and does not reorder the label values to match the sorted data, leaving labels mismatched to their spectra. I left this one for you to steer: fix `sort()`s multi-label handling first (it is cross-cutting, beyond a reader-local change), or do a reader-local reindex. The wavenumber-ordering `# Todo` just below the sort also bears on the intended `x` ordering. Happy to implement whichever direction you prefer.

**2. Import history is not overwritten.** The `history` setter appends when assigned a string (only assigning a *list* replaces), so `dataset.history = "Imported from jdx file"` followed by `dataset.history = "Sorted by date"` keeps **both** entries. Verified on a real read (`len(ds.history) == 2`). No change needed.

## Verification

`read_jcamp` reader tests pass; ruff + full pre-commit (incl. the regenerated `latest.rst`) are clean.

---
Working with AI assistance under my direction; the findings above were each verified empirically against the reader.