### PR TITLE
FIX: restore RR/RI/IR/II quaternion display after hypercomplex plugin migration

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Restored historical hypercomplex/quaternion dataset display (#1147).  Detailed
+  terminal and HTML representations once again show explicit ``RR``/``RI``/``IR``/``II``
+  component blocks and preserve complex-dimension shape annotations, instead of
+  falling back to raw quaternion scalar dumps.
+
 - JCAMP-DX I/O is more robust (#1080, #1132, #1150).  ``read_jcamp`` now
   handles ``##YUNITS=TRANSMITTANCE`` as the ``transmittance`` unit, accepts
   header values containing ``=``, reports invalid axis metadata with a clear

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Restored historical hypercomplex/quaternion dataset display (#1147).  Detailed
+  terminal and HTML representations once again show explicit ``RR``/``RI``/``IR``/``II``
+  component blocks and preserve complex-dimension shape annotations, instead of
+  falling back to raw quaternion scalar dumps.
+
 - JCAMP-DX I/O is more robust (#1080, #1132, #1150).  ``read_jcamp`` now
   handles ``##YUNITS=TRANSMITTANCE`` as the ``transmittance`` unit, accepts
   header values containing ``=``, reports invalid axis metadata with a clear

--- a/plugins/spectrochempy-hypercomplex/src/spectrochempy_hypercomplex/__init__.py
+++ b/plugins/spectrochempy-hypercomplex/src/spectrochempy_hypercomplex/__init__.py
@@ -10,6 +10,7 @@ import numpy as np
 from spectrochempy.api.plugins import CORE_PLUGIN_API_VERSION
 from spectrochempy.api.plugins import PluginCapability
 from spectrochempy.api.plugins import SpectroChemPyPlugin
+from spectrochempy.utils.print import _format_array_values
 
 # Public quaternion utilities — safe for other plugins to import
 from ._quaternion import _HAS_QUATERNION as is_available  # noqa: F401, N811
@@ -302,6 +303,44 @@ def _hyper_numpy_min(dataset, *args, **kwargs):
 
 
 # ------------------------------------------------------------------
+# Display handlers for quaternion data
+# ------------------------------------------------------------------
+
+
+def _hyper_display_array_values(dataset, *, sep="\n", ufmt=" {:~P}"):
+    """Return RR/RI/IR/II display blocks for quaternion datasets."""
+    if not _is_quaternion_dataset(dataset):
+        return None
+
+    hyper = getattr(dataset, "hyper", None)
+    if hyper is None or not hyper.is_quaternion:
+        return None
+
+    units = ufmt.format(dataset.units) if dataset.has_units else ""
+    parts = []
+    for pref in ("RR", "RI", "IR", "II"):
+        data = np.asarray(getattr(hyper, pref))
+        parts.append(
+            _format_array_values(
+                data,
+                is_masked=False,
+                dtype=data.dtype,
+                sep=sep,
+                prefix=pref,
+                units=units,
+            )
+        )
+    return sep.join(parts)
+
+
+def _hyper_display_complex_dim_flags(dataset):
+    """Mark quaternion dataset dimensions as complex in detailed display."""
+    if not _is_quaternion_dataset(dataset):
+        return None
+    return [True] * dataset.ndim
+
+
+# ------------------------------------------------------------------
 # Plugin class
 # ------------------------------------------------------------------
 
@@ -335,4 +374,6 @@ class HyperComplexPlugin(SpectroChemPyPlugin):
             "ndmath.numpy_method.conjugate": _hyper_numpy_conjugate,
             "ndmath.numpy_method.amax": _hyper_numpy_max,
             "ndmath.numpy_method.amin": _hyper_numpy_min,
+            "display.array_values": _hyper_display_array_values,
+            "display.complex_dim_flags": _hyper_display_complex_dim_flags,
         }

--- a/plugins/spectrochempy-hypercomplex/tests/test_hypercomplex.py
+++ b/plugins/spectrochempy-hypercomplex/tests/test_hypercomplex.py
@@ -1,4 +1,5 @@
 # ruff: noqa: S101
+import re
 from importlib.metadata import version
 
 import numpy as np
@@ -10,6 +11,8 @@ from spectrochempy.api.plugins import PluginCapability
 from spectrochempy.api.plugins import PluginState
 from spectrochempy.api.plugins import check_plugin_compatibility
 from spectrochempy.testing.plugins import PluginTestHarness
+from spectrochempy.utils.print import _format_array_values
+from spectrochempy.utils.print import pstr
 
 
 class TestPluginLifecycle:
@@ -93,6 +96,8 @@ class TestNDMathHandlers:
         registry = manager.plugin_manager.registry
         assert registry.get_handler("ndmath.execution_branch") is not None
         assert registry.get_handler("ndmath.execute") is not None
+        assert registry.get_handler("display.array_values") is not None
+        assert registry.get_handler("display.complex_dim_flags") is not None
 
 
 class TestQuaternionFunctions:
@@ -171,3 +176,66 @@ class TestQuaternionFunctions:
         result = interleaved2complex(data)
         expected = np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j])
         assert np.allclose(result, expected)
+
+
+def _make_hypercomplex_dataset():
+    ds = scp.NDDataset(np.arange(16.0).reshape(4, 4))
+    return ds.hyper.set_quaternion()
+
+
+class TestHypercomplexDisplayRegression:
+    def test_terminal_display_restores_component_labels(self):
+        ds = _make_hypercomplex_dataset()
+
+        rendered = ds._str_value()
+
+        for label in ["RR", "RI", "IR", "II"]:
+            assert label in rendered
+        assert "quaternion(" not in rendered
+
+    def test_detailed_display_uses_component_blocks(self):
+        ds = _make_hypercomplex_dataset()
+
+        rendered = pstr(ds)
+
+        for label in ["RR", "RI", "IR", "II"]:
+            assert label in rendered
+        assert "quaternion(" not in rendered
+
+    def test_html_display_restores_component_labels(self):
+        ds = _make_hypercomplex_dataset()
+
+        html = ds._repr_html_()
+
+        for label in ["RR", "RI", "IR", "II"]:
+            assert label in html
+        assert "quaternion(" not in html
+
+    def test_component_values_match_accessor_components_in_terminal_and_html(self):
+        ds = _make_hypercomplex_dataset()
+
+        rendered = ds._str_value()
+        html = ds._repr_html_()
+        normalize_text = lambda s: re.sub(r"\n\s+", "\n", s)
+        normalize_html = lambda s: re.sub(r"<br/>\s+", "<br/>", s)
+
+        for label in ["RR", "RI", "IR", "II"]:
+            component = np.asarray(getattr(ds.hyper, label))
+            expected = _format_array_values(
+                component,
+                dtype=component.dtype,
+                sep="\n",
+                prefix=label,
+                units="",
+            )
+            assert normalize_text(expected) in normalize_text(rendered)
+            assert normalize_html(expected.replace("\n", "<br/>")) in normalize_html(
+                html
+            )
+
+    def test_shape_annotation_marks_quaternion_dimensions_as_complex(self):
+        ds = _make_hypercomplex_dataset()
+
+        shape = ds._str_shape()
+
+        assert "(y:4(complex), x:2(complex))" in shape

--- a/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
@@ -363,7 +363,10 @@ class NDComplexArray(NDArray):
 
         out = ""
         cplx = [False] * self.ndim
-        if self.is_complex:
+        display_flags = self._display_complex_dim_flags()
+        if display_flags is not None:
+            cplx = display_flags
+        elif self.is_complex:
             cplx[-1] = True
 
         shcplx = (
@@ -391,19 +394,57 @@ class NDComplexArray(NDArray):
 
         return out
 
-    def _str_value(self, sep="\n", ufmt=" {:~P}", header="       values: ... \n"):
-        prefix = [""]
-        if self.is_empty:
-            return header + "{}".format(textwrap.indent("empty", " " * 9))
+    def _display_complex_dim_flags(self):
+        """Return plugin-provided complex dimension flags for display, if any."""
+        from spectrochempy.plugins import manager as manager_module  # noqa: PLC0415
 
-        if self.has_complex_dims:
-            # we will display the different component separately
-            prefix = ["R", "I"]
+        handler = manager_module.plugin_manager.registry.get_handler(
+            "display.complex_dim_flags"
+        )
+        if handler is None:
+            return None
+        try:
+            flags = handler(self)
+        except Exception:
+            return None
+        if flags is None:
+            return None
+        if isinstance(flags, (str, bytes)):
+            return None
+        try:
+            flags = list(flags)
+        except TypeError:
+            return None
+        if len(flags) != self.ndim:
+            return None
+        if not all(isinstance(flag, (bool, np.bool_)) for flag in flags):
+            return None
+        return [bool(flag) for flag in flags]
+
+    def _plugin_display_values(self, sep="\n", ufmt=" {:~P}"):
+        """Return plugin-provided display values, if any."""
+        from spectrochempy.plugins import manager as manager_module  # noqa: PLC0415
+
+        handler = manager_module.plugin_manager.registry.get_handler(
+            "display.array_values"
+        )
+        if handler is None:
+            return None
+        try:
+            return handler(self, sep=sep, ufmt=ufmt)
+        except Exception:
+            return None
+
+    def _format_display_values(self, sep="\n", ufmt=" {:~P}"):
+        """Format array values for terminal and HTML display paths."""
+        plugin_values = self._plugin_display_values(sep=sep, ufmt=ufmt)
+        if plugin_values is not None:
+            return plugin_values
 
         units = ufmt.format(self.units) if self.has_units else ""
 
         text = ""
-        if "I" not in "".join(prefix):  # case of pure real data
+        if not self.has_complex_dims:  # case of pure real data
             if self._data is not None:
                 data = self.umasked_data
                 if isinstance(data, Quantity):
@@ -416,25 +457,33 @@ class NDComplexArray(NDArray):
                     prefix="",
                     units=units,
                 )
-        else:
-            for pref in prefix:
-                if self._data is not None:
-                    component = self.copy()
-                    if pref == "R":
-                        component._data = component._data.real
-                    else:
-                        component._data = component._data.imag
-                    data = component.umasked_data
-                    if isinstance(data, Quantity):
-                        data = data.magnitude
-                    text += _format_array_values(
-                        data,
-                        is_masked=self.is_masked,
-                        dtype=self.dtype,
-                        sep=sep,
-                        prefix=pref,
-                        units=units,
-                    )
+            return text
+
+        for pref in ("R", "I"):
+            if self._data is not None:
+                component = self.copy()
+                if pref == "R":
+                    component._data = component._data.real
+                else:
+                    component._data = component._data.imag
+                data = component.umasked_data
+                if isinstance(data, Quantity):
+                    data = data.magnitude
+                text += _format_array_values(
+                    data,
+                    is_masked=self.is_masked,
+                    dtype=self.dtype,
+                    sep=sep,
+                    prefix=pref,
+                    units=units,
+                )
+
+        return text
+
+    def _str_value(self, sep="\n", ufmt=" {:~P}", header="       values: ... \n"):
+        if self.is_empty:
+            return header + "{}".format(textwrap.indent("empty", " " * 9))
+        text = self._format_display_values(sep=sep, ufmt=ufmt)
 
         out = "          DATA \n"
         out += f"        title: {self.title}\n" if self.title else ""

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -53,7 +53,6 @@ from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 from spectrochempy.core.dataset.basearrays.ndcomplex import NDComplexArray
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
-from spectrochempy.core.units import Quantity
 from spectrochempy.extern.traittypes import Array
 from spectrochempy.utils._logging import warning_
 from spectrochempy.utils.datetimeutils import utcnow
@@ -61,7 +60,6 @@ from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.optional import import_optional_dependency
 from spectrochempy.utils.print import DisplayItem
 from spectrochempy.utils.print import DisplaySection
-from spectrochempy.utils.print import _format_array_values
 from spectrochempy.utils.print import _html_heading
 from spectrochempy.utils.print import _render_sections
 from spectrochempy.utils.print import colored_output
@@ -693,42 +691,13 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         )
 
         if not self.is_empty and self._data is not None:
-            units = f" {self.units:~P}" if self.has_units else ""
-
-            if self.has_complex_dims:
-                # R/I split — mirrors NDComplexArray._str_value()
-                text = ""
-                for pref in ("R", "I"):
-                    component = self.copy()
-                    if pref == "R":
-                        component._data = component._data.real
-                    else:
-                        component._data = component._data.imag
-                    data = component.umasked_data
-                    if isinstance(data, Quantity):
-                        data = data.magnitude
-                    text += _format_array_values(
-                        data,
-                        is_masked=self.is_masked,
-                        dtype=self.dtype,
-                        sep="\n",
-                        prefix=pref,
-                        units=units,
-                    )
-                data_items.append(DisplayItem("data", text, "values"))
-            else:
-                data = self.umasked_data
-                if isinstance(data, Quantity):
-                    data = data.magnitude
-                formatted = _format_array_values(
-                    data,
-                    is_masked=self.is_masked,
-                    dtype=self.dtype,
-                    sep="\n",
-                    prefix="",
-                    units=units,
+            data_items.append(
+                DisplayItem(
+                    "data",
+                    self._format_display_values(sep="\n"),
+                    "values",
                 )
-                data_items.append(DisplayItem("data", formatted, "values"))
+            )
 
         shape_text = self._str_shape()
         if shape_text:

--- a/tests/test_core/test_display_characterization.py
+++ b/tests/test_core/test_display_characterization.py
@@ -1406,6 +1406,143 @@ class TestNDComplexStrValuePreservation:
         assert "I[" in text
 
 
+class TestDisplayPluginHookFallbacks:
+    """Plugin-facing display hooks must always preserve core fallback behavior."""
+
+    @staticmethod
+    def _complex_dataset():
+        return NDDataset([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
+
+    def test_array_values_no_handler_uses_core_fallback(self, monkeypatch):
+        """Missing display.array_values handler leaves standard R/I display intact."""
+        from spectrochempy.plugins import manager as manager_module
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: None if name == "display.array_values" else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "R[" in ds._str_value()
+        assert "I[" in ds._str_value()
+        assert "R[" in ds._repr_html_()
+        assert "I[" in ds._repr_html_()
+
+    def test_array_values_none_uses_core_fallback(self, monkeypatch):
+        """A None-valued display.array_values result falls back safely."""
+        from spectrochempy.plugins import manager as manager_module
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: (lambda dataset, **kwargs: None)
+            if name == "display.array_values"
+            else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "R[" in ds._str_value()
+        assert "I[" in ds._str_value()
+
+    def test_array_values_handler_exception_uses_core_fallback(self, monkeypatch):
+        """A faulty display.array_values handler must not break core display."""
+        from spectrochempy.plugins import manager as manager_module
+
+        def broken_handler(dataset, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: broken_handler if name == "display.array_values" else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "R[" in ds._str_value()
+        assert "I[" in ds._str_value()
+        assert "R[" in ds._repr_html_()
+        assert "I[" in ds._repr_html_()
+
+    def test_complex_dim_flags_non_iterable_uses_core_fallback(self, monkeypatch):
+        """A non-iterable display.complex_dim_flags result falls back safely."""
+        from spectrochempy.plugins import manager as manager_module
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: (lambda dataset: 1)
+            if name == "display.complex_dim_flags"
+            else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "(y:2, x:2(complex))" in ds._str_shape()
+
+    def test_complex_dim_flags_none_uses_core_fallback(self, monkeypatch):
+        """A None-valued display.complex_dim_flags result falls back safely."""
+        from spectrochempy.plugins import manager as manager_module
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: (lambda dataset: None)
+            if name == "display.complex_dim_flags"
+            else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "(y:2, x:2(complex))" in ds._str_shape()
+
+    def test_complex_dim_flags_handler_exception_uses_core_fallback(self, monkeypatch):
+        """A faulty display.complex_dim_flags handler must not break core display."""
+        from spectrochempy.plugins import manager as manager_module
+
+        def broken_handler(dataset):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: broken_handler
+            if name == "display.complex_dim_flags"
+            else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "(y:2, x:2(complex))" in ds._str_shape()
+
+    def test_complex_dim_flags_wrong_length_uses_core_fallback(self, monkeypatch):
+        """A wrong-length display.complex_dim_flags result falls back safely."""
+        from spectrochempy.plugins import manager as manager_module
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: (lambda dataset: [True])
+            if name == "display.complex_dim_flags"
+            else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "(y:2, x:2(complex))" in ds._str_shape()
+
+    def test_complex_dim_flags_invalid_contents_are_rejected(self, monkeypatch):
+        """Non-boolean display.complex_dim_flags contents are rejected and fallback is used."""
+        from spectrochempy.plugins import manager as manager_module
+
+        monkeypatch.setattr(
+            manager_module.plugin_manager.registry,
+            "get_handler",
+            lambda name: (lambda dataset: [True, 1])
+            if name == "display.complex_dim_flags"
+            else None,
+        )
+
+        ds = self._complex_dataset()
+        assert "(y:2, x:2(complex))" in ds._str_shape()
+
+
 # ======================================================================================
 # PHASE B: SEMANTIC HTML RENDERING FOR COORD
 # ======================================================================================


### PR DESCRIPTION
Closes #1147.

## Summary

This PR restores and hardens hypercomplex display through generic plugin-owned display hooks while keeping core display plugin-agnostic.

## What Changed

- added generic core display extension points for plugin-provided array values and complex-dimension flags
- restored `RR` / `RI` / `IR` / `II` terminal and HTML display in the hypercomplex plugin
- hardened both display hooks so missing, partial, or faulty plugin handlers always fall back to standard core display behavior
- added focused core fallback tests and kept the plugin-present regression coverage
- documented the user-facing fix in the changelog, including generated `latest.rst`

## Why

Historical hypercomplex display used explicit component labels, but that behavior regressed after plugin extraction. The initial restoration was functional, but this version keeps quaternion semantics in the plugin and limits core changes to generic dispatch and fallback behavior.

## Impact

- hypercomplex users get the historical component-labelled display back in terminal and notebook HTML
- ordinary real and complex datasets keep their existing display behavior
- faulty plugin handlers no longer make core display less robust

## Validation

- `conda run -n scpy-core python -m pytest tests/test_core/test_display_characterization.py -k "TestDisplayPluginHookFallbacks or TestNDComplexStrValuePreservation" -q`
- `conda run -n scpy env PYTHONPATH=/home/christian/GitHub/spectrochempy/plugins/spectrochempy-hypercomplex/src:/home/christian/GitHub/spectrochempy/src python -m pytest plugins/spectrochempy-hypercomplex/tests/test_hypercomplex.py::TestHypercomplexDisplayRegression -q`

## Root Cause

The regression originated when hypercomplex behavior moved out of core during plugin extraction, leaving no display hook for plugin-owned quaternion semantics. This PR restores that path without reintroducing quaternion-specific branches into core display code.