### PR TITLE
MAINT: extend Result Object support to MCRALS

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -77,7 +77,7 @@ Developer
   ``AnalysisResult``, ``FitResult``) for analysis and fitting workflows.
   (:pr:`1208`)
 
-- MAINT: extend Result Object support to PCA, SVD, NMF, and Optimize,
-  providing unified access to analysis and fitting outputs while
-  preserving backward compatibility. (:pr:`1208`, :pr:`1209`, :pr:`1211`,
-  :pr:`1213`)
+- MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
+  and MCRALS, providing unified access to analysis and fitting outputs
+  while preserving backward compatibility. (:pr:`1208`, :pr:`1209`,
+  :pr:`1211`, :pr:`1213`, :pr:`1215`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -42,7 +42,7 @@ Developer
   ``AnalysisResult``, ``FitResult``) for analysis and fitting workflows.
   (:pr:`1208`)
 
-- MAINT: extend Result Object support to PCA, SVD, NMF, and Optimize,
-  providing unified access to analysis and fitting outputs while
-  preserving backward compatibility. (:pr:`1208`, :pr:`1209`, :pr:`1211`,
-  :pr:`1213`)
+- MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
+  and MCRALS, providing unified access to analysis and fitting outputs
+  while preserving backward compatibility. (:pr:`1208`, :pr:`1209`,
+  :pr:`1211`, :pr:`1213`, :pr:`1215`)

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -27,6 +27,7 @@ from sklearn import decomposition
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.application.application import info_
 from spectrochempy.extern.traittypes import Array
 from spectrochempy.utils.decorators import deprecated
@@ -523,6 +524,9 @@ and `St`.
             self.getConc = dill.loads(base64.b64decode(self.getConc))  # noqa: S301
         if self.getSpec is not None and isinstance(self.getSpec, str):
             self.getSpec = dill.loads(base64.b64decode(self.getSpec))  # noqa: S301
+
+        # storage for ALS diagnostics captured during _fit
+        self._fit_meta = None
 
     # ----------------------------------------------------------------------------------
     # Private methods
@@ -1055,6 +1059,14 @@ and `St`.
                 )
                 info_("Stop ALS optimization.")
 
+        # capture ALS diagnostics for the result property
+        self._fit_meta = {
+            "n_iter": niter,
+            "change": change,
+            "residual_std": stdev,
+            "converged": change < self.tol,
+        }
+
         # return _fit results
         self._components = St
         return (
@@ -1245,6 +1257,80 @@ and `St`.
         Requires `MCRALS.storeIterations` set to True.
         """
         return self._outfit[9]
+
+    # ----------------------------------------------------------------------------------
+    # Result property
+    # ----------------------------------------------------------------------------------
+
+    @property
+    def result(self):
+        """
+        ``AnalysisResult`` object wrapping the fitted MCRALS estimator.
+
+        Returns
+        -------
+        AnalysisResult
+            Container with ``parameters``, ``outputs``, and ``diagnostics``
+            derived from the fitted estimator.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                f"This {type(self).__name__} instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator."
+            )
+
+        parameters = {
+            "n_components": self.n_components,
+            "max_iter": self.max_iter,
+            "tol": self.tol,
+            "maxdiv": self.maxdiv,
+            "solverConc": self.solverConc,
+            "solverSpec": self.solverSpec,
+            "nonnegConc": self.nonnegConc,
+            "nonnegSpec": self.nonnegSpec,
+            "unimodConc": self.unimodConc,
+            "unimodSpec": self.unimodSpec,
+            "unimodConcMod": self.unimodConcMod,
+            "unimodSpecMod": self.unimodSpecMod,
+            "unimodConcTol": self.unimodConcTol,
+            "unimodSpecTol": self.unimodSpecTol,
+            "closureConc": self.closureConc,
+            "closureTarget": (
+                f"<array shape={self.closureTarget.shape}>"
+                if isinstance(self.closureTarget, np.ndarray)
+                else self.closureTarget
+            ),
+            "closureMethod": self.closureMethod,
+            "monoDecConc": self.monoDecConc,
+            "monoDecTol": self.monoDecTol,
+            "monoIncConc": self.monoIncConc,
+            "monoIncTol": self.monoIncTol,
+            "hardConc": self.hardConc,
+            "hardSpec": self.hardSpec,
+            "normSpec": self.normSpec,
+            "storeIterations": self.storeIterations,
+        }
+
+        outputs = {
+            "C": self.C,
+            "components": self.components,
+        }
+
+        diagnostics = {}
+        if self._fit_meta is not None:
+            diagnostics = {k: v for k, v in self._fit_meta.items() if v is not None}
+
+        return AnalysisResult(
+            estimator="MCRALS",
+            parameters=parameters,
+            outputs=outputs,
+            diagnostics=diagnostics,
+        )
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_analysis/test_decomposition/test_mcrals_result.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_result.py
@@ -1,0 +1,216 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the MCRALS result object.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.decomposition.mcrals import MCRALS
+
+
+# ======================================================================================
+# Fixtures
+# ======================================================================================
+@pytest.fixture()
+def mcrals_dataset():
+    """Small synthetic non-negative dataset and initial guess for MCRALS."""
+    rng = np.random.RandomState(42)
+    C_true = rng.rand(10, 2)
+    St_true = rng.rand(2, 6)
+    D = C_true @ St_true
+    X = D + 0.01 * rng.randn(10, 6)
+    C0 = np.abs(C_true + 0.1 * rng.randn(10, 2))
+    return X, C0
+
+
+@pytest.fixture()
+def fitted_mcrals(mcrals_dataset):
+    X, C0 = mcrals_dataset
+    mcr = MCRALS()
+    mcr.fit(X, C0)
+    return mcr
+
+
+# ======================================================================================
+# MCRALS result integration tests
+# ======================================================================================
+class TestMCRALSResult:
+    def test_result_is_analysis_result(self, fitted_mcrals):
+        result = fitted_mcrals.result
+        assert isinstance(result, AnalysisResult)
+        assert isinstance(result, ResultBase)
+
+    def test_estimator_name(self, fitted_mcrals):
+        assert fitted_mcrals.result.estimator == "MCRALS"
+
+    def test_outputs_contain_keys(self, fitted_mcrals):
+        result = fitted_mcrals.result
+        for name in ("C", "components"):
+            assert name in result.outputs, f"{name} missing from result.outputs"
+        assert "St" not in result.outputs
+
+    def test_diagnostics_contain_keys(self, fitted_mcrals):
+        result = fitted_mcrals.result
+        for name in ("n_iter", "change", "residual_std", "converged"):
+            assert name in result.diagnostics, f"{name} missing from result.diagnostics"
+
+    def test_output_values_match_properties(self, fitted_mcrals):
+        result = fitted_mcrals.result
+        np.testing.assert_array_equal(
+            result.outputs["C"].data,
+            fitted_mcrals.C.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["components"].data,
+            fitted_mcrals.components.data,
+        )
+
+    def test_diagnostic_values(self, fitted_mcrals):
+        result = fitted_mcrals.result
+        assert result.diagnostics["n_iter"] >= 1
+        assert isinstance(result.diagnostics["converged"], (bool, np.bool_))
+        assert isinstance(result.diagnostics["change"], float)
+        assert isinstance(result.diagnostics["residual_std"], float)
+        assert result.diagnostics["residual_std"] >= 0.0
+
+    def test_repr_contains_expected_fields(self, fitted_mcrals):
+        text = repr(fitted_mcrals.result)
+        assert "AnalysisResult" in text
+        assert "MCRALS" in text
+        assert "C" in text
+        assert "components" in text
+        assert "n_iter" in text
+        assert "converged" in text
+
+    def test_result_is_not_cached(self, fitted_mcrals):
+        assert fitted_mcrals.result is not fitted_mcrals.result, (
+            "AnalysisResult is recreated on every access; "
+            "change this assertion if caching is added later"
+        )
+
+    def test_parameters_contain_expected_keys(self, fitted_mcrals):
+        params = fitted_mcrals.result.parameters
+        for name in (
+            "n_components",
+            "max_iter",
+            "tol",
+            "maxdiv",
+            "solverConc",
+            "solverSpec",
+            "nonnegConc",
+            "nonnegSpec",
+            "unimodConc",
+            "unimodSpec",
+            "unimodConcMod",
+            "unimodSpecMod",
+            "unimodConcTol",
+            "unimodSpecTol",
+            "closureConc",
+            "closureTarget",
+            "closureMethod",
+            "monoDecConc",
+            "monoDecTol",
+            "monoIncConc",
+            "monoIncTol",
+            "hardConc",
+            "hardSpec",
+            "normSpec",
+            "storeIterations",
+        ):
+            assert name in params, f"{name} missing from result.parameters"
+
+    def test_parameters_values(self, fitted_mcrals):
+        params = fitted_mcrals.result.parameters
+        assert params["n_components"] == 2
+        assert params["max_iter"] == 50
+        assert params["tol"] == 0.1
+        assert params["maxdiv"] == 5
+        assert params["solverConc"] == "lstsq"
+        assert params["solverSpec"] == "lstsq"
+        assert params["nonnegConc"] == [0, 1]
+        assert params["nonnegSpec"] == [0, 1]
+        assert params["unimodConc"] == [0, 1]
+        assert params["unimodSpec"] == []
+        assert params["unimodConcMod"] == "strict"
+        assert params["unimodSpecMod"] == "strict"
+        assert params["unimodConcTol"] == 1.1
+        assert params["unimodSpecTol"] == 1.1
+        assert params["closureConc"] == []
+        assert params["closureTarget"].startswith("<array shape=")
+        assert params["closureMethod"] == "scaling"
+        assert params["monoDecConc"] == []
+        assert params["monoDecTol"] == 1.1
+        assert params["monoIncConc"] == []
+        assert params["monoIncTol"] == 1.1
+        assert params["hardConc"] == []
+        assert params["hardSpec"] == []
+        assert params["normSpec"] is None
+        assert params["storeIterations"] is False
+
+    def test_parameters_match_estimator_config(self):
+        X, C0 = _synthetic_data(rng=np.random.RandomState(0), n_rows=10, n_cols=6)
+        mcr = MCRALS(
+            max_iter=100,
+            tol=1e-4,
+            maxdiv=10,
+            nonnegConc=[],
+            unimodSpec=[0],
+            normSpec="max",
+            closureConc=[0, 1],
+            closureMethod="constantSum",
+        )
+        mcr.fit(X, C0)
+        params = mcr.result.parameters
+        assert params["n_components"] == 2
+        assert params["max_iter"] == 100
+        assert params["tol"] == 1e-4
+        assert params["maxdiv"] == 10
+        assert params["nonnegConc"] == []
+        assert params["unimodSpec"] == [0]
+        assert params["normSpec"] == "max"
+        assert params["closureConc"] == [0, 1]
+        assert params["closureMethod"] == "constantSum"
+
+    def test_repr_contains_parameters(self, fitted_mcrals):
+        text = repr(fitted_mcrals.result)
+        assert "parameters:" in text
+        assert "n_components" in text
+        assert "max_iter" in text
+
+    def test_raises_before_fit(self):
+        mcr = MCRALS()
+        with pytest.raises(NotFittedError):
+            _ = mcr.result
+
+    def test_fit_still_returns_self(self, mcrals_dataset):
+        X, C0 = mcrals_dataset
+        mcr = MCRALS()
+        ret = mcr.fit(X, C0)
+        assert ret is mcr
+
+    def test_existing_properties_unchanged(self, fitted_mcrals):
+        assert fitted_mcrals.components.shape == (2, 6)
+        c_result = fitted_mcrals.C
+        assert c_result.shape == (10, 2)
+        assert fitted_mcrals.n_components == 2
+
+
+# ======================================================================================
+# Helpers
+# ======================================================================================
+def _synthetic_data(rng, n_rows=10, n_cols=6):
+    """Create synthetic non-negative dataset and initial guess C0."""
+    C_true = rng.rand(n_rows, 2)
+    St_true = rng.rand(2, n_cols)
+    X = C_true @ St_true + 0.01 * rng.randn(n_rows, n_cols)
+    C0 = np.abs(C_true + 0.1 * rng.randn(n_rows, 2))
+    return X, C0


### PR DESCRIPTION
## Summary

Add `MCRALS.result` property returning `AnalysisResult`, completing the Result Object migration for all decomposition estimators (PCA, SVD, NMF, MCRALS) and Optimize.

### Changes

- **Capture ALS diagnostics** (`n_iter`, `change`, `residual_std`, `converged`) in `_fit_meta` during `_fit()`
- **Add `result` property** exposing 25 parameters, 2 outputs (`C`, `components`), 4 diagnostics
- **`closureTarget` serialized** as compact string when it becomes an ndarray during fit
- **New test suite** `test_mcrals_result.py` with 15 tests (pattern identical to `test_nmf_result.py`)
- **Backward compatible**: all 14 existing MCRALS tests pass unchanged

### Review follow-up

- `St` excluded from `result.outputs` — it is an alias of `components` (same NDDataset, only `.name` differs)
- `hardConc` / `hardSpec` included in `result.parameters` — user-facing serializable config, not plumbing

### Verification

44/44 tests pass (15 new MCRALS result + 14 existing MCRALS + 15 NMF result)

Closes #TBD