### PR TITLE
DOC: improve tutorial and docstring wording

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -192,9 +192,27 @@ jobs:
             echo "build_subdir=build/branch_preview" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Determine documentation execution mode
+        id: docs_mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BRANCH="${{ github.head_ref }}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
+
+          if [[ "$BRANCH" == docs/* || "$BRANCH" == codex/doc-* ]]; then
+            echo "fresh_docs=true" >> "$GITHUB_OUTPUT"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "Documentation fresh-run mode enabled for branch: $BRANCH"
+          else
+            echo "fresh_docs=false" >> "$GITHUB_OUTPUT"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          fi
+
       # ---------- restore reusable Sphinx/Sphinx-Gallery outputs for previews ----------
       - name: Restore documentation build cache
-        if: steps.preview.outputs.is_preview == 'true'
+        if: steps.preview.outputs.is_preview == 'true' && steps.docs_mode.outputs.fresh_docs != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -205,6 +223,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docs-${{ steps.preview.outputs.preview_path }}-
             ${{ runner.os }}-docs-
+
+      - name: Clear documentation caches for fresh-run branches
+        if: steps.docs_mode.outputs.fresh_docs == 'true'
+        run: |
+          rm -rf \
+            build/branch_preview/~doctrees \
+            docs/sources/gettingstarted/examples/gallery
+          echo "Cleared reusable documentation caches for fresh-run mode"
 
       # ---------- clone gh-pages (preserve existing content) ----------
       - name: Clone gh-pages branch
@@ -219,7 +245,12 @@ jobs:
           set -e
           . .venv/bin/activate
           start=$SECONDS
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.preview.outputs.is_preview }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.preview.outputs.is_preview }}" == "true" && "${{ steps.docs_mode.outputs.fresh_docs }}" == "true" ]]; then
+            SCPY_BUILDDIR=${{ steps.preview.outputs.build_subdir }} \
+              python3 docs/make.py -j auto html
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.docs_mode.outputs.fresh_docs }}" == "true" ]]; then
+            python3 docs/make.py -j auto html
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ steps.preview.outputs.is_preview }}" == "true" ]]; then
             SCPY_BUILDDIR=${{ steps.preview.outputs.build_subdir }} \
               python3 docs/make.py --no-exec -j auto html
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then

--- a/docs/sources/gettingstarted/quickstart.py
+++ b/docs/sources/gettingstarted/quickstart.py
@@ -228,8 +228,9 @@ _ = smoothed.plot(colormap="magma")
 # %% [markdown]
 # ### Baseline Correction
 #
-# Various algorithms are available for baseline correction, including polynomial fitting, rubberband, and more. Here an
-# example of multivariate polynomial baseline correction using PCHIP interpolation is shown:
+# Various algorithms are available for baseline correction, including polynomial
+# fitting, rubberband, and more. Here is an example of multivariate polynomial
+# baseline correction using PCHIP interpolation:
 
 # %% [markdown]
 # Configure baseline correction

--- a/docs/sources/userguide/analysis/peak_finding.py
+++ b/docs/sources/userguide/analysis/peak_finding.py
@@ -27,15 +27,14 @@
 # %% [markdown]
 # # Peak Maxima Finding
 #
-# This tutorial shows how to find peaks and determine peak maxima with spectrochempy.
-# As prerequisite, the user is
-# expected to have read the [Import](../importexport/import.rst),
+# This tutorial shows how to find peaks and determine peak maxima with SpectroChemPy.
+# As a prerequisite, the user is expected to have read the [Import](../importexport/import.rst),
 # [Import IR](../importexport/importIR.rst),
-# [slicing](../processing/slicing.rst) tutorials.
+# and [Slicing](../processing/slicing.rst) tutorials.
 #
 
 # %% [markdown]
-# Fist, as usual, we need to load the API.
+# First, as usual, we need to load the API.
 
 # %%
 import spectrochempy as scp
@@ -44,18 +43,18 @@ import spectrochempy as scp
 # ## Loading an experimental dataset
 
 # %% [markdown]
-# A typical IR dataset (CO adsorption on supported CoMo catalyst
-# in the 2300-1900 cm-1 region) will be used throughout.
+# A typical IR dataset (CO adsorption on a supported CoMo catalyst in the
+# 2300-1900 cm$^{-1}$ region) will be used throughout.
 
 # %% [markdown]
-# We load the data using the generic API method  `read` (the type of data is inferred
-# from the extension)
+# We load the data using the generic API method `read` (the data type is inferred
+# from the extension).
 
 # %%
 ds = scp.read("irdata/CO@Mo_Al2O3.SPG")
 
 # %%
-ds.y -= ds.y.data[0]  # start time a 0 for the  first spectrum
+ds.y -= ds.y.data[0]  # start time at 0 for the first spectrum
 ds.y.title = "time"
 ds.y = ds.y.to("minutes")
 
@@ -76,30 +75,31 @@ _ = reg.plot()
 
 # %% [markdown]
 # ## Find maxima by manual inspection of the plot
-# Once a given maximum has been approximately located manually with the mouse, it is
-# possible to obtain [markdown]
-# For instance, after zooming on the highest peak of the last spectrum,
+# Once a given maximum has been approximately located manually with the mouse,
+# it is possible to obtain its exact position.
+#
+# For instance, after zooming in on the highest peak of the last spectrum,
 # one finds that it is located at ~ 2115.5 cm$^{-1}$. The exact x-coordinate value can
 # be obtained using the
 # following code
-# (see the [slicing tutorial](../processing/slicing.rst) for more info):
+# (see the [Slicing tutorial](../processing/slicing.rst) for more information):
 
 # %%
 pos = reg.x[2115.5].values
 pos
 
 # %% [markdown]
-# We can easily get the list of all individual maximas at this position
+# We can easily get the list of all individual maxima at this position.
 
 # %%
-maximas = reg[:, pos].squeeze()
-_ = maximas.plot(marker="s", ls="--", color="blue")
+maxima = reg[:, pos].squeeze()
+_ = maxima.plot(marker="s", ls="--", color="blue")
 
 # %%
 ax = reg.plot()
 
 x = pos.max()
-y = maximas.max()
+y = maxima.max()
 
 ax.set_ylim(-0.01, 0.3)
 _ = ax.annotate(
@@ -113,24 +113,22 @@ _ = ax.annotate(
 
 # %% [markdown]
 # ## Find maxima with an automated method: `find_peaks()`
-# Exploring the spectra manually is useful, but cannot be made systematically in large
-# datasets with many - possibly
-# shifting peaks. The maxima of a given spectrum can be found automatically by the
-# find_peaks() method which is based
-# on [scpy.signal.find_peaks()](
+# Exploring the spectra manually is useful, but it cannot be done systematically
+# for large datasets with many, possibly shifting, peaks. The maxima of a given
+# spectrum can be found automatically by the `find_peaks()` method, which is based
+# on [scipy.signal.find_peaks()](
 # https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.find_peaks.html).
-# It returns two outputs: `peaks` a NDDataset grouping the peak maxima (wavenumbers and
-# absorbance) and `properties`
-# a dictionary containing properties of the returned peaks (it is empty
-# if no particular option is selected,
-# `see below<#options>`_ for more information).
+# It returns two outputs: `peaks`, an NDDataset grouping the peak maxima
+# (wavenumbers and absorbance), and `properties`, a dictionary containing
+# properties of the returned peaks. The dictionary is empty if no particular
+# option is selected; see below for more information.
 
 # %% [markdown]
-# ###  Default behaviour
+# ### Default behavior
 
 # %% [markdown]
-# Applying this method on the last spectrum without any option will yield 7 peaks. But
-# some peaks are very close so we use the option `distance` to avoid this.
+# Applying this method to the last spectrum without any option yields 7 peaks.
+# However, some peaks are very close, so we use the `distance` option to avoid this.
 
 # %%
 last = reg[-1]
@@ -147,7 +145,7 @@ peaks_units, _ = last.find_peaks(distance="5 cm^-1")
 peaks_units.x.values
 
 # %% [markdown]
-# `peaks` is a NDDataset. Its `x` attribute gives the peak position:
+# `peaks` is an NDDataset. Its `x` attribute gives the peak position:
 
 # %%
 peaks.x.values
@@ -156,14 +154,14 @@ peaks.x.values
 # The code below shows how the peaks found by this method can be marked on the plot:
 
 # %%
-ax = last.plot_pen()  # output the spectrum on ax. ax will receive next plot too
-pks = peaks + 0.02  # add a small offset on the y position of the markers
+ax = last.plot_pen()  # output the spectrum on ax; ax will receive the next plot too
+pks = peaks + 0.02  # add a small offset to the y position of the markers
 _ = pks.plot_scatter(
     ax=ax,
     marker="v",
     color="black",
     clear=False,  # we need to keep the previous output on ax
-    data_only=True,  # we don't need to redraw all things like labels, etc...
+    data_only=True,  # we do not need to redraw labels and similar elements
     ylim=(-0.01, 0.35),
 )
 
@@ -177,7 +175,7 @@ for p in pks:
         textcoords="offset points",
     )
 # %% [markdown]
-# Now we will do a peak-finding for the whole dataset:
+# Now we will perform peak finding for the whole dataset:
 
 # %%
 peakslist = [s.find_peaks(distance=5)[0] for s in reg]
@@ -196,13 +194,11 @@ for peaks in peakslist:
     )
 
 # %% [markdown]
-# It should be noted that this method finds only true maxima, not shoulders (!).
-# For the detection of such underlying
-# peaks, the use of methods based on derivatives or advanced detection methods -
-# which will be treated in separate
-# tutorial - are required. Once their maxima of a given peak have been found,
-# it is possible, for instance,
-# to plot its evolution with, e.g. the time. For instance for the peaks located
+# It should be noted that this method finds only true maxima, not shoulders.
+# Detecting such underlying peaks requires methods based on derivatives or more
+# advanced detection techniques, which will be treated in a separate tutorial.
+# Once the maxima of a given peak have been found, it is possible, for instance,
+# to plot their evolution with time. This is illustrated below for peaks located
 # at 2220-2180 cm$^{-1}$:
 
 # %%
@@ -213,14 +209,14 @@ positions = [s.find_peaks(distance=5)[0].x.values for s in reg[:, 2220.0:2180.0]
 evol = scp.NDDataset(positions, title="wavenumber at the maximum")
 evol.x = scp.Coord(
     reg.y, title="acquisition time"
-)  # the x coordinate is st to the acquisition time for each spectra
+)  # the x coordinate is set to the acquisition time for each spectrum
 
 # plot it
 _ = evol.plot(ls=":")
 
 # %% [markdown]
-# ###  Options of `find_peaks()` <a id='options'></a>
-# The default behaviour of find_peaks() will return *all* the detected maxima.
+# ### Options of `find_peaks()` <a id='options'></a>
+# The default behavior of `find_peaks()` is to return *all* detected maxima.
 # The user can choose various options to
 # select among these peaks:
 #
@@ -229,7 +225,7 @@ _ = evol.plot(ls=":")
 # and maximal heights
 # (sequence of two numbers)
 # - `prominence` : minimal prominence of the peak to be detected
-# (single number) or minimal and maximal prominence (sequence of 2 numbers). In brief
+# (single number) or minimal and maximal prominence (sequence of 2 numbers). In brief,
 # the "prominence" of a peak
 # measures how much a peak stands out from its surrounding and is the vertical distance
 # between the peak and its
@@ -238,7 +234,7 @@ _ = evol.plot(ls=":")
 # prominence when surrounded by other peaks (see below for an illustration).
 #     - in addition to the prominence, the user can define `wlen` , the width (in points)
 #     of the window used to look
-#     at neighboring minima, the peak maximum being is at the center of the window.
+#     at neighboring minima, with the peak maximum at the center of the window.
 # - `threshold` : a single number (the minimal required threshold) or a sequence of two
 # numbers (minimal and maximal).
 # The thresholds are the difference of height of the
@@ -256,8 +252,8 @@ _ = evol.plot(ls=":")
 # to compute the width - see the [scipy documentation](
 # https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.peak_widths.html)
 # for further details.
-# - Finally, we mention en passant a last parameter, `plateau_size()` used for
-# selecting peaks having truly flat tops (as in e.g. square-boxed signals).
+# - Finally, we mention one last parameter, `plateau_size()`, used for
+# selecting peaks with truly flat tops (as in square-shaped signals, for example).
 # As for `distance` and `width`, `wlen` and `plateau_size` can also be expressed
 # in coordinate units when the axis is linear.
 #
@@ -265,14 +261,14 @@ _ = evol.plot(ls=":")
 # non-linear coordinates, use plain point counts by setting `use_coord=False`.
 #
 # The use of some of these options for the last spectrum of the dataset is
-# exemplified in the following:
+# illustrated below:
 
 # %%
 s = reg[-1].squeeze()
 
 # %% [markdown]
-# we use squeeze it because one of the dimensions for this dataset of shape (1, N)
-# is useless
+# We use `squeeze()` because one of the dimensions of this dataset, which has
+# shape `(1, N)`, is unnecessary.
 
 # %%
 # default settings

--- a/docs/sources/userguide/processing/baseline.py
+++ b/docs/sources/userguide/processing/baseline.py
@@ -27,13 +27,12 @@
 # %% [markdown]
 # # Baseline corrections
 #
-# This tutorial shows how to make baseline corrections with **SpectroChemPy** using the
-# `Baseline` class processor, which exposes all implemented correction models with a
-# high degree of flexibility, or using the equivalent SpectroChemPy API / NDDataset
-# methods for more direct one-step corrections.
+# This tutorial shows how to perform baseline correction with **SpectroChemPy**
+# using the `Baseline` class processor, which provides access to all implemented
+# correction models with a high degree of flexibility, or using equivalent
+# SpectroChemPy API or NDDataset methods for more direct one-step corrections.
 #
-# As prerequisite,
-# the user is expected to have read the [Import](../importexport/import.rst)
+# As a prerequisite, the user is expected to have read the [Import](../importexport/import.rst)
 # and [Import IR](../importexport/importIR.rst) tutorials.
 
 
@@ -44,7 +43,7 @@
 import spectrochempy as scp
 
 # %% [markdown]
-# Then we load a FTIR series of spectra on which we will demonstrate the processor capabilities.
+# Then we load an FTIR series of spectra on which we will demonstrate the processor capabilities.
 
 # %%
 # loading
@@ -55,30 +54,32 @@ _ = X.plot()
 # %% [markdown]
 # ## The `Baseline` processor
 #
-# The `Baseline` class processor proposes several algorithms (models) for Baseline determination.
+# The `Baseline` class processor provides several algorithms (models) for baseline determination.
 #
 # - `detrend` : Remove polynomial trend along a dimension from dataset.
-# - `polynomial` : Perform a polynomial interpolation on pretermined regions
+# - `polynomial` : Perform a polynomial interpolation on predetermined regions.
 # - `asls` : Perform an Asymmetric Least Squares Smoothing baseline correction.
 # - `snip` : Perform a Simple Non-Iterative Peak (SNIP) detection algorithm.
 # - `rubberband` : Perform a Rubberband baseline correction.
 #
 # ### How it works?
 #
-# Basically, determining a correct `baseline`, belongs to the decomposition type methods (See `Analysis`):
+# Basically, determining a correct `baseline` belongs to the decomposition-type
+# methods (see `Analysis`):
 #
 # The sequence of command is thus quite similar:
 #
-# 1) Initialize an instance of the processor and set the models parameters
+# 1) Initialize an instance of the processor and set the model parameters.
 # 2) Fit the model on a given dataset to extract a `baseline`.
 # 3) Transform the original spectra by subtracting the determined baseline.
 #
 # ### Example
-# Let's fit a simple `rubberband` correction model. This is actually the only model in SpectroChemPy which is fully automatic (no parameter).
+# Let's fit a simple `rubberband` correction model. This is currently the only
+# fully automatic model in SpectroChemPy, with no parameter to tune.
 #
 
 # %%
-# instance initalisation and model selection
+# instance initialization and model selection
 blc = scp.Baseline()
 blc.model = "rubberband"
 # model can also be passed as a parameter
@@ -98,7 +99,7 @@ _ = blc.plot()
 X1 = blc.corrected
 
 # %% [markdown]
-# Of course, we can also apply the model to the complete series sequentially
+# Of course, we can also apply the model sequentially to the complete series.
 
 # %%
 # fit the model on the full X series
@@ -129,17 +130,18 @@ _ = blc.plot()
 X3[:, 891.0:1234.0].mask.all(), blc.baseline[:, 891.0:1234.0].mask.all()
 
 # %% [markdown]
-# ### Overview of the other model
+# ### Overview of the other models
 
 # %% [markdown]
 # #### Polynomial
-# With this model, a polynomial is fitted using range of coordinate which are considered as belonging to the baseline.
+# With this model, a polynomial is fitted using coordinate ranges that are
+# considered to belong to the baseline.
 
 # %% [markdown]
 # - The first step is then to select the various regions that we expect to belong to
 #   the baseline.
-# - Then the degree of the polynomial is set (using the `order` parameters).
-#   A special cas is encountered, if `order` is set to "pchip". In this case a piecewise cubic hermite interpolation
+# - Then the degree of the polynomial is set (using the `order` parameter).
+#   A special case is encountered if `order` is set to `"pchip"`. In this case, a piecewise cubic Hermite interpolation
 #   is performed in place of the classic polynomial interpolation.
 #
 # **Range selection**
@@ -170,7 +172,7 @@ ranges = (
 # In this case, the base methods used for the interpolation are those of the
 # [polynomial module](
 # https://numpy.org/doc/stable/reference/routines.polynomials.polynomial.html)
-# of spectrochempy, in particular the
+# of NumPy, in particular the
 # [numpy.polynomial.polynomial.polyfit()](
 # https://numpy.org/doc/stable/reference/generated/numpy.polynomial.polynomial.polyfit.html#numpy.polynomial.polynomial.polyfit)
 # method.
@@ -238,13 +240,30 @@ _ = X7.plot()
 
 # %% [markdown]
 # ### Multivariate approach
-# In the previous example, we have fitted the model sequentially on all spectra.
+# In the previous example, we fitted the model sequentially on all spectra.
 #
-# Another useful approach is multivariate, where SVD/PCA or NMF is used to perform a dimensionality reduction into principal components (eignenvectors), followed by a model fitting on each of these components. This obviously require a 2D dataset, so it is not applicable to single spectra.
+# Another useful approach is multivariate, where SVD/PCA or NMF is used to perform
+# a dimensionality reduction into principal components (eigenvectors), followed by
+# model fitting on each of these components. This obviously requires a 2D dataset,
+# so it is not applicable to single spectra.
 #
-# The 'multivariate' option is useful when the signal to noise ratio is low and/or when baseline changes in different regions of the spectrum are different regions of the spectrum are correlated. It consists of (i) modeling the baseline regions by a principal component analysis (PCA), (ii) interpolating the loadings of the first principal components over the whole spectrum and (iii) model the baselines of the spectra from the product of the PCA scores and the interpolated loadings. (For details: see Vilmin et al. Analytica Chimica Acta 891 (2015)).
+# The `multivariate` option is useful when the signal-to-noise ratio is low and/or
+# when baseline changes in different regions of the spectrum are correlated. It
+# consists of (i) modeling the baseline regions by principal component analysis
+# (PCA), (ii) interpolating the loadings of the first principal components over
+# the whole spectrum, and (iii) modeling the baselines of the spectra from the
+# product of the PCA scores and the interpolated loadings. For details, see
+# Vilmin et al., Analytica Chimica Acta 891 (2015).
 #
-# If this option is selected, the user must also set the n_components parameter, i.e. the number of principal components used to model the baseline. In a sense, this parameter has the same role as the order parameter, except that it affects how the baseline fits the selected regions on both dimensions: wavelength and acquisition time. In particular, a large value of n_components will lead to an overfitting of the baseline variation with time and lead to the same result as the while a value that is too small may fail to detect a main component underlying the baseline variation over time. Typical optimal values are n_components=2 or n_components=3.
+# If this option is selected, the user must also set the `n_components`
+# parameter, i.e. the number of principal components used to model the baseline.
+# In a sense, this parameter has the same role as the `order` parameter, except
+# that it affects how the baseline fits the selected regions on both dimensions:
+# wavelength and acquisition time. In particular, a large value of
+# `n_components` will lead to overfitting of the baseline variation with time,
+# while a value that is too small may fail to detect a main component underlying
+# the baseline variation over time. Typical optimal values are
+# `n_components=2` or `n_components=3`.
 #
 # Let's demonstrate this on the previously used dataset.
 #
@@ -265,7 +284,10 @@ X8 = blc.transform()
 _ = X8.plot()
 
 # %% [markdown]
-# Finally, for all the example shown above, we have used the same instance of Baseline. It may be a problem to remember which setting has been done, and may impact new output. To know the actual status, one can use the `params` method. This will list all actual parameters.
+# Finally, in all the examples shown above, we used the same `Baseline`
+# instance. It may become difficult to remember which settings have been applied,
+# and this may affect subsequent outputs. To inspect the current state, use the
+# `params` method. This lists all current parameters.
 #
 
 # %%
@@ -275,8 +297,9 @@ blc.params()
 # ## Baseline correction using NDDataset or API methods
 
 # %% [markdown]
-# The `Baseline` processor is very flexible but it may be useful to use simpler way to compute baseline. This is the role of the methods
-# described below (which call the `Baseline` processor transparently).
+# The `Baseline` processor is very flexible, but it can also be useful to use
+# simpler one-step methods to compute a baseline. This is the role of the
+# methods described below, which call the `Baseline` processor transparently.
 
 # %% [markdown]
 # As an example, we can now use a dataset consisting of 80 samples of corn measured on a NIR
@@ -286,7 +309,7 @@ blc.params()
 A = scp.read("http://www.eigenvector.com/data/Corn/corn.mat", merge=False)[4]
 
 # %% [markdown]
-# Add some label for a better reading of the data axis
+# Add some labels for easier reading of the data axis.
 
 # %%
 A.title = "absorbance"
@@ -309,13 +332,14 @@ _ = A.plot()
 # It is quite clear that this spectrum series has an increasing trend with both a
 # vertical shift and a drift.
 #
-# The `detrend` method can help to remove such trends (Note that we did not talk about this before, but the model is also available in the`Baseline`processor:
-# `model='detrend'`)
+# The `detrend` method can help remove such trends. Note that, although we have
+# not discussed it yet, the model is also available in the `Baseline`
+# processor with `model="detrend"`.
 
 # %% [markdown]
 # #### Constant trend
 #
-# When the trend is simply a shift one can subtract the mean absorbance to each spectrum.
+# When the trend is simply a shift, one can subtract the mean absorbance from each spectrum.
 
 # %%
 A1 = A.detrend(order="constant")  # Here we use a NDDataset method

--- a/docs/sources/userguide/processing/slicing.py
+++ b/docs/sources/userguide/processing/slicing.py
@@ -17,8 +17,8 @@
 # %% [markdown]
 # # Slicing NDDatasets
 #
-# This tutorial shows how to handle NDDatasets using python slicing. As prerequisite, the user is
-# expected to have read the [Import Tutorials](../importexport/import.rst).
+# This tutorial shows how to handle NDDatasets using Python slicing. As a
+# prerequisite, the user is expected to have read the [Import tutorial](../importexport/import.rst).
 
 # %%
 import numpy as np
@@ -26,20 +26,20 @@ import numpy as np
 import spectrochempy as scp
 
 # %% [markdown]
-# ## What is the slicing ?
+# ## What is slicing?
 #
-# The slicing of a list or an array means taking elements from a given index
-# (or set of indexes) to another index (or set of indexes).
+# Slicing a list or an array means taking elements from a given index
+# (or set of indices) to another index (or set of indices).
 # Slicing is specified using the colon operator `:` with a `from` and `to` index
-# before and after the first column, and a `step` after the second column.
+# before and after the first colon, and a `step` after the second colon.
 # Hence, a slice of the object `X` will be set as:
 #
 # `X[from:to:step]`
 #
-# and will extend from the ‘from’ index, ends one item before the ‘to’ index
-# and with an increment of `step`between each index. When not given the default
-# values are respectively 0 (i.e. starts at the 1st index),
-# length in the dimension (stops at the last index), and 1.
+# and extends from the `from` index, ends one item before the `to` index,
+# and uses increments of `step` between indices. When not given, the default
+# values are respectively 0 (i.e. start at the 1st index),
+# the length of the dimension (stop at the last index), and 1.
 #
 # Let's first illustrate the concept on a 1D example:
 
@@ -62,7 +62,7 @@ print(X.shape)
 print(X[2:5, :].shape)  # slices along the 1st dimension, X[2:5,] is equivalent
 print(
     X[2:5, ::2].shape
-)  # same slice along 1st dimension and takes one 1 column out of two along the second
+)  # same slice along the 1st dimension and takes one column out of two along the second
 
 # %% [markdown]
 # ## Slicing of NDDatasets
@@ -75,12 +75,12 @@ X.y = (X.y - X[0].y).to("minute")
 X
 
 # %%
-subplot = X.plot()  # assignment avoids the display of the object address (<matplotlib.axes._subplots.AxesSubplot ...)
+subplot = X.plot()  # assignment avoids displaying the object address (<matplotlib.axes._subplots.AxesSubplot ...>)
 
 # %% [markdown]
 # ### Slicing with indexes
 #
-# The classical slicing, using integers, can be used. For instance, along the 1st dimension:
+# Classical slicing using integers can be used. For instance, along the 1st dimension:
 
 # %%
 print(X[:4])  # selects the first four spectra
@@ -88,19 +88,20 @@ print(X[-3:])  # selects the last three spectra
 print(X[::2])  # selects one spectrum out of 2
 
 # %% [markdown]
-# The same can be made along the second dimension, simultaneously or not with the first one. For instance
+# The same can be done along the second dimension, either together with the first
+# one or independently. For instance:
 
 # %%
 print(
     X[:, ::2]
-)  # all spectra, one wavenumber out of 2   (note the bug: X[,::2] generates an error)
+)  # all spectra, one wavenumber out of 2 (note: X[,::2] generates an error)
 print(
     X[0:3, 200:1000:2]
-)  # 3 first spectra, one wavenumbers out of 2, from index 200 to 1000
+)  # first 3 spectra, one wavenumber out of 2, from index 200 to 1000
 
 # %% [markdown]
-# Would you easily guess which wavenumber range have been actually selected ?...
-# probably not because the relationship between the index and the wavenumber
+# Would you easily guess which wavenumber range has actually been selected?
+# Probably not, because the relationship between the index and the wavenumber
 # is not straightforward as it depends on the value of the first wavenumber,
 # the wavenumber spacing, and whether the wavenumbers are arranged in ascending
 # or descending order...
@@ -115,32 +116,34 @@ X[
 # ### Slicing with coordinates
 #
 # Now the spectroscopist is generally interested in a particular region of the
-# spectrum, for instance, 2300-1900 cm$^{-1}$. Can you easily guess the indexes
-# that one should use to spectrum this region ? probably not without a calculator...
+# spectrum, for instance, 2300-1900 cm$^{-1}$. Can you easily guess the indices
+# that should be used to select this region? Probably not without a calculator.
 #
-# Fortunately, a simple mechanism has been implemented in spectrochempy
+# Fortunately, a simple mechanism has been implemented in SpectroChemPy
 # for this purpose: the use of floats instead of integers will slice the
-# NDDataset at the corresponding coordinates. For instance to select the 2300-1900 cm$^{-1}$ region:
+# NDDataset at the corresponding coordinates. For instance, to select the
+# 2300-1900 cm$^{-1}$ region:
 
 # %%
 subplot = X[:, 2300.0:1900.0:].plot()
 
 # %% [markdown]
-# The same mechanism can be used along the first dimension (`y` ).
-# For instance, to select and plot the same region and the spectra recorded between 80 and 180 minutes:
+# The same mechanism can be used along the first dimension (`y`).
+# For instance, to select and plot the same region and the spectra recorded
+# between 80 and 180 minutes:
 
 # %%
 subplot = X[
     80.0:180.0, 2300.0:1900.0
-].plot()  # Note that a decimal point is enough to get a float
+].plot()  # Note that a decimal point is enough to create a float
 # a warning is raised if one or several values are beyond the limits
 
 # %% [markdown]
-# Similarly, the spectrum recorded at the time the closest to 60 minutes can be selected using a float:
+# Similarly, the spectrum recorded closest to 60 minutes can be selected using a float:
 
 # %%
-X[60.0].y  # X[60.] slices the spectrum,  .y returns the corresponding `y` axis.
+X[60.0].y  # X[60.] slices the spectrum; .y returns the corresponding `y` axis.
 
 # %% [markdown]
 # --- End of Tutorial ---
-#    (todo: add advanced slicing by array of indexes, array of bool,  ...)
+#    (todo: add advanced slicing by array of indices, array of bool, ...)

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -234,7 +234,7 @@ def find_peaks(
             ):
                 raise ValueError(
                     "Coordinate-aware `distance`, `width`, `wlen`, and "
-                    "`plateau_size` requires a linear coordinate axis. "
+                    "`plateau_size` require a linear coordinate axis. "
                     "Use plain point counts with `use_coord=False` for non-linear "
                     "coordinates."
                 )

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -234,7 +234,7 @@ def find_peaks(
             ):
                 raise ValueError(
                     "Coordinate-aware `distance`, `width`, `wlen`, and "
-                    "`plateau_size` require a linear coordinate axis. "
+                    "`plateau_size` requires a linear coordinate axis. "
                     "Use plain point counts with `use_coord=False` for non-linear "
                     "coordinates."
                 )

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -872,7 +872,7 @@ def get_baseline(dataset, *ranges, **kwargs):
     if blc.model == "polynomial":
         if not ranges and blc.order != 1:
             warning_(
-                f"As no ranges was provided, baseline() uses the features limit "
+                f"As no ranges were provided, baseline() uses the feature limits "
                 f"with order='linear'. Provided order={blc.order} is ignored",
             )
             blc.order = "linear"
@@ -896,8 +896,8 @@ def basc(dataset, *ranges, **kwargs):
     *ranges : a variable number of pair-tuples
         The regions taken into account for the manual baseline correction.
     **kwargs
-        Optional keyword parameters (see `Baseline` Parameters for a detailed
-        information).
+        Optional keyword parameters (see `Baseline` Parameters for more
+        detailed information).
 
     Returns
     -------
@@ -930,8 +930,9 @@ def detrend(dataset, order="linear", breakpoints=None, **kwargs):
     r"""
     Remove polynomial trend along a dimension from dataset.
 
-    Depending on the ``order`` parameter, `detrend` removes the best-fit polynomial line
-    (in the least squares sense) from the data and returns the remaining data.
+    Depending on the ``order`` parameter, `detrend` removes the best-fit
+    polynomial line (in the least-squares sense) from the data and returns the
+    remaining data.
 
     Parameters
     ----------
@@ -940,11 +941,11 @@ def detrend(dataset, order="linear", breakpoints=None, **kwargs):
     order : non-negative `int` or `str` among ['constant', 'linear', 'quadratic', 'cubic'], optional, default:'linear'
         The order of the polynomial trend.
 
-        * If ``order=0`` or ``'constant'`` , the mean of data is subtracted to remove
+        * If ``order=0`` or ``'constant'``, the mean of the data is subtracted to remove
           a shift trend.
         * If ``order=1`` or ``'linear'`` (default), the best straight-fit line is
           subtracted from data to remove a linear trend (drift).
-        * If order=2 or ``order=quadratic`` ,  the best fitted nth-degree polynomial
+        * If ``order=2`` or ``order='quadratic'``, the best-fit nth-degree polynomial
           line is subtracted from data to remove a quadratic polynomial trend.
         * ``order=n`` can also be used to remove any nth-degree polynomial trend.
 
@@ -995,14 +996,16 @@ def asls(dataset, lamb=1e5, asymmetry=0.05, tol=1e-3, max_iter=50):
         The input data.
     lamb : `float`, optional, default:1e5
         The smoothness parameter for the AsLS method. Larger values make the
-        baseline stiffer. Values should be in the range (0, 1e9)
-    asymmetry : `float`, optional, default:0.05,
+        baseline stiffer. Values should be in the range `(0, 1e9)`.
+    asymmetry : `float`, optional, default:0.05
         The asymmetry parameter for the AsLS method. It is typically between 0.001
         and 0.1. 0.001 gives almost the same fit as the unconstrained least squares.
-    tol = `float`, optional, default:1e-3
-        The tolerance parameter for the AsLS method. Smaller values make the fitting better but potentially increases the number of iterations and the running time. Values should be in the range (0, 1).
-    max_iter = `int`, optional, default:50
-        Maximum number of :term:`AsLS` iteration.
+    tol : `float`, optional, default:1e-3
+        The tolerance parameter for the AsLS method. Smaller values improve the
+        fit but may increase the number of iterations and the runtime. Values
+        should be in the range `(0, 1)`.
+    max_iter : `int`, optional, default:50
+        Maximum number of :term:`AsLS` iterations.
 
     Returns
     -------
@@ -1036,9 +1039,9 @@ def asls(dataset, lamb=1e5, asymmetry=0.05, tol=1e-3, max_iter=50):
 
 def snip(dataset, snip_width=50):
     """
-    Perform Simple Non-Iterative Peak (SNIP) detection algorithm.
+    Perform the Simple Non-Iterative Peak (SNIP) detection algorithm.
 
-    See :cite:t:`ryan:1988` .
+    See :cite:t:`ryan:1988`.
 
     Parameters
     ----------

--- a/src/spectrochempy/utils/baseconfigurable.py
+++ b/src/spectrochempy/utils/baseconfigurable.py
@@ -49,7 +49,7 @@ class BaseConfigurable(MetaConfigurable):
     _masked_rc = tr.Tuple(allow_none=True, help="List of masked rows and columns")
     _X = NDDatasetType(allow_none=True, help="Data to fit a model")
     _X_mask = Array(allow_none=True, help="Mask information of the input X data")
-    _X_preprocessed = Array(help="Preprocessed inital input X data")
+    _X_preprocessed = Array(help="Preprocessed initial input X data")
     _X_shape = tr.Tuple(
         help="Original shape of the input X data, before any transformation",
     )


### PR DESCRIPTION
## Summary

This PR is the first documentation language pass (`PR A`). It focuses on wording, grammar, spelling, and readability improvements in user-facing tutorials and public docstrings without changing behavior or redesigning the documentation structure.

It also adds a small CI safeguard for documentation branches so that docs examples can be exercised in a fresher mode when needed.

## What changed

- cleaned up wording and syntax in the baseline, slicing, and peak-finding tutorials
- improved phrasing in the quickstart baseline section
- corrected several public docstring/help-text issues in baseline processing, peak finding, and base configurable internals
- added a documentation-branch CI mode in `build_docs.yml`

## CI change

For documentation-focused branches (`docs/*` and `codex/doc-*`):

- the docs workflow skips restoration of the reusable Sphinx/Gallery cache
- the workflow clears the relevant docs build caches before building
- pull-request docs builds run without `--no-exec`, so examples are actually executed

This is intended to reduce the risk of stale cache hiding problems on documentation-only or documentation-heavy PRs, including this one.

## Scope

This PR intentionally stays conservative:

- no API changes
- no behavior changes in library code
- no semantic or architectural rewrites
- no documentation restructuring

It is meant to make the existing docs easier to read and review while keeping deeper coherence or terminology work for later follow-up PRs if needed.

## Validation

- `python3` YAML parse of `.github/workflows/build_docs.yml`
- `conda run -n scpy-core python -m py_compile docs/sources/userguide/processing/baseline.py docs/sources/gettingstarted/quickstart.py docs/sources/userguide/analysis/peak_finding.py docs/sources/userguide/processing/slicing.py src/spectrochempy/processing/baselineprocessing/baselineprocessing.py src/spectrochempy/analysis/peakfinding/peakfinding.py src/spectrochempy/utils/baseconfigurable.py`
- `git diff --check`

I also attempted to execute the touched tutorial scripts locally, but that could not complete in this environment because the required documentation testdata was not available offline.