### PR TITLE
fix: append history for local shape-like operations

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -44,6 +44,10 @@ Bug Fixes
   now honours the requested dimension instead of incorrectly defaulting to the
   last axis.
 
+- Fixed history tracking for ``squeeze()`` and ``diagonal()``: both now preserve
+  existing history and append their own operation entry, consistent with other
+  shape-like operations.
+
 - Restored historical hypercomplex/quaternion dataset display (#1147).  Detailed
   terminal and HTML representations once again show explicit ``RR``/``RI``/``IR``/``II``
   component blocks and preserve complex-dimension shape annotations, instead of

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -36,6 +36,10 @@ Bug Fixes
   now honours the requested dimension instead of incorrectly defaulting to the
   last axis.
 
+- Fixed history tracking for ``squeeze()`` and ``diagonal()``: both now preserve
+  existing history and append their own operation entry, consistent with other
+  shape-like operations.
+
 - Restored historical hypercomplex/quaternion dataset display (#1147).  Detailed
   terminal and HTML representations once again show explicit ``RR``/``RI``/``IR``/``II``
   component blocks and preserve complex-dimension shape annotations, instead of

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -1358,7 +1358,6 @@ class NDMath:
 
         if dtype is not None:
             cls.data = cls.data.astype(dtype)
-        cls.history = []
 
         # set the new coordinates
         if hasattr(cls, "coordset") and cls.coordset is not None:

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -1194,6 +1194,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
                 missing="ignore",
             )
 
+        new.history = "Data squeezed"
         return new
 
     def atleast_2d(self, inplace=False):

--- a/tests/test_core/test_dataset/test_metadata_characterization.py
+++ b/tests/test_core/test_dataset/test_metadata_characterization.py
@@ -281,7 +281,8 @@ def test_find_peaks_preserves_metadata_with_name_and_history_overrides(
     assert result.dims == ["x"]
     assert result.coordset is not None
     np.testing.assert_allclose(result.x.data, [0.5, 1.5, 2.5, 3.5])
-    assert len(result.history) == 3
+    assert len(result.history) == 4  # initial + squeezed + slice + find_peaks
     assert "Initial history marker" in result.history[0]
-    assert "Slice extracted" in result.history[1]
-    assert "Find_peaks(): 4 peak(s) found" in result.history[2]
+    assert "Data squeezed" in result.history[1]
+    assert "Slice extracted" in result.history[2]
+    assert "Find_peaks(): 4 peak(s) found" in result.history[3]

--- a/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
@@ -132,10 +132,14 @@ class TestSingleSourceTransformations:
         assert len(result.history) == 1
         assert "Data transposed" in _entry(result.history[-1])
 
-    def test_squeeze_preserves_history(self, ds1):
-        """Squeeze preserves history (no explicit append in squeeze)."""
-        result = ds1.squeeze()
-        assert len(result.history) == 0
+    def test_squeeze_appends(self):
+        """Squeeze preserves prior history and appends a new entry."""
+        d = scp.NDDataset([[1.0, 2.0, 3.0]], name="squeeze_test")
+        d.history = "Prior op"
+        result = d.squeeze()
+        assert len(result.history) == 2
+        assert _entry(result.history[0]) == "Prior op"
+        assert "Data squeezed" in _entry(result.history[-1])
 
     def test_reshape_appends(self, ds1):
         """Reshape appends a history entry."""
@@ -254,13 +258,14 @@ class TestReductions:
         result = ds1.argmax()
         assert isinstance(result, (int, np.integer))
 
-    def test_diagonal_resets_history(self):
-        """Diagonal resets history to empty then decorator appends."""
+    def test_diagonal_appends(self):
+        """Diagonal preserves prior history and appends its own entry."""
         d = scp.NDDataset([[1, 2], [3, 4]], name="diag")
         d.history = "Prior"
         result = d.diagonal()
-        # diagonal sets cls.history = [] then decorator appends one entry
-        assert len(result.history) == 1
+        assert len(result.history) == 2
+        assert _entry(result.history[0]) == "Prior"
+        assert "diagonal" in _entry(result.history[-1])
 
     def test_ptp_appends(self, ds2d):
         """Ptp with explicit dim appends."""
@@ -601,12 +606,13 @@ class TestHistoryLoss:
         assert len(result.history) == 1
         assert "trapezoid" in _entry(result.history[0])
 
-    def test_diagonal_loses_prior_history(self):
-        """Diagonal loses prior history."""
+    def test_diagonal_preserves_prior_history(self):
+        """Diagonal preserves prior history."""
         d = scp.NDDataset([[1, 2], [3, 4]], name="diag_test")
         d.history = "Prior operation"
         result = d.diagonal()
-        assert len(result.history) == 1
+        assert len(result.history) == 2
+        assert _entry(result.history[0]) == "Prior operation"
 
 
 # ===========================================================================

--- a/tests/test_core/test_dataset/test_shape_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_shape_semantics_baseline.py
@@ -311,11 +311,12 @@ class TestSqueezeCharacterization:
         assert sq.coordset is not None
         assert sq.coordset["y"].is_same_dim
 
-    def test_squeeze_does_not_record_history(self, singleton_dataset):
-        """SURPRISE: squeeze does NOT append history."""
+    def test_squeeze_records_history(self, singleton_dataset):
+        """Squeeze now appends a history entry (consistent with other shape ops)."""
         sq = singleton_dataset.squeeze()
-        assert len(sq.history) == 1
+        assert len(sq.history) == 2
         assert sq.history[0] == singleton_dataset.history[0]
+        assert "Data squeezed" in sq.history[-1]
 
     def test_squeeze_returns_new_object(self, singleton_dataset):
         sq = singleton_dataset.squeeze()
@@ -584,11 +585,12 @@ class TestShapeOperationHistory:
         assert isinstance(s.history[-1], str)
         assert "Data swapped" in s.history[-1]
 
-    def test_squeeze_does_not_append_history(self, singleton_dataset):
-        """SURPRISE: squeeze is the only shape op that does NOT record history."""
+    def test_squeeze_appends_history(self, singleton_dataset):
+        """Squeeze now appends history (consistent with other shape ops)."""
         sq = singleton_dataset.squeeze()
-        assert len(sq.history) == 1
+        assert len(sq.history) == 2
         assert sq.history[0] == singleton_dataset.history[0]
+        assert "Data squeezed" in sq.history[-1]
 
     def test_reshape_appends_history(self, shape_dataset):
         r = shape_dataset.reshape((7, 5), dims=("x", "y"))


### PR DESCRIPTION
Two local inconsistencies identified during the history semantics characterization campaign (PR #1194) are now cleaned up:

| Operation | Before | After |
|---|---|---|
| `squeeze()` | History unchanged (no entry added) | Preserves prior, appends `"Data squeezed"` |
| `diagonal()` | `cls.history = []` cleared prior history | Preserves prior, decorator appends its entry |

Both changes ensure these shape-like operations follow the same **Append** pattern used by `reshape()`, `transpose()`, `swapdims()`, and the majority of NDDataset operations.

### What is NOT changed

- `concatenate()` / `stack()` / `merge_datasets()` — still rewrite
- `trapezoid()` / `simpson()` — still rewrite
- Analysis wrappers — still rewrite
- Binary-op second-operand history — still discarded
- History setter semantics — unchanged
- History string formats — globally unchanged

The high-level conclusion stands: history is a hybrid human-readable audit log, not a fully authoritative provenance system.

### Validation

```
pytest tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py -v  # 66/66
pytest tests/test_core/test_dataset/test_shape_semantics_baseline.py -k squeeze -v  # 17/17
```

Pre-commit: all hooks green.