### PR TITLE
DOC: reduce documentation warning noise

### DIFF
--- a/docs/sources/gettingstarted/examples/index.rst
+++ b/docs/sources/gettingstarted/examples/index.rst
@@ -1,3 +1,4 @@
+.. _examples-gallery:
 .. _examples-index:
 
 =================

--- a/docs/sources/gettingstarted/install/install_mac_linux.rst
+++ b/docs/sources/gettingstarted/install/install_mac_linux.rst
@@ -110,7 +110,7 @@ Verifying Installation
 Next Steps
 ----------
 
-Proceed to the :ref:`userguide` to start using SpectroChemPy.
+Proceed to the :ref:`user_guide` to start using SpectroChemPy.
 
 .. note::
    If you encounter any issues, see :doc:`../getting_help` for support options.

--- a/docs/sources/gettingstarted/install/install_win.rst
+++ b/docs/sources/gettingstarted/install/install_win.rst
@@ -119,7 +119,7 @@ Save as `activate-scpy.bat` and create a shortcut named "Mamba prompt (scpy)".
 Next Steps
 ----------
 
-Proceed to the :ref:`userguide` to start using SpectroChemPy.
+Proceed to the :ref:`user_guide` to start using SpectroChemPy.
 
 .. note::
    If you encounter any issues, see :doc:`../getting_help` for support options.

--- a/docs/sources/gettingstarted/whyscpy.rst
+++ b/docs/sources/gettingstarted/whyscpy.rst
@@ -61,7 +61,7 @@ Why NOT SpectroChemPy ?
 
 You might **NOT** want to use `SpectroChemPy` if:
 
-- You are averse to command line code (Python) or scripting. Since   `SpectroChemPy` is essentially an Application Programming Interface (API), it   requires writing commands and small scripts. Its documentation and resources contain fully documented   examples (see :ref:`examples-index`) and tutorials (see :ref:`userguide`),   which should be easy to translate into   your own data. In particular, the use of Jupyter notebooks mixing texts, code blocks and figures, so that basic   procedures (data import, basic processing and analysis, etc.) do not require much programming knowledge.
+- You are averse to command line code (Python) or scripting. Since `SpectroChemPy` is essentially an Application Programming Interface (API), it requires writing commands and small scripts. Its documentation and resources contain fully documented examples (see :ref:`examples-index`) and tutorials (see :ref:`user_guide`), which should be easy to translate into your own data. In particular, the use of Jupyter notebooks mixing text, code blocks, and figures means that basic procedures (data import, basic processing, analysis, etc.) do not require much programming knowledge.
 
 - you are working on spectroscopic data that are difficult to process with `SpectroChemPy` (currently mainly   focused on optical spectroscopy and NMR) because some components or tools (e.g., importing your raw data, ...) are   missing: please suggest new features that should be added (:ref:`contributing.bugs_report`). We will take into   consideration all suggestions to make `SpectroChemPy` more widely and easily usable.
 

--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -58,7 +58,7 @@ NDDataset can also have labeled coordinates where labels can be different kinds 
 nd.ndarray or other NDDatasets, etc...).
 
 This offers a lot of flexibility in using NDDatasets that, we hope, will be useful for applications. See the
-:ref:`userguide` for more information about such possible applications.
+:ref:`user_guide` for more information about such possible applications.
 
 .. autosummary::
     :nosignatures:
@@ -102,7 +102,7 @@ The above code in `SpectroChemPy` can be simplified using the `random` creation 
     X = NDDataset.random((4,4))
 
 
-(see the :ref:`userguide` for a large set of examples on how to use this constructor.)
+(see the :ref:`user_guide` for a large set of examples on how to use this constructor.)
 
 Many SpectroChemPy methods mimics `numpy` equivalent, but output a `NDDataset` object.
 

--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -107,7 +107,8 @@ X
 # Other reader functions return either a single `NDDataset` or multiple `NDDataset`
 # objects, depending on the file type and content.
 #
-# Further details on specific cases are provided below. See the section [Reading directories](#Reading-directories).
+# Further details on specific cases are provided below, especially in the
+# section on reading directories.
 
 # %% [markdown]
 # ## Using relative or absolute pathnames
@@ -117,124 +118,74 @@ X
 #
 # If the file is located in another directory, the full path to the file can be provided. For example:
 #
-# ```ipython
-# X = scp.read('/users/Brian/s/Life/wodger.spg')
-# ```
+#     X = scp.read('/users/Brian/s/Life/wodger.spg')
 #
 # or, for Windows:
 #
-# ```ipython
-# X = scp.read(r'C:\users\Brian\s\Life\wodger.spg')
-# ```
+#     X = scp.read(r'C:\\users\\Brian\\s\\Life\\wodger.spg')
 #
 # Notes:
-# - The path separator is a backslash `\` on Windows, but in many contexts, backslash is also used as an escape character to
+# - The path separator is a backslash ``\\`` on Windows, but in many contexts, backslash is also used as an escape character to
 #   represent non-printable characters.
 #   To avoid problems, either it has to be escaped itself, a double backslash `\\`, or one can also use raw string literals
 #   to represent Windows paths.
-#   These are string literals that have an `r` prepended to them. In raw string literals, the `\\` represents
-#   a literal backslash: `r'C:\users\Brian'`.
+#   These are string literals that have an `r` prepended to them. In raw
+#   string literals, `\\` represents a literal backslash, e.g.
+#   `r'C:\\users\\Brian'`.
 # - In python, the slash `/` is used as the path separator in all systems (Windows, Linux, OSX, ...).
 #   So it can be used in all cases. For exemple:
 #
-#   ```ipython
-#   X = scp.read('C:/users/Brian/s/Life/wodger.spg')
-#
-#   ```
+#       X = scp.read('C:/users/Brian/s/Life/wodger.spg')
 #
 # - The use of relative pathnames is a good practice. SpectroChemPy readers use relative paths.
 #   If the given path is not absolute,
-#   then SpectroChemPy will search relative to the current directory or to a directory specified using the `directory`keywords.
+#   then SpectroChemPy will search relative to the current directory or to a
+#   directory specified using the `directory` keyword.
 #
 #   For example:
 #
-#   ```ipython
-#   X = scp.read('wodger.spg', directory='C:/users/Brian/s/Life')
-#   X = scp.read('Life/wodger.spg', directory='C:\\users\\Brian\\s')
-#
-#   ```
+#       X = scp.read('wodger.spg', directory='C:/users/Brian/s/Life')
+#       X = scp.read('Life/wodger.spg', directory='C:\\users\\Brian\\s')
 #
 # - The `os` or `pathlib` modules can be used to work with pathnames.
-#   See the section
-#   [Good practice:Use of os or pathlib packages](#Use-os-or-pathlib-packages).
+#   See the "Use os or pathlib packages" section below.
 # - The `preferences.datadir` variable can be used to set a default directory where to look for data.
-#   See the section [Another default search directory: datadir](#Another-default-search-directory:-datadir).
+#   See the "Another default search directory: datadir" section below.
 #
 
 # %% [markdown]
 # ## Good practices
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
-#
 # ### Use relative paths
 #
 # As path are system dependent, it is a good practice to use relative pathnames in scripts and notebooks.
 #
-# If, for instance, Brian has a project organised in a folder (`s` ) with a directory
-# dedicated to input data (`Life` )
-# and a notebook for preprocessing (`welease.ipynb` ) as illustrate below:
+# If, for instance, Brian has a project organised in a folder (`s`) with a
+# directory dedicated to input data (`Life`) and a notebook for preprocessing
+# (`welease.ipynb`) as illustrated below:
 #
-# ```
-# C:\users
-# |    +-- Brian
-# |    |    +-- s
-# |    |    |   +-- Life
-# |    |    |   |   +-- wodger.spg
-# |    |    |   +-- welease.ipynb
-#
-# ```
+#     C:\users
+#     |    +-- Brian
+#     |    |    +-- s
+#     |    |    |   +-- Life
+#     |    |    |   |   +-- wodger.spg
+#     |    |    |   +-- welease.ipynb
 #
 # Then running this project in John's Linux computer (e.g. in `/home/john/s_copy` )
 # will certainly result in execution
 # errors if absolute paths are used in the notebook:
 #
-# ```text
-# OSError: Can't find this filename C:\users\Brian\s\life\wodger.spg
-# ```
+#     OSError: Can't find this filename C:\\users\\Brian\\s\\life\\wodger.spg
 #
 # Fortunately, SpectroChemPy readers use relative paths. If the given path is not
 # absolute, then SpectroChemPy will search in the current directory. Hence, the opening
 # of the `spg` file from scripts in `welease.ipynb` can be made
 # by the command:
 #
-# ```ipython
-# X = scp.read('Life/wodger.spg')
-# ```
+#     X = scp.read('Life/wodger.spg')
 #
 # or:
 #
-# ```ipython
-# X = scp.read('wodger.spg', directory='Life')
-# ```
+#     X = scp.read('wodger.spg', directory='Life')
 #
 # ### Use os or pathlib packages
 #
@@ -242,25 +193,17 @@ X
 # `os` or `pathlib` python modules.
 # With `os` we mention the following methods that can be particularly useful:
 #
-# ```ipython
-# import os
-# os.getcwd()              # returns the absolute path of the current working directory
-#                          # preferences.datadir
-# os.path.expanduser("~")  # returns the home directory of the user
-# os.path.join('path1','path2','path3', ...)
-#                          # intelligently concatenates path components
-#                          # using the system separator (`/` or `\\` )
-# ```
+#     import os
+#     os.getcwd()              # returns the absolute path of the current working directory
+#     os.path.expanduser("~")  # returns the home directory of the user
+#     os.path.join('path1', 'path2', 'path3', ...)
 #
 # Using `Pathlib` is even simpler:
 #
-# ```ipython
-# from pathlib import Path
-# Path.cwd()               # returns the absolute path of the current working directory
-# Path.home()              # returns the home directory of the user
-# Path('path1') / 'path2' / 'path3' / '...'   # intelligently concatenates path
-# components
-# ```
+#     from pathlib import Path
+#     Path.cwd()               # returns the absolute path of the current working directory
+#     Path.home()              # returns the home directory of the user
+#     Path('path1') / 'path2' / 'path3' / '...'
 #
 # The interested readers will find more details on the use of these modules here:
 #
@@ -272,7 +215,7 @@ X
 # Spectrochempy also comes with the definition of a second default directory path where
 # to look at the data: the `datadir` directory. It is defined in the variable `preferences.datadir` which
 # is imported at the same time as spectrochempy. By default, `datadir` points in the
-# '$HOME/.spectrochempy/tesdata' directory.:
+# `$HOME/.spectrochempy/testdata` directory.
 
 # %%
 DATADIR = scp.preferences.datadir
@@ -288,13 +231,11 @@ scp.read_omnic(DATADIR / "wodger.spg")
 # It can be set to another pathname *permanently* (i.e., even after computer restart)
 # by a new assignment:
 #
-# ```python
-# scp.preferences.datadir = 'C:/users/Brian/s/Life'
-# ```
+#     scp.preferences.datadir = 'C:/users/Brian/s/Life'
 #
 # This will change the default value in the SCPy preference file located in the hidden
 # folder
-# ` .spectrochempy/` at the root of the user home directory.
+# `.spectrochempy/` at the root of the user home directory.
 #
 # Finally, by default, the import functions used in Spectrochempy will search the data
 # files using this order of
@@ -309,28 +250,35 @@ scp.read_omnic(DATADIR / "wodger.spg")
 # ## Reading directories
 
 # %% [markdown]
-# The `read_dir` function is designed to read an entire directory, create NDDatasets for each file, and finally merge all compatible datasets. Let's see an example:
+# The `read_dir` function is designed to read an entire directory, create
+# NDDatasets for each file, and finally merge all compatible datasets. Let's
+# see an example:
 
 # %% [markdown]
-# - Here is a list of the files presents in `DATADIR/irdata/subdir/`
+# - Here is a list of the files present in `DATADIR/irdata/subdir/`.
 
 # %%
 folder = DATADIR / "irdata" / "subdir"
 [str(item.relative_to(DATADIR)) for item in folder.glob("*.*")]
 
 # %% [markdown]
-# - Now read all files in the `DATADIR/irdata/subdir/` directory  (*i.e.,*, four `.spa` files and one `.srs` file). Any file in unknown format will be ignored silently:
+# - Now read all files in the `DATADIR/irdata/subdir/` directory (*i.e.*, four
+#   `.spa` files and one `.srs` file). Any file in an unknown format will be
+#   ignored silently:
 
 # %%
 scp.read_dir(folder)
 # %% [markdown]
-# The above command have read all files in the `DATADIR/irdata/subdir/` directory and merged them into two groups of compatible NDDatasets:
+# The above command reads all files in the `DATADIR/irdata/subdir/`
+# directory and merges them into two groups of compatible NDDatasets:
 #
 # * a first `NDDataset` object (id: 0, shape [335,1868]) comes from the single `.srs` file.
 # * a second `NDDataset` object (id: 1, shape [335,1868]) comes from the merging of four `.spa` files.
 
 # %% [markdown]
-# Merging  compatible NDDataset is the default behavior of `read_dir`  (or  equivalently `read`). If you want to read the files separately, you can use the `merge=False` keyword:
+# Merging compatible NDDatasets is the default behavior of `read_dir`
+# (or, equivalently, `read`). If you want to read the files separately, you
+# can use the `merge=False` keyword:
 # %%
 scp.read_dir(folder, merge=False)
 
@@ -343,8 +291,10 @@ scp.read_dir(folder, merge=False)
 # %% [markdown]
 # The `read_dir`/`read` function has additional options to control the behavior of the reading process:
 #
-# - `recursive`: if `True`, the function will scan the directory recursively and read all supported files in all subdirectories.
-# - `pattern`: a string or a list of strings that can be used to filter the files to be read. Only files whose name matches the pattern will be read.
+# - `recursive`: if `True`, the function scans the directory recursively and
+#   reads all supported files in all subdirectories.
+# - `pattern`: a string or a list of strings that can be used to filter the
+#   files to be read. Only files whose name matches the pattern will be read.
 
 # %% [markdown]
 # Let's see an example with the `recursive` option:
@@ -355,7 +305,8 @@ scp.read_dir(folder, merge=False)
 [str(item.relative_to(DATADIR)) for item in folder.glob("**/*.*")]
 
 # %% [markdown]
-# the ìrdata/subdir/` directory contains two subdirectory `1-20` and `20-50` with two additional `.spa` files.
+# The `irdata/subdir/` directory contains two subdirectories, `1-20` and
+# `20-50`, with additional `.spa` files.
 #
 # Now we read all files (a total of 9) in the `DATADIR/irdata/subdir/` directory and its subdirectories:
 # %%
@@ -368,7 +319,7 @@ scp.read_dir(folder, recursive=True)
 # As the 8 `.spa` files are compatible, they are merged into a single `NDDataset` object. The `.srs` file is read separately.
 
 # %% [markdown]
-# Specific reader can equivalently read folder recursively:
+# A specific reader can equivalently read the folder recursively:
 # %%
 scp.read_omnic(folder, recursive=True)
 
@@ -380,7 +331,8 @@ scp.read_omnic(folder, recursive=True)
 scp.read_dir(folder, recursive=True, pattern="*4*")
 
 # %% [markdown]
-# The above pattern "\*4\*" match only two files which are then merged and returned as a single `NDDataset` object.
+# The above pattern `*4*` matches only two files, which are then merged and
+# returned as a single `NDDataset` object.
 
 # %% [markdown]
 # This `pattern` option is obviously interesting to select only a type of extension:
@@ -401,9 +353,10 @@ scp.read_omnic(folder, recursive=True, pattern="*4.spa")  # equivalent
 # ## Reading files from a ZIP archive
 
 # %% [markdown]
-# The `read_zip` function is designed to read files from a ZIP archive. It can be used to read a single file
-# or all files in the archive. As usual, by default all files are merged. The `merge` keyword can be used to
-# read the files separately.
+# The `read_zip` function is designed to read files from a ZIP archive. It can
+# be used to read a single file or all files in the archive. As usual, by
+# default all files are merged. The `merge` keyword can be used to read the
+# files separately.
 
 # %%
 scp.read(

--- a/docs/sources/userguide/importexport/importOMNIC.py
+++ b/docs/sources/userguide/importexport/importOMNIC.py
@@ -40,14 +40,13 @@
 # - .spg files which contain a group of spectra
 #
 # Both have been reverse engineered, hence allowing extracting their key data.
-# The Omnic reader of Spectrochempy ( `read_omnic()` ) has been developed based on
+# The OMNIC reader in SpectroChemPy (`read_omnic()`) has been developed based on
 # posts in open forums on the .spa file format and extended to .spg file formats.
 
 # %% [markdown]
 # ## Import spg file
 #
-# Let's import an .spg file from the `datadir` (see :ref:`import.ipynb` for details)):
-# and display its main attributes:
+# Let's import an .spg file from the `datadir` and display its main attributes:
 
 # %%
 import spectrochempy as scp
@@ -69,10 +68,10 @@ X
 #   our knowledge, does not have
 #   this type of attribute). The string is composed of the username and of the machine
 #   name as given by the OS, e.g., `"username@machinename"`.
-#   It can be accessed and changed using `X.author` .
+#   It can be accessed and changed using `X.author`.
 #
 # - `created` is the creation date of the NDDataset (again not that of the .spg file).
-#   It can be accessed (or even changed) using `X.created` .
+#   It can be accessed (or even changed) using `X.created`.
 #
 # - `description` indicates the complete pathname of the .spg file. As the pathname is
 #   also given in the history (below), it can be a good practice to give a
@@ -102,8 +101,8 @@ X.description
 # - `values` shows the data as quantity (with their units when they exist - here a.u.
 #   for absorbance units).
 #
-# - The numerical values ar accessed through the `data` attribute and the units
-#   throughout `units` attribute.
+# - The numerical values are accessed through the `data` attribute and the units
+#   through the `units` attribute.
 
 # %%
 X.values
@@ -140,14 +139,12 @@ X.x
 X.y
 
 # %% [markdown]
-# - `dims` : Note that the `x` and `y` dimensions are the second and first
-#    dimension respectively. Hence, `X[i,j]` will return the absorbance of the ith
-#    spectrum at the jth  wavenumber.
-#    However, this is subject to change, for instance if you perform operation on your
-#    data such as
-#    [Transposition](../processing/transformations.ipynb#Transposition). At any time
-#    the attribute `dims` gives the correct names (which can be modified) and order of
-#    the dimensions.
+# - `dims`: note that the `x` and `y` dimensions are the second and first
+#   dimensions respectively. Hence, `X[i, j]` returns the absorbance of the ith
+#   spectrum at the jth wavenumber.
+#   However, this is subject to change, for instance after a transposition
+#   operation. At any time, the `dims` attribute gives the correct names
+#   (which can be modified) and order of the dimensions.
 
 # %%
 X.dims
@@ -185,10 +182,8 @@ X.y -= X.y[0]
 # It is also possible to use the ability of SpectroChemPy to handle unit changes. For
 # this one can use the `to` or `ito` (inplace) methods.
 #
-# ```ipython
-# val = val.to(some_units)
-# val.ito(some_units)   # the same inplace
-# ```
+#     val = val.to(some_units)
+#     val.ito(some_units)   # same operation, in place
 
 # %%
 X.y.ito("minute")
@@ -248,20 +243,19 @@ X = X[::-1]  # reorders the NDDataset along the first dimension going backward
 X.y.values  # displays the `y` dimension
 
 # %% [markdown]
-# <div class='alert alert-info'>
-# <b>Note</b>
+# **Note**
 #
-# <strong>Case of groups with different wavenumbers</strong> <br/>
-# An OMNIC .spg file can contain spectra having different wavenumber axes (e.g.
-# different spacings or wavenumber
-# ranges). In its current implementation, the spg reader will purposely return an error
-# because such spectra
-# <i>cannot</i> be included in a single NDDataset which, by definition, contains items that
-# share common axes or dimensions !
-# Future releases might include an option to deal with such a case and return a list of
-# NDDatasets. Let us know if you
-# are interested in such a feature, see <a href="https://www.spectrochempy.fr/devguide/issues.html">Bug reports and enhancement requests.</a>
-# </div>
+# **Case of groups with different wavenumbers**
+#
+# An OMNIC `.spg` file can contain spectra having different wavenumber axes
+# (e.g. different spacings or wavenumber ranges). In its current
+# implementation, the `.spg` reader purposely returns an error because such
+# spectra cannot be included in a single `NDDataset`, which by definition
+# contains items that share common axes or dimensions.
+#
+# A future release might include an option to deal with such a case and return
+# a list of NDDatasets. If you are interested in such a feature, see the bug
+# reports and enhancement requests in the project documentation.
 #
 
 # %% [markdown]
@@ -274,7 +268,7 @@ X.y.values  # displays the `y` dimension
 scp.read_omnic("irdata/subdir/7_CZ0-100_Pd_101.SPA")
 
 # %% [markdown]
-# The omnic reader can also import several spa files together, providing that they share
+# The OMNIC reader can also import several `.spa` files together, provided that they share
 # a common axis for the wavenumbers.
 #
 # This is the case of the following files in the irdata/subdir directory:
@@ -294,15 +288,16 @@ list_files = (
 scp.read_omnic(list_files, directory="irdata/subdir", name="Merged 7_CZ0-100 Pd")
 
 # %% [markdown]
-# When compatible .spa files are alone in a directory, a very convenient is to call the
-# read_omnic method
+# When compatible `.spa` files are alone in a directory, a very convenient
+# approach is to call the `read_omnic` method
 # using only the directory path as argument that will gather the .spa files together:
 
 # %%
 scp.read_omnic("irdata/subdir/1-20")
 
 # %% [markdown]
-# In the case  where not all files are compatibles, they are returned in different NDDatasets(with independent merging).
+# In cases where not all files are compatible, they are returned in different
+# NDDatasets (with independent merging).
 #
 # For example:
 
@@ -311,7 +306,8 @@ Y = scp.read_omnic("irdata/subdir/")
 Y
 
 # %% [markdown]
-# Here we get a list of two NDDataset because there is two type of file in the directory (`.spa` and `.srs`).
+# Here we get a list of two NDDatasets because there are two file types in the
+# directory (`.spa` and `.srs`).
 #
 # The desired dataset can be obtained using a list:
 
@@ -319,9 +315,9 @@ Y
 Y[1]
 
 # %% [markdown]
-# Other ways to select only the required file with extension (`.spa`)are:
+# Other ways to select only files with the `.spa` extension are:
 #
-# - writing a list as previously explicitely  listing the required files.
+# - writing a list that explicitly enumerates the required files.
 # - using a more specific reader:
 
 # %%
@@ -334,7 +330,8 @@ scp.read_spa("irdata/subdir/")
 scp.read_omnic("irdata/subdir/", pattern="*.spa")
 
 # %% [markdown]
-# One advantage of the latter solution is a greter flexibility. For instance the lollowing will select only the `*101.spa` and `*102.spa`:
+# One advantage of the latter solution is greater flexibility. For instance,
+# the following selects only `*101.spa` and `*102.spa`:
 
 # %%
 scp.read_omnic("irdata/subdir/", pattern="*10[12].spa", merge=False)
@@ -364,7 +361,7 @@ print(f"Origin: {X.origin}")
 print(f"Description: {X.description}")
 
 # %% [markdown]
-# Reading the metadata now reflect the change
+# Reading the metadata now reflects the change.
 
 # %%
 X.title
@@ -373,7 +370,8 @@ X.title
 # ## Error Handling
 
 # %% [markdown]
-# When trying to read file, it is a good practice to handle errors explicitely. For example:
+# When trying to read a file, it is good practice to handle errors explicitly.
+# For example:
 
 # %%
 try:

--- a/docs/sources/userguide/index.rst
+++ b/docs/sources/userguide/index.rst
@@ -1,5 +1,6 @@
 :orphan:
 
+.. _userguide:
 .. _user_guide:
 
 User Guide and Tutorials

--- a/docs/sources/userguide/objects/dataset/dataset.py
+++ b/docs/sources/userguide/objects/dataset/dataset.py
@@ -57,7 +57,7 @@
 # * [Introduction](#Introduction)
 #   * [1D-Dataset (unidimensional dataset)](#1D-Dataset-(unidimensional-dataset))
 #   * [nD-Dataset (multidimensional dataset)](#nD-Dataset-(multidimensional-dataset))
-# * [Metadata and Attributes](#About-the-dates-and-times)
+# * [Metadata and Attributes](#About-dates-and-times)
 #   * [About dates and times](#About-dates-and-times)
 #   * [About the history attribute](#About-the-history-attribute)
 # * [Units](#Units)

--- a/docs/sources/userguide/plugins/experimental_plugins.rst
+++ b/docs/sources/userguide/plugins/experimental_plugins.rst
@@ -16,7 +16,8 @@ What "experimental" means
 * Installation is manual.
 * Support is limited; they are provided mainly for developers and early testers.
 * Some experimental plugins may eventually become official, but there is no
-defined timeline.
+  defined timeline.
+
 
 Installing experimental plugins
 ===============================

--- a/docs/sources/whatsnew/v0.8.4.rst
+++ b/docs/sources/whatsnew/v0.8.4.rst
@@ -38,7 +38,7 @@ Dependency Updates
 - removed docrep dependency
 
 Breaking Changes
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 - Dropped support for Python 3.10 and below.
 - ``restore_rcparams()`` is now deprecated: SpectroChemPy no longer modifies global ``matplotlib.rcParams``, so restoration is unnecessary.

--- a/docs/sources/whatsnew/v0.9.0.rst
+++ b/docs/sources/whatsnew/v0.9.0.rst
@@ -58,7 +58,7 @@ Breaking Changes
 - IRIS analysis is now provided by the official IRIS plugin. Use
   ``scp.iris.IRIS`` or ``from spectrochempy.iris import IRIS`` after installing
   ``spectrochempy[iris]``. Limited root-level compatibility aliases remain
-   available with deprecation warnings.
+  available with deprecation warnings.
 
 
 Developer

--- a/docs/sources/whatsnew/v0.9.2.rst
+++ b/docs/sources/whatsnew/v0.9.2.rst
@@ -38,7 +38,7 @@ Deprecations
 
 - Removed ``IRIS.plotdistribution()`` from the ``spectrochempy-iris`` plugin
   (target ``removed="0.9.0"`` was reached). Use ``IRIS.f[index].plot()`` instead.
-- Added explicit ``removed="0.10.0`` to all remaining API deprecations that
+- Added explicit ``removed="0.10.0"`` to all remaining API deprecations that
   did not yet specify a removal version :
   ``Baseline.show_regions``, ``PCA.screeplot``, ``PCA.scoreplot``,
   ``DecompositionAnalysis.reduce``, ``DecompositionAnalysis.reconstruct``,
@@ -48,7 +48,7 @@ Deprecations
   ``Project.remove_all_dataset``, ``Project.remove_all_project``,
   ``Project.remove_all_script``, ``restore_rcparams``,
   ``get_import_time_rcparams``, and legacy plot-method aliases
-   (``stack`` → ``lines``, ``map`` → ``contour``, ``image`` → ``contourf``).
+  (``stack`` → ``lines``, ``map`` → ``contour``, ``image`` → ``contourf``).
 
 Developer
 ~~~~~~~~~

--- a/src/spectrochempy/analysis/integration/integrate.py
+++ b/src/spectrochempy/analysis/integration/integrate.py
@@ -71,7 +71,7 @@ def trapezoid(dataset, **kwargs):
     r"""
     Integrate using the composite trapezoidal rule.
 
-    Wrapper of `scpy.integrate.trapezoid`.
+    Wrapper of ``scipy.integrate.trapezoid``.
 
     Performs the integration along the last or given dimension.
 
@@ -92,11 +92,11 @@ def trapezoid(dataset, **kwargs):
     dim : `int` or `str`, optional, default: ``"x"``
         Dimension along which to integrate.
         If an integer is provided, it is equivalent to the numpy axis
-        parameter for `~numpy.ndarray`s.
+        parameter for ``numpy.ndarray``.
 
     See Also
     --------
-    trapz : An alias of `trapezoid`.
+    trapz : An alias of ``trapezoid``.
     simpson : Integrate using the composite simpson rule.
 
     Example
@@ -115,7 +115,7 @@ def trapz(dataset, **kwargs):
 
 
 trapz.__doc__ = f"""
-    An alias of `trapezoid` kept for backwards compatibility.
+    An alias of ``trapezoid`` kept for backwards compatibility.
 {trapezoid.__doc__}"""
 
 
@@ -124,7 +124,7 @@ def simpson(dataset, *args, **kwargs):
     r"""
     Integrate using the composite Simpson's rule.
 
-    Wrapper of `scpy.integrate.simpson`.
+    Wrapper of ``scipy.integrate.simpson``.
 
     Performs the integration along the last or given dimension.
 
@@ -148,9 +148,9 @@ def simpson(dataset, *args, **kwargs):
     ----------------
     dim : `int` or `str`, optional, default: ``"x"``
         Dimension along which to integrate.
-        If an integer is provided, it is equivalent to the `numpy.axis` parameter
-        for `~numpy.ndarray`s.
-    even : any of [``'avg'``, ``'first'``, ``'last'``\ }, optional, default: ``'avg'``
+        If an integer is provided, it is equivalent to the ``numpy.axis`` parameter
+        for ``numpy.ndarray``.
+    even : {``'avg'``, ``'first'``, ``'last'``}, optional, default: ``'avg'``
 
         * ``'avg'`` : Average two results: 1) use the first N-2 intervals with
           a trapezoidal rule on the last interval and 2) use the last
@@ -162,7 +162,7 @@ def simpson(dataset, *args, **kwargs):
 
     See Also
     --------
-    simps : An alias of simpson (Deprecated).
+    simps : An alias of ``simpson`` (deprecated).
     trapezoid : Integrate using the composite simpson rule.
 
     Example
@@ -182,5 +182,5 @@ def simps(dataset, **kwargs):
 
 
 simps.__doc__ = f"""
-    An alias of `simpson` kept for backwards compatibility.
+    An alias of ``simpson`` kept for backwards compatibility.
 {trapezoid.__doc__}"""

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -1657,37 +1657,13 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         **kwargs
             Additional arguments passed to the plotting function.
 
-            For method="stack", the following specific kwargs are supported:
-            - palette : str or list, optional
-                Color palette. If None, auto-detect based on dataset.
-                If "continuous": use continuous colormap (viridis).
-                If "categorical": use matplotlib default color cycle.
-                If colormap name: use that colormap.
-                If list/tuple of colors: use as explicit categorical colors.
+            For ``method="stack"``, ``palette`` controls categorical or continuous
+            color selection. It accepts ``None``, a colormap name, or an explicit
+            list of colors.
 
-            For method="image", "map", "surface" (2D plots), the following kwargs are supported:
-            - cmap : str, optional
-                Colormap name. If None, auto-detected based on data.
-                Defaults to "viridis" (sequential) or "RdBu_r" (diverging).
-            - cmap_mode : str, optional, default: "auto"
-                Colormap mode for 2D plots. Possible values:
-                "auto" - automatically choose sequential or diverging based on data
-                "sequential" - force sequential colormap (viridis)
-                "diverging" - force diverging colormap (RdBu_r)
-            - center : numeric or str, optional
-                Center value for diverging colormaps. Possible values:
-                None - use 0 for diverging mode
-                "auto" - auto-detect center (0 if data crosses zero, else midpoint)
-                numeric - use this value as center
-            - norm : matplotlib.colors.Normalize, optional
-                Explicit normalization object. If provided, overrides cmap and center.
-            - contrast_safe : bool, optional, default: True
-                If True, trim colormap ends to ensure minimum contrast with background.
-                Prevents low-luminance colors (e.g., yellow in viridis) from blending
-                with white backgrounds.
-            - min_contrast : float, optional, default: 2.5
-                Minimum WCAG contrast ratio for contrast-safe colormaps.
-                2.5 = AA large text, 3.0 = AA normal text, 4.5 = AAA.
+            For ``method="image"``, ``"map"``, or ``"surface"``, common
+            2D-specific kwargs include ``cmap``, ``cmap_mode``, ``center``,
+            ``norm``, ``contrast_safe``, and ``min_contrast``.
 
         Returns
         -------

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -273,7 +273,7 @@ def read(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -343,7 +343,7 @@ def read(*paths, **kwargs):
     read_opus : Read OPUS spectra.
     read_labspec : Read Raman LABSPEC spectra (:file:`.txt`).
     read_omnic : Read Omnic spectra (:file:`.spa`, :file:`.spg`, :file:`.srs`).
-    read_soc : Read Surface Optics Corps. files (:file:`.ddr` , :file:`.hdr` or :file:`.sdr`).
+    read_soc : Read Surface Optics Corp. files (:file:`.ddr`, :file:`.hdr`, or :file:`.sdr`).
     read_galactic : Read Galactic files (:file:`.spc`).
     read_quadera : Read a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
     read_csv : Read CSV files (:file:`.csv`).

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -54,7 +54,7 @@ def read_csv(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -101,10 +101,10 @@ def read_csv(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ``'matlab'``, ``'jcamp'``,
-        ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -43,7 +43,7 @@ def read_jcamp(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -90,10 +90,10 @@ def read_jcamp(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``, ``'csv'``,
-        ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_labspec.py
+++ b/src/spectrochempy/core/readers/read_labspec.py
@@ -38,7 +38,7 @@ def read_labspec(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -85,10 +85,10 @@ def read_labspec(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-        ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -42,7 +42,7 @@ def read_matlab(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -89,10 +89,10 @@ def read_matlab(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-        ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -66,7 +66,7 @@ def read_omnic(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -113,10 +113,10 @@ def read_omnic(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``, ``'csv'``,
-        ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by
@@ -137,7 +137,7 @@ def read_omnic(*paths, **kwargs):
     read_opus : Read OPUS spectra.
     read_labspec : Read Raman LABSPEC spectra (:file:`.txt`).
     read_omnic : Read Omnic spectra (:file:`.spa`, :file:`.spg`, :file:`.srs`).
-    read_soc : Read Surface Optics Corps. files (:file:`.ddr` , :file:`.hdr` or :file:`.sdr`).
+    read_soc : Read Surface Optics Corp. files (:file:`.ddr`, :file:`.hdr`, or :file:`.sdr`).
     read_galactic : Read Galactic files (:file:`.spc`).
     read_quadera : Read a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
 
@@ -239,7 +239,7 @@ def read_spg(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -286,10 +286,10 @@ def read_spg(*paths, **kwargs):
 
     .. versionadded:: 0.7.2
     protocol : `str`, optional
-    ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-    ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-    ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-    is inferred (whenever it is possible) from the filename extension.
+    ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+    ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+    If not provided, the correct protocol is inferred whenever possible
+    from the filename extension.
     read_only: `bool`, optional, default: `True`
     Used only when url are specified.  If True, saving of the
     files is performed in the current directory, or in the directory specified by
@@ -313,7 +313,7 @@ def read_spg(*paths, **kwargs):
     read_opus : Read OPUS spectra.
     read_labspec : Read Raman LABSPEC spectra (:file:`.txt`).
     read_omnic : Read Omnic spectra (:file:`.spa`, :file:`.spg`, :file:`.srs`).
-    read_soc : Read Surface Optics Corps. files (:file:`.ddr` , :file:`.hdr` or :file:`.sdr`).
+    read_soc : Read Surface Optics Corp. files (:file:`.ddr`, :file:`.hdr`, or :file:`.sdr`).
     read_galactic : Read Galactic files (:file:`.spc`).
     read_quadera : Read a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
 
@@ -355,7 +355,7 @@ def read_spa(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -402,10 +402,10 @@ def read_spa(*paths, **kwargs):
 
     .. versionadded:: 0.7.2
     protocol : `str`, optional
-    ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-    ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-    ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-    is inferred (whenever it is possible) from the filename extension.
+    ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+    ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+    If not provided, the correct protocol is inferred whenever possible
+    from the filename extension.
     read_only: `bool`, optional, default: `True`
     Used only when url are specified.  If True, saving of the
     files is performed in the current directory, or in the directory specified by
@@ -426,7 +426,7 @@ def read_spa(*paths, **kwargs):
     read_opus : Read OPUS spectra.
     read_labspec : Read Raman LABSPEC spectra (:file:`.txt`).
     read_omnic : Read Omnic spectra (:file:`.spa`, :file:`.spg`, :file:`.srs`).
-    read_soc : Read Surface Optics Corps. files (:file:`.ddr` , :file:`.hdr` or :file:`.sdr`).
+    read_soc : Read Surface Optics Corp. files (:file:`.ddr`, :file:`.hdr`, or :file:`.sdr`).
     read_galactic : Read Galactic files (:file:`.spc`).
     read_quadera : Read a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
 
@@ -470,7 +470,7 @@ def read_srs(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -525,10 +525,10 @@ def read_srs(*paths, **kwargs):
 
     .. versionadded:: 0.7.2
     protocol : `str`, optional
-    ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-    ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-    ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-    is inferred (whenever it is possible) from the filename extension.
+    ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+    ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+    If not provided, the correct protocol is inferred whenever possible
+    from the filename extension.
     read_only: `bool`, optional, default: `True`
     Used only when url are specified.  If True, saving of the
     files is performed in the current directory, or in the directory specified by
@@ -549,7 +549,7 @@ def read_srs(*paths, **kwargs):
     read_opus : Read OPUS spectra.
     read_labspec : Read Raman LABSPEC spectra (:file:`.txt`).
     read_omnic : Read Omnic spectra (:file:`.spa`, :file:`.spg`, :file:`.srs`).
-    read_soc : Read Surface Optics Corps. files (:file:`.ddr` , :file:`.hdr` or :file:`.sdr`).
+    read_soc : Read Surface Optics Corp. files (:file:`.ddr`, :file:`.hdr`, or :file:`.sdr`).
     read_galactic : Read Galactic files (:file:`.spc`).
     read_quadera : Read a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
 

--- a/src/spectrochempy/core/readers/read_opus.py
+++ b/src/spectrochempy/core/readers/read_opus.py
@@ -48,7 +48,7 @@ def read_opus(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
     type : str, optional
@@ -118,10 +118,10 @@ def read_opus(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``, ``'csv'``,
-        ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by
@@ -141,7 +141,7 @@ def read_opus(*paths, **kwargs):
     read_dir : Read an entire directory.
     read_labspec : Read Raman LABSPEC spectra (:file:`.txt`).
     read_omnic : Read Omnic spectra (:file:`.spa`, :file:`.spg`, :file:`.srs`).
-    read_soc : Read Surface Optics Corps. files (:file:`.ddr` , :file:`.hdr` or :file:`.sdr`).
+    read_soc : Read Surface Optics Corp. files (:file:`.ddr`, :file:`.hdr`, or :file:`.sdr`).
     read_galactic : Read Galactic files (:file:`.spc`).
     read_quadera : Read a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
 

--- a/src/spectrochempy/core/readers/read_quadera.py
+++ b/src/spectrochempy/core/readers/read_quadera.py
@@ -40,7 +40,7 @@ def read_quadera(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -87,10 +87,10 @@ def read_quadera(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-        ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_soc.py
+++ b/src/spectrochempy/core/readers/read_soc.py
@@ -33,7 +33,7 @@ def read_soc(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -78,10 +78,10 @@ def read_soc(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``, ``'csv'``,
-        ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by
@@ -130,7 +130,7 @@ def read_ddr(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -175,10 +175,10 @@ def read_ddr(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``, ``'csv'``,
-        ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by
@@ -227,7 +227,7 @@ def read_hdr(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -272,10 +272,10 @@ def read_hdr(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``, ``'csv'``,
-        ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by
@@ -324,7 +324,7 @@ def read_sdr(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -369,10 +369,10 @@ def read_sdr(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``, ``'csv'``,
-        ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_spc.py
+++ b/src/spectrochempy/core/readers/read_spc.py
@@ -42,7 +42,7 @@ def read_spc(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -89,10 +89,10 @@ def read_spc(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-        ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_wire.py
+++ b/src/spectrochempy/core/readers/read_wire.py
@@ -808,7 +808,7 @@ def read_wire(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -855,10 +855,10 @@ def read_wire(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-        ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/core/readers/read_zip.py
+++ b/src/spectrochempy/core/readers/read_zip.py
@@ -32,7 +32,7 @@ def read_zip(*paths, **kwargs):
         - e.g., ( [filename1, filename2, ...], kwargs )
 
         The returned datasets are merged to form a single dataset,
-        except if ``merge`` is set to `False`.
+        except if ``merge`` is set to ``False``.
     **kwargs : keyword parameters, optional
         See Other Parameters.
 
@@ -79,10 +79,10 @@ def read_zip(*paths, **kwargs):
 
         .. versionadded:: 0.7.2
     protocol : `str`, optional
-        ``Protocol`` used for reading. It can be one of {``'scp'``, ``'omnic'``,
-        ``'opus'``, ````, ``'matlab'``, ``'jcamp'``,
-        ``'csv'``, ``'excel'``}. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the filename extension.
+        ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
+        ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.
+        If not provided, the correct protocol is inferred whenever possible
+        from the filename extension.
     read_only: `bool`, optional, default: `True`
         Used only when url are specified.  If True, saving of the
         files is performed in the current directory, or in the directory specified by

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -8,15 +8,15 @@
 MCR-ALS with kinetic constraints
 ================================
 
-In this example, we perform the MCR ALS optimization of the UV-vis of spectra resulting
-from a three-component reaction `A` -> `B` -> `C` which was investigated by UV–Vis
-spectroscopy. Full details on the reaction and data acquisition conditions can be found
-in :cite:t:`bijlsma:2001` .
-The data can be downloded from the author website `Biosystems Data Analysis group
-University of Amsterdam
-<http://www.bdagroup.nl/content/Downloads/datasets/datasets.php>`__
-(Copyright 2005 Biosystems Data Analysis Group ; Universiteit van Amsterdam ). For the user convenience,
-# this dataset is present in the 'datadir' of spectrochempy in 'matlabdata/METING9.MAT'.
+In this example, we perform MCR-ALS optimization on UV-Vis spectra from a
+three-component reaction ``A -> B -> C`` investigated by UV-Vis spectroscopy.
+Full details on the reaction and data acquisition conditions can be found in
+:cite:t:`bijlsma:2001`.
+
+The data can be downloaded from the `Biosystems Data Analysis Group, University
+of Amsterdam <http://www.bdagroup.nl/content/Downloads/datasets/datasets.php>`__.
+For convenience, this dataset is also available in the SpectroChemPy test-data
+directory as ``matlabdata/METING9.MAT``.
 """
 
 import numpy as np

--- a/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
@@ -74,8 +74,7 @@ x
 try:
     x.to("hour")
 except Exception as e:
-    scp.error_(e)
-    # scp.error_(pint.DimensionalityError, e)
+    print(f"Expected incompatible-unit conversion error: {e}")
 
 # %%
 # This, of course, also applies to NDDataset.
@@ -95,7 +94,7 @@ _ = ds.plot()
 try:
     ds.x.ito("nanometer")
 except Exception as e:
-    scp.error_(Exception, e)
+    print(f"Expected incompatible coordinate conversion error: {e}")
 
 ds.x = ds.x.to("nanometer")
 ds.x

--- a/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
@@ -17,8 +17,9 @@ In this example, we show how units can be used in SpectroChemPy
 import spectrochempy as scp
 
 # %%
-# Spectrochempy can do calculations with units - it uses [pint](https://pint.readthedocs.io) to define and perform
-# operation on data with units.
+# SpectroChemPy can do calculations with units. It uses
+# [pint](https://pint.readthedocs.io) to define and perform operations on
+# data with units.
 
 # %%
 # Create quantities
@@ -37,7 +38,8 @@ ur = scp.ur
 10.0 * ur.meter / ur.gram / ur.volt
 
 # %%
-# `ur` stands for **unit registry**, which handle many type of units (and conversion between them)
+# `ur` stands for **unit registry**, which handles many types of units
+# and conversions between them.
 
 # %%
 # Units for dataset
@@ -77,13 +79,15 @@ except Exception as e:
 
 # %%
 # This, of course, also applies to NDDataset.
-# Let's try for the `x` coordinate. It is `wavenumber` in $cm^{-1}$ that can be transformed in $Hz$ for instance:
+# Let's try for the `x` coordinate. It is a `wavenumber` in $cm^{-1}$ that
+# can be transformed to $Hz$, for instance:
 
 ds.x.ito("terahertz")
 _ = ds.plot()
 # %%
-# We can also change the wavenumbers (or frequency units), to energy units or wavelength as
-# Spectrochempy (thanks to [pint](https://pint.readthedocs.io)) knows how to make the transformation.
+# We can also change wavenumber or frequency units to energy or wavelength,
+# as SpectroChemPy, thanks to [pint](https://pint.readthedocs.io), knows how
+# to make the transformation.
 
 ds.x.ito("eV")
 _ = ds.plot()
@@ -104,7 +108,7 @@ _ = ds.plot()
 ds.ito("transmittance")
 _ = ds.plot()
 # %%
-# back into `ansorbance
+# Back to `absorbance`.
 ds.ito("absorbance")
 ds.x.ito("cm^-1")
 _ = ds.plot()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
@@ -83,19 +83,20 @@ new = mydataset["hot"]
 # As the section NDDataset is 2D, a stack plot is displayed by default. As you can see, the x-axis is in wavenumber
 # and the ordinate axis is in absorbance units (au). The y dimension of the dataset is the time-on-stream (in minutes).
 # Because the time-on-stream values are floats, this triggers the default sequential colormap ('viridis'). The
-# corresponding values can be seen if `colorbar' is passed as `True`:
+# corresponding values can be seen if `colorbar` is passed as `True`:
 _ = new.plot(colorbar=True)
 
 # %%
 # It is also possible to display this dataset as an image (actually a filled contour plot).
 # The x is the same as before, but the ordinates are now the time-on-stream values. The color of the pixels is now
 # related to the value of the absorbance. As the dataset contains both negative and positive values, the default
-# colormap is diverging (`RdBu').
+# colormap is diverging (`RdBu`).
 #
 # sphinx_gallery_thumbnail_number = 2
 _ = new.plot(method="image", colorbar=True)
 # %%
-# If a dataset contains only positive values, the default colormap is sequential (`:
+# If a dataset contains only positive values, the default colormap is
+# sequential (`viridis`):
 
 _ = np.abs(new).plot(method="image", colorbar=True)
 

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -32,10 +32,11 @@ _ = dataset.plot(method="image")
 
 # %%
 # In this example, the diverging colormap is triggered because the dataset
-# contains few, but some negative values. If the smaller lobe is at larger than `diverging_margin` (default 5%) of
-# the total # range, i.e. if the following condition is satisfied:
-#       min(|vmin|, |vmax|) / (vmax - vmin) > margin
-#  Then a diverging colormap is used.
+# contains a few negative values. If the smaller lobe is larger than
+# `diverging_margin` (default 5%) of the total range, i.e. if the following
+# condition is satisfied:
+# `min(abs(vmin), abs(vmax)) / (vmax - vmin) > margin`
+# then a diverging colormap is used.
 #
 # To avoid this behavior, you can explicitly enforce a sequential colormap,
 # for example "viridis":
@@ -44,7 +45,8 @@ _ = dataset.plot_image(cmap="cividis")
 
 # %%
 # Alternatively, you can increase the `diverging_margin` that determines when the
-# diverging colormap is applied. Then the default sequential colormap (`viridis') will be used:
+# diverging colormap is applied. Then the default sequential colormap
+# (`viridis`) will be used:
 
 _ = dataset.plot(method="image", diverging_margin=0.1)
 

--- a/src/spectrochempy/examples/core/e_project/plot_project.py
+++ b/src/spectrochempy/examples/core/e_project/plot_project.py
@@ -65,10 +65,3 @@ proj.save()
 
 newproj = scp.Project.load("project_1")
 newproj
-
-
-# %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
-# scp.show()

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -35,18 +35,18 @@ def plot_1D(dataset, method=None, **kwargs):
 
     Parameters
     ----------
-    dataset : :class:~spectrochempy.ddataset.nddataset.NDDataset
+    dataset : :class:`~spectrochempy.core.dataset.nddataset.NDDataset`
         Source of data to plot.
     method : str, optional, default: auto-detected from data dimensionality
         Name of plotting method to use. If None, method is chosen based on data
         dimensionality.
 
-        1D plotting methods:
+        Available 1D plotting methods include:
 
-        - `pen` : Solid line plot
-        - `bar` : Bar graph
-        - `scatter` : Scatter plot
-        - `scatter+pen` : Scatter plot with solid line
+        - ``pen``: solid line plot
+        - ``bar``: bar graph
+        - ``scatter``: scatter plot
+        - ``scatter+pen``: scatter plot with solid line
 
 
     **kwargs
@@ -114,7 +114,7 @@ def plot_1D(dataset, method=None, **kwargs):
         styles for plotting.
     title : str
         Title of the plot (or subplot) axe.
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -606,7 +606,7 @@ def plot_scatter(dataset, **kwargs):
         styles for plotting.
     title : str
         Title of the plot (or subplot) axe.
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -718,7 +718,7 @@ def plot_pen(dataset, **kwargs):
         styles for plotting.
     title : str
         Title of the plot (or subplot) axe.
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -830,7 +830,7 @@ def plot_scatter_pen(dataset, **kwargs):
         styles for plotting.
     title : str
         Title of the plot (or subplot) axe.
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -942,7 +942,7 @@ def plot_bar(dataset, **kwargs):
         styles for plotting.
     title : str
         Title of the plot (or subplot) axe.
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -344,7 +344,7 @@ def plot_lines(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -475,7 +475,7 @@ def plot_contour(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -610,7 +610,7 @@ def plot_contourf(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -755,7 +755,7 @@ def plot_stack(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -890,7 +890,7 @@ def plot_map(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -1025,7 +1025,7 @@ def plot_image(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -1160,7 +1160,7 @@ def plot_2D(dataset, method=None, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional

--- a/src/spectrochempy/plotting/plot3d.py
+++ b/src/spectrochempy/plotting/plot3d.py
@@ -95,7 +95,7 @@ def plot_surface(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -213,7 +213,7 @@ def plot_waterfall(dataset, **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional
@@ -352,7 +352,7 @@ def plot_3D(dataset, method="surface", **kwargs):
         Title of the plot (or subplot) axe.
     transposed : bool, optional, default: False
         Transpose the data before plotting (2D plots only).
-    twinx : :class:~matplotlib.axes.Axes instance, optional, default: None
+    twinx : :class:`~matplotlib.axes.Axes`, optional, default: None
         If this is not None, then a twin axes will be created with a
         common x dimension.
     uselabel_x: bool, optional

--- a/src/spectrochempy/processing/psd/psd.py
+++ b/src/spectrochempy/processing/psd/psd.py
@@ -36,14 +36,19 @@ class PSDResult:
     ----------
     prs : NDDataset
         Phase-resolved spectra with shape (n_phi, n_channels).
+
     in_phase : NDDataset
         In-phase component (phi=0°) with shape (n_channels,).
+
     quadrature : NDDataset
         Quadrature component (phi=90°) with shape (n_channels,).
+
     amplitude : NDDataset
         Amplitude = sqrt(in_phase² + quadrature²).
+
     phase : NDDataset
         Phase = atan2(quadrature, in_phase).
+
     T : NDDataset or None
         Transform matrix T with shape (n_phi, n_spectra_per_cycle).
         None when ``demodulation="integration"``.
@@ -82,8 +87,7 @@ class PSD(BaseConfigurable):
 
     Supports two demodulation strategies:
 
-    1. Matrix transform demodulation:
-       ``A_demodulated = T · A_averaged``
+    1. Matrix transform demodulation: ``A_demodulated = T · A_averaged``
     2. Explicit integration demodulation:
        ``A_demodulated(φ, λ) = (2/period) ∫ A_averaged(t, λ) · sin(k·ω·t + φ) dt``
 


### PR DESCRIPTION
## Summary
This PR reduces documentation build warning noise by cleaning fragile RST/Markdown markup across user docs, gallery sources, and several docstrings.

## What changed
- cleaned Jupytext-backed import/export tutorials that were generating malformed notebook output
- fixed broken labels, anchors, headings, and spacing in a few documentation pages and old whatsnew files
- normalized several reader, plotting, integration, and PSD docstrings to avoid repeated Sphinx/docutils warnings
- cleaned gallery example prose that was producing invalid generated RST

## Out of scope
- no runtime behavior changes
- no scientific example changes beyond documentation/rendering cleanup
- no broad docs build configuration changes

## Validation
- targeted local text audit against the last noisy docs build log
- full local docs build was not rerun here because the environment attempted external test-data downloads
