### PR TITLE
FIX: handle SVD compute_uv=False outputs consistently

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
+  ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
+  values and crashes for all properties when ``compute_uv=False``.
+  (:pr:`1210`)
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,14 @@ What's New in Revision 0.10.1.dev
 These are the changes in SpectroChemPy-0.10.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+Bug Fixes
+~~~~~~~~~
+
+- FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
+  ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
+  values and crashes for all properties when ``compute_uv=False``.
+  (:pr:`1210`)
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/decomposition/svd.py
+++ b/src/spectrochempy/analysis/decomposition/svd.py
@@ -142,13 +142,20 @@ class SVD(DecompositionAnalysis):
         # Y is ignored in this model
         full_matrices = self.full_matrices
         compute_uv = self.compute_uv
-        _outfit = np.linalg.svd(X, full_matrices, compute_uv)
+        result = np.linalg.svd(X, full_matrices, compute_uv)
         # Sign correction to ensure deterministic output from SVD.
         # This doesn't work will full_matrices=True.
-        if compute_uv and not full_matrices:
-            U, s, VT = _outfit
-            U, VT = _svd_flip(U, VT)
-            _outfit = U, s, VT
+        if compute_uv:
+            U, s, VT = result
+            if not full_matrices:
+                U, VT = _svd_flip(U, VT)
+            _outfit = (U, s, VT)
+        else:
+            # compute_uv=False: np.linalg.svd returns only the singular
+            # values vector s, not the (U, s, VT) tuple.  Normalise
+            # _outfit to a consistent (U, s, VT) tuple so that all
+            # downstream properties can safely index _outfit[0|1|2].
+            _outfit = (None, result, None)
         return _outfit
 
     # ----------------------------------------------------------------------------------
@@ -158,7 +165,8 @@ class SVD(DecompositionAnalysis):
         if self.compute_uv:
             U, s, VT = self._outfit
             return f"<svd: U{U.shape}, s({s.size}), VT{VT.shape}>"
-        s = self._outfit
+        # _outfit is always a (U, s, VT) tuple after _fit normalisation
+        s = self._outfit[1]
         return f"<svd: s({s.size}), U and VT not computed>"
 
     # ----------------------------------------------------------------------------------

--- a/tests/test_analysis/test_decomposition/test_svd.py
+++ b/tests/test_analysis/test_decomposition/test_svd.py
@@ -85,3 +85,36 @@ def test_svd(low_rank_dataset):
     assert svd.U.shape == (3, 3)
     assert svd.VT.shape == (4, 4)
     assert_allclose(svd.s, [5.0, 3.0, 0.0])
+
+
+def test_svd_compute_uv_false(low_rank_dataset):
+    dataset = low_rank_dataset
+    svd = SVD(compute_uv=False)
+    result = svd.fit(dataset)
+
+    assert result is svd
+    # _outfit is always a (U, s, VT) tuple after _fit normalisation
+    assert isinstance(svd._outfit, tuple)
+    assert len(svd._outfit) == 3
+    # U and VT are None when compute_uv=False
+    assert svd.U is None
+    assert svd.VT is None
+    # Singular values are correct
+    assert_allclose(svd.s, [5.0, 3.0, 0.0, 0.0])
+    assert svd.sv.shape == (4,)
+    assert svd.sv.title == "Singular values"
+    # Diagnostics work correctly
+    assert svd.ev.shape == (4,)
+    assert svd.ev_ratio.shape == (4,)
+    assert svd.ev_cum.shape == (4,)
+    assert_allclose(svd.ev_ratio.data, [2500.0 / 34.0, 900.0 / 34.0, 0.0, 0.0])
+    assert_allclose(svd.ev_cum.data, [2500.0 / 34.0, 100.0, 100.0, 100.0])
+    # repr shows U and VT not computed
+    assert "U and VT not computed" in repr(svd)
+
+    # full_matrices=True + compute_uv=False
+    svd2 = SVD(full_matrices=True, compute_uv=False)
+    svd2.fit(dataset)
+    assert svd2.U is None
+    assert svd2.VT is None
+    assert_allclose(svd2.s, [5.0, 3.0, 0.0, 0.0])


### PR DESCRIPTION
## Summary

When `compute_uv=False`, `np.linalg.svd` returns only the singular values vector `s` (1D ndarray), not the `(U, s, VT)` tuple. The private `_outfit` attribute stored it as-is, causing all properties indexed as `_outfit[0|1|2]` to return wrong values or crash:

| Property | Broken behaviour |
|---|---|
| `svd.s` | Returns scalar `3.0` (2nd element) instead of full vector |
| `singular_values` | Crashes on NDDataset wrapping |
| `ev`, `ev_ratio`, `ev_cum` | Cascading crash |

## Fix

Normalise `_outfit` in `_fit` to always be a `(U, s, VT)` tuple:
- `compute_uv=True` → `(U, s, VT)` *(unchanged behaviour)*
- `compute_uv=False` → `(None, s, None)`

`__repr__` also fixed to use `_outfit[1]` instead of `_outfit`.

## Validation

All 91 decomposition tests pass:

```
conda run -n scpy-core python -m pytest tests/test_analysis/test_decomposition/ -q
# 91 passed, 1 skipped
```

Closes the pre-existing `compute_uv=False` bug in SVD, which was previously documented as a known limitation in the PR2 (Result Object Contract for SVD) audit.