### PR TITLE
MAINT: add AnalysisResult support for SVD

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -64,3 +64,9 @@ Developer
   prototype exposes ``pca.result`` as an ``AnalysisResult`` with named outputs
   (scores, loadings, components) and diagnostics (explained variance metrics)
   while preserving all existing public API and behavior. (:pr:`1208`)
+
+- MAINT: extend ``AnalysisResult`` support to the SVD estimator. The new
+  ``svd.result`` property exposes raw outputs (``U``, ``s``, ``VT``) and
+  diagnostics (``singular_values``, ``explained_variance``,
+  ``explained_variance_ratio``) while preserving all existing public API
+  and backward compatibility. (:pr:`1211`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -28,3 +28,9 @@ Developer
   prototype exposes ``pca.result`` as an ``AnalysisResult`` with named outputs
   (scores, loadings, components) and diagnostics (explained variance metrics)
   while preserving all existing public API and behavior. (:pr:`1208`)
+
+- MAINT: extend ``AnalysisResult`` support to the SVD estimator. The new
+  ``svd.result`` property exposes raw outputs (``U``, ``s``, ``VT``) and
+  diagnostics (``singular_values``, ``explained_variance``,
+  ``explained_variance_ratio``) while preserving all existing public API
+  and backward compatibility. (:pr:`1211`)

--- a/src/spectrochempy/analysis/decomposition/svd.py
+++ b/src/spectrochempy/analysis/decomposition/svd.py
@@ -9,7 +9,9 @@ import numpy as np
 import traitlets as tr
 
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
+from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
+from spectrochempy.analysis._base._result import AnalysisResult
 
 __all__ = ["SVD"]
 __configurables__ = ["SVD"]
@@ -266,3 +268,44 @@ class SVD(DecompositionAnalysis):
     def s(self):
         """Return Vector of singular values ."""
         return self._outfit[1]
+
+    @property
+    def result(self):
+        """
+        Return the SVD result object.
+
+        Returns
+        -------
+        AnalysisResult
+            Result object containing outputs (U, s, VT)
+            and diagnostics (singular_values, explained_variance,
+            explained_variance_ratio).
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                "The fit method must be used before accessing the result",
+            )
+
+        # NOTE: a new AnalysisResult is created on every access.
+        # Caching is deliberately deferred to keep the implementation
+        # simple and aligned with the PCA result behaviour.
+
+        diagnostics = {
+            "singular_values": self.singular_values,
+            "explained_variance": self.explained_variance,
+            "explained_variance_ratio": self.explained_variance_ratio,
+        }
+
+        return AnalysisResult(
+            estimator="SVD",
+            parameters={
+                "full_matrices": self.full_matrices,
+                "compute_uv": self.compute_uv,
+            },
+            outputs={
+                "U": self.U,
+                "s": self.s,
+                "VT": self.VT,
+            },
+            diagnostics=diagnostics,
+        )

--- a/tests/test_analysis/test_decomposition/test_svd_result.py
+++ b/tests/test_analysis/test_decomposition/test_svd_result.py
@@ -1,0 +1,240 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the SVD result object contract prototype.
+"""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.decomposition.svd import SVD
+
+
+# ======================================================================================
+# Fixtures
+# ======================================================================================
+@pytest.fixture()
+def low_rank_dataset():
+    y = scp.Coord.arange(4, title="sample")
+    x = scp.Coord.arange(5, title="feature")
+    data = np.zeros((4, 5))
+    data[0, 0] = 5.0
+    data[1, 1] = 3.0
+    return scp.NDDataset(
+        data,
+        coordset=[y, x],
+        units="absorbance",
+        title="synthetic low-rank matrix",
+    )
+
+
+# ======================================================================================
+# SVD result integration tests
+# ======================================================================================
+class TestSVDResult:
+    def test_result_is_analysis_result(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        result = svd.result
+        assert isinstance(result, AnalysisResult)
+
+    def test_result_is_instance_of_base(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        assert isinstance(svd.result, ResultBase)
+
+    def test_estimator_name(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        assert svd.result.estimator == "SVD"
+
+    def test_result_is_not_cached(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        assert svd.result is not svd.result, (
+            "AnalysisResult is recreated on every access; "
+            "change this assertion if caching is added later"
+        )
+
+    # ----------------------------------------------------------------------------------
+    # Outputs
+    # ----------------------------------------------------------------------------------
+    def test_outputs_contain_keys(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        result = svd.result
+        for name in ("U", "s", "VT"):
+            assert name in result.outputs, f"{name} missing from result.outputs"
+
+    def test_output_values_match_properties(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        result = svd.result
+        np.testing.assert_array_equal(result.outputs["U"], svd.U)
+        np.testing.assert_array_equal(result.outputs["s"], svd.s)
+        np.testing.assert_array_equal(result.outputs["VT"], svd.VT)
+
+    def test_output_types_preserved(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        result = svd.result
+        assert isinstance(result.outputs["U"], np.ndarray)
+        assert isinstance(result.outputs["s"], np.ndarray)
+        assert isinstance(result.outputs["VT"], np.ndarray)
+
+    def test_output_shapes_default(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        result = svd.result
+        assert result.outputs["U"].shape == (4, 4)
+        assert result.outputs["s"].shape == (4,)
+        assert result.outputs["VT"].shape == (4, 5)
+
+    # ----------------------------------------------------------------------------------
+    # Diagnostics
+    # ----------------------------------------------------------------------------------
+    def test_diagnostics_contain_keys(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        result = svd.result
+        for name in (
+            "singular_values",
+            "explained_variance",
+            "explained_variance_ratio",
+        ):
+            assert name in result.diagnostics, f"{name} missing from result.diagnostics"
+
+    def test_diagnostic_values_match_properties(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        result = svd.result
+        np.testing.assert_array_equal(
+            result.diagnostics["singular_values"].data,
+            svd.singular_values.data,
+        )
+        np.testing.assert_array_equal(
+            result.diagnostics["explained_variance"].data,
+            svd.explained_variance.data,
+        )
+        np.testing.assert_array_equal(
+            result.diagnostics["explained_variance_ratio"].data,
+            svd.explained_variance_ratio.data,
+        )
+
+    # ----------------------------------------------------------------------------------
+    # Parameters
+    # ----------------------------------------------------------------------------------
+    def test_parameters_contain_expected_keys(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        params = svd.result.parameters
+        for name in ("full_matrices", "compute_uv"):
+            assert name in params, f"{name} missing from result.parameters"
+
+    def test_parameters_values_default(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        params = svd.result.parameters
+        assert params["full_matrices"] is False
+        assert params["compute_uv"] is True
+
+    def test_parameters_match_estimator_config(self, low_rank_dataset):
+        svd = SVD(full_matrices=True, compute_uv=True)
+        svd.fit(low_rank_dataset)
+        params = svd.result.parameters
+        assert params["full_matrices"] is True
+        assert params["compute_uv"] is True
+
+    # ----------------------------------------------------------------------------------
+    # Representation
+    # ----------------------------------------------------------------------------------
+    def test_repr_contains_expected_fields(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        text = repr(svd.result)
+        assert "AnalysisResult" in text
+        assert "SVD" in text
+        assert "U" in text
+        assert "s" in text
+        assert "VT" in text
+        assert "singular_values" in text
+        assert "explained_variance" in text
+        assert "full_matrices" in text
+
+    def test_repr_does_not_crash(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        _ = repr(svd.result)
+
+    # ----------------------------------------------------------------------------------
+    # Pre-fit guard
+    # ----------------------------------------------------------------------------------
+    def test_raises_before_fit(self):
+        svd = SVD()
+        with pytest.raises(NotFittedError):
+            _ = svd.result
+
+    # ----------------------------------------------------------------------------------
+    # Existing behaviour preserved
+    # ----------------------------------------------------------------------------------
+    def test_fit_still_returns_self(self, low_rank_dataset):
+        svd = SVD()
+        ret = svd.fit(low_rank_dataset)
+        assert ret is svd
+
+    def test_existing_properties_unchanged(self, low_rank_dataset):
+        svd = SVD()
+        svd.fit(low_rank_dataset)
+        assert svd.U.shape == (4, 4)
+        assert svd.s.shape == (4,)
+        assert svd.VT.shape == (4, 5)
+        assert svd.sv.shape == (4,)
+        np.testing.assert_allclose(svd.s, [5.0, 3.0, 0.0, 0.0])
+
+    def test_compute_uv_false(self, low_rank_dataset):
+        svd = SVD(compute_uv=False)
+        svd.fit(low_rank_dataset)
+        # The _outfit normalisation fix (PR #1210) ensures _outfit is always
+        # a (U, s, VT) tuple, so all properties and diagnostics work
+        # correctly even when compute_uv=False.
+        result = svd.result
+        assert isinstance(result, AnalysisResult)
+        assert result.estimator == "SVD"
+        # outputs — U and VT are None, s is correct
+        assert result.outputs["U"] is None
+        np.testing.assert_array_equal(
+            result.outputs["s"],
+            [5.0, 3.0, 0.0, 0.0],
+        )
+        assert result.outputs["VT"] is None
+        # diagnostics are fully populated
+        for name in (
+            "singular_values",
+            "explained_variance",
+            "explained_variance_ratio",
+        ):
+            assert name in result.diagnostics, f"{name} missing from diagnostics"
+        # diagnostics values match properties
+        np.testing.assert_array_equal(
+            result.diagnostics["singular_values"].data,
+            svd.singular_values.data,
+        )
+        np.testing.assert_array_equal(
+            result.diagnostics["explained_variance"].data,
+            svd.explained_variance.data,
+        )
+        np.testing.assert_array_equal(
+            result.diagnostics["explained_variance_ratio"].data,
+            svd.explained_variance_ratio.data,
+        )
+        # params still reflect user configuration
+        assert result.parameters["compute_uv"] is False
+        assert result.parameters["full_matrices"] is False


### PR DESCRIPTION
## Summary

Extend the `AnalysisResult` infrastructure (introduced in PR #1208 for PCA) to the SVD estimator.

### Changes

- **`svd.py`** : new `result` property returning an `AnalysisResult` with:
  - **outputs** : `U`, `s`, `VT` (raw ndarray, preserving existing types)
  - **diagnostics** : `singular_values`, `explained_variance`, `explained_variance_ratio` (NDDataset)
  - **parameters** : `full_matrices`, `compute_uv`
- Diagnostics work correctly in both `compute_uv=True` and `compute_uv=False` modes
  (the pre-existing `compute_uv=False` bug was fixed in PR #1210, merged before this PR).
- **`test_svd_result.py`** : 19 integration tests covering outputs, diagnostics, parameters, repr, error handling, and edge cases.

### Backward compatibility

All existing public API and behavior preserved. All 22 SVD + result tests and 21 PCA result tests pass.