### PR TITLE
FIX: update plugin test assertions for 0.11.0 deprecation target

### DIFF
--- a/plugins/spectrochempy-cantera/tests/test_cantera.py
+++ b/plugins/spectrochempy-cantera/tests/test_cantera.py
@@ -185,7 +185,7 @@ def test_pfr_root_compatibility_alias_warns_once():
     assert len(captured) == 1
     assert captured[0].category is DeprecationWarning
     assert "scp.PFR is deprecated since SpectroChemPy 0.9.0" in str(captured[0].message)
-    assert "will be removed in 0.10.0" in str(captured[0].message)
+    assert "will be removed in 0.11.0" in str(captured[0].message)
     assert "scp.cantera.PFR" in str(captured[0].message)
 
 

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -266,7 +266,7 @@ def test_iris_root_alias_warns_once(monkeypatch, alias, heavy_module):
     assert f"scp.{alias} is deprecated since SpectroChemPy 0.9.0" in str(
         captured[0].message
     )
-    assert "will be removed in 0.10.0" in str(captured[0].message)
+    assert "will be removed in 0.11.0" in str(captured[0].message)
     assert f"scp.iris.{alias}" in str(captured[0].message)
 
     if heavy_module:

--- a/plugins/spectrochempy-tensor/tests/test_tensor_plugin.py
+++ b/plugins/spectrochempy-tensor/tests/test_tensor_plugin.py
@@ -106,5 +106,5 @@ def test_root_alias_warns_once(monkeypatch):
     assert captured[0].category is DeprecationWarning
     message = str(captured[0].message)
     assert "scp.CP is deprecated since SpectroChemPy 0.9.0" in message
-    assert "will be removed in 0.10.0" in message
+    assert "will be removed in 0.11.0" in message
     assert "scp.tensor.CP" in message


### PR DESCRIPTION
PR #1200 updated deprecation messages from 0.10.0 → 0.11.0 in `src/spectrochempy/`, but three plugin test files still assert the old version string, causing test failures:

- `plugins/spectrochempy-iris/tests/test_iris.py`
- `plugins/spectrochempy-tensor/tests/test_tensor_plugin.py`  
- `plugins/spectrochempy-cantera/tests/test_cantera.py`

3 files, 1 line each.