### PR TITLE
MAINT: remove legacy Project _others support

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -151,6 +151,12 @@ Breaking Changes
   files containing ``_scripts`` entries remain load-compatible — the field is
   silently ignored on deserialization.
 
+- Removed legacy ``Project._others`` support.  The ``_others`` dict and its
+  ``_set_from_type`` fallback are removed — ``Project`` now rejects objects
+  that are neither ``NDDataset`` nor ``Project`` with a clear ``TypeError``.
+  Legacy ``.pscp`` files containing ``_others`` entries remain load-compatible —
+  the field is silently ignored on deserialization.
+
 - Mixed arithmetic between ``NDDataset`` and ``Coord`` is now rejected
   (e.g. ``dataset + coord`` or ``coord * dataset``).  ``Coord`` is treated as
   axis support, not as a signal-bearing operand.  Workflows needing correction

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -136,6 +136,12 @@ Breaking Changes
   files containing ``_scripts`` entries remain load-compatible — the field is
   silently ignored on deserialization.
 
+- Removed legacy ``Project._others`` support.  The ``_others`` dict and its
+  ``_set_from_type`` fallback are removed — ``Project`` now rejects objects
+  that are neither ``NDDataset`` nor ``Project`` with a clear ``TypeError``.
+  Legacy ``.pscp`` files containing ``_others`` entries remain load-compatible —
+  the field is silently ignored on deserialization.
+
 - Mixed arithmetic between ``NDDataset`` and ``Coord`` is now rejected
   (e.g. ``dataset + coord`` or ``coord * dataset``).  ``Coord`` is treated as
   axis support, not as a signal-bearing operand.  Workflows needing correction

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -395,6 +395,7 @@ class NDIO(tr.HasTraits):
                 "modeldata",
                 "_modeldata",
                 "_scripts",
+                "_others",
             }
             for key, val in dic.items():
                 try:

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -81,7 +81,6 @@ class Project(AbstractProject, NDIO):
     _parent = tr.This()
     _projects = tr.Dict(tr.This())
     _datasets = tr.Dict(NDDatasetType())
-    _others = tr.Dict()
     _meta = tr.Instance(Meta)
 
     _filename = tr.Instance(pathlib.Path, allow_none=True)
@@ -113,16 +112,13 @@ class Project(AbstractProject, NDIO):
             # add it to the _datasets dictionary
             self.add_dataset(obj, name)
 
-        elif isinstance(obj, type(self)):  # can not use Project here!
+        elif isinstance(obj, type(self)):
             self.add_project(obj, name)
 
-        elif hasattr(obj, "name"):
-            self._others[obj.name] = obj
-
         else:
-            raise ValueError(
-                f"objects of type {type(obj).__name__} has no name and so "
-                "cannot be appended to the project ",
+            raise TypeError(
+                f"Project does not accept objects of type {type(obj).__name__}. "
+                "Only NDDataset and Project instances are supported."
             )
 
     def _get_from_type(self, name):

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -118,26 +118,14 @@ class TestProjectInit:
 class TestSetFromType:
     """Tests for _set_from_type method."""
 
-    def test_set_from_type_with_other_object_having_name(self):
+    def test_set_from_type_rejects_unsupported_type(self):
         proj = Project(name="test")
 
-        class NamedObject:
-            name = "custom_object"
+        with pytest.raises(TypeError, match="does not accept"):
+            proj._set_from_type(42)
 
-        obj = NamedObject()
-        proj._set_from_type(obj)
-        assert "custom_object" in proj._others
-        assert proj._others["custom_object"] is obj
-
-    def test_set_from_type_invalid_object(self):
-        proj = Project(name="test")
-
-        class UnnamedObject:
-            pass
-
-        obj = UnnamedObject()
-        with pytest.raises(ValueError, match="has no name"):
-            proj._set_from_type(obj)
+        with pytest.raises(TypeError, match="does not accept"):
+            proj._set_from_type("not a supported object")
 
 
 class TestGetItem:
@@ -471,21 +459,6 @@ class TestProjectProperties:
         assert proj.directory is None
 
 
-class TestOthersDict:
-    """Tests for _others dictionary functionality."""
-
-    def test_others_dict_populated(self):
-        proj = Project(name="test")
-
-        class CustomObject:
-            name = "custom"
-
-        obj = CustomObject()
-        proj._set_from_type(obj)
-        assert "custom" in proj._others
-        assert proj._others["custom"] is obj
-
-
 class TestEdgeCases:
     """Edge case tests."""
 
@@ -557,7 +530,7 @@ class TestSerializationRoundtrip:
         assert filename2.exists()
         assert filename1 != filename2
 
-    def test_save_load_ignores_legacy_roi_and_modeldata_fields(self, ds1):
+    def test_save_load_ignores_legacy_fields(self, ds1):
         proj = Project(name="legacy_fields_test")
         ds1.name = "data"
         proj.add_dataset(ds1)
@@ -570,6 +543,7 @@ class TestSerializationRoundtrip:
 
         js["datasets"][0]["roi"] = [0.0, 1.0]
         js["datasets"][0]["modeldata"] = [42.0]
+        js["_others"] = {"unused": "should be ignored"}
 
         with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
             zipf.writestr(member, json.dumps(js, indent=2))
@@ -578,6 +552,7 @@ class TestSerializationRoundtrip:
 
         assert not hasattr(loaded.data, "roi")
         assert not hasattr(loaded.data, "modeldata")
+        assert not hasattr(loaded, "_others")
 
 
 class TestArgNamesEdgeCases:


### PR DESCRIPTION
Remove legacy Project `_others` support. The `_others` dict and `_set_from_type` fallback for arbitrary objects are removed.

Intentionally out of scope:
- No changes to dataset/subproject behavior
- No changes to native serialization format
- No changes to Script (handled in separate PR)

Closes #1129