### PR TITLE
FIX: use Coord heading for same-dim CoordSet children

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -144,8 +144,12 @@ Developer
   subgroup separators.  ``CoordSet._repr_html_()`` now uses the semantic
   path (``_repr_sections`` + ``_render_sections``) instead of the
   sentinel-based ``convert_to_html()``, producing cleaner HTML without
-  inline sentinel markers.  The docs cache key was updated to invalidate
-  the sphinx-gallery cache when display source files change.
+  inline sentinel markers.  Same-dimension ``CoordSet`` sections now show
+  ``Coord`` headings (e.g. ``Coord \`_1\```) instead of ``Dimension``,
+  since synthetic child names like ``_1`` / ``_2`` are coordinates of a
+  shared dimension, not dimensions themselves.  The docs cache key was
+  updated to invalidate the sphinx-gallery cache when display source
+  files change.
 
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -122,8 +122,12 @@ Developer
   subgroup separators.  ``CoordSet._repr_html_()`` now uses the semantic
   path (``_repr_sections`` + ``_render_sections``) instead of the
   sentinel-based ``convert_to_html()``, producing cleaner HTML without
-  inline sentinel markers.  The docs cache key was updated to invalidate
-  the sphinx-gallery cache when display source files change.
+  inline sentinel markers.  Same-dimension ``CoordSet`` sections now show
+  ``Coord`` headings (e.g. ``Coord \`_1\```) instead of ``Dimension``,
+  since synthetic child names like ``_1`` / ``_2`` are coordinates of a
+  shared dimension, not dimensions themselves.  The docs cache key was
+  updated to invalidate the sphinx-gallery cache when display source
+  files change.
 
 - MAINT: Moved CP/PARAFAC implementation and TensorLy dependency ownership into
   the new tensor plugin, keeping the core package tensor-agnostic.

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -2344,7 +2344,8 @@ class CoordSet(HasTraits):
         for dim in self.names:
             coord = getattr(self, dim)
 
-            title = f"Dimension `{dim}`"
+            prefix = "Coord" if self._is_same_dim else "Dimension"
+            title = f"{prefix} `{dim}`"
             for k, v in self.references.items():
                 if dim == v:
                     title += f"={k}"

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -1697,6 +1697,26 @@ class TestSemanticCoordSet:
         x_section = next(s for s in sections if "x" in s.title and "=" in s.title)
         assert "=y" in x_section.title
 
+    def test_multi_dim_uses_dimension_title(self):
+        """Multi-dim CoordSet uses 'Dimension' in section titles."""
+        x = Coord([1.0, 2.0])
+        y = Coord([3.0, 4.0])
+        cs = CoordSet(x=x, y=y)
+        sections = cs._repr_sections()
+        for s in sections:
+            assert "Dimension" in s.title
+
+    def test_same_dim_uses_coord_title(self):
+        """Same-dim CoordSet shows 'Coord' not 'Dimension' for child names."""
+        c1 = Coord([1.0, 2.0, 3.0], title="alpha")
+        c2 = Coord([4.0, 5.0, 6.0], title="beta")
+        cs = CoordSet([c1, c2])
+        # cs.x is the inner same-dim CoordSet with _is_same_dim=True
+        inner = cs.x
+        sections = inner._repr_sections()
+        for s in sections:
+            assert "Coord" in s.title
+
     def test_same_dim_has_block_markers(self):
         """Same-dim nested CoordSet has block items as subgroup separators."""
         c1 = Coord([1.0, 2.0, 3.0], title="alpha")
@@ -1816,6 +1836,24 @@ class TestCoordSetSemanticHTML:
         cs = CoordSet(x=x, y="x")
         html = cs._repr_html_()
         assert "=y" in html.replace(" ", "")
+
+    def test_multi_dim_html_has_dimension(self):
+        """Multi-dim CoordSet HTML contains Dimension labels."""
+        x = Coord([1.0, 2.0])
+        y = Coord([3.0, 4.0])
+        cs = CoordSet(x=x, y=y)
+        html = cs._repr_html_()
+        assert "Dimension" in html
+
+    def test_same_dim_html_has_coord_not_dimension(self):
+        """Same-dim CoordSet HTML uses Coord labels, not Dimension."""
+        c1 = Coord([1.0, 2.0, 3.0], title="alpha")
+        c2 = Coord([4.0, 5.0, 6.0], title="beta")
+        cs = CoordSet([c1, c2])
+        # cs.x is the inner same-dim CoordSet
+        inner = cs.x
+        html = inner._repr_html_()
+        assert "Coord" in html
 
     def test_subgroup_markers_in_html(self):
         """Same-dim nested CoordSet shows subgroup markers in HTML."""


### PR DESCRIPTION
## Problem

For same-dimension CoordSets (e.g. `CoordSet [y] — _1:timestamp, _2:pressure`),
the HTML display showed `Dimension \`_1\`` and `Dimension \`_2\``,
which is misleading — `_1` and `_2` are coordinates of dimension `y`,
not dimensions themselves.

## Fix

Section titles now use `Coord \`_1\`` instead of `Dimension \`_1\`` when
`_is_same_dim` is True. Regular multi-dim CoordSet displays are unchanged.

## Tests

- `test_same_dim_uses_coord_title` — same-dim sections have "Coord" in title
- `test_multi_dim_uses_dimension_title` — multi-dim sections have "Dimension"
- `test_same_dim_html_has_coord_not_dimension` — HTML contains "Coord"
- `test_multi_dim_html_has_dimension` — HTML contains "Dimension"