### PR TITLE
MAINT: tighten peakfinding constraints and docs

### DIFF
--- a/docs/sources/userguide/analysis/peak_finding.py
+++ b/docs/sources/userguide/analysis/peak_finding.py
@@ -138,6 +138,15 @@ peaks, _ = last.find_peaks(distance=5.0)
 # we do not catch the second output (properties) as it is void in this case
 
 # %% [markdown]
+# On spectra with linear coordinates, spacing-related constraints can also be
+# expressed with physical units. For example, the following call is equivalent
+# to the previous one:
+
+# %%
+peaks_units, _ = last.find_peaks(distance="5 cm^-1")
+peaks_units.x.values
+
+# %% [markdown]
 # `peaks` is a NDDataset. Its `x` attribute gives the peak position:
 
 # %%
@@ -237,18 +246,23 @@ _ = evol.plot(ls=":")
 #
 # **Parameters relative to "peak spacing":**
 # - `distance` : the required minimal horizontal distance between neighbouring peaks.
-# Smaller peaks are removed first.
-# - `width` : Required minimal width of peaks in samples (single number) or minimal and
-# maximal width. The width is
+# Smaller peaks are removed first. On a linear coordinate axis it can be given either
+# in points or in coordinate units, e.g. ``distance="10 cm^-1"``.
+# - `width` : Required minimal width of peaks or minimal and maximal width. The width is
 # assessed from the peak height,
-# prominence and neighboring signal. - In addition the user can define `rel_height`
-# (a float between 0. and 1.) used
+# prominence and neighboring signal. On a linear coordinate axis, `width` can be
+# passed either in points or in coordinate units, e.g. ``width=5 * ur("cm^-1")``.
+# - In addition the user can define `rel_height` (a float between 0. and 1.) used
 # to compute the width - see the [scipy documentation](
 # https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.peak_widths.html)
 # for further details.
 # - Finally, we mention en passant a last parameter, `plateau_size()` used for
-# selecting peaks having truly flat tops (
-# as in e.g. square-boxed signals).
+# selecting peaks having truly flat tops (as in e.g. square-boxed signals).
+# As for `distance` and `width`, `wlen` and `plateau_size` can also be expressed
+# in coordinate units when the axis is linear.
+#
+# Coordinate-aware spacing constraints currently assume a linear axis. On strongly
+# non-linear coordinates, use plain point counts by setting `use_coord=False`.
 #
 # The use of some of these options for the last spectrum of the dataset is
 # exemplified in the following:
@@ -321,6 +335,10 @@ offset = 0.20
 (peaks + offset).plot_scatter(
     ax=ax, label=label, m="v", mfc=color, mec=color, ms=5, clear=False, data_only=True
 )
+
+# The same constraint can be written with explicit coordinate units.
+peaks_units, _ = s.find_peaks(distance="10 cm^-1")
+peaks_units.x.values
 
 # find peaks with width >= 10 (none of the two maxima at ~ 2075 is detected)
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,8 +26,12 @@ New Features
   (#1078).  When coordinate units are available, ``distance`` and ``width`` can
   now be passed as `Quantity` objects or unit strings such as ``"10 cm^-1"``,
   and ``wlen`` / ``plateau_size`` follow the same coordinate-aware conversion
-  to sample points.  Plain numeric values keep their previous behavior, and
-  incompatible units now raise a clear error.
+  to sample points.  Plain numeric values keep their previous behavior,
+  incompatible units now raise a clear error, and coordinate-aware spacing
+  constraints are now explicitly rejected on non-linear axes instead of being
+  interpreted approximately.  Peak interpolation near dataset borders is also
+  more robust, and the ``find_peaks`` doc examples are now synthetic instead of
+  depending on downloadable test data.
 
 
 .. section

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -30,8 +30,7 @@ New Features
   incompatible units now raise a clear error, and coordinate-aware spacing
   constraints are now explicitly rejected on non-linear axes instead of being
   interpreted approximately.  Peak interpolation near dataset borders is also
-  more robust, and the ``find_peaks`` doc examples are now synthetic instead of
-  depending on downloadable test data.
+  more robust.
 
 
 .. section
@@ -42,9 +41,8 @@ Bug Fixes
 
 - Fixed ``interpolate`` `dim` argument resolution when ``dims=None`` is in
   scope.  Calling ``interpolate(dim=0, ...)`` or ``interpolate(dim="y", ...)``
-  previously defaulted to the last axis instead of honouring the requested
-  dimension, because ``_get_dims_from_args`` pops the ``dims`` key first and
-  could not distinguish an explicit ``None`` from an absent argument.
+  now honours the requested dimension instead of incorrectly defaulting to the
+  last axis.
 
 - Restored historical hypercomplex/quaternion dataset display (#1147).  Detailed
   terminal and HTML representations once again show explicit ``RR``/``RI``/``IR``/``II``
@@ -63,23 +61,18 @@ Bug Fixes
   (#1093, #1094, #1098, #1100).  Bare-array targets keep the source
   coordinate's units and title; PCHIP interpolation honours ``fill_value``;
   output follows the requested target order even when the source coordinate is
-  decreasing; masks and secondary coordinates stay aligned; and labels are
-  carried to target points that exactly match original coordinate values while
-  genuinely resampled points remain unlabelled.
+  decreasing; masks and secondary coordinates stay aligned; and labels now
+  follow only target points that exactly match original coordinate values.
 
 - ``write_csv`` now exports masked samples as missing values (``NaN``) instead
-  of writing their underlying data (#1135).  The writer previously iterated over
-  ``dataset.data`` directly, leaking the stored values of points the user had
-  explicitly masked; masked samples are now filled with ``NaN`` (mirroring the
-  ``write_jcamp`` fix), so they round-trip back as ``NaN`` through ``read_csv``
-  and unmasked datasets are unaffected.
+  of writing their underlying data (#1135).  Masked values now round-trip as
+  missing values through CSV I/O instead of leaking the stored data beneath the
+  mask.
 
 - Fixed ``Project.__str__()`` tree formatting when a project contains both
-  sub-projects and sibling datasets or scripts at the same level.  The
-  recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which
-  stripped the trailing newline from the entire accumulated string, causing
-  sibling entries to appear on the same line as the last child of the
-  preceding sub-project.
+  sub-projects and sibling datasets or scripts at the same level.  Project
+  trees now render with correct line breaks instead of collapsing sibling
+  entries onto the same line.
 
 - ``concatenate`` now handles coordinate metadata more consistently (#1101).
   Coordinate values expressed in compatible but different units are converted
@@ -88,14 +81,13 @@ Bug Fixes
   longer crash during concatenation.  Coordinate-aware operations now also
   report incompatible coordinate units more clearly (#1099): ``align``,
   ``concatenate``, and ``interpolate`` identify the failing operation, the
-  dimension involved, and the mismatched units instead of surfacing backend or
-  overly generic conversion errors.
+  dimension involved, and the mismatched units.
 
 - ``read_opus`` now supports more assembled and time-resolved OPUS files
   (#1035, #1036): data series blocks such as ``a``, ``sm``, ``igsm``,
   ``phsm``, and ``tr`` are read, the ``TRACE``, ``GCIG``, and ``GCSC`` type
-  selectors are exposed, and malformed acquisition sub-second fields fall back
-  to whole-second precision instead of returning ``None``.
+  selectors are exposed, and malformed acquisition sub-second fields now fall
+  back to whole-second precision instead of returning ``None``.
 
 - Fixed parsing of the ``a.u.`` (absorbance) and ``K.M.`` (Kubelka-Munk) unit
   symbols from strings, which previously failed because the dots were read as a
@@ -104,18 +96,15 @@ Bug Fixes
 - ``CoordSet`` and same-dimension coordinate handling are more stable.  Native
   save/load now preserves selected non-first default coordinates and restores
   reference-based coordinates, while copying ``CoordSet`` and ``NDDataset``
-  objects keeps reference-based coordinates intact.  Same-dimension
-  ``CoordSet`` replacement by name, numeric index, title, or synthetic child
-  alias no longer double-wraps inner coordinates, which also improves
-  concatenation of multi-coordinate datasets.  Empty ``CoordSet`` objects now
-  have consistent empty-state properties instead of raising ``TypeError`` or
-  ``IndexError``.
+  objects keeps reference-based coordinates intact.  Same-dimension coordinate
+  replacement is also more reliable, which improves concatenation of
+  multi-coordinate datasets.  Empty ``CoordSet`` objects now behave
+  consistently instead of raising ``TypeError`` or ``IndexError``.
 
 - Stabilized 1D CSV round-trip support: ``read_csv`` now tolerates header rows
   (e.g., column titles) written by ``write_csv``, and correctly handles both
-  single-column (data-only) and multi-column (coordinate + data) CSV files.
-  Synthetic tests for CSV reading/writing have been added, removing the dependency
-  on external test data for these functionalities (#1077).
+  single-column (data-only) and multi-column (coordinate + data) CSV files
+  (#1077).
 
 - Preserved scientific-context metadata (``meta``, ``author``,
   ``description``, ``origin``, and ``filename``) in wrapper-based processing
@@ -140,14 +129,11 @@ Breaking Changes
   (e.g. ``dataset + coord`` or ``coord * dataset``).  ``Coord`` is treated as
   axis support, not as a signal-bearing operand.  Workflows needing correction
   vectors, weighting profiles, response curves, or other signal-like 1D
-  operands should represent them as 1D ``NDDataset`` objects instead.  This
-   clarifies the math semantics under the broader ``#1103`` arithmetic and
-   metadata characterization work.
+  operands should represent them as 1D ``NDDataset`` objects instead.
 
 - Removed the orphaned ``roi`` and ``NDDataset.modeldata`` attributes from the
-  public data model (#1168).  ``roi`` no longer had active production use, and
-  ``NDDataset.modeldata`` no longer had a reliable semantic contract.  Fit/model
-  outputs should be stored and plotted as explicit ``NDDataset`` objects or
+  public data model (#1168).  Fit/model outputs should be stored and plotted as
+  explicit ``NDDataset`` objects or
   dedicated fit-result objects rather than hidden structural state on
   ``NDDataset``.  Legacy serialized ``roi`` and ``modeldata`` fields in native
   SpectroChemPy files remain load-compatible and are ignored during loading.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,8 +22,12 @@ New Features
   (#1078).  When coordinate units are available, ``distance`` and ``width`` can
   now be passed as `Quantity` objects or unit strings such as ``"10 cm^-1"``,
   and ``wlen`` / ``plateau_size`` follow the same coordinate-aware conversion
-  to sample points.  Plain numeric values keep their previous behavior, and
-  incompatible units now raise a clear error.
+  to sample points.  Plain numeric values keep their previous behavior,
+  incompatible units now raise a clear error, and coordinate-aware spacing
+  constraints are now explicitly rejected on non-linear axes instead of being
+  interpreted approximately.  Peak interpolation near dataset borders is also
+  more robust, and the ``find_peaks`` doc examples are now synthetic instead of
+  depending on downloadable test data.
 
 Bug Fixes
 ~~~~~~~~~

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -26,17 +26,15 @@ New Features
   incompatible units now raise a clear error, and coordinate-aware spacing
   constraints are now explicitly rejected on non-linear axes instead of being
   interpreted approximately.  Peak interpolation near dataset borders is also
-  more robust, and the ``find_peaks`` doc examples are now synthetic instead of
-  depending on downloadable test data.
+  more robust.
 
 Bug Fixes
 ~~~~~~~~~
 
 - Fixed ``interpolate`` `dim` argument resolution when ``dims=None`` is in
   scope.  Calling ``interpolate(dim=0, ...)`` or ``interpolate(dim="y", ...)``
-  previously defaulted to the last axis instead of honouring the requested
-  dimension, because ``_get_dims_from_args`` pops the ``dims`` key first and
-  could not distinguish an explicit ``None`` from an absent argument.
+  now honours the requested dimension instead of incorrectly defaulting to the
+  last axis.
 
 - Restored historical hypercomplex/quaternion dataset display (#1147).  Detailed
   terminal and HTML representations once again show explicit ``RR``/``RI``/``IR``/``II``
@@ -55,23 +53,18 @@ Bug Fixes
   (#1093, #1094, #1098, #1100).  Bare-array targets keep the source
   coordinate's units and title; PCHIP interpolation honours ``fill_value``;
   output follows the requested target order even when the source coordinate is
-  decreasing; masks and secondary coordinates stay aligned; and labels are
-  carried to target points that exactly match original coordinate values while
-  genuinely resampled points remain unlabelled.
+  decreasing; masks and secondary coordinates stay aligned; and labels now
+  follow only target points that exactly match original coordinate values.
 
 - ``write_csv`` now exports masked samples as missing values (``NaN``) instead
-  of writing their underlying data (#1135).  The writer previously iterated over
-  ``dataset.data`` directly, leaking the stored values of points the user had
-  explicitly masked; masked samples are now filled with ``NaN`` (mirroring the
-  ``write_jcamp`` fix), so they round-trip back as ``NaN`` through ``read_csv``
-  and unmasked datasets are unaffected.
+  of writing their underlying data (#1135).  Masked values now round-trip as
+  missing values through CSV I/O instead of leaking the stored data beneath the
+  mask.
 
 - Fixed ``Project.__str__()`` tree formatting when a project contains both
-  sub-projects and sibling datasets or scripts at the same level.  The
-  recursive ``_listproj`` helper previously used ``s.strip("\\n")`` which
-  stripped the trailing newline from the entire accumulated string, causing
-  sibling entries to appear on the same line as the last child of the
-  preceding sub-project.
+  sub-projects and sibling datasets or scripts at the same level.  Project
+  trees now render with correct line breaks instead of collapsing sibling
+  entries onto the same line.
 
 - ``concatenate`` now handles coordinate metadata more consistently (#1101).
   Coordinate values expressed in compatible but different units are converted
@@ -80,14 +73,13 @@ Bug Fixes
   longer crash during concatenation.  Coordinate-aware operations now also
   report incompatible coordinate units more clearly (#1099): ``align``,
   ``concatenate``, and ``interpolate`` identify the failing operation, the
-  dimension involved, and the mismatched units instead of surfacing backend or
-  overly generic conversion errors.
+  dimension involved, and the mismatched units.
 
 - ``read_opus`` now supports more assembled and time-resolved OPUS files
   (#1035, #1036): data series blocks such as ``a``, ``sm``, ``igsm``,
   ``phsm``, and ``tr`` are read, the ``TRACE``, ``GCIG``, and ``GCSC`` type
-  selectors are exposed, and malformed acquisition sub-second fields fall back
-  to whole-second precision instead of returning ``None``.
+  selectors are exposed, and malformed acquisition sub-second fields now fall
+  back to whole-second precision instead of returning ``None``.
 
 - Fixed parsing of the ``a.u.`` (absorbance) and ``K.M.`` (Kubelka-Munk) unit
   symbols from strings, which previously failed because the dots were read as a
@@ -96,18 +88,15 @@ Bug Fixes
 - ``CoordSet`` and same-dimension coordinate handling are more stable.  Native
   save/load now preserves selected non-first default coordinates and restores
   reference-based coordinates, while copying ``CoordSet`` and ``NDDataset``
-  objects keeps reference-based coordinates intact.  Same-dimension
-  ``CoordSet`` replacement by name, numeric index, title, or synthetic child
-  alias no longer double-wraps inner coordinates, which also improves
-  concatenation of multi-coordinate datasets.  Empty ``CoordSet`` objects now
-  have consistent empty-state properties instead of raising ``TypeError`` or
-  ``IndexError``.
+  objects keeps reference-based coordinates intact.  Same-dimension coordinate
+  replacement is also more reliable, which improves concatenation of
+  multi-coordinate datasets.  Empty ``CoordSet`` objects now behave
+  consistently instead of raising ``TypeError`` or ``IndexError``.
 
 - Stabilized 1D CSV round-trip support: ``read_csv`` now tolerates header rows
   (e.g., column titles) written by ``write_csv``, and correctly handles both
-  single-column (data-only) and multi-column (coordinate + data) CSV files.
-  Synthetic tests for CSV reading/writing have been added, removing the dependency
-  on external test data for these functionalities (#1077).
+  single-column (data-only) and multi-column (coordinate + data) CSV files
+  (#1077).
 
 - Preserved scientific-context metadata (``meta``, ``author``,
   ``description``, ``origin``, and ``filename``) in wrapper-based processing
@@ -125,14 +114,11 @@ Breaking Changes
   (e.g. ``dataset + coord`` or ``coord * dataset``).  ``Coord`` is treated as
   axis support, not as a signal-bearing operand.  Workflows needing correction
   vectors, weighting profiles, response curves, or other signal-like 1D
-  operands should represent them as 1D ``NDDataset`` objects instead.  This
-   clarifies the math semantics under the broader ``#1103`` arithmetic and
-   metadata characterization work.
+  operands should represent them as 1D ``NDDataset`` objects instead.
 
 - Removed the orphaned ``roi`` and ``NDDataset.modeldata`` attributes from the
-  public data model (#1168).  ``roi`` no longer had active production use, and
-  ``NDDataset.modeldata`` no longer had a reliable semantic contract.  Fit/model
-  outputs should be stored and plotted as explicit ``NDDataset`` objects or
+  public data model (#1168).  Fit/model outputs should be stored and plotted as
+  explicit ``NDDataset`` objects or
   dedicated fit-result objects rather than hidden structural state on
   ``NDDataset``.  Legacy serialized ``roi`` and ``modeldata`` fields in native
   SpectroChemPy files remain load-compatible and are ignored during loading.

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -90,8 +90,29 @@ def _convert_peak_parameter_to_points(name, value, step, xunits, use_coord, dim)
         )
 
     if use_coord:
-        return int(round(value / step))
+        points = int(round(value / step))
+        if value > 0 and points <= 0:
+            raise ValueError(
+                f"Parameter `{name}`={value} along dimension '{dim}' is smaller "
+                f"than the coordinate sampling interval ({step}). Increase the "
+                "value or use a plain point count with `use_coord=False`."
+            )
+        return points
     return value
+
+
+def _normalize_interpolation_window(window_length):
+    """
+    Normalize the quadratic-interpolation window.
+
+    Quadratic interpolation needs at least three samples and is symmetric only
+    for odd window lengths. Values smaller than 3 disable interpolation.
+    """
+    if window_length is None or window_length < 3:
+        return 0
+    if window_length % 2 == 0:
+        return window_length - 1
+    return window_length
 
 
 def find_peaks(
@@ -164,21 +185,18 @@ def find_peaks(
 
     Examples
     --------
-    Basic peak finding with height threshold:
-    >>> dataset = scp.read("irdata/nh4y-activation.spg")
-    >>> X = dataset[0, 1800.0:1300.0]
-    >>> peaks, props = X.find_peaks(height=1.5)
+    Basic peak finding with a synthetic spectrum:
+    >>> x = np.linspace(0.0, 10.0, 501)
+    >>> y = np.exp(-((x - 3.0) ** 2) / 0.08) + 0.8 * np.exp(-((x - 7.0) ** 2) / 0.12)
+    >>> ds = scp.NDDataset(y, coordset=[scp.Coord(x, title="x", units="cm^-1")])
+    >>> peaks, props = ds.find_peaks(height=0.5)
+    >>> len(peaks)
+    2
 
-    Find well-separated peaks with minimum width:
-    >>> peaks, props = X.find_peaks(distance=50.0, width=10.0)
-
-    Complex filtering with multiple criteria:
-    >>> peaks, props = X.find_peaks(
-    ...     height=1.5,
-    ...     distance=50.0,
-    ...     prominence=0.5,
-    ...     width=20.0
-    ... )
+    Physical-unit spacing constraints are accepted when coordinates carry units:
+    >>> peaks, props = ds.find_peaks(distance="1 cm^-1", width=0.2)
+    >>> len(peaks)
+    2
 
     """
     # get the dataset
@@ -209,11 +227,20 @@ def find_peaks(
         xunits = lastcoord.units if lastcoord.units is not None else 1
         dunits = X.units if X.units is not None else 1
 
-        # assume linear x coordinates
-        # TODO: what if the coordinates are not linear?
         if not lastcoord.linear:
+            if any(
+                parameter is not None
+                for parameter in (distance, width, wlen, plateau_size)
+            ):
+                raise ValueError(
+                    "Coordinate-aware `distance`, `width`, `wlen`, and "
+                    "`plateau_size` require a linear coordinate axis. "
+                    "Use plain point counts with `use_coord=False` for non-linear "
+                    "coordinates."
+                )
             warning_(
-                "The x coordinates are not linear. The peak finding might be wrong.",
+                "The x coordinates are not linear. Peak detection still runs, "
+                "but quadratic refinement and reported widths remain approximate.",
             )
             spacing = np.mean(lastcoord.spacing)
         else:
@@ -261,17 +288,22 @@ def find_peaks(
     if not use_coord:
         out.coordset = None  # remove the coordinates
 
-    # quadratic interpolation to find the maximum
-    window_length = window_length if window_length % 2 == 0 else window_length - 1
+    # quadratic interpolation to refine the peak maximum
+    window_length = _normalize_interpolation_window(window_length)
     x_pos = []
     if window_length > 1:
+        half_window = window_length // 2
         for i, peak in enumerate(peaks):
-            start = peak - window_length // 2
-            end = peak + window_length // 2 + 1
+            start = max(0, peak - half_window)
+            end = min(X.shape[-1], peak + half_window + 1)
             sle = slice(start, end)
 
             y = X.data[sle]
-            x = lastcoord.data[sle] if use_coord else range(start, end)
+            if y.size < 3:
+                # Too close to the border for a quadratic fit: keep the discrete peak.
+                continue
+
+            x = lastcoord.data[sle] if use_coord else np.arange(start, end)
 
             coef = np.polyfit(x, y, 2)
 

--- a/tests/test_analysis/test_peakfinding/test_peakfinding.py
+++ b/tests/test_analysis/test_peakfinding/test_peakfinding.py
@@ -248,6 +248,14 @@ def test_incompatible_peakfinding_units_raise_clear_error(simple_peaks_dataset):
     assert "cm" in message
 
 
+def test_too_small_unit_aware_spacing_rejected(simple_peaks_dataset):
+    """A positive physical spacing that rounds to zero points should be rejected."""
+    with pytest.raises(
+        ValueError, match="smaller than the coordinate sampling interval"
+    ):
+        find_peaks(simple_peaks_dataset, height=0.5, distance="0.001 cm^-1")
+
+
 def test_window_length_interpolation(simple_peaks_dataset):
     """Test peak position interpolation with different window lengths."""
     # Test with different window lengths
@@ -255,6 +263,28 @@ def test_window_length_interpolation(simple_peaks_dataset):
         peaks, _ = find_peaks(simple_peaks_dataset, window_length=window)
         # Positions should be similar regardless of window length
         assert np.allclose(peaks.x.values, [2, 5, 8] * ur("cm^-1"), atol=0.1)
+
+
+def test_even_window_length_is_normalized_to_odd(simple_peaks_dataset):
+    """Even interpolation windows should behave like the previous odd window."""
+    odd_peaks, _ = find_peaks(simple_peaks_dataset, window_length=5)
+    even_peaks, _ = find_peaks(simple_peaks_dataset, window_length=6)
+
+    assert np.allclose(even_peaks.x.values, odd_peaks.x.values, atol=1e-8)
+
+
+def test_peak_interpolation_near_dataset_edge_is_safe():
+    """Quadratic refinement should not fail for peaks near the array border."""
+    x = np.linspace(0.0, 10.0, 11)
+    y = np.zeros_like(x)
+    y[1] = 1.0
+    dataset = NDDataset(y, coordset=[Coord(x, title="x", units="cm⁻¹")])
+
+    peaks, properties = find_peaks(dataset, height=0.5, window_length=7)
+
+    assert len(peaks) == 1
+    assert float(peaks.x.values.magnitude) == pytest.approx(1.0, abs=0.5)
+    assert float(properties["peak_heights"][0]) == pytest.approx(1.0, abs=1e-12)
 
 
 def test_units_handling():
@@ -281,6 +311,17 @@ def test_non_linear_coordinates():
     # Should work but issue a warning about non-linear coordinates
     with pytest.warns(UserWarning):
         peaks, _ = find_peaks(dataset)
+
+
+def test_non_linear_coordinates_reject_unit_aware_spacing_constraints():
+    """Physical spacing constraints should be rejected on non-linear coordinates."""
+    x = np.exp(np.linspace(0, 2, 1000))
+    y = np.sin(x)
+    coord = Coord(x, title="x", units="cm⁻¹")
+    dataset = NDDataset(y, coordset=[coord], units="absorbance")
+
+    with pytest.raises(ValueError, match="require a linear coordinate axis"):
+        find_peaks(dataset, height=0.5, distance="1 cm^-1")
 
 
 def test_use_as_a_dataset_method(simple_peaks_dataset):


### PR DESCRIPTION
## Summary

This follow-up PR tightens `find_peaks()` behavior after the unit-aware spacing support from #1186 and updates the user-facing documentation accordingly.

## What changed

### Runtime behavior

- quadratic peak interpolation now normalizes `window_length` to a valid odd window;
- peak interpolation near dataset borders is now guarded so truncated edge windows do not break the quadratic fit path;
- positive coordinate-aware spacing constraints that would round to `0` sample points are now rejected explicitly instead of being silently accepted;
- coordinate-aware `distance`, `width`, `wlen`, and `plateau_size` are now rejected on non-linear axes instead of being interpreted approximately.

### Documentation

- replaced the `find_peaks()` docstring examples with synthetic examples that do not depend on downloadable test data;
- updated the user guide peak-finding page to show unit-aware spacing constraints explicitly;
- documented the linear-axis requirement for coordinate-aware spacing constraints;
- updated the changelog entry to reflect the follow-up tightening.

## Why this matters

The first PR established unit-aware spacing support. This follow-up makes the contract clearer and safer:

- no silent `0`-point spacing conversions;
- no approximate physical-unit interpretation on non-linear coordinates;
- more robust interpolation near array edges;
- documentation that matches the current behavior and validates offline.

## Validation

Targeted tests:

```bash
conda run -n scpy-core python -m pytest tests/test_analysis/test_peakfinding/test_peakfinding.py -k 'not docstrings'
conda run -n scpy-core python -m pytest tests/test_analysis/test_peakfinding/test_peakfinding.py -k docstrings
```

Results:

- `20 passed, 1 deselected`
- `1 passed, 20 deselected`

Pre-commit on touched files:

```bash
pre-commit run --files docs/sources/userguide/analysis/peak_finding.py docs/sources/whatsnew/changelog.rst src/spectrochempy/analysis/peakfinding/peakfinding.py tests/test_analysis/test_peakfinding/test_peakfinding.py
```
