### PR TITLE
FIX: resolve OMNIC SPA/SPG reader inconsistencies

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -37,6 +37,14 @@ Bug Fixes
   during sklearn initialisation, so the default solver was always used
   regardless of the configured value. (:pr:`TODO`)
 
+- Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
+  <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
+  ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error
+  messages in SPG unit-consistency checks now name the correct quantity;
+  a single SPA comment is now included in the description (previously only
+  ≥2 comments were shown); SPA history content is now checked via the
+  variable instead of a literal string; and invalid ``return_ifg`` values
+  now produce a clear ``ValueError``. (PR by @gaoflow)
 
 .. section
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -44,7 +44,7 @@ Bug Fixes
   a single SPA comment is now included in the description (previously only
   ≥2 comments were shown); SPA history content is now checked via the
   variable instead of a literal string; and invalid ``return_ifg`` values
-  now produce a clear ``ValueError``. (PR by @gaoflow)
+  now produce a clear warning. (PR by @gaoflow)
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -26,6 +26,15 @@ Bug Fixes
   during sklearn initialisation, so the default solver was always used
   regardless of the configured value. (:pr:`TODO`)
 
+- Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
+  <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
+  ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error
+  messages in SPG unit-consistency checks now name the correct quantity;
+  a single SPA comment is now included in the description (previously only
+  ≥2 comments were shown); SPA history content is now checked via the
+  variable instead of a literal string; and invalid ``return_ifg`` values
+  now produce a clear ``ValueError``. (PR by @gaoflow)
+
 Developer
 ~~~~~~~~~
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -33,7 +33,7 @@ Bug Fixes
   a single SPA comment is now included in the description (previously only
   ≥2 comments were shown); SPA history content is now checked via the
   variable instead of a literal string; and invalid ``return_ifg`` values
-  now produce a clear ``ValueError``. (PR by @gaoflow)
+  now produce a clear warning. (PR by @gaoflow)
 
 Developer
 ~~~~~~~~~

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -333,7 +333,7 @@ def read_spg(*paths, **kwargs):
 
     """
     kwargs["filetypes"] = ["OMNIC files (*.spg)"]
-    kwargs["protocol"] = ["spg", "spa"]
+    kwargs["protocol"] = ["spg"]
     importer = Importer()
     return importer(*paths, **kwargs)
 
@@ -687,11 +687,11 @@ def _read_spg(*args, **kwargs):
         )
     if len(set(xunits)) != 1:  # pragma: no cover
         raise ValueError(
-            "Error : Inconsistent data set - data units should be identical",
+            "Error : Inconsistent data set - x axis units should be identical",
         )
     if len(set(units)) != 1:  # pragma: no cover
         raise ValueError(
-            "Error : Inconsistent data set - x axis units should be identical",
+            "Error : Inconsistent data set - data units should be identical",
         )
     data = np.ndarray((nspec, nx[0]), dtype="float32")
 
@@ -808,6 +808,11 @@ def _read_spa(*args, **kwargs):
     fid, kwargs = _openfid(filename, **kwargs)
 
     return_ifg = kwargs.get("return_ifg", None)
+    if return_ifg not in (None, "sample", "background"):
+        raise ValueError(
+            f"Invalid return_ifg value: {return_ifg!r}. "
+            "Expected None, 'sample', or 'background'."
+        )
 
     # Read name:
     # The name  starts at position hex 1e = decimal 30. Its max length
@@ -977,14 +982,14 @@ def _read_spa(*args, **kwargs):
     # Omnic spg file don't have specific "origin" field stating the oirigin of the data
 
     dataset.description = kwargs.get("description", default_description) + "\n"
-    if len(spa_comments) > 1:
+    if spa_comments:
         dataset.description += "# Comments from Omnic:\n"
         for comment in spa_comments:
             dataset.description += comment + "\n---------------------\n"
 
     dataset.history = "Imported from spa file(s)"
 
-    if "spa_history" in locals() and len("spa_history".strip(" ")) > 0:
+    if "spa_history" in locals() and len(spa_history.strip()) > 0:
         dataset.history = (
             "Data processing history from Omnic :\n------------------------------------\n"
             + spa_history

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -67,9 +67,9 @@ def test_read_omnic():
     nd = scp.read_spa(IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA")
     assert str(nd) == "NDDataset: [float64] a.u. (shape: (y:1, x:5549))"
 
-    nd2 = scp.read_spg(
+    nd2 = scp.read_omnic(
         IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA"
-    )  # wrong protocol but acceptable
+    )
     assert nd2 == nd
 
     # test import sample IFG
@@ -107,3 +107,30 @@ def test_read_omnic():
     # high speed series, import bg
     a = scp.read_srs("irdata/omnic_series/high_speed.srs", return_bg=True)
     assert str(a) == "NDDataset: [float64] unitless (shape: (y:1, x:13898))"
+
+
+def test_read_spg_history_appended():
+    """Regression test for #1144: sort history should be appended, not overwrite
+    the import history. The history setter appends string values — both entries
+    are preserved."""
+    nd = scp.read_spg(WODGER, sortbydate=True)
+    # History is a list of timestamp-prefixed strings
+    history_text = " ".join(nd.history)
+    assert "Imported from spg file" in history_text
+    assert "Sorted by date" in history_text
+
+
+def test_return_ifg_validation(tmp_path):
+    """Regression test for #1144: invalid return_ifg values must raise a clear error.
+    The Importer catches exceptions and re-emits them as warnings, so we check
+    for the warning."""
+    import warnings
+
+    spa_file = tmp_path / "dummy.spa"
+    spa_file.write_bytes(b"\x00" * 1024)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = scp.read_spa(spa_file, return_ifg="invalid")
+    assert result is None
+    assert len(w) >= 1
+    assert any("Invalid return_ifg value" in str(warning.message) for warning in w)

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -119,7 +119,7 @@ def test_read_spg_history_appended():
 
 
 def test_return_ifg_validation(tmp_path):
-    """Regression test for #1144: invalid return_ifg values must raise a clear error.
+    """Regression test for #1144: invalid return_ifg values must warn clearly.
     The Importer catches exceptions and re-emits them as warnings, so we check
     for the warning."""
     import warnings

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -67,9 +67,7 @@ def test_read_omnic():
     nd = scp.read_spa(IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA")
     assert str(nd) == "NDDataset: [float64] a.u. (shape: (y:1, x:5549))"
 
-    nd2 = scp.read_omnic(
-        IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA"
-    )
+    nd2 = scp.read_omnic(IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA")
     assert nd2 == nd
 
     # test import sample IFG


### PR DESCRIPTION
Fixes #1144.

**Changes:**

- `read_spg()` protocol list no longer advertises `spa` (SPA files should use `read_spa` or `read_omnic`)
- Swap inverted error messages in SPG unit-consistency checks (xunits message said "data" and vice versa)
- Include single SPA comments in the dataset description — was incorrectly gated on `len(spa_comments) > 1`
- Fix `spa_history` variable check — was testing the literal string `"spa_history"` instead of the variable content
- Validate `return_ifg` parameter values, emitting a clear warning for invalid values through the public reader API
- Update the test that previously relied on `read_spg` accepting `.spa` files

**Note on item 3 (history overwrite):** The history setter appends string values rather than replacing them, so the import and sort histories were already both preserved — no code change was needed for that item.

Built with SpectroChemPy under my direction.

**Checklist**:

- [x] Close the #1144.
- [x] Tests have been added.
- [ ] `pyproject.toml` file has been updated with new dependencies.
- [x] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
- [ ] Developer changes (tests, CI, refactoring, tooling) have been documented in the ``Developer`` section of `docs/sources/whatsnew/changelog.rst`.
- [ ] The new API methods have been included in a section of `docs/sources/reference/index.rst`.
- [ ] If you are a new contributor, you have added your name (affiliation and ORCID if you have one) in the `zenodo.json` in the field contributors field.
