### PR TITLE
ENH: support unit-aware peakfinding spacing constraints

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -22,6 +22,13 @@ New Features
 - Added the official ``spectrochempy-tensor`` plugin for TensorLy-backed tensor
   decompositions, exposing CP/PARAFAC as ``scp.tensor.CP``.
 
+- ``find_peaks`` now accepts physical units for point-spacing constraints
+  (#1078).  When coordinate units are available, ``distance`` and ``width`` can
+  now be passed as `Quantity` objects or unit strings such as ``"10 cm^-1"``,
+  and ``wlen`` / ``plateau_size`` follow the same coordinate-aware conversion
+  to sample points.  Plain numeric values keep their previous behavior, and
+  incompatible units now raise a clear error.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,6 +18,13 @@ New Features
 - Added the official ``spectrochempy-tensor`` plugin for TensorLy-backed tensor
   decompositions, exposing CP/PARAFAC as ``scp.tensor.CP``.
 
+- ``find_peaks`` now accepts physical units for point-spacing constraints
+  (#1078).  When coordinate units are available, ``distance`` and ``width`` can
+  now be passed as `Quantity` objects or unit strings such as ``"10 cm^-1"``,
+  and ``wlen`` / ``plateau_size`` follow the same coordinate-aware conversion
+  to sample points.  Plain numeric values keep their previous behavior, and
+  incompatible units now raise a clear error.
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -24,6 +24,7 @@ import scipy
 
 from spectrochempy.application.application import error_
 from spectrochempy.application.application import warning_
+from spectrochempy.core.units import DimensionalityError
 from spectrochempy.core.units import Quantity
 
 # Todo:
@@ -31,6 +32,66 @@ from spectrochempy.core.units import Quantity
 # argrelmin(data[, axis, order, mode]) 	Calculate the relative minima of data.
 # argrelmax(data[, axis, order, mode]) 	Calculate the relative maxima of data.
 # argrelextrema(data, comparator[, axis, ...]) 	Calculate the relative extrema of data.
+
+
+def _as_peakfinding_quantity(value):
+    if isinstance(value, str):
+        return Quantity(value)
+    if isinstance(value, Quantity):
+        return value
+    return None
+
+
+def _format_peakfinding_units_error(name, supplied_units, coord_units, dim):
+    return (
+        f"Cannot use peak-finding parameter `{name}` along dimension '{dim}': "
+        f"incompatible coordinate units ({supplied_units} and {coord_units}). "
+        "Convert the parameter to coordinate units before retrying."
+    )
+
+
+def _convert_peak_parameter_to_points(name, value, step, xunits, use_coord, dim):
+    """
+    Convert coordinate-aware peak-finding constraints to sample-point counts.
+
+    ``scipy.signal.find_peaks()`` expects values such as ``distance`` and
+    ``width`` in sample points. When SpectroChemPy is working in coordinate
+    space, we accept physical-unit inputs and convert them to the nearest
+    integer point count using the current coordinate spacing.
+    """
+    if value is None:
+        return None
+
+    quantity = _as_peakfinding_quantity(value)
+    if quantity is not None:
+        if not use_coord:
+            raise ValueError(
+                f"Parameter `{name}` with physical units requires coordinate-aware "
+                "peak finding. Provide a plain numeric value or keep `use_coord=True`."
+            )
+        try:
+            value = quantity.to(xunits).magnitude
+        except DimensionalityError as exc:
+            raise ValueError(
+                _format_peakfinding_units_error(
+                    name,
+                    quantity.units,
+                    xunits,
+                    dim,
+                )
+            ) from exc
+
+    if isinstance(value, tuple):
+        return tuple(
+            _convert_peak_parameter_to_points(name, item, step, xunits, use_coord, dim)
+            if item is not None
+            else None
+            for item in value
+        )
+
+    if use_coord:
+        return int(round(value / step))
+    return value
 
 
 def find_peaks(
@@ -161,12 +222,18 @@ def find_peaks(
             spacing = spacing.magnitude
         step = np.abs(spacing)
 
-    # transform coord (if exists) to index
-    # TODO: allow units for distance, width, wlen, plateau_size
-    distance = int(round(distance / step)) if distance is not None else None
-    width = int(round(width / step)) if width is not None else None
-    wlen = int(round(wlen / step)) if wlen is not None else None
-    plateau_size = int(round(plateau_size / step)) if plateau_size is not None else None
+    # transform coordinate-aware constraints to sample-point counts
+    dim = X.dims[-1]
+    distance = _convert_peak_parameter_to_points(
+        "distance", distance, step, xunits, use_coord, dim
+    )
+    width = _convert_peak_parameter_to_points(
+        "width", width, step, xunits, use_coord, dim
+    )
+    wlen = _convert_peak_parameter_to_points("wlen", wlen, step, xunits, use_coord, dim)
+    plateau_size = _convert_peak_parameter_to_points(
+        "plateau_size", plateau_size, step, xunits, use_coord, dim
+    )
 
     # now the distance, width ... parameters are given in data points
     peaks, properties = scipy.signal.find_peaks(

--- a/tests/test_analysis/test_peakfinding/test_peakfinding.py
+++ b/tests/test_analysis/test_peakfinding/test_peakfinding.py
@@ -197,6 +197,57 @@ def test_peak_properties(simple_peaks_dataset):
     assert all(p.m > 0 for p in properties["prominences"])
 
 
+def test_distance_accepts_physical_units(simple_peaks_dataset):
+    """Unit-aware distance matches existing numeric coordinate-space behavior."""
+    numeric_peaks, _ = find_peaks(simple_peaks_dataset, height=0.5, distance=1.0)
+    quantity_peaks, _ = find_peaks(
+        simple_peaks_dataset, height=0.5, distance=1.0 * ur("cm^-1")
+    )
+    string_peaks, _ = find_peaks(simple_peaks_dataset, height=0.5, distance="1 cm^-1")
+
+    assert np.allclose(quantity_peaks.x.values, numeric_peaks.x.values)
+    assert np.allclose(string_peaks.x.values, numeric_peaks.x.values)
+
+
+def test_width_accepts_physical_units(simple_peaks_dataset):
+    """Unit-aware width matches existing numeric coordinate-space behavior."""
+    numeric_peaks, numeric_props = find_peaks(
+        simple_peaks_dataset, height=0.5, width=0.1, prominence=0.4
+    )
+    quantity_peaks, quantity_props = find_peaks(
+        simple_peaks_dataset,
+        height=0.5,
+        width=0.1 * ur("cm^-1"),
+        prominence=0.4,
+    )
+    string_peaks, string_props = find_peaks(
+        simple_peaks_dataset, height=0.5, width="0.1 cm^-1", prominence=0.4
+    )
+
+    assert np.allclose(quantity_peaks.x.values, numeric_peaks.x.values)
+    assert np.allclose(string_peaks.x.values, numeric_peaks.x.values)
+    assert np.allclose(
+        [width.m for width in quantity_props["widths"]],
+        [width.m for width in numeric_props["widths"]],
+    )
+    assert np.allclose(
+        [width.m for width in string_props["widths"]],
+        [width.m for width in numeric_props["widths"]],
+    )
+
+
+def test_incompatible_peakfinding_units_raise_clear_error(simple_peaks_dataset):
+    """Incompatible physical units should raise a clear coordinate-space error."""
+    with pytest.raises(ValueError) as exc:
+        find_peaks(simple_peaks_dataset, height=0.5, distance="1 s")
+
+    message = str(exc.value)
+    assert "peak-finding parameter `distance`" in message
+    assert "dimension 'x'" in message
+    assert "s" in message
+    assert "cm" in message
+
+
 def test_window_length_interpolation(simple_peaks_dataset):
     """Test peak position interpolation with different window lengths."""
     # Test with different window lengths


### PR DESCRIPTION
## Summary

This PR adds physical-unit support for coordinate-spacing constraints in `find_peaks()`.

When coordinate units are available, the following parameters can now be given as either plain numeric values, `Quantity` objects, or unit strings:

- `distance`
- `width`
- `wlen`
- `plateau_size`

Unit-aware values are converted internally to sample-point counts before calling `scipy.signal.find_peaks()`.

## What changed

- added conversion support for unit-bearing peakfinding spacing parameters;
- preserved the existing behavior for plain numeric inputs;
- added clear errors for incompatible units;
- added synthetic regression tests for:
  - `distance` with physical units;
  - `width` with physical units;
  - incompatible-unit failures.

## Notes

This PR intentionally stays within the current 1D / linear-coordinate peakfinding contract. It does not redesign the peakfinding API or change non-linear coordinate handling.

## Validation

Pre-commit on touched files:

```bash
pre-commit run --files docs/sources/whatsnew/changelog.rst docs/sources/whatsnew/latest.rst src/spectrochempy/analysis/peakfinding/peakfinding.py tests/test_analysis/test_peakfinding/test_peakfinding.py
```

Targeted tests:

```bash
conda run -n scpy-core python -m pytest tests/test_analysis/test_peakfinding/test_peakfinding.py -k 'not docstrings'
```

Result:

- `16 passed, 1 deselected`

The docstring network-backed doctest path was not used for final validation here.

Closes #1078.
