### PR TITLE
MAINT: migrate NDDataset display to semantic _repr_sections() / _repr_html_()

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -137,6 +137,14 @@ Developer
   render through the shared ``convert_to_html()`` path, and summary metadata is
   displayed inline under the main heading.
 
+- MAINT: Extended the semantic HTML migration to ``NDDataset`` (#843).
+  ``NDDataset._repr_sections()`` builds summary, data, and dimension
+  ``DisplaySection`` objects, reusing ``CoordSet._repr_sections()``
+  for coordinate dimensions.  ``NDDataset._repr_html_()`` now uses the
+  semantic path instead of the sentinel-based ``convert_to_html()``,
+  producing clean inline summary metadata, collapsible data and dimension
+  sections, and removing exposure of internal UUIDs from the heading.
+
 - MAINT: Extended the semantic HTML migration to ``CoordSet`` (#843).
   Added ``CoordSet._repr_sections()`` which builds one ``DisplaySection``
   per dimension, reusing child ``Coord._repr_sections()`` items for simple

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -58,7 +58,13 @@ from spectrochempy.utils._logging import warning_
 from spectrochempy.utils.datetimeutils import utcnow
 from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.optional import import_optional_dependency
+from spectrochempy.core.units import Quantity
+from spectrochempy.utils.print import _format_array_values
+from spectrochempy.utils.print import _html_heading
+from spectrochempy.utils.print import _render_sections
 from spectrochempy.utils.print import colored_output
+from spectrochempy.utils.print import DisplayItem
+from spectrochempy.utils.print import DisplaySection
 from spectrochempy.utils.system import get_user_and_node
 from spectrochempy.utils.typeutils import is_sequence
 
@@ -645,6 +651,113 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         return txt.rstrip()  # remove the trailing '\n'
 
     _repr_dims = _str_dims
+
+    def _repr_sections(self):
+        """
+        Build semantic display sections from NDDataset attributes.
+
+        Returns
+        -------
+        list of DisplaySection
+            ``"summary"``, ``"data"``, and ``"dimension"`` sections.
+        """
+        sections: list[DisplaySection] = []
+
+        # ------------------------------------------------------------------
+        # SUMMARY
+        # ------------------------------------------------------------------
+        summary_items: list[DisplayItem] = []
+        summary_items.append(DisplayItem("field", self.name, "name"))
+        summary_items.append(DisplayItem("field", self.author, "author"))
+        summary_items.append(DisplayItem("field", self.created, "created"))
+        if (self._modified - self._created.replace(tzinfo=UTC)).seconds > 30:
+            summary_items.append(DisplayItem("field", self.modified, "modified"))
+        if self.description.strip():
+            summary_items.append(
+                DisplayItem("field", self.description.strip(), "description")
+            )
+        if self._history:
+            hist = self.history
+            if isinstance(hist, list):
+                hist = "\n".join(hist)
+            summary_items.append(DisplayItem("field", hist, "history"))
+
+        sections.append(DisplaySection("summary", "Summary", summary_items))
+
+        # ------------------------------------------------------------------
+        # DATA
+        # ------------------------------------------------------------------
+        data_items: list[DisplayItem] = []
+        data_items.append(
+            DisplayItem("field", self.title if self.title else "<untitled>", "title")
+        )
+
+        if not self.is_empty and self._data is not None:
+            units = f" {self.units:~P}" if self.has_units else ""
+
+            if self.has_complex_dims:
+                # R/I split — mirrors NDComplexArray._str_value()
+                text = ""
+                for pref in ("R", "I"):
+                    component = self.copy()
+                    if pref == "R":
+                        component._data = component._data.real
+                    else:
+                        component._data = component._data.imag
+                    data = component.umasked_data
+                    if isinstance(data, Quantity):
+                        data = data.magnitude
+                    text += _format_array_values(
+                        data,
+                        is_masked=self.is_masked,
+                        dtype=self.dtype,
+                        sep="\n",
+                        prefix=pref,
+                        units=units,
+                    )
+                data_items.append(DisplayItem("data", text, "values"))
+            else:
+                data = self.umasked_data
+                if isinstance(data, Quantity):
+                    data = data.magnitude
+                formatted = _format_array_values(
+                    data,
+                    is_masked=self.is_masked,
+                    dtype=self.dtype,
+                    sep="\n",
+                    prefix="",
+                    units=units,
+                )
+                data_items.append(DisplayItem("data", formatted, "values"))
+
+        shape_text = self._str_shape()
+        if shape_text:
+            stripped = shape_text.strip()
+            if ": " in stripped:
+                skey, sval = stripped.split(": ", 1)
+                data_items.append(DisplayItem("field", sval, skey.strip()))
+            else:
+                data_items.append(DisplayItem("field", stripped, "shape"))
+
+        sections.append(DisplaySection("data", "Data", data_items))
+
+        # ------------------------------------------------------------------
+        # DIMENSION
+        # ------------------------------------------------------------------
+        if self._coordset and not self.is_empty and len(self._coordset) > 0:
+            sections.extend(self._coordset._repr_sections())
+
+        return sections
+
+    def _repr_html_(self):
+        sections = self._repr_sections()
+        body = _render_sections(sections)
+        heading = _html_heading(self)
+        return (
+            '<div class="scp-output">'
+            f"<details><summary>{heading}</summary>\n{body}\n"
+            "</details></div>"
+        )
 
     def _dims_update(self, change=None):
         # when notified that a coords names have been updated

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -1898,3 +1898,257 @@ class TestCoordSetSemanticHTML:
                 len(common) > 0
             ), f"No overlapping content between old and new HTML for {cs}"
             assert "CoordSet" in new_html
+
+
+# ======================================================================================
+# PHASE D: SEMANTIC DISPLAY FOR NDDataset
+# ======================================================================================
+
+
+class TestSemanticNDDataset:
+    """Tests for NDDataset._repr_sections() semantic structure."""
+
+    def test_returns_list(self):
+        """_repr_sections returns a list."""
+        ds = NDDataset([1.0, 2.0])
+        sections = ds._repr_sections()
+        assert isinstance(sections, list)
+
+    def test_has_summary_and_data_sections(self):
+        """Simple dataset returns summary + data sections."""
+        ds = NDDataset([1.0, 2.0])
+        sections = ds._repr_sections()
+        roles = [s.role for s in sections]
+        assert "summary" in roles
+        assert "data" in roles
+
+    def test_summary_contains_name(self):
+        """Summary includes the dataset name."""
+        ds = NDDataset([1.0, 2.0], name="test_ds")
+        sections = ds._repr_sections()
+        summary = next(s for s in sections if s.role == "summary")
+        name_items = [i for i in summary.items if i.key == "name"]
+        assert len(name_items) == 1
+        assert name_items[0].value == "test_ds"
+
+    def test_summary_contains_author(self):
+        """Summary includes the author."""
+        ds = NDDataset([1.0, 2.0])
+        ds.author = "test_author"
+        sections = ds._repr_sections()
+        summary = next(s for s in sections if s.role == "summary")
+        auth_items = [i for i in summary.items if i.key == "author"]
+        assert len(auth_items) == 1
+        assert auth_items[0].value == "test_author"
+
+    def test_summary_contains_created(self):
+        """Summary includes the creation timestamp."""
+        ds = NDDataset([1.0, 2.0])
+        sections = ds._repr_sections()
+        summary = next(s for s in sections if s.role == "summary")
+        created_items = [i for i in summary.items if i.key == "created"]
+        assert len(created_items) == 1
+
+    def test_summary_contains_description_when_set(self):
+        """Description is present when set."""
+        ds = NDDataset([1.0, 2.0], description="test description")
+        sections = ds._repr_sections()
+        summary = next(s for s in sections if s.role == "summary")
+        desc_items = [i for i in summary.items if i.key == "description"]
+        assert len(desc_items) == 1
+        assert desc_items[0].value == "test description"
+
+    def test_summary_no_description_when_empty(self):
+        """No description item when description is empty."""
+        ds = NDDataset([1.0, 2.0])
+        sections = ds._repr_sections()
+        summary = next(s for s in sections if s.role == "summary")
+        desc_items = [i for i in summary.items if i.key == "description"]
+        assert len(desc_items) == 0
+
+    def test_data_contains_title(self):
+        """Data section has a title field."""
+        ds = NDDataset([1.0, 2.0], title="my_data")
+        sections = ds._repr_sections()
+        data = next(s for s in sections if s.role == "data")
+        title_items = [i for i in data.items if i.key == "title"]
+        assert len(title_items) == 1
+        assert title_items[0].value == "my_data"
+
+    def test_data_contains_values(self):
+        """Data section has a values field."""
+        ds = NDDataset([1.0, 2.0, 3.0])
+        sections = ds._repr_sections()
+        data = next(s for s in sections if s.role == "data")
+        values_items = [i for i in data.items if i.key == "values"]
+        assert len(values_items) == 1
+        assert "1" in values_items[0].value
+        assert "3" in values_items[0].value
+
+    def test_data_contains_shape(self):
+        """Data section has a size or shape field."""
+        ds = NDDataset([1.0, 2.0, 3.0])
+        sections = ds._repr_sections()
+        data = next(s for s in sections if s.role == "data")
+        shape_items = [i for i in data.items if i.key in ("size", "shape")]
+        assert len(shape_items) >= 1
+
+    def test_coordset_adds_dimension_sections(self):
+        """Dataset with CoordSet appends dimension sections."""
+        x = Coord([1.0, 2.0, 3.0])
+        y = Coord([4.0, 5.0])
+        # CoordSet iterates coords in reverse and pops dims from end,
+        # so we pass reversed: [y, x] → after reverse + pop gives x→"x", y→"y"
+        ds = NDDataset([[1, 2, 3], [4, 5, 6]], coordset=[y, x])
+        sections = ds._repr_sections()
+        dim_sections = [s for s in sections if s.role == "dimension"]
+        assert len(dim_sections) == 2
+
+    def test_unit_preserved_in_values(self):
+        """Data values include unit string when units are set."""
+        ds = NDDataset([1.0, 2.0, 3.0], units="m")
+        sections = ds._repr_sections()
+        data = next(s for s in sections if s.role == "data")
+        values = next(i for i in data.items if i.key == "values")
+        assert "m" in values.value
+
+    def test_complex_shows_r_and_i(self):
+        """Complex data shows R and I components."""
+        ds = NDDataset([1 + 2j, 3 + 4j])
+        sections = ds._repr_sections()
+        data = next(s for s in sections if s.role == "data")
+        values = next(i for i in data.items if i.key == "values")
+        assert "R" in values.value
+        assert "I" in values.value
+
+    def test_masked_shows_mask_symbol(self):
+        """Masked data shows -- for masked values."""
+        data = np.ma.MaskedArray(
+            [1.0, 2.0, 3.0], mask=[False, True, False]
+        )
+        ds = NDDataset(data)
+        sections = ds._repr_sections()
+        data_sec = next(s for s in sections if s.role == "data")
+        values = next(i for i in data_sec.items if i.key == "values")
+        assert "--" in values.value
+
+    def test_empty_has_sections(self):
+        """Empty dataset still returns summary and data sections."""
+        ds = NDDataset()
+        sections = ds._repr_sections()
+        roles = [s.role for s in sections]
+        assert "summary" in roles
+        assert "data" in roles
+
+
+class TestNDDatasetSemanticHTML:
+    """Tests for NDDataset._repr_html_() via the semantic path."""
+
+    def test_heading_contains_type(self):
+        """HTML heading contains the type name."""
+        ds = NDDataset([1.0, 2.0])
+        html = ds._repr_html_()
+        assert "NDDataset" in html
+
+    def test_heading_contains_name(self):
+        """HTML heading contains the dataset name when set."""
+        ds = NDDataset([1.0, 2.0], name="my_ds")
+        html = ds._repr_html_()
+        assert "my_ds" in html
+
+    def test_summary_inline_no_details(self):
+        """Summary metadata is rendered inline (no details wrapper)."""
+        ds = NDDataset([1.0, 2.0], name="inline_test")
+        html = ds._repr_html_()
+        # Summary items should not have their own <details> tag
+        assert "inline_test" in html
+
+    def test_data_section_collapsible(self):
+        """Data section has a details collapsible wrapper."""
+        ds = NDDataset([1.0, 2.0])
+        html = ds._repr_html_()
+        assert "<summary>Data</summary>" in html
+
+    def test_dimension_sections_present(self):
+        """Dimension sections appear in HTML for datasets with coords."""
+        x = Coord([1.0, 2.0])
+        y = Coord([3.0, 4.0])
+        ds = NDDataset([[1, 2], [3, 4]], coordset=[y, x])
+        html = ds._repr_html_()
+        assert "Dimension" in html
+
+    def test_data_values_present(self):
+        """Data values appear in the HTML."""
+        ds = NDDataset([1.0, 2.0, 3.0])
+        html = ds._repr_html_()
+        assert "1" in html
+        assert "3" in html
+
+    def test_units_present(self):
+        """Units appear in the HTML."""
+        ds = NDDataset([1.0, 2.0, 3.0], units="m")
+        html = ds._repr_html_()
+        assert "m" in html
+
+    def test_no_uuid_in_heading(self):
+        """No internal UUID or long hex IDs in the heading."""
+        ds = NDDataset([1.0, 2.0], name="no_uuid")
+        html = ds._repr_html_()
+        # The heading is in the first <summary> tag
+        import re
+
+        match = re.search(r"<summary>(.*?)</summary>", html)
+        assert match is not None
+        heading = match.group(1)
+        # Should not contain long hex strings
+        assert not re.search(r"[0-9a-f]{8,}", heading)
+
+    def test_outer_wrapper_structure(self):
+        """HTML has the expected outer wrapper structure."""
+        ds = NDDataset([1.0, 2.0])
+        html = ds._repr_html_()
+        assert '<div class="scp-output">' in html
+        assert "<details>" in html
+        assert "</details>" in html
+        assert "</div>" in html
+
+    def test_complex_r_i_in_html(self):
+        """Complex data R/I notation appears in HTML."""
+        ds = NDDataset([1 + 2j, 3 + 4j])
+        html = ds._repr_html_()
+        assert "R[" in html
+        assert "I[" in html
+
+    def test_temporary_equivalence_with_sentinel(self):
+        """
+        Semantic HTML contains core content present in sentinel HTML.
+
+        This is a temporary migration equivalence test.
+        """
+        from spectrochempy.utils.print import convert_to_html
+
+        x = Coord([1.0, 2.0], title="alpha", units="m")
+        y = Coord([3.0, 4.0], title="beta", units="s")
+
+        configs = [
+            NDDataset([1.0, 2.0, 3.0], name="simple"),
+            NDDataset(
+                [[1, 2], [3, 4]],
+                coordset=[y, x],
+                name="with_coords",
+                title="test",
+            ),
+        ]
+
+        for ds in configs:
+            old_html = convert_to_html(ds)
+            new_html = ds._repr_html_()
+
+            old_content = set(old_html.split())
+            new_content = set(new_html.split())
+
+            common = old_content & new_content
+            assert len(common) > 0, (
+                f"No overlapping content between old and new HTML for {ds}"
+            )
+            assert "NDDataset" in new_html


### PR DESCRIPTION
Add `NDDataset._repr_sections()` returning summary, data, and dimension `DisplaySection`s, and override `_repr_html_()` to use the semantic `_render_sections()` path instead of the sentinel-based `convert_to_html()`.

**Out of scope**:
- `Coord._repr_html_()` still uses the sentinel path (Phase E)
- Sentinel pipeline removal (Phase F)
- Docs cache and gallery image refresh (Phase G)

**Checklist**:
- [X] Close the #843.
- [X] Tests have been added.
- [ ] `pyproject.toml` file has been updated with new dependencies.
- [X] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
- [X] Developer changes (tests, CI, refactoring, tooling) have been documented in the ``Developer`` section of `docs/sources/whatsnew/changelog.rst`.
- [ ] The new API methods have been included in a section of `docs/sources/reference/index.rst`.