### PR TITLE
MAINT: remove stale test_scripts target from CI workflow

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -71,7 +71,7 @@ jobs:
             docs_examples: false
             plugins: false
             core_only: true
-            test_targets: tests/test_core/test_dataset tests/test_core/test_units tests/test_core/test_projects tests/test_core/test_scripts tests/test_core/test_plotters
+            test_targets: tests/test_core/test_dataset tests/test_core/test_units tests/test_core/test_projects tests/test_core/test_plotters
             validation: core-only
             check_name: Test core-only using ubuntu-latest and python 3.14
           - os: ubuntu-latest


### PR DESCRIPTION
The `tests/test_core/test_scripts` directory was deleted in PR #1196 but the CI workflow still references it as a test target for core-only runs, causing CI failures on that matrix entry.

This PR removes the stale reference.