### PR TITLE
fix: propagate squared units in variance calculation

### DIFF
--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -2520,7 +2520,7 @@ class NDMath:
         m = np.ma.var(dataset, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims)
 
         if np.isscalar(m):
-            return Quantity(m, cls.units) if cls.units is not None else m
+            return Quantity(m, cls.units ** 2) if cls.units is not None else m
 
         dims, coordset = _reduce_dims(cls, dim, keepdims)
         cls._data = m.data


### PR DESCRIPTION
## Problem

`NDDataset.var()` and `Coord.var()` preserve input units instead of squaring them:

```python
ds.units = "m"
var = ds.var()   # result.units == "m", should be "m**2"
```

**Closes #1191**

## Fix

Change `cls.units` to `cls.units ** 2` in the scalar return path of `var()`:

```python
# Before
return Quantity(m, cls.units) if cls.units is not None else m

# After
return Quantity(m, cls.units ** 2) if cls.units is not None else m
```

## Testing

```python
ds = scp.NDDataset([1.0, 2.0, 3.0, 4.0, 5.0])
ds.units = 'm'
var = ds.var()
assert var.units == ds.units ** 2  # m² ✓
```