### PR TITLE
fix: replace bare NotImplementedError in _write_excel with descriptive message (fixes #1131)

### DIFF
--- a/src/spectrochempy/core/writers/write_excel.py
+++ b/src/spectrochempy/core/writers/write_excel.py
@@ -52,4 +52,4 @@ write_xls.__doc__ = "This method is an alias of `write_excel` ."
 
 @exportermethod
 def _write_excel(*args, **kwargs):
-    raise NotImplementedError
+    raise NotImplementedError("Excel export is not yet implemented")


### PR DESCRIPTION
The write_excel() and write_xls() public API methods delegate to _write_excel() which raised a bare NotImplementedError, giving users no indication that Excel export is simply not yet implemented.

This replaces it with a descriptive message so users understand the feature is planned but not currently available.