### PR TITLE
FIX: correct PLSRegression n_iter property attribute name

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -37,6 +37,11 @@ Bug Fixes
   during sklearn initialisation, so the default solver was always used
   regardless of the configured value. (:pr:`1212`)
 
+- FIX: correct ``PLSRegression.n_iter`` property attribute name. Previously,
+  the property referenced ``self._n_iter_`` instead of the actual stored
+  attribute ``self._n_iter``, causing an ``AttributeError`` after a
+  successful fit. (:pr:`1216`)
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -26,6 +26,11 @@ Bug Fixes
   during sklearn initialisation, so the default solver was always used
   regardless of the configured value. (:pr:`1212`)
 
+- FIX: correct ``PLSRegression.n_iter`` property attribute name. Previously,
+  the property referenced ``self._n_iter_`` instead of the actual stored
+  attribute ``self._n_iter``, causing an ``AttributeError`` after a
+  successful fit. (:pr:`1216`)
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/src/spectrochempy/analysis/crossdecomposition/pls.py
+++ b/src/spectrochempy/analysis/crossdecomposition/pls.py
@@ -274,7 +274,7 @@ class PLSRegression(CrossDecompositionAnalysis):
 
     @property
     def n_iter(self):
-        return self._n_iter_
+        return self._n_iter
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis/test_crossdecomposition/test_pls.py
+++ b/tests/test_analysis/test_crossdecomposition/test_pls.py
@@ -148,6 +148,14 @@ class TestPLSUnivariate:
         assert np.all(np.isfinite(pls.x_scores.data))
         assert np.all(np.isfinite(pls.y_scores.data))
 
+    def test_n_iter_available(self):
+        pls = self.pls
+        skl = self.skl
+        n_iter = pls.n_iter
+        assert n_iter is not None
+        assert len(n_iter) == pls.n_components
+        assert_allclose(n_iter, skl.n_iter_)
+
     def test_fit_against_sklearn(self):
         pls = self.pls
         skl = self.skl
@@ -260,6 +268,14 @@ class TestPLSMultivariate:
         assert pls.y_scores.shape == (d["n_cal"], d["n_components"])
         assert np.all(np.isfinite(pls.x_loadings.data))
         assert np.all(np.isfinite(pls.y_loadings.data))
+
+    def test_n_iter_available(self):
+        pls = self.pls
+        skl = self.skl
+        n_iter = pls.n_iter
+        assert n_iter is not None
+        assert len(n_iter) == pls.n_components
+        assert_allclose(n_iter, skl.n_iter_)
 
     def test_fit_against_sklearn(self):
         pls = self.pls


### PR DESCRIPTION
## Summary

The `PLSRegression.n_iter` property referenced `self._n_iter_` (with trailing underscore) but `_fit()` stores the value as `self._n_iter` (without trailing underscore). This caused `pls.n_iter` to raise `AttributeError` after a successful fit.

## Change

`src/spectrochempy/analysis/crossdecomposition/pls.py:277` — one-character fix: `self._n_iter_` → `self._n_iter`.

## Tests

Two regression tests added:
- `TestPLSUnivariate.test_n_iter_available` — single response variable
- `TestPLSMultivariate.test_n_iter_available` — multiple response variables

Each test verifies `pls.n_iter` returns a non-None value matching sklearn's `n_iter_` attribute.

## Out of scope

- No Result object changes
- No refactoring
- No API changes

17/17 PLS tests pass.