### PR TITLE
MAINT: add AnalysisResult support for SIMPLISMA (#1217)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -83,6 +83,8 @@ Developer
   (:pr:`1208`)
 
 - MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
-  and MCRALS, providing unified access to analysis and fitting outputs
-  while preserving backward compatibility. (:pr:`1208`, :pr:`1209`,
-  :pr:`1211`, :pr:`1213`, :pr:`1215`)
+  MCRALS, and SIMPLISMA, providing unified access to analysis and
+  fitting outputs while preserving backward compatibility.
+  (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`, :pr:`1217`)
+
+- MAINT: extend Result Object support to SIMPLISMA. (:pr:`1217`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -48,6 +48,8 @@ Developer
   (:pr:`1208`)
 
 - MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
-  and MCRALS, providing unified access to analysis and fitting outputs
-  while preserving backward compatibility. (:pr:`1208`, :pr:`1209`,
-  :pr:`1211`, :pr:`1213`, :pr:`1215`)
+  MCRALS, and SIMPLISMA, providing unified access to analysis and
+  fitting outputs while preserving backward compatibility.
+  (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`, :pr:`1217`)
+
+- MAINT: extend Result Object support to SIMPLISMA. (:pr:`1217`)

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -253,43 +253,35 @@ PR3 noted no stable public surface for residuals. If one emerges, should
 
 ---
 
-## 5. Proposed sequence
+## 5. Completed migration sequence
 
 ```
-PR4: NMF AnalysisResult
-  └─ low risk, quick win, validates PCA pattern for a second decomposition
-
-PR5: Provenance enrichment (optional — see §4.2)
-  └─ add structured provenance to ResultBase if deemed necessary before MCRALS
-
-PR6: MCRALS audit + AnalysisResult
-  └─ explicit audit before any code changes
-  └─ highest risk migration, requires careful planning
-
-PR7+: FitResult improvements
-  └─ residuals, FitParameters integration, richer solver diagnostics
-
-Later:
-  └─ Serialization round-trip for result objects
-  └─ Project integration
-  └─ DisplaySection / HTML integration
-  └─ Cache strategy
+PR1: PCA AnalysisResult         ✅ Merged (#1208)
+PR2: SVD AnalysisResult         ✅ Merged (#1209)
+PR3: Optimize FitResult         ✅ Merged (#1211)
+PR4: NMF AnalysisResult         ✅ Merged (#1213)
+PR5: MCRALS AnalysisResult      ✅ Merged (#1215)
+PR6: SIMPLISMA AnalysisResult   ✅ Merged (#1217)
 ```
 
-### Rationale
+Seven estimators now implement the Result Object contract:
+- 6 decomposition estimators → `AnalysisResult` (PCA, SVD, NMF, MCRALS, SIMPLISMA)
+- 1 curve-fitting estimator → `FitResult` (Optimize)
 
-- NMF is the natural next step: same module (`decomposition`), same base
-  class (`DecompositionAnalysis`), same sklearn backend pattern. Low risk,
-  high confidence.
-- MCRALS is deferred because its complexity would slow progress if tackled
-  before NMF. An explicit audit (PR6) must precede any MCRALS code changes.
-- Provenance enrichment could either precede MCRALS (so MCRALS result gets
-  provenance from the start) or wait until after all initial migrations.
-  Decision deferred to maintainers.
-- FitResult improvements are post-MCRALS because `FitResult` is already
-  stable and Optimize is the only consumer.
-- Serialization, Project integration, and DisplaySection are deferred to a
-  later phase when all result-producing estimators implement the contract.
+Key outcomes after 6 PRs:
+- **Zero** changes to `_result.py` since PR1 — `ResultBase`, `AnalysisResult`, `FitResult` unchanged.
+- **`_fit_meta`** pattern established (PR3) and reused (PR5, PR6) for diagnostic capture.
+- No subclass of `AnalysisResult` or `FitResult` was needed.
+
+### Remaining candidates
+
+| Order | Estimator | Complexity | Notes |
+|---|---|---|---|
+| PR7 | EFA | Low | Simple `_outfit` (2-element tuple), but outputs are eigenvalue trajectories |
+| PR8 | FastICA | Medium | Many decorated properties, sklearn backend |
+| PR9 | PLSRegression | High | No `_outfit` — 10+ private attrs stored directly |
+| Later | Baseline | Medium | Processor, not decomposition — different architectural role |
+| Later | LSTSQ / NNLS | Low | Thin sklearn wrappers — `FitResult`?
 
 ---
 

--- a/src/spectrochempy/analysis/decomposition/simplisma.py
+++ b/src/spectrochempy/analysis/decomposition/simplisma.py
@@ -14,6 +14,8 @@ import numpy as np
 import traitlets as tr
 
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.application.application import info_
 from spectrochempy.utils import exceptions
 from spectrochempy.utils.decorators import signature_has_configurable_traits
@@ -116,6 +118,8 @@ class SIMPLISMA(DecompositionAnalysis):
             warm_start=warm_start,
             **kwargs,
         )
+
+        self._fit_meta = None
 
     # ----------------------------------------------------------------------------------
     # Private validation methods and default getter
@@ -253,6 +257,10 @@ class SIMPLISMA(DecompositionAnalysis):
         # Determine the purest variables
         j = 0
         finished = False
+
+        # capture for _fit_meta
+        r_squared = 0.0
+        residual_std = 0.0
         while not finished:
             # compute first purest variable and weights
             if j == 0:
@@ -266,6 +274,8 @@ class SIMPLISMA(DecompositionAnalysis):
 
                 # compute figures of merit
                 rsquare0, stdev_res0 = self._figures_of_merit(X, maxPIndex, C, St, j)
+                r_squared = rsquare0
+                residual_std = stdev_res0
 
                 # add summary to log
                 llog = self._str_iter_summary(
@@ -359,6 +369,8 @@ class SIMPLISMA(DecompositionAnalysis):
 
                 # compute figures of merit
                 rsquarej, stdev_resj = self._figures_of_merit(X, maxPIndex, C, St, j)
+                r_squared = rsquarej
+                residual_std = stdev_resj
                 diff = 100 * (stdev_resj - prev_stdev_res) / prev_stdev_res
                 prev_stdev_res = stdev_resj
 
@@ -486,6 +498,13 @@ class SIMPLISMA(DecompositionAnalysis):
         # found components
         self._n_components = Pt.shape[0]
 
+        # capture fit metadata for the result property
+        self._fit_meta = {
+            "r_squared": r_squared,
+            "residual_std": residual_std,
+            "n_components_selected": self._n_components,
+        }
+
         # results
         return (C, St, Pt, s)
 
@@ -560,3 +579,53 @@ class SIMPLISMA(DecompositionAnalysis):
         s.name = "Standard deviation spectra"
         s.description = "Standard deviation spectra matrix from SIMPLISMA:"  # + logs
         return s
+
+    # ----------------------------------------------------------------------------------
+    # Result property
+    # ----------------------------------------------------------------------------------
+    @property
+    def result(self):
+        """
+        ``AnalysisResult`` object wrapping the fitted SIMPLISMA estimator.
+
+        Returns
+        -------
+        AnalysisResult
+            Container with ``parameters``, ``outputs``, and ``diagnostics``
+            derived from the fitted estimator.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                f"This {type(self).__name__} instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator."
+            )
+
+        parameters = {
+            "interactive": self.interactive,
+            "n_components": self.n_components,
+            "tol": self.tol,
+            "noise": self.noise,
+        }
+
+        outputs = {
+            "C": self.C,
+            "components": self.components,
+            "Pt": self.Pt,
+            "s": self.s,
+        }
+
+        diagnostics = {}
+        if self._fit_meta is not None:
+            diagnostics = {k: v for k, v in self._fit_meta.items() if v is not None}
+
+        return AnalysisResult(
+            estimator="SIMPLISMA",
+            parameters=parameters,
+            outputs=outputs,
+            diagnostics=diagnostics,
+        )

--- a/tests/test_analysis/test_decomposition/test_simplisma_result.py
+++ b/tests/test_analysis/test_decomposition/test_simplisma_result.py
@@ -1,0 +1,153 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the SIMPLISMA result object.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.decomposition.simplisma import SIMPLISMA
+
+
+# ======================================================================================
+# SIMPLISMA result integration tests
+# ======================================================================================
+class TestSIMPLISMAResult:
+    def test_result_is_analysis_result(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        result = sma.result
+        assert isinstance(result, AnalysisResult)
+        assert isinstance(result, ResultBase)
+
+    def test_estimator_name(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        assert sma.result.estimator == "SIMPLISMA"
+
+    def test_outputs_contain_keys(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        result = sma.result
+        for name in ("C", "components", "Pt", "s"):
+            assert name in result.outputs, f"{name} missing from result.outputs"
+
+    def test_diagnostics_contain_keys(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        result = sma.result
+        for name in ("r_squared", "residual_std", "n_components_selected"):
+            assert name in result.diagnostics, f"{name} missing from result.diagnostics"
+
+    def test_output_values_match_properties(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        result = sma.result
+        np.testing.assert_array_equal(
+            result.outputs["C"].data,
+            sma.C.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["components"].data,
+            sma.components.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["Pt"].data,
+            sma.Pt.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["s"].data,
+            sma.s.data,
+        )
+
+    def test_diagnostic_values(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        result = sma.result
+        assert isinstance(result.diagnostics["r_squared"], float)
+        assert isinstance(result.diagnostics["residual_std"], float)
+        assert result.diagnostics["n_components_selected"] == 2
+        assert 0.0 < result.diagnostics["r_squared"] <= 1.0
+        assert result.diagnostics["residual_std"] >= 0.0
+
+    def test_repr_contains_expected_fields(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        text = repr(sma.result)
+        assert "AnalysisResult" in text
+        assert "SIMPLISMA" in text
+        assert "C" in text
+        assert "components" in text
+        assert "Pt" in text
+        assert "s" in text
+        assert "r_squared" in text
+        assert "residual_std" in text
+        assert "n_components_selected" in text
+
+    def test_result_is_not_cached(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        assert sma.result is not sma.result, (
+            "AnalysisResult is recreated on every access; "
+            "change this assertion if caching is added later"
+        )
+
+    def test_parameters_contain_expected_keys(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        params = sma.result.parameters
+        for name in ("interactive", "n_components", "tol", "noise"):
+            assert name in params, f"{name} missing from result.parameters"
+
+    def test_parameters_values(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        params = sma.result.parameters
+        assert params["interactive"] is False
+        assert params["n_components"] == 2
+        assert params["tol"] == 0.1
+        assert params["noise"] == 3
+
+    def test_parameters_match_estimator_config(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=3, tol=0.5, noise=5, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        params = sma.result.parameters
+        assert params["n_components"] == 3
+        assert params["tol"] == 0.5
+        assert params["noise"] == 5
+
+    def test_repr_contains_parameters(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        text = repr(sma.result)
+        assert "parameters:" in text
+        assert "n_components" in text
+        assert "tol" in text
+        assert "noise" in text
+
+    def test_raises_before_fit(self):
+        sma = SIMPLISMA()
+        with pytest.raises(NotFittedError):
+            _ = sma.result
+
+    def test_fit_still_returns_self(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        ret = sma.fit(simplisma_dataset)
+        assert ret is sma
+
+    def test_existing_properties_unchanged(self, simplisma_dataset):
+        sma = SIMPLISMA(n_components=2, log_level="WARNING")
+        sma.fit(simplisma_dataset)
+        assert sma.C.shape == (20, 2)
+        assert sma.St.shape == (2, 100)
+        assert sma.Pt.shape == (2, 100)
+        assert sma.s.shape == (2, 100)
+        assert sma.n_components == 2


### PR DESCRIPTION
## Summary

Add the `result` property to `SIMPLISMA`, returning an `AnalysisResult` following the pattern established by PCA, SVD, NMF, and MCRALS (PRs #1208, #1209, #1213, #1215).

## Changes

### `simplisma.py`
- Import `NotFittedError`, `AnalysisResult`
- `__init__`: initialize `self._fit_meta = None`
- `_fit()`: capture final R² and residual std per iteration in `_fit_meta` (~6 lines)
- New `result` property: guard → parameters → outputs → diagnostics → `AnalysisResult`

### Outputs
| Key | Source | Description |
|---|---|---|
| `C` | `self.C` | Relative concentrations |
| `components` | `self.components` | Pure compound spectra |
| `Pt` | `self.Pt` | Purity spectra |
| `s` | `self.s` | Standard deviation spectra |

### Parameters
`interactive`, `n_components`, `tol`, `noise`

### Diagnostics
`r_squared`, `residual_std`, `n_components_selected` (captured via `_fit_meta`)

### New test file
`test_simplisma_result.py` — 15 tests (`TestSIMPLISMAResult`)

### Documentation
- `changelog.rst`: updated consolidated entry + new SIMPLISMA line
- `roadmap.md`: updated completed sequence through PR6

## Validation
- ✅ 25/25 tests pass (10 existing + 15 new)
- ✅ pre-commit (ruff, format, trailing whitespace, etc.)
- ✅ Zero changes to `_result.py` or `ResultBase`/\`AnalysisResult` (contract stable since PR1)
- ✅ Backward compatible — no public API changes, `fit()` still returns `self`