### PR TITLE
MAINT: relax plugin version bounds for 0.10.0 compatibility

### DIFF
--- a/plugins/plugin-template/pyproject.toml
+++ b/plugins/plugin-template/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A SpectroChemPy plugin"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.9,<0.11",
 ]
 
 [project.entry-points."spectrochempy.plugins"]

--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -9,7 +9,7 @@ description = "Cantera-based thermodynamics and reactive chemistry for SpectroCh
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.9,<0.11",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-cantera/recipe.yaml
+++ b/plugins/spectrochempy-cantera/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.10
+    - spectrochempy >=0.9,<0.11
     - cantera >=3.0
     - numpy
     - scipy

--- a/plugins/spectrochempy-carroucell/pyproject.toml
+++ b/plugins/spectrochempy-carroucell/pyproject.toml
@@ -9,7 +9,7 @@ description = "Carroucell experiment reader for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.9,<0.11",
     "xlrd",
     "scipy",
 ]

--- a/plugins/spectrochempy-carroucell/recipe.yaml
+++ b/plugins/spectrochempy-carroucell/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.10
+    - spectrochempy >=0.9,<0.11
     - xlrd
     - scipy
 

--- a/plugins/spectrochempy-hypercomplex/pyproject.toml
+++ b/plugins/spectrochempy-hypercomplex/pyproject.toml
@@ -9,7 +9,7 @@ description = "Hypercomplex / quaternion support plugin for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.9,<0.11",
     "numpy",
     "numpy-quaternion>=2024.0.7",
 ]

--- a/plugins/spectrochempy-hypercomplex/recipe.yaml
+++ b/plugins/spectrochempy-hypercomplex/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.10
+    - spectrochempy >=0.9,<0.11
     - numpy
     - quaternion >=2024.0.7
 

--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -9,7 +9,7 @@ description = "IRIS analysis extension for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.9,<0.11",
     "scipy",
     "osqp",
 ]

--- a/plugins/spectrochempy-iris/recipe.yaml
+++ b/plugins/spectrochempy-iris/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.10
+    - spectrochempy >=0.9,<0.11
     - scipy
     - osqp
 

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -9,7 +9,7 @@ description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.9,<0.11",
     "numpy",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.
 ]

--- a/plugins/spectrochempy-nmr/recipe.yaml
+++ b/plugins/spectrochempy-nmr/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.10
+    - spectrochempy >=0.9,<0.11
     - numpy
 
 tests:

--- a/plugins/spectrochempy-tensor/pyproject.toml
+++ b/plugins/spectrochempy-tensor/pyproject.toml
@@ -9,7 +9,7 @@ description = "Tensor decompositions plugin for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.9,<0.11",
     "tensorly",
 ]
 

--- a/plugins/spectrochempy-tensor/recipe.yaml
+++ b/plugins/spectrochempy-tensor/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.10
+    - spectrochempy >=0.9,<0.11
     - tensorly
 
 tests:


### PR DESCRIPTION
All 7 plugins (including `plugin-template`) and 6 conda recipes currently pin `spectrochempy` to `>=0.9,<0.10`, which blocks installation alongside spectrochempy 0.10.0.

Bump the upper bound to `<0.11` to allow both 0.9.x and 0.10.x.

Files changed: 13 files (7 pyproject.toml + 6 recipe.yaml), 1 line each.