### PR TITLE
MAINT: introduce AnalysisResult prototype for PCA

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -53,3 +53,9 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- MAINT: introduce ``ResultBase``, ``AnalysisResult``, and ``FitResult`` result
+  object infrastructure as defined in the Result Object Contract RFC. A PCA-only
+  prototype exposes ``pca.result`` as an ``AnalysisResult`` with named outputs
+  (scores, loadings, components) and diagnostics (explained variance metrics)
+  while preserving all existing public API and behavior. (:pr:`1208`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,3 +11,12 @@ What's New in Revision 0.10.1.dev
 
 These are the changes in SpectroChemPy-0.10.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Developer
+~~~~~~~~~
+
+- MAINT: introduce ``ResultBase``, ``AnalysisResult``, and ``FitResult`` result
+  object infrastructure as defined in the Result Object Contract RFC. A PCA-only
+  prototype exposes ``pca.result`` as an ``AnalysisResult`` with named outputs
+  (scores, loadings, components) and diagnostics (explained variance metrics)
+  while preserving all existing public API and behavior. (:pr:`1208`)

--- a/src/spectrochempy/analysis/_base/__init__.pyi
+++ b/src/spectrochempy/analysis/_base/__init__.pyi
@@ -8,6 +8,8 @@
 
 __all__ = [
     "_analysisbase",
+    "_result",
 ]
 
 from . import _analysisbase
+from . import _result

--- a/src/spectrochempy/analysis/_base/_result.py
+++ b/src/spectrochempy/analysis/_base/_result.py
@@ -1,0 +1,98 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Result object infrastructure for analysis and fit outputs."""
+
+__all__ = ["ResultBase", "AnalysisResult", "FitResult"]
+
+
+class ResultBase:
+    """
+    Base class for result objects produced by fitted estimators.
+
+    Provides common identity, provenance, named output access,
+    diagnostics, and a compact text representation.
+    """
+
+    def __init__(self, *, estimator, parameters=None, outputs=None, diagnostics=None):
+        self._estimator = (
+            str(estimator) if not isinstance(estimator, str) else estimator
+        )
+        self._parameters = dict(parameters or {})
+        self._outputs = dict(outputs or {})
+        self._diagnostics = dict(diagnostics or {})
+
+    # ----------------------------------------------------------------------------------
+    # Public properties
+    # ----------------------------------------------------------------------------------
+    @property
+    def estimator(self):
+        """Name of the estimator that produced this result."""
+        return self._estimator
+
+    @property
+    def parameters(self):
+        """Public estimator parameters used for the run."""
+        return self._parameters
+
+    @property
+    def outputs(self):
+        """Named output datasets produced by the operation."""
+        return self._outputs
+
+    @property
+    def diagnostics(self):
+        """Named diagnostic values produced by the operation."""
+        return self._diagnostics
+
+    # ----------------------------------------------------------------------------------
+    # Representation
+    # ----------------------------------------------------------------------------------
+    def __repr__(self):
+        lines = [type(self).__name__]
+        lines.append(f"  estimator: {self._estimator}")
+        if self._parameters:
+            lines.append("  parameters:")
+            for name, value in self._parameters.items():
+                lines.append(f"      {name}: {value}")
+        if self._outputs:
+            lines.append("  outputs:")
+            for name, obj in self._outputs.items():
+                shape = getattr(obj, "shape", None)
+                if shape is not None:
+                    lines.append(f"      {name} {shape}")
+                else:
+                    lines.append(f"      {name}")
+        if self._diagnostics:
+            lines.append("  diagnostics:")
+            for name, obj in self._diagnostics.items():
+                shape = getattr(obj, "shape", None)
+                if shape is not None:
+                    lines.append(f"      {name} {shape}")
+                else:
+                    lines.append(f"      {name}")
+        return "\n".join(lines)
+
+
+class AnalysisResult(ResultBase):
+    """
+    Result of a decomposition or projection analysis.
+
+    Typical outputs include scores, loadings, and components.
+    Typical diagnostics include explained variance.
+    """
+
+    pass
+
+
+class FitResult(ResultBase):
+    """
+    Result of a fit or optimization operation.
+
+    Typical outputs include fitted curves, components, and residuals.
+    Typical diagnostics include convergence and goodness-of-fit metrics.
+    """
+
+    pass

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -15,6 +15,7 @@ from sklearn import decomposition
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.application.application import info_
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 
@@ -325,6 +326,49 @@ for reproducible results across multiple function calls.""",
     def scores(self):
         """Returns PCA scores."""
         return self.transform(self.X)
+
+    @property
+    def result(self):
+        """
+        Return the PCA result object.
+
+        Returns
+        -------
+        AnalysisResult
+            Result object containing outputs (scores, loadings, components)
+            and diagnostics (explained_variance, explained_variance_ratio).
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                "The fit method must be used before accessing the result",
+            )
+
+        # NOTE: a new AnalysisResult is created on every access.
+        # Caching is deliberately deferred to PR1 to keep the implementation
+        # simple and easy to review. This means repeated calls to `result`
+        # will re-fetch outputs from the estimator's live properties.
+        # A caching strategy (e.g., lazy creation with cache invalidation
+        # on re-fit) may be introduced in a follow-up PR if profiling shows
+        # a measurable cost.
+        return AnalysisResult(
+            estimator="PCA",
+            parameters={
+                "n_components": self.n_components,
+                "standardized": self.standardized,
+                "scaled": self.scaled,
+                "whiten": self.whiten,
+                "svd_solver": self.svd_solver,
+            },
+            outputs={
+                "scores": self.scores,
+                "loadings": self.loadings,
+                "components": self.components,
+            },
+            diagnostics={
+                "explained_variance": self.explained_variance,
+                "explained_variance_ratio": self.explained_variance_ratio,
+            },
+        )
 
     @property
     @_wrap_ndarray_output_to_nddataset(

--- a/tests/test_analysis/test_decomposition/test_pca_result.py
+++ b/tests/test_analysis/test_decomposition/test_pca_result.py
@@ -1,0 +1,237 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the PCA result object contract prototype.
+"""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis._base._result import FitResult
+from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.decomposition.pca import PCA
+
+
+# ======================================================================================
+# Fixtures
+# ======================================================================================
+@pytest.fixture()
+def low_rank_dataset():
+    u1 = np.array([1.0, 1.0, 1.0, -1.0, -1.0, -1.0]) / np.sqrt(6.0)
+    u2 = np.array([1.0, -1.0, 0.0, 1.0, -1.0, 0.0]) / 2.0
+    u3 = np.array([1.0, 1.0, -2.0, 1.0, 1.0, -2.0]) / np.sqrt(12.0)
+    data = np.column_stack(
+        [
+            6.0 * u1,
+            3.0 * u2,
+            u3,
+            np.zeros(6),
+            np.zeros(6),
+        ]
+    )
+    return scp.NDDataset(
+        data,
+        coordset=[
+            scp.Coord.arange(6, title="sample"),
+            scp.Coord.arange(5, title="feature"),
+        ],
+        units="absorbance",
+        title="synthetic PCA matrix",
+    )
+
+
+# ======================================================================================
+# ResultBase and AnalysisResult creation tests
+# ======================================================================================
+class TestResultBase:
+    def test_minimal_creation(self):
+        result = ResultBase(estimator="TestEstimator")
+        assert result.estimator == "TestEstimator"
+        assert result.outputs == {}
+        assert result.diagnostics == {}
+        assert result.parameters == {}
+
+    def test_with_outputs_and_diagnostics(self):
+        result = ResultBase(
+            estimator="Test",
+            outputs={"a": np.ones(3), "b": np.ones((2, 3))},
+            diagnostics={"d": np.array([1.0, 2.0])},
+        )
+        assert "a" in result.outputs
+        assert "b" in result.outputs
+        assert "d" in result.diagnostics
+
+    def test_repr(self):
+        result = ResultBase(
+            estimator="Test",
+            outputs={"x": np.ones((3, 4))},
+            diagnostics={"y": np.ones(2)},
+        )
+        text = repr(result)
+        assert "ResultBase" in text
+        assert "Test" in text
+        assert "x" in text
+        assert "(3, 4)" in text
+        assert "y" in text
+
+
+class TestAnalysisResult:
+    def test_creation(self):
+        result = AnalysisResult(estimator="PCA")
+        assert isinstance(result, AnalysisResult)
+        assert isinstance(result, ResultBase)
+
+    def test_repr(self):
+        result = AnalysisResult(
+            estimator="PCA",
+            outputs={"scores": np.ones((6, 5))},
+            diagnostics={"explained_variance": np.ones(5)},
+        )
+        text = repr(result)
+        assert "AnalysisResult" in text
+        assert "PCA" in text
+
+
+class TestFitResult:
+    def test_creation(self):
+        result = FitResult(estimator="Optimize")
+        assert isinstance(result, FitResult)
+        assert isinstance(result, ResultBase)
+
+
+# ======================================================================================
+# PCA result integration tests
+# ======================================================================================
+class TestPCAResult:
+    def test_result_is_analysis_result(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        result = pca.result
+        assert isinstance(result, AnalysisResult)
+
+    def test_estimator_name(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        assert pca.result.estimator == "PCA"
+
+    def test_outputs_contain_keys(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        result = pca.result
+        for name in ("scores", "loadings", "components"):
+            assert name in result.outputs, f"{name} missing from result.outputs"
+
+    def test_diagnostics_contain_keys(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        result = pca.result
+        for name in ("explained_variance", "explained_variance_ratio"):
+            assert name in result.diagnostics, f"{name} missing from result.diagnostics"
+
+    def test_outputs_match_properties(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        result = pca.result
+        np.testing.assert_array_equal(
+            result.outputs["scores"].data,
+            pca.scores.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["loadings"].data,
+            pca.loadings.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["components"].data,
+            pca.components.data,
+        )
+
+    def test_diagnostics_match_properties(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        result = pca.result
+        np.testing.assert_array_equal(
+            result.diagnostics["explained_variance"].data,
+            pca.explained_variance.data,
+        )
+        np.testing.assert_array_equal(
+            result.diagnostics["explained_variance_ratio"].data,
+            pca.explained_variance_ratio.data,
+        )
+
+    def test_repr_contains_expected_fields(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        result = pca.result
+        text = repr(result)
+        assert "AnalysisResult" in text
+        assert "PCA" in text
+        assert "scores" in text
+        assert "loadings" in text
+        assert "components" in text
+        assert "explained_variance" in text
+
+    def test_result_is_not_cached(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        assert pca.result is not pca.result, (
+            "AnalysisResult is recreated on every access; "
+            "change this assertion if caching is added later"
+        )
+
+    def test_parameters_contain_expected_keys(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        params = pca.result.parameters
+        for name in ("n_components", "standardized", "scaled", "whiten", "svd_solver"):
+            assert name in params, f"{name} missing from result.parameters"
+
+    def test_parameters_values(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        params = pca.result.parameters
+        assert params["n_components"] == 5
+        assert params["standardized"] is False
+        assert params["scaled"] is False
+        assert params["whiten"] is False
+        assert params["svd_solver"] == "auto"
+
+    def test_parameters_match_estimator_config(self, low_rank_dataset):
+        pca = PCA(n_components=3, whiten=True, svd_solver="full")
+        pca.fit(low_rank_dataset)
+        params = pca.result.parameters
+        assert params["n_components"] == 3
+        assert params["whiten"] is True
+        assert params["svd_solver"] == "full"
+
+    def test_repr_contains_parameters(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        text = repr(pca.result)
+        assert "parameters:" in text
+        assert "n_components" in text
+        assert "standardized" in text
+
+    def test_raises_before_fit(self):
+        pca = PCA()
+        with pytest.raises(NotFittedError):
+            _ = pca.result
+
+    def test_fit_still_returns_self(self, low_rank_dataset):
+        pca = PCA()
+        ret = pca.fit(low_rank_dataset)
+        assert ret is pca
+
+    def test_existing_properties_unchanged(self, low_rank_dataset):
+        pca = PCA()
+        pca.fit(low_rank_dataset)
+        assert pca.loadings.shape == (5, 5)
+        assert pca.scores.shape == (6, 5)
+        assert pca.components.shape == (5, 5)
+        assert pca.n_components == 5


### PR DESCRIPTION
- Introduce `ResultBase`, `AnalysisResult`, `FitResult` result object infrastructure as defined in the Result Object Contract RFC.

- Add PCA-only prototype exposing `pca.result` as an `AnalysisResult` with:
  - outputs: scores, loadings, components
  - diagnostics: explained_variance, explained_variance_ratio
  - parameters: n_components, standardized, scaled, whiten, svd_solver

- `_outfit` unchanged, PCA continues to rely on it internally
- All existing public API and behavior preserved
- `pca.result` creates a new object on each access (caching deliberately deferred)

**Out of scope:** SVD, NMF, MCRALS, Optimize, Project integration, serialization, DisplaySection, general analysis refactoring.

**Validation:** `python -m pytest tests/test_analysis/test_decomposition/test_pca.py tests/test_analysis/test_decomposition/test_pca_result.py -v` (29/29 passed)