### PR TITLE
FIX: export masked values as missing in the CSV writer (#1135)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -45,6 +45,13 @@ Bug Fixes
   carried to target points that exactly match original coordinate values while
   genuinely resampled points remain unlabelled.
 
+- ``write_csv`` now exports masked samples as missing values (``NaN``) instead
+  of writing their underlying data (#1135).  The writer previously iterated over
+  ``dataset.data`` directly, leaking the stored values of points the user had
+  explicitly masked; masked samples are now filled with ``NaN`` (mirroring the
+  ``write_jcamp`` fix), so they round-trip back as ``NaN`` through ``read_csv``
+  and unmasked datasets are unaffected.
+
 - Fixed ``Project.__str__()`` tree formatting when a project contains both
   sub-projects and sibling datasets or scripts at the same level.  The
   recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -37,6 +37,13 @@ Bug Fixes
   carried to target points that exactly match original coordinate values while
   genuinely resampled points remain unlabelled.
 
+- ``write_csv`` now exports masked samples as missing values (``NaN``) instead
+  of writing their underlying data (#1135).  The writer previously iterated over
+  ``dataset.data`` directly, leaking the stored values of points the user had
+  explicitly masked; masked samples are now filled with ``NaN`` (mirroring the
+  ``write_jcamp`` fix), so they round-trip back as ``NaN`` through ``read_csv``
+  and unmasked datasets are unaffected.
+
 - Fixed ``Project.__str__()`` tree formatting when a project contains both
   sub-projects and sibling datasets or scripts at the same level.  The
   recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -8,6 +8,8 @@
 # import os as os
 import csv
 
+import numpy as np
+
 from spectrochempy.application.preferences import preferences as prefs
 from spectrochempy.core.writers.exporter import Exporter
 from spectrochempy.core.writers.exporter import exportermethod
@@ -94,11 +96,14 @@ def _write_csv(*args, **kwargs):
             coltitles = [title_1, title_2] if col_coord else [title_2]
 
         writer.writerow(coltitles)
+        # export masked samples as missing values (NaN) instead of leaking their
+        # underlying stored data (#1135), mirroring the JCAMP-DX writer (#1132)
+        ydata = np.ma.filled(dataset.masked_data, np.nan)
         if col_coord:
-            for i, data in enumerate(dataset.data):
+            for i, data in enumerate(ydata):
                 writer.writerow([dataset.coordset[-1].data[i], data])
         else:
-            for _i, data in enumerate(dataset.data):
+            for data in ydata:
                 writer.writerow([data])
 
     return filename

--- a/tests/test_core/test_writers/test_write_csv.py
+++ b/tests/test_core/test_writers/test_write_csv.py
@@ -56,3 +56,29 @@ def test_write_csv_with_coords(mock_cwd, ds_1d_with_coords, ds_2d_with_coords):
     assert f.name == "myfile.csv"
     assert scp.pathclean(mock_cwd.joinpath("../myfile.csv")).exists()
     f.unlink()
+
+
+def test_write_csv_masked_values(tmp_path):
+    # masked samples must be exported as missing values (NaN), not as their
+    # (stale) underlying data (#1135), mirroring the JCAMP-DX writer (#1132)
+    coord = scp.Coord(np.linspace(4000, 1000, 10), title="wavenumber", units="cm^-1")
+    data = np.linspace(0.1, 0.9, 10)
+    data[3:6] = 999.0  # sentinel hidden under the mask
+    ds = scp.NDDataset(data, coordset=[coord], units="absorbance", name="masked")
+    mask = np.zeros(10, dtype=bool)
+    mask[3:6] = True
+    ds.mask = mask
+
+    f = ds.write_csv(tmp_path / "masked.csv", confirm=False)
+    text = f.read_text()
+
+    # the masked underlying value never leaks into the file
+    assert "999" not in text
+    # each masked sample is written as the missing-value marker (NaN)
+    assert text.lower().count("nan") == 3
+
+    # round-trip: the masked region reads back as NaN, the rest stays finite
+    back = scp.read_csv(f)
+    arr = np.asarray(back.data, dtype=float).ravel()
+    assert np.isnan(arr[3:6]).all()
+    assert np.isfinite(np.concatenate([arr[:3], arr[6:]])).all()


### PR DESCRIPTION
Fixes #1135.

`write_csv` iterated over `dataset.data` directly, so the underlying stored
values of points the user had explicitly masked were written to the CSV. This
is the CSV twin of the `write_jcamp` masking leak fixed in #1134 (the issue
references it).

## Fix

In `write_csv._write_csv`, build the export array once with
`np.ma.filled(dataset.masked_data, np.nan)` (after the existing squeeze) and
iterate that in both the coordinate and no-coordinate branches. Masked samples
are written as `NaN`, which round-trips back to `NaN` through `read_csv`;
unmasked datasets are byte-identical to before.

## Test

`test_write_csv_masked_values` (offline, `tmp_path`): a dataset with a
sentinel value hidden under a mask is exported; the masked positions come back
as `NaN` (the sentinel does not leak) and the finite values are preserved on
round-trip. Mirrors the `write_jcamp` masked test added in #1134.

Verified `3 passed` offline, pre-commit clean. This change was prepared by an
AI agent under my direction; I reviewed and verified it.
