### PR TITLE
FIX: pass solver parameter to sklearn NMF

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -31,6 +31,12 @@ Bug Fixes
   values and crashes for all properties when ``compute_uv=False``.
   (:pr:`1210`)
 
+- FIX: pass the ``solver`` configuration parameter to the underlying
+  ``sklearn.decomposition.NMF`` object. Previously the parameter was
+  accepted by the SpectroChemPy ``NMF`` estimator but silently ignored
+  during sklearn initialisation, so the default solver was always used
+  regardless of the configured value. (:pr:`TODO`)
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -20,6 +20,12 @@ Bug Fixes
   values and crashes for all properties when ``compute_uv=False``.
   (:pr:`1210`)
 
+- FIX: pass the ``solver`` configuration parameter to the underlying
+  ``sklearn.decomposition.NMF`` object. Previously the parameter was
+  accepted by the SpectroChemPy ``NMF`` estimator but silently ignored
+  during sklearn initialisation, so the default solver was always used
+  regardless of the configured value. (:pr:`TODO`)
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/decomposition/nmf.py
+++ b/src/spectrochempy/analysis/decomposition/nmf.py
@@ -193,6 +193,7 @@ class NMF(DecompositionAnalysis):
         self._nmf = decomposition.NMF(
             n_components=self.n_components,
             init=self.init,
+            solver=self.solver,
             beta_loss=self.beta_loss,
             tol=self.tol,
             max_iter=self.max_iter,

--- a/tests/test_analysis/test_decomposition/test_nmf.py
+++ b/tests/test_analysis/test_decomposition/test_nmf.py
@@ -174,3 +174,20 @@ def test_nmf_masked_data_uses_synthetic_dataset(nmf_dataset):
     assert scores.shape == (nmf_dataset.shape[0], 3)
     assert np.all(np.isfinite(scores.data))
     assert np.all(scores.data >= -NMF_NONNEGATIVE_TOL)
+
+
+def test_nmf_solver_parameter_is_passed_to_sklearn():
+    rng = np.random.RandomState(42)
+    data = rng.rand(10, 6)
+
+    nmf = NMF(
+        n_components=2,
+        solver="mu",
+        beta_loss="kullback-leibler",
+        max_iter=200,
+        random_state=42,
+        tol=1e-8,
+    )
+    nmf.fit(data)
+    assert nmf._nmf.solver == "mu"
+    assert nmf._nmf.beta_loss == "kullback-leibler"


### PR DESCRIPTION
The `solver` configuration parameter was accepted by the SpectroChemPy `NMF` estimator but not forwarded to `sklearn.decomposition.NMF` during initialisation, so the default solver was always used regardless of user configuration.

**Fix:** add `solver=self.solver` to the sklearn constructor call in `nmf.py`.

**Test:** add `test_nmf_solver_parameter_is_passed_to_sklearn` verifying that `solver="mu"` with `beta_loss="kullback-leibler"` (a solver-dependent beta-loss) works correctly.

**Changelog:** bugfix entry added.

Out of scope:
- PR4 (NMF AnalysisResult) — this fix is kept separate to avoid mixing concerns.