### PR TITLE
MAINT: remove orphaned ROI support and harden legacy load compatibility

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -129,11 +129,13 @@ Breaking Changes
    clarifies the math semantics under the broader ``#1103`` arithmetic and
    metadata characterization work.
 
-- Removed the orphaned ``NDDataset.modeldata`` attribute (#1168).  Fit/model
+- Removed the orphaned ``roi`` and ``NDDataset.modeldata`` attributes from the
+  public data model (#1168).  ``roi`` no longer had active production use, and
+  ``NDDataset.modeldata`` no longer had a reliable semantic contract.  Fit/model
   outputs should be stored and plotted as explicit ``NDDataset`` objects or
   dedicated fit-result objects rather than hidden structural state on
-  ``NDDataset``.  ``plot(plot_model=True)`` now emits a ``FutureWarning``
-  explaining the removal.
+  ``NDDataset``.  Legacy serialized ``roi`` and ``modeldata`` fields in native
+  SpectroChemPy files remain load-compatible and are ignored during loading.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -114,11 +114,13 @@ Breaking Changes
    clarifies the math semantics under the broader ``#1103`` arithmetic and
    metadata characterization work.
 
-- Removed the orphaned ``NDDataset.modeldata`` attribute (#1168).  Fit/model
+- Removed the orphaned ``roi`` and ``NDDataset.modeldata`` attributes from the
+  public data model (#1168).  ``roi`` no longer had active production use, and
+  ``NDDataset.modeldata`` no longer had a reliable semantic contract.  Fit/model
   outputs should be stored and plotted as explicit ``NDDataset`` objects or
   dedicated fit-result objects rather than hidden structural state on
-  ``NDDataset``.  ``plot(plot_model=True)`` now emits a ``FutureWarning``
-  explaining the removal.
+  ``NDDataset``.  Legacy serialized ``roi`` and ``modeldata`` fields in native
+  SpectroChemPy files remain load-compatible and are ignored during loading.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -390,8 +390,12 @@ class NDIO(tr.HasTraits):
             return coordset
 
         def item_to_attr(obj: Any, dic: dict[str, Any]) -> Any:
+            legacy_ignored_fields = {"roi", "_roi", "modeldata", "_modeldata"}
             for key, val in dic.items():
                 try:
+                    if key in legacy_ignored_fields:
+                        continue
+
                     if "readonly" in dic and key in ["readonly", "name"]:
                         # case of the meta and preferences
                         pass

--- a/src/spectrochempy/core/dataset/basearrays/ndarray.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndarray.py
@@ -199,9 +199,6 @@ class NDArray(tr.HasTraits):
     _units = tr.Instance(Unit, allow_none=True)
     _meta = tr.Instance(Meta, allow_none=True)
 
-    # Region of interest
-    _roi = tr.List(allow_none=True)
-
     # Transposition flag
     _transposed = tr.Bool(False)
 
@@ -266,7 +263,6 @@ class NDArray(tr.HasTraits):
             "meta",
             "title",
             "name",
-            "roi",
             "transposed",
         ]
 
@@ -304,7 +300,7 @@ class NDArray(tr.HasTraits):
         if attrs is None:
             attrs = self._attributes_()
 
-        for attr in ["name", "linear", "roi"]:
+        for attr in ["name", "linear"]:
             if attr in attrs:
                 attrs.remove(attr)
 
@@ -935,10 +931,6 @@ class NDArray(tr.HasTraits):
         numpyprintoptions()
         return "".join([prefix, body, units, size])
 
-    @tr.default("_roi")
-    def _roi_default(self):
-        return None
-
     def _set_data(self, data):
         if data is None:
             return
@@ -1089,10 +1081,6 @@ class NDArray(tr.HasTraits):
         udata = (new.data * oldunits).to(units)
         new._data = udata.m
         new._units = udata.units
-
-        if new._roi is not None:
-            roi = (np.array(new.roi) * oldunits).to(units)
-            new._roi = list(roi)
 
         return new
 
@@ -1734,23 +1722,6 @@ class NDArray(tr.HasTraits):
         self._mask = NOMASK
 
     @property
-    def roi(self):
-        """Region of interest (ROI) limits (list)."""
-        if self._roi is None:
-            self._roi = self.limits
-        return self._roi
-
-    @roi.setter
-    def roi(self, val):
-        self._roi = val
-
-    @property
-    def roi_values(self):
-        if self.units is None:
-            return list(np.array(self.roi))
-        return list(self._uarray(self.roi, self.units))
-
-    @property
     def shape(self):
         """
         A tuple with the size of each dimension - Readonly property.
@@ -2073,7 +2044,6 @@ class NDArray(tr.HasTraits):
             self._data = new._data
             self._units = new._units
             self._title = new._title
-            self._roi = new._roi
             return None
 
         return new

--- a/src/spectrochempy/core/dataset/coord.py
+++ b/src/spectrochempy/core/dataset/coord.py
@@ -326,7 +326,6 @@ class Coord(NDMath, NDArray):
             # the _linear attribute is set to True if the data are linearized
             self._units = new._units
             self._title = new._title
-            self._roi = new._roi
             return None
         new.data = new._data  # here we assign to the data attribute to fire
         # the linearisation (eventually) and the rounding
@@ -594,7 +593,6 @@ class Coord(NDMath, NDArray):
             "meta",
             "title",
             "name",
-            "roi",
             "linear",
             "sigdigits",
         ]
@@ -768,9 +766,6 @@ class Coord(NDMath, NDArray):
         udata = (new.data * oldunits).to(units)
         new._data = udata.m
         new._units = udata.units
-        if new._roi is not None:
-            roi = (np.array(new._roi) * oldunits).to(units)
-            new._roi = list(roi)
         return new
 
     # ----------------------------------------------------------------------------------

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -172,8 +172,6 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
     origin : `str`, optional
         Origin of the data: Name of organization, address, telephone number,
         name of individual contributor, etc., as appropriate.
-    roi : `list`
-        Region of interest (ROI) limits.
     history : `str`, optional
         A string to add to the object history.
     copy : `bool`, optional
@@ -323,7 +321,6 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             "modified",
             # "acquisition_date",
             "origin",
-            "roi",
             "transposed",
             # "processeddata",
             # "referencedata",
@@ -490,7 +487,6 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             "created",
             "modified",
             "origin",
-            "roi",
         ):
             # These attributes are not used for comparison (comparison based on data and units!)
             with suppress(ValueError):

--- a/src/spectrochempy/core/plotters/plotly.py
+++ b/src/spectrochempy/core/plotters/plotly.py
@@ -134,16 +134,6 @@
 #     dimy = new.dims[-2]
 #     y = getattr(new, dimy)
 #
-#     # ------------------------------------------------------------------------
-#     # Should we display only ROI region?
-#     # ------------------------------------------------------------------------
-#
-#     if 'Processed' in selector:
-#         # in this case we make the selection
-#         new = new[y.roi[0]:y.roi[1], x.roi[0]:x.roi[1]]
-#         x = getattr(new, dimx)
-#         y = getattr(new, dimy)
-#
 #     xsize = new.shape[-1]
 #     ysize = new.shape[-2]
 #
@@ -398,12 +388,6 @@
 #                     )
 #     fig.add_traces(data)
 #
-#     # show out of X ROI zone
-#     fullrange = getattr(new, dimx).limits
-#     roirange = getattr(new, dimx).roi
-#
-#     x0, x1 = fullrange[0], roirange[0] - offset
-#     x2, x3 = fullrange[1], roirange[1] - offset
 #     fig.update_layout(
 #             shapes=[
 #                     dict(

--- a/src/spectrochempy/utils/testing.py
+++ b/src/spectrochempy/utils/testing.py
@@ -388,7 +388,6 @@ def compare_datasets(
             "created",
             "modified",
             "origin",
-            "roi",
             "size",
             "name",
             "processeddata",

--- a/tests/test_core/test_dataset/test_combination_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_combination_semantics_baseline.py
@@ -6,7 +6,7 @@ It does NOT validate a desired future policy.
 
 Coverage:
     - concatenate: data, CoordSet, units, masks, metadata, history,
-      ROI, identity/provenance, edge cases
+      identity/provenance, edge cases
     - stack: data, CoordSet, metadata, provenance
 
 Result Assembly Pattern observations (see RFC):
@@ -51,7 +51,6 @@ def dataset_x():
     ds.description = "description_x"
     ds.origin = "origin_x"
     ds.meta.project = "project_x"
-    ds.roi = [0.0, 10.0]
     ds.history = ["original_x"]
     return ds
 
@@ -76,7 +75,6 @@ def dataset_y():
     ds.description = "description_y"
     ds.origin = "origin_y"
     ds.meta.project = "project_y"
-    ds.roi = [5.0, 20.0]
     ds.history = ["original_y"]
     return ds
 
@@ -446,24 +444,6 @@ class TestConcatenateHistory:
 
 
 # ======================================================================================
-# ROI
-# ======================================================================================
-
-
-class TestConcatenateRoi:
-    """
-    Characterize ROI behavior through concatenation.
-
-    Observations (not policy):
-    - ROI propagates from the LAST dataset (via copy of last input)
-    """
-
-    def test_roi_from_last_dataset(self, dataset_x, dataset_y):
-        c = concatenate(dataset_x, dataset_y, dims="x")
-        assert c.roi == [5.0, 20.0]
-
-
-# ======================================================================================
 # IDENTITY / PROVENANCE OBSERVATIONS
 # ======================================================================================
 
@@ -476,7 +456,7 @@ class TestConcatenateIdentityProvenance:
     - title, author, description, name are handled individually
       (title: first, name: last, author: merged, description: synthesized)
       This is NOT a copy-first identity preservation pattern.
-    - origin, meta, roi come from the last dataset (copy artifact)
+    - origin and meta come from the last dataset (copy artifact)
     - history is rewritten — provenance is not preserved
     - This most closely resembles Pattern B (Rebuild / Synthesize):
       the result is a synthesized object, not an identity-preserved

--- a/tests/test_core/test_dataset/test_dataset_regressions.py
+++ b/tests/test_core/test_dataset/test_dataset_regressions.py
@@ -98,6 +98,18 @@ def test_modeldata_removed_from_nddataset():
     assert not hasattr(ds, "modeldata")
 
 
+def test_roi_removed_from_nddataset():
+    """NDDataset should no longer expose a roi property."""
+    ds = scp.NDDataset([1, 2, 3])
+    assert not hasattr(ds, "roi")
+
+
+def test_roi_removed_from_coord():
+    """Coord should no longer expose a roi property."""
+    coord = scp.Coord(np.array([1.0, 2.0, 3.0]), title="x")
+    assert not hasattr(coord, "roi")
+
+
 def test_plot_model_emits_future_warning():
     """plot(plot_model=True) should emit FutureWarning, not error."""
     import warnings
@@ -113,6 +125,13 @@ def test_copy_no_modeldata():
     ds = scp.NDDataset([1, 2, 3])
     ds2 = ds.copy()
     assert not hasattr(ds2, "modeldata")
+
+
+def test_copy_no_roi():
+    """copy() should not carry roi."""
+    ds = scp.NDDataset([1, 2, 3])
+    ds2 = ds.copy()
+    assert not hasattr(ds2, "roi")
 
 
 def test_arithmetic_no_modeldata():
@@ -135,6 +154,13 @@ def test_interpolation_no_modeldata():
     ds = scp.NDDataset(np.array([1.0, 2.0, 3.0]), coordset=[x])
     itp = ds.interpolate(coord=scp.Coord(np.array([1.5, 2.5]), title="x"))
     assert not hasattr(itp, "modeldata")
+
+
+def test_unit_conversion_no_roi():
+    """Unit conversion should not create or propagate roi."""
+    ds = scp.NDDataset(np.array([1.0, 2.0, 3.0]), units="m")
+    converted = ds.to("cm")
+    assert not hasattr(converted, "roi")
 
 
 def test_optimize_modeldata_preserved():

--- a/tests/test_core/test_dataset/test_indexing_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_indexing_semantics_baseline.py
@@ -8,7 +8,6 @@ Coverage:
     - Return type, shape, dims
     - CoordSet behavior (preserve/reduce/slice)
     - Units, masks, metadata, history
-    - ROI
     - Identity, provenance
     - Integer, slice, ellipsis, step, label, float, fancy indexing
 """
@@ -50,7 +49,6 @@ def ds():
     ds.description = "test description"
     ds.origin = "test_origin"
     ds.meta.project = "test_project"
-    ds.roi = [0.0, 10.0]
     ds.history = ["original entry"]
     return ds
 
@@ -493,41 +491,6 @@ class TestHistory:
         assert "Original entry" in r.history[0]
 
 
-# ======================================================================================
-# ROI
-# ======================================================================================
-
-
-class TestRoi:
-    """
-    Characterize ROI behavior through indexing.
-
-    Observations: roi is copied unchanged through all indexing forms.
-    It is NOT sliced or adjusted to match the new data shape.
-    """
-
-    def test_roi_preserved_on_single_index(self, ds):
-        r = ds[0]
-        assert r.roi == [0.0, 10.0]
-
-    def test_roi_preserved_on_slice(self, ds):
-        r = ds[1:3]
-        assert r.roi == [0.0, 10.0]
-
-    def test_roi_preserved_on_submatrix(self, ds):
-        r = ds[1:4, 2:5]
-        assert r.roi == [0.0, 10.0]
-
-    def test_roi_preserved_on_scalar_like(self, ds):
-        r = ds[0, 0]
-        assert r.roi == [0.0, 10.0]
-
-    def test_roi_preserved_on_fancy(self, ds):
-        r = ds[[0, 2, 4]]
-        assert r.roi == [0.0, 10.0]
-
-
-# ======================================================================================
 # LABELS
 # ======================================================================================
 

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -126,6 +126,44 @@ def test_ndio_load_without_default_field_keeps_legacy_behavior(tmp_path):
     assert_array_equal(loaded.x.data, legacy_default_data)
 
 
+def test_ndio_load_ignores_legacy_roi_fields(tmp_path):
+    ds = NDDataset([0.0, 1.0, 2.0], coordset=[Coord([10.0, 20.0, 30.0], title="x")])
+    filename = ds.save_as(tmp_path / "legacy_roi", confirm=False)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    js["roi"] = [0.0, 1.0]
+    js["coordset"]["coords"][0]["roi"] = [10.0, 20.0]
+
+    with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(member, json.dumps(js, indent=2))
+
+    loaded = NDDataset.load(filename)
+
+    assert not hasattr(loaded, "roi")
+    assert not hasattr(loaded.x, "roi")
+
+
+def test_ndio_load_ignores_legacy_modeldata_field(tmp_path):
+    ds = NDDataset([0.0, 1.0, 2.0])
+    filename = ds.save_as(tmp_path / "legacy_modeldata", confirm=False)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    js["modeldata"] = [42.0, 42.0, 42.0]
+
+    with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(member, json.dumps(js, indent=2))
+
+    loaded = NDDataset.load(filename)
+
+    assert not hasattr(loaded, "modeldata")
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
 

--- a/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
@@ -15,7 +15,6 @@ Coverage:
     - metadata propagation
     - CoordSet reduction / preservation
     - history behavior (appended, not replaced)
-    - ROI stale-field behavior
     - identity / provenance observations
 """
 
@@ -38,7 +37,6 @@ def reduction_dataset():
     - dims: ['y', 'x'] (5, 7)
     - CoordSet with titles, units
     - title, name, metadata, history
-    - ROI (UI/selection state — to reassess)
     """
     y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
     x = Coord(np.linspace(4000.0, 1000.0, 7), title="wavenumber", units="cm^-1")
@@ -48,7 +46,6 @@ def reduction_dataset():
     ds.description = "test description"
     ds.origin = "test_origin"
     ds.meta.project = "test_project"
-    ds.roi = [0.0, 10.0]
     ds.history = ["original entry"]
     return ds
 
@@ -155,10 +152,6 @@ class TestSumCharacterization:
         expected = np.sum(np.arange(35.0).reshape(5, 7), axis=1)
         expected[0] = expected[0] - 0.0
         assert np.isclose(s.data[0], expected[0])
-
-    def test_sum_preserves_roi(self, reduction_dataset):
-        s = reduction_dataset.sum(dim="x")
-        assert s.roi == [0.0, 10.0]
 
 
 # ======================================================================================
@@ -594,31 +587,6 @@ class TestReductionHistory:
         """Original history entry is preserved, history is appended."""
         s = reduction_dataset.sum(dim="x")
         assert "original entry" in s.history[0].lower()
-
-
-# ======================================================================================
-# ROI
-# ======================================================================================
-
-
-class TestReductionRoi:
-    """
-    Characterize ROI behavior through reductions.
-
-    ROI is current behavior only — likely UI/selection state, to reassess.
-    """
-
-    def test_roi_preserved_after_sum(self, reduction_dataset):
-        s = reduction_dataset.sum(dim="x")
-        assert s.roi == [0.0, 10.0]
-
-    def test_roi_preserved_after_mean(self, reduction_dataset):
-        m = reduction_dataset.mean(dim="x")
-        assert m.roi == [0.0, 10.0]
-
-    def test_roi_preserved_after_max(self, reduction_dataset):
-        mx = reduction_dataset.max(dim="x")
-        assert mx.roi == [0.0, 10.0]
 
 
 # ======================================================================================

--- a/tests/test_core/test_dataset/test_shape_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_shape_semantics_baseline.py
@@ -11,7 +11,6 @@ Coverage:
     - reshape
     - atleast_2d
     - CoordSet semantics (Preserve / Reduce / Rebuild / Synthesize)
-    - ROI behavior
     - history behavior
 """
 
@@ -35,7 +34,6 @@ def shape_dataset():
     - dims: ['y', 'x'] (5, 7)
     - CoordSet with titles, units
     - title, name, metadata, history
-    - ROI (UI/selection state — to reassess)
     """
     y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
     x = Coord(np.linspace(4000.0, 1000.0, 7), title="wavenumber", units="cm^-1")
@@ -46,7 +44,6 @@ def shape_dataset():
     ds.origin = "test_origin"
     ds.meta.project = "test_project"
     ds.history = ["original entry"]
-    ds.roi = [0.0, 10.0]
     return ds
 
 
@@ -174,10 +171,6 @@ class TestTransposeCharacterization:
         t = shape_dataset.transpose()
         assert t is not shape_dataset
 
-    def test_transpose_preserves_roi(self, shape_dataset):
-        t = shape_dataset.transpose()
-        assert t.roi == [0.0, 10.0]
-
     def test_transpose_noop_for_1d(self, shape_dataset_1d):
         t = shape_dataset_1d.transpose()
         assert t.dims == shape_dataset_1d.dims
@@ -250,10 +243,6 @@ class TestSwapdimsCharacterization:
     def test_swapdims_inplace_returns_same(self, shape_dataset):
         s = shape_dataset.swapdims("y", "x", inplace=True)
         assert s is shape_dataset
-
-    def test_swapdims_preserves_roi(self, shape_dataset):
-        s = shape_dataset.swapdims("y", "x")
-        assert s.roi == [0.0, 10.0]
 
     def test_swapdims_noop_on_1d(self, shape_dataset_1d):
         """SURPRISE: swapdims on 1D returns a copy without error (no-op)."""
@@ -337,12 +326,6 @@ class TestSqueezeCharacterization:
         sq = ds.squeeze(inplace=True)
         assert sq is ds
 
-    def test_squeeze_preserves_roi(self):
-        ds = NDDataset(np.ones((1, 4)), roi=[0.0, 10.0])
-        ds.roi = [0.0, 10.0]
-        sq = ds.squeeze()
-        assert sq.roi == [0.0, 10.0]
-
     def test_squeeze_preserves_metadata(self):
         ds = NDDataset(np.ones((1, 4)), title="squeeze_meta")
         ds.author = "author_x"
@@ -424,10 +407,6 @@ class TestReshapeCharacterization:
         r = shape_dataset.reshape((7, 5), dims=("x", "y"))
         assert r is not shape_dataset
 
-    def test_reshape_preserves_roi(self, shape_dataset):
-        r = shape_dataset.reshape((7, 5), dims=("x", "y"))
-        assert r.roi == [0.0, 10.0]
-
     def test_reshape_with_explicit_coords(self, shape_dataset):
         c = Coord(np.linspace(0.0, 60.0, 7), title="new_time", units="s")
         r = shape_dataset.reshape((7, 5), dims=("y", "x"), coords={"y": c})
@@ -496,11 +475,6 @@ class TestAtleast2dCharacterization:
         a = shape_dataset_1d.atleast_2d()
         assert len(a.history) == 1
         assert a.history[0] == shape_dataset_1d.history[0]
-
-    def test_atleast_2d_preserves_roi(self, shape_dataset_1d):
-        shape_dataset_1d.roi = [0.0, 100.0]
-        a = shape_dataset_1d.atleast_2d()
-        assert a.roi == [0.0, 100.0]
 
     def test_atleast_2d_semantic_pattern(self):
         """CoordSet semantics: Rebuild (new dim 'u' gets None coord, original preserved)."""
@@ -588,39 +562,6 @@ class TestCoordSetSemanticsClassification:
         a = shape_dataset.atleast_2d()
         assert a.coordset is not None
         assert a.coordset.names == shape_dataset.coordset.names
-
-
-# ======================================================================================
-# ROI CHARACTERIZATION
-# ======================================================================================
-
-
-class TestRoiCharacterization:
-    """
-    Characterize ROI behavior under shape operations.
-
-    ROI is current behavior only — it is likely historical UI/interactive
-    selection state, not stable scientific metadata. Its propagation through
-    shape operations should be reassessed later.
-    """
-
-    def test_roi_preserved_through_all_ops(self, shape_dataset):
-        """ROI is preserved through all shape ops (current behavior, to reassess)."""
-        t = shape_dataset.transpose()
-        assert t.roi == [0.0, 10.0]
-        s = shape_dataset.swapdims("y", "x")
-        assert s.roi == [0.0, 10.0]
-        sq = shape_dataset.squeeze()
-        assert sq.roi == [0.0, 10.0]
-        r = shape_dataset.reshape((7, 5), dims=("x", "y"))
-        assert r.roi == [0.0, 10.0]
-        a = shape_dataset.atleast_2d()
-        assert a.roi == [0.0, 10.0]
-
-    def test_roi_defaults_to_limits(self):
-        """Roi falls back to data limits when not explicitly set."""
-        ds = NDDataset(np.array([1.0, 2.0, 3.0]))
-        assert ds.roi == [1.0, 3.0]
 
 
 # ======================================================================================

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -4,6 +4,9 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 
+import json
+import zipfile
+
 import pytest
 
 from spectrochempy.application.preferences import preferences
@@ -707,6 +710,28 @@ class TestSerializationRoundtrip:
         assert filename1.exists()
         assert filename2.exists()
         assert filename1 != filename2
+
+    def test_save_load_ignores_legacy_roi_and_modeldata_fields(self, ds1):
+        proj = Project(name="legacy_fields_test")
+        ds1.name = "data"
+        proj.add_dataset(ds1)
+
+        filename = proj.save()
+
+        with zipfile.ZipFile(filename, "r") as zipf:
+            member = zipf.namelist()[0]
+            js = json.loads(zipf.read(member).decode("utf-8"))
+
+        js["datasets"][0]["roi"] = [0.0, 1.0]
+        js["datasets"][0]["modeldata"] = [42.0]
+
+        with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+            zipf.writestr(member, json.dumps(js, indent=2))
+
+        loaded = Project.load(filename)
+
+        assert not hasattr(loaded.data, "roi")
+        assert not hasattr(loaded.data, "modeldata")
 
 
 class TestArgNamesEdgeCases:

--- a/tests/test_processing/test_interpolation/test_interpolation_semantics_baseline.py
+++ b/tests/test_processing/test_interpolation/test_interpolation_semantics_baseline.py
@@ -14,7 +14,7 @@ characterised separately.
 Coverage:
     - Return type, shape, dims, CoordSet, units, masks
     - Metadata (title, name, author, description, origin, meta)
-    - History, ROI, identity, provenance
+    - History, identity, provenance
     - Coordinate rebuild semantics (increasing, decreasing, shifted,
       denser / sparser grids)
     - Label point-wise carry-over policy
@@ -27,7 +27,6 @@ Key observed patterns:
     - Copy-first + domain rebuild (not inplace by default)
     - Same scientific object, changed representation
     - History appended with timestamp formatting
-    - ROI preserved but stale after coordinate rebuild
     - Mask reconstruction is operation-dependent
     - Labels on exact coordinate matches only
     - Multi-coordinate interpolation currently raises a ValueError
@@ -73,7 +72,6 @@ def ds_2d():
     ds.description = "test description"
     ds.origin = "test_origin"
     ds.meta.project = "test_project"
-    ds.roi = [0.0, 10.0]
     ds.history = ["original entry"]
     return ds
 
@@ -387,28 +385,6 @@ class TestHistory:
             dim="x", coord=np.linspace(3500.0, 1500.0, 3), inplace=True
         )
         assert len(r.history) == 2
-
-
-# ======================================================================================
-# ROI
-# ======================================================================================
-
-
-class TestROI:
-    """Characterize ROI (region of interest) behavior: preserved but stale."""
-
-    def test_roi_preserved_after_interpolation(self, ds_2d):
-        r = ds_2d.interpolate(dim="x", coord=np.linspace(3500.0, 1500.0, 3))
-        assert r.roi == ds_2d.roi
-
-    def test_roi_preserved_unchanged(self, ds_2d):
-        """
-        ROI is preserved unchanged and may therefore become stale
-        when the coordinate grid is rebuilt.
-        """
-        r = ds_2d.interpolate(dim="x", coord=np.linspace(3500.0, 1500.0, 3))
-        assert r.roi[0] == ds_2d.roi[0]
-        assert r.roi[1] == ds_2d.roi[1]
 
 
 # ======================================================================================

--- a/tests/test_processing/test_processing_wrapper_semantics_baseline.py
+++ b/tests/test_processing/test_processing_wrapper_semantics_baseline.py
@@ -8,14 +8,14 @@ It does NOT validate a desired future policy.
 Coverage:
     - Return type, shape, dims, CoordSet, units, masks
     - Metadata (title, name, author, description, origin, meta)
-    - History, ROI, identity, provenance
+    - History, identity, provenance
 
 Two distinct assembly patterns emerge:
     Group A (Filter/PCA-based: smooth, savgol, whittaker, denoise):
-        name appended, no modeldata attribute, roi recomputed,
+        name appended, no modeldata attribute,
         history rewritten
     Group B (Baseline-based: basc, detrend, asls):
-        name preserved, no modeldata attribute, roi preserved,
+        name preserved, no modeldata attribute,
         history appended
 """
 
@@ -63,7 +63,6 @@ def ds():
     ds.description = "test description"
     ds.origin = "test_origin"
     ds.meta.project = "test_project"
-    ds.roi = [0.0, 10.0]
     ds.history = ["original entry"]
     return ds
 
@@ -105,7 +104,7 @@ class TestFilterWrappers:
     Characterize Filter-based wrappers: smooth, savgol, whittaker.
 
     Observation: these all rewrite history, append _Filter.transform
-    to name, expose no modeldata attribute, and recompute roi from data range.
+    to name, and expose no modeldata attribute.
     """
 
     @pytest.mark.parametrize("method", ["smooth", "savgol", "whittaker"])
@@ -178,14 +177,6 @@ class TestFilterWrappers:
         r = _call_filter(ds, method)
         assert not hasattr(r, "modeldata")
 
-    @pytest.mark.parametrize("method", ["smooth", "savgol", "whittaker"])
-    def test_roi_recomputed(self, ds, method):
-        """Notable: roi is recomputed from data range, not preserved."""
-        r = _call_filter(ds, method)
-        assert r.roi != [0.0, 10.0]
-        # roi reflects data min/max after processing
-        assert len(r.roi) == 2
-
 
 # ======================================================================================
 # GROUP B: BASELINE-BASED WRAPPERS (basc, detrend, asls)
@@ -197,7 +188,7 @@ class TestBaselineWrappers:
     Characterize Baseline-based wrappers: basc, detrend, asls.
 
     Observation: these all append history, preserve name unchanged,
-    expose no modeldata attribute, and preserve roi unchanged.
+    and expose no modeldata attribute.
     """
 
     @pytest.mark.parametrize("method", ["basc", "detrend", "asls"])
@@ -266,15 +257,6 @@ class TestBaselineWrappers:
         r = getattr(ds, method)()
         assert not hasattr(r, "modeldata")
 
-    @pytest.mark.parametrize("method", ["basc", "detrend", "asls"])
-    def test_roi_preserved(self, ds, method):
-        """
-        Notable: roi is preserved unchanged (unlike Filter wrappers
-        which recompute it from data range).
-        """
-        r = getattr(ds, method)()
-        assert r.roi == [0.0, 10.0]
-
 
 # ======================================================================================
 # GROUP C: PCA-BASED WRAPPER (denoise)
@@ -286,7 +268,7 @@ class TestPcaWrapper:
     Characterize PCA-based denoise wrapper.
 
     Observation: Follows Group A pattern (name appended, no modeldata
-    attribute, roi recomputed, history rewritten) but with different
+    attribute, history rewritten) but with different
     method suffix (_PCA.inverse_transform).
     """
 
@@ -340,11 +322,6 @@ class TestPcaWrapper:
         """Notable: wrappers no longer expose a modeldata attribute."""
         r = ds.denoise(ratio=99.0)
         assert not hasattr(r, "modeldata")
-
-    def test_roi_recomputed(self, ds):
-        """Notable: roi recomputed from data (Group A pattern)."""
-        r = ds.denoise(ratio=99.0)
-        assert r.roi != [0.0, 10.0]
 
 
 # ======================================================================================


### PR DESCRIPTION
Remove the orphaned `roi` attribute from the public dataset model and harden native load compatibility for legacy serialized `roi` and `modeldata` fields.

### Why

The ROI audit found no active production contract for `NDDataset.roi`: it behaved as stale structural state that propagated inconsistently across operations, with remaining usage concentrated in characterization tests rather than user-facing features. In parallel, native loading still needed an explicit safeguard so older serialized `modeldata` payloads cannot be reattached silently.

### Changes

- remove `roi` from the public runtime model (`NDArray`, `Coord`, `NDDataset`)
- delete stale ROI propagation and testing helpers tied to removed state
- ignore legacy serialized `roi` / `_roi` / `modeldata` / `_modeldata` fields during native dataset and project loading
- replace ROI characterization expectations with focused regression coverage asserting the attribute is absent
- consolidate changelog coverage for both removed orphaned fields and preserved load compatibility
- include regenerated `docs/sources/whatsnew/latest.rst` so CI stays aligned with the changelog update

### Validation

- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_dataset_regressions.py tests/test_core/test_dataset/test_mixins/test_ndio.py tests/test_core/test_projects/test_projects.py`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_shape_semantics_baseline.py tests/test_core/test_dataset/test_reduction_semantics_baseline.py tests/test_core/test_dataset/test_indexing_semantics_baseline.py tests/test_core/test_dataset/test_combination_semantics_baseline.py tests/test_processing/test_interpolation/test_interpolation_semantics_baseline.py tests/test_processing/test_processing_wrapper_semantics_baseline.py`

### Notes

Legacy native `.scp` / `.pscp` payloads remain load-compatible: obsolete serialized `roi` and `modeldata` entries are ignored on read rather than restored onto live objects.