### PR TITLE
FIX: clarify incompatible coordinate unit errors

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -74,7 +74,11 @@ Bug Fixes
   Coordinate values expressed in compatible but different units are converted
   to the units of the first dataset, incompatible coordinate units raise a
   ``UnitsCompatibilityError``, and mixed labeled/unlabeled coordinates no
-  longer crash during concatenation.
+  longer crash during concatenation.  Coordinate-aware operations now also
+  report incompatible coordinate units more clearly (#1099): ``align``,
+  ``concatenate``, and ``interpolate`` identify the failing operation, the
+  dimension involved, and the mismatched units instead of surfacing backend or
+  overly generic conversion errors.
 
 - ``read_opus`` now supports more assembled and time-resolved OPUS files
   (#1035, #1036): data series blocks such as ``a``, ``sm``, ``igsm``,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -66,7 +66,11 @@ Bug Fixes
   Coordinate values expressed in compatible but different units are converted
   to the units of the first dataset, incompatible coordinate units raise a
   ``UnitsCompatibilityError``, and mixed labeled/unlabeled coordinates no
-  longer crash during concatenation.
+  longer crash during concatenation.  Coordinate-aware operations now also
+  report incompatible coordinate units more clearly (#1099): ``align``,
+  ``concatenate``, and ``interpolate`` identify the failing operation, the
+  dimension involved, and the mismatched units instead of surfacing backend or
+  overly generic conversion errors.
 
 - ``read_opus`` now supports more assembled and time-resolved OPUS files
   (#1035, #1036): data series blocks such as ``a``, ``sm``, ``igsm``,

--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -1070,9 +1070,12 @@ class CoordSet(HasTraits):
             or coord.units.dimensionality != base.units.dimensionality
         ):
             raise exceptions.UnitsCompatibilityError(
-                f"Coordinates of the '{dim}' dimension have incompatible units "
-                f"({coord.units} and {base.units}). The datasets can't be "
-                "concatenated.",
+                exceptions.format_incompatible_units_message(
+                    "concatenate datasets",
+                    coord.units,
+                    base.units,
+                    dim=dim,
+                ),
             )
         converted = coord.copy()
         converted.ito(base.units)

--- a/src/spectrochempy/processing/alignement/align.py
+++ b/src/spectrochempy/processing/alignement/align.py
@@ -218,7 +218,12 @@ def align(dataset, *others, **kwargs):
             if not coord.is_units_compatible(ref_coord):
                 # not compatible, stop everything
                 raise exceptions.UnitsCompatibilityError(
-                    "NDataset to align must have compatible units!",
+                    exceptions.format_incompatible_units_message(
+                        "align datasets",
+                        coord.units,
+                        ref_coord.units,
+                        dim=dim,
+                    ),
                 )
 
             # do units transform if necesssary so coords can be compared

--- a/src/spectrochempy/processing/interpolation/interpolate.py
+++ b/src/spectrochempy/processing/interpolation/interpolate.py
@@ -14,6 +14,7 @@ from scipy.interpolate import interp1d
 
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
+from spectrochempy.utils import exceptions
 
 
 def _interp_along_axis(values, old_x, new_x, axis, method, fill_value):
@@ -293,7 +294,12 @@ def interpolate(
         if primary_old_coord.has_units and target_coord.has_units:
             if not primary_old_coord.is_units_compatible(target_coord):
                 raise ValueError(
-                    f"Incompatible units: {primary_old_coord.units} vs {target_coord.units}"
+                    exceptions.format_incompatible_units_message(
+                        "interpolate coordinates",
+                        primary_old_coord.units,
+                        target_coord.units,
+                        dim=dim,
+                    )
                 )
             if primary_old_coord.units != target_coord.units:
                 target_coord = target_coord.copy()

--- a/src/spectrochempy/utils/exceptions.py
+++ b/src/spectrochempy/utils/exceptions.py
@@ -167,6 +167,27 @@ class InvalidUnitsError(SpectroChemPyError):
     """Exception raised when units is not valid."""
 
 
+def format_incompatible_units_message(operation, left_units, right_units, dim=None):
+    """
+    Build a clear error message for incompatible units in coordinate-aware operations.
+
+    Parameters
+    ----------
+    operation : str
+        Short operation description, e.g. ``"align datasets"``.
+    left_units, right_units : any
+        Units involved in the failed operation.
+    dim : str, optional
+        Dimension name, when available.
+    """
+    location = f" along dimension '{dim}'" if dim is not None else ""
+    return (
+        f"Cannot {operation}{location}: incompatible coordinate units "
+        f"({left_units} and {right_units}). "
+        "Convert the coordinates to compatible units before retrying."
+    )
+
+
 class InvalidReferenceError(SpectroChemPyError):
     """Exception raised when a reference to another coordinate is not valid."""
 

--- a/tests/test_processing/test_alignement/test_align.py
+++ b/tests/test_processing/test_alignement/test_align.py
@@ -7,7 +7,11 @@
 
 """Tests for the interpolate module"""
 
+import pytest
+
+import spectrochempy as scp
 from spectrochempy.processing.alignement.align import align
+from spectrochempy.utils.exceptions import UnitsCompatibilityError
 
 # align
 # -------
@@ -40,3 +44,17 @@ def test_align(ds1, ds2):
 
     # align inner
     a, b = align(ds1, ds2, method="inner")
+
+
+def test_align_rejects_incompatible_coord_units_with_clear_message():
+    ds1 = scp.NDDataset([1.0, 2.0], coordset=[scp.Coord([100.0, 200.0], units="cm^-1")])
+    ds2 = scp.NDDataset([3.0, 4.0], coordset=[scp.Coord([1.0, 2.0], units="s")])
+
+    with pytest.raises(UnitsCompatibilityError) as exc:
+        align(ds1, ds2, dim="x")
+    message = str(exc.value)
+    assert "Cannot align datasets" in message
+    assert "dimension 'x'" in message
+    assert "s" in message
+    assert "cm" in message
+    assert "Convert the coordinates to compatible units before retrying." in message

--- a/tests/test_processing/test_interpolation/test_interpolate.py
+++ b/tests/test_processing/test_interpolation/test_interpolate.py
@@ -87,6 +87,25 @@ class TestInterpolateBasic:
 
         assert result.shape == (4,)
 
+    def test_interpolate_incompatible_coord_units_message(self):
+        """Interpolation should identify the operation and incompatible units."""
+        ds = NDDataset(
+            np.array([0.0, 2.0, 4.0]),
+            coordset=[
+                Coord(np.array([4000.0, 3000.0, 2000.0]), title="x", units="cm^-1")
+            ],
+        )
+        target = Coord(np.array([1.0, 2.0, 3.0]), title="x", units="s")
+
+        with pytest.raises(ValueError) as exc:
+            ds.interpolate(dim="x", coord=target)
+        message = str(exc.value)
+        assert "Cannot interpolate coordinates" in message
+        assert "dimension 'x'" in message
+        assert "s" in message
+        assert "cm" in message
+        assert "Convert the coordinates to compatible units before retrying." in message
+
 
 class TestInterpolateDecreasingCoord:
     """Interpolation must honour the target order even for decreasing axes (#1100)."""

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -305,8 +305,14 @@ def test_concatenate_rejects_incompatible_coord_units():
     ds1 = scp.NDDataset([1.0, 2.0], coordset=[scp.Coord([1.0, 2.0], units="cm^-1")])
     ds2 = scp.NDDataset([3.0, 4.0], coordset=[scp.Coord([1.0, 2.0], units="s")])
 
-    with pytest.raises(UnitsCompatibilityError):
+    with pytest.raises(UnitsCompatibilityError) as exc:
         concatenate(ds1, ds2)
+    message = str(exc.value)
+    assert "Cannot concatenate datasets" in message
+    assert "dimension 'x'" in message
+    assert "s" in message
+    assert "cm" in message
+    assert "Convert the coordinates to compatible units before retrying." in message
 
 
 def test_stack_regression():


### PR DESCRIPTION
## Summary

This PR improves user-facing error messages when coordinate-aware operations fail because coordinate units are incompatible.

It makes the affected operations report:

- which operation failed;
- which dimension was involved;
- which coordinate units were incompatible;
- how to resolve the failure.

In practice, this harmonizes the error surface for:

- `align`
- `concatenate`
- `interpolate`

## Root cause

Several coordinate-aware paths were still surfacing either backend conversion errors or overly generic compatibility errors.

This made failures harder to interpret than necessary, especially when the actual problem was simply that two coordinate units could not be reconciled for the requested operation.

## What changed

- added a shared helper for formatting incompatible-coordinate-unit messages;
- updated `align` to raise a clear `UnitsCompatibilityError`;
- updated `concatenate` to use the same clearer message shape;
- updated `interpolate` to report the same information when target/source coordinate units are incompatible;
- added focused regression tests for all three operations;
- updated the changelog entry covering coordinate-aware operation fixes.

## Validation

Pre-commit on touched files:

```bash
pre-commit run --files docs/sources/whatsnew/changelog.rst docs/sources/whatsnew/latest.rst src/spectrochempy/core/dataset/coordset.py src/spectrochempy/processing/alignement/align.py src/spectrochempy/processing/interpolation/interpolate.py src/spectrochempy/utils/exceptions.py tests/test_processing/test_alignement/test_align.py tests/test_processing/test_interpolation/test_interpolate.py tests/test_processing/test_transformation/test_concatenate.py
```

Targeted tests:

```bash
conda run -n scpy-core python -m pytest tests/test_processing/test_alignement/test_align.py tests/test_processing/test_transformation/test_concatenate.py tests/test_processing/test_interpolation/test_interpolate.py
```

Result:

- `66 passed, 1 skipped`

Closes #1099.
