### PR TITLE
FIX: variance should propagate squared units (#1191)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -115,6 +115,13 @@ Bug Fixes
   ``description``, ``origin``, and ``filename``) in wrapper-based processing
   and analysis outputs such as ``Filter(...).transform(...)`` (#1103).
 
+- ``NDDataset.var()`` now squares the units on the result instead of
+  preserving input units unchanged (#1191).  Variance is the average of
+  squared deviations from the mean, so the result units are U² when the
+  input has units U.  This aligns ``var`` with correct dimensional
+  semantics — all other reductions (``sum``, ``mean``, ``std``, ``min``,
+  ``max``) already handled units correctly.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -107,6 +107,13 @@ Bug Fixes
   ``description``, ``origin``, and ``filename``) in wrapper-based processing
   and analysis outputs such as ``Filter(...).transform(...)`` (#1103).
 
+- ``NDDataset.var()`` now squares the units on the result instead of
+  preserving input units unchanged (#1191).  Variance is the average of
+  squared deviations from the mean, so the result units are U² when the
+  input has units U.  This aligns ``var`` with correct dimensional
+  semantics — all other reductions (``sum``, ``mean``, ``std``, ``min``,
+  ``max``) already handled units correctly.
+
 Dependency Updates
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -2506,12 +2506,12 @@ class NDMath:
         >>> nd
         NDDataset: [float64] a.u. (shape: (y:55, x:5549))
         >>> scp.var(nd)
-        <Quantity(0.652818786, 'absorbance')>
+        <Quantity(0.652818786, 'absorbance ** 2')>
         >>> scp.var(nd, keepdims=True)
-        NDDataset: [float64] a.u. (shape: (y:1, x:1))
+        NDDataset: [float64] a.u. ** 2 (shape: (y:1, x:1))
         >>> m = scp.var(nd, dim='y')
         >>> m
-        NDDataset: [float64] a.u. (size: 5549)
+        NDDataset: [float64] a.u. ** 2 (size: 5549)
         >>> m.data
         array([0.007262, 0.007299, ...,  0.06298,  0.06438])
 
@@ -2520,13 +2520,15 @@ class NDMath:
         m = np.ma.var(dataset, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims)
 
         if np.isscalar(m):
-            return Quantity(m, cls.units) if cls.units is not None else m
+            return Quantity(m, cls.units**2) if cls.units is not None else m
 
         dims, coordset = _reduce_dims(cls, dim, keepdims)
         cls._data = m.data
         cls._mask = m.mask
         cls.dims = dims
         cls._coordset = coordset
+        if cls.units is not None:
+            cls._units = cls.units**2
 
         return cls
 

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -1786,6 +1786,8 @@ def test_var_with_units():
     r = ds.var()
     # var of data with units returns a Quantity
     assert isinstance(r, Quantity)
+    # Units must be squared
+    assert r.units == ur.Unit("m") ** 2
     # Numerical validation against NumPy
     ref = np.var(np.array([1.0, 2.0, 3.0]))
     assert abs(r.magnitude - ref) < 1e-10
@@ -1805,6 +1807,15 @@ def test_var_dim():
     ds = NDDataset(np.array([[1.0, 2.0], [3.0, 4.0]]))
     r = ds.var(dim="x")
     ref = np.var(ds.data, axis=1)
+    assert_array_equal(r.data, ref)
+
+
+def test_var_dim_with_units():
+    """Var along a dimension with units."""
+    ds = NDDataset(np.array([[1.0, 2.0], [3.0, 4.0]]), units="m")
+    r = ds.var(dim="y")
+    assert r.units == ur.Unit("m") ** 2
+    ref = np.var(ds.data, axis=0)
     assert_array_equal(r.data, ref)
 
 


### PR DESCRIPTION
## Summary

`NDDataset.var()` now squares the units on the result. Variance is the
average of squared deviations from the mean, so the result units should be
U² when the input has units U.

## Changes

- **Scalar path** (`var()` with no dim): result `Quantity` now has `units ** 2`
- **Array path** (`var(dim=...)`): result `NDDataset` now has `units ** 2`
- Updated docstring examples to reflect the correct unit annotation
- Added unit assertion to `test_var_with_units`
- Added `test_var_dim_with_units` for the array path

## Impact

Low. The numerical values were always correct. Only the unit annotation was
wrong. This affects display and downstream unit-dependent consumers.

## Reference

Identified in the Units and Dimensional Semantics Architecture Audit
(`audit/~units-and-dimensional-semantics-audit.md`).

Fixes #1191.