### PR TITLE
MAINT: introduce FitResult prototype for Optimize

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -70,3 +70,9 @@ Developer
   diagnostics (``singular_values``, ``explained_variance``,
   ``explained_variance_ratio``) while preserving all existing public API
   and backward compatibility. (:pr:`1211`)
+
+- MAINT: introduce ``FitResult`` prototype for the ``Optimize`` estimator.
+  The new ``opt.result`` property exposes fitted model outputs
+  (``fitted``, ``components``) and solver diagnostics (``cost``,
+  ``niter``, ``ncalls``) while preserving all existing public API and
+  backward compatibility. (:pr:`1211`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -34,3 +34,9 @@ Developer
   diagnostics (``singular_values``, ``explained_variance``,
   ``explained_variance_ratio``) while preserving all existing public API
   and backward compatibility. (:pr:`1211`)
+
+- MAINT: introduce ``FitResult`` prototype for the ``Optimize`` estimator.
+  The new ``opt.result`` property exposes fitted model outputs
+  (``fitted``, ``components``) and solver diagnostics (``cost``,
+  ``niter``, ``ncalls``) while preserving all existing public API and
+  backward compatibility. (:pr:`1211`)

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -16,6 +16,8 @@ from IPython import display
 from scipy import optimize
 
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis.curvefitting import _models as models_
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.application.application import info_
@@ -271,6 +273,7 @@ class Optimize(DecompositionAnalysis):
             else fun_residuals
         )
 
+        fopt = None
         if not self.dry:
             fp, fopt = _optimize(
                 func,
@@ -282,6 +285,14 @@ class Optimize(DecompositionAnalysis):
                 constraints=self.constraints,
                 callback=callback,
             )
+
+        # Store solver metadata for the result object.
+        # Created on every _fit call so it always reflects the last fit.
+        self._fit_meta = {
+            "cost": float(fopt) if fopt is not None else None,
+            "niter": niter,
+            "ncalls": ncalls,
+        }
 
         # replace the previous script with new fp parameters
         self.script = str(fp)
@@ -955,6 +966,45 @@ class Optimize(DecompositionAnalysis):
 
         """
         return super().fit(X, Y=None)
+
+    # ----------------------------------------------------------------------------------
+    # Result object
+    # ----------------------------------------------------------------------------------
+    @property
+    def result(self):
+        """
+        Return the Optimize fit result object.
+
+        Returns
+        -------
+        FitResult
+            Result object containing fitted model outputs,
+            solver diagnostics, and estimator parameters.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                "The fit method must be used before accessing the result",
+            )
+
+        # NOTE: a new FitResult is created on every access.
+        # Caching is deliberately deferred to keep the implementation
+        # simple and aligned with the PCA / SVD result behaviour.
+
+        return FitResult(
+            estimator="Optimize",
+            parameters={
+                "method": self.method,
+                "max_iter": self.max_iter,
+                "max_fun_calls": self.max_fun_calls,
+                "autobase": self.autobase,
+                "amplitude_mode": self.amplitude_mode,
+            },
+            outputs={
+                "fitted": self.predict(),
+                "components": self.components,
+            },
+            diagnostics=dict(getattr(self, "_fit_meta", {})),
+        )
 
 
 # ======================================================================================

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -169,7 +169,13 @@ class TestOptimizeResult:
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
         params = opt.result.parameters
-        for name in ("method", "max_iter", "max_fun_calls", "autobase", "amplitude_mode"):
+        for name in (
+            "method",
+            "max_iter",
+            "max_fun_calls",
+            "autobase",
+            "amplitude_mode",
+        ):
             assert name in params, f"{name} missing from result.parameters"
 
     def test_parameters_values_default(self, synthetic_two_peak_dataset, script):
@@ -184,7 +190,9 @@ class TestOptimizeResult:
         assert params["autobase"] is True
         assert params["amplitude_mode"] == "height"
 
-    def test_parameters_match_estimator_config(self, synthetic_two_peak_dataset, script):
+    def test_parameters_match_estimator_config(
+        self, synthetic_two_peak_dataset, script
+    ):
         opt = scp.Optimize()
         opt.script = script
         opt.autobase = True

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -1,0 +1,291 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the Optimize FitResult prototype.
+"""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import FitResult
+from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.curvefitting._models import asymmetricvoigtmodel
+
+
+# ======================================================================================
+# Fixtures (same as test_optimize.py)
+# ======================================================================================
+@pytest.fixture()
+def script():
+    return """
+
+    #-----------------------------------------------------------
+    # syntax for parameters definition :
+    # name : value, low_bound,  high_bound
+    #  * for fixed parameters
+    #  $ for variable parameters
+    #  > for reference to a parameter in the COMMON block
+    #    (> is forbidden in the COMMON block)
+    # common block parameters should not have a _ in their names
+    #-----------------------------------------------------------
+    #
+    COMMON:
+    # common parameters ex.
+    # $ gwidth: 1.0, 0.0, none
+    $ gratio: 0.1, 0.0, 1.0
+
+    MODEL: LINE_1
+    shape: asymmetricvoigtmodel
+        * ampl:  1.0, 0.0, none
+        $ pos:   3620, 3400.0, 3700.0
+        $ ratio: 0.0147, 0.0, 1.0
+        $ asym: 0.1, 0, 1
+        $ width: 200, 0, 1000
+
+    MODEL: LINE_2
+    shape: asymmetricvoigtmodel
+        $ ampl:  0.2, 0.0, none
+        $ pos:   3520, 3400.0, 3700.0
+        > ratio: gratio
+        $ asym: 0.1, 0, 1
+        $ width: 200, 0, 1000
+    """
+
+
+@pytest.fixture()
+def synthetic_two_peak_dataset():
+    x = scp.Coord(np.linspace(3700.0, 3400.0, 301), title="wavenumber", units="cm^-1")
+    model = asymmetricvoigtmodel()
+    y = (
+        model.f(x.data, ampl=1.0, pos=3620.0, width=200.0, ratio=0.0147, asym=0.1)
+        + model.f(x.data, ampl=0.2, pos=3520.0, width=200.0, ratio=0.1, asym=0.1)
+        + 0.0002 * x.data
+        - 0.5
+    )
+    return scp.NDDataset(
+        y,
+        coordset=[x],
+        units="absorbance",
+        title="synthetic optimize spectrum",
+    )
+
+
+# ======================================================================================
+# Optimize result tests
+# ======================================================================================
+class TestOptimizeResult:
+    # ----------------------------------------------------------------------------------
+    # Identity and type
+    # ----------------------------------------------------------------------------------
+    def test_result_is_fit_result(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        result = opt.result
+        assert isinstance(result, FitResult)
+
+    def test_result_is_instance_of_base(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        assert isinstance(opt.result, ResultBase)
+
+    def test_estimator_name(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        assert opt.result.estimator == "Optimize"
+
+    def test_result_is_not_cached(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        assert opt.result is not opt.result, (
+            "FitResult is recreated on every access; "
+            "change this assertion if caching is added later"
+        )
+
+    # ----------------------------------------------------------------------------------
+    # Outputs
+    # ----------------------------------------------------------------------------------
+    def test_outputs_contain_keys(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        result = opt.result
+        for name in ("fitted", "components"):
+            assert name in result.outputs, f"{name} missing from result.outputs"
+
+    def test_output_values_match_properties(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        result = opt.result
+        np.testing.assert_array_equal(
+            result.outputs["fitted"].data,
+            opt.predict().data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["components"].data,
+            opt.components.data,
+        )
+
+    def test_output_fitted_shape(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        dataset = synthetic_two_peak_dataset
+        result = opt.result
+        # fitted shape matches the original dataset
+        assert result.outputs["fitted"].shape == (1, dataset.size)
+
+    # ----------------------------------------------------------------------------------
+    # Parameters
+    # ----------------------------------------------------------------------------------
+    def test_parameters_contain_expected_keys(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        params = opt.result.parameters
+        for name in ("method", "max_iter", "max_fun_calls", "autobase", "amplitude_mode"):
+            assert name in params, f"{name} missing from result.parameters"
+
+    def test_parameters_values_default(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        params = opt.result.parameters
+        assert params["method"] == "least_squares"
+        assert params["max_iter"] == 10
+        assert params["autobase"] is True
+        assert params["amplitude_mode"] == "height"
+
+    def test_parameters_match_estimator_config(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 20
+        opt.method = "simplex"
+        opt.amplitude_mode = "area"
+        opt.fit(synthetic_two_peak_dataset)
+        params = opt.result.parameters
+        assert params["method"] == "simplex"
+        assert params["max_iter"] == 20
+        assert params["amplitude_mode"] == "area"
+
+    # ----------------------------------------------------------------------------------
+    # Diagnostics
+    # ----------------------------------------------------------------------------------
+    def test_diagnostics_contain_keys(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        diag = opt.result.diagnostics
+        for name in ("cost", "niter", "ncalls"):
+            assert name in diag, f"{name} missing from result.diagnostics"
+
+    def test_diagnostics_are_scalars(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        diag = opt.result.diagnostics
+        assert isinstance(diag["cost"], float) or diag["cost"] is None
+        assert isinstance(diag["niter"], int)
+        assert isinstance(diag["ncalls"], int)
+
+    def test_diagnostics_meaningful_values(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        diag = opt.result.diagnostics
+        # cost should be a small positive number after a reasonable fit
+        assert diag["cost"] is None or diag["cost"] >= 0.0
+        # at least one iteration and function call should have occurred
+        assert diag["niter"] >= 0
+        assert diag["ncalls"] >= 0
+
+    # ----------------------------------------------------------------------------------
+    # Representation
+    # ----------------------------------------------------------------------------------
+    def test_repr_contains_expected_fields(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        text = repr(opt.result)
+        assert "FitResult" in text
+        assert "Optimize" in text
+        assert "fitted" in text
+        assert "components" in text
+        assert "cost" in text
+
+    def test_repr_does_not_crash(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+        _ = repr(opt.result)
+
+    # ----------------------------------------------------------------------------------
+    # Pre-fit guard
+    # ----------------------------------------------------------------------------------
+    def test_raises_before_fit(self, script):
+        opt = scp.Optimize()
+        opt.script = script
+        with pytest.raises(NotFittedError):
+            _ = opt.result
+
+    # ----------------------------------------------------------------------------------
+    # Existing behaviour preserved
+    # ----------------------------------------------------------------------------------
+    def test_fit_still_returns_self(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        ret = opt.fit(synthetic_two_peak_dataset)
+        assert ret is opt
+
+    def test_existing_properties_unchanged(self, synthetic_two_peak_dataset, script):
+        opt = scp.Optimize()
+        opt.script = script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        assert opt.n_components == 2
+        assert opt.components.shape == (3, synthetic_two_peak_dataset.size)
+        assert opt.predict().shape == (1, synthetic_two_peak_dataset.size)
+        assert opt.transform().shape == (1, 2)


### PR DESCRIPTION
## Summary

Introduce a minimal `FitResult` prototype for the `Optimize` estimator, completing the third step of the Result Object Contract RFC implementation.

### Changes

- **`optimize.py`** : new `result` property returning a `FitResult` with:
  - **outputs** : `fitted`, `components` (`NDDataset`, matching existing public API types)
  - **diagnostics** : `cost` (final solver cost), `niter` (iterations), `ncalls` (function evaluations)
  - **parameters** : `method`, `max_iter`, `max_fun_calls`, `autobase`, `amplitude_mode`
- Solver metadata stored in a new private `_fit_meta` dict during `_fit`
- **`test_optimize_result.py`** : 18 integration tests covering identity, outputs, diagnostics, parameters, repr, error handling, and backward compatibility

### Design decisions

| Category | Keys | Type | Rationale |
|---|---|---|---|
| outputs | `fitted`, `components` | NDDataset | Scientific outputs, types match public API |
| diagnostics | `cost`, `niter`, `ncalls` | scalar | Solver metadata, not primary science |
| parameters | `method`, `max_iter`, ... | config | Stable configurable traits |

`FitResult` required no adaptation — the PR1 infrastructure sufficed.

### Validation

```
python -m pytest tests/test_analysis/test_curvefitting/ tests/test_analysis/test_decomposition/ -q
# 188 passed, 2 skipped
```

### Out of scope

Cache, serialization, Project integration, DisplaySection, MCRALS, NMF, `FitParameters` serialization, residuals output (no stable public surface yet), richer solver diagnostics (requires modifying `_optimize` return signature).