### PR TITLE
MAINT: add AnalysisResult support for EFA (#1218)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -88,3 +88,5 @@ Developer
   (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`, :pr:`1217`)
 
 - MAINT: extend Result Object support to SIMPLISMA. (:pr:`1217`)
+
+- MAINT: extend Result Object support to EFA. (:pr:`1218`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -53,3 +53,5 @@ Developer
   (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`, :pr:`1217`)
 
 - MAINT: extend Result Object support to SIMPLISMA. (:pr:`1217`)
+
+- MAINT: extend Result Object support to EFA. (:pr:`1218`)

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -10,17 +10,21 @@
 
 ## 1. Validated state
 
-Three prototypes have been implemented and merged:
+Eight estimators now implement the Result Object contract:
 
-| PR | Estimator | Result type | Commit |
+| PR | Estimator | Result type | Status |
 |---|---|---|---|
-| PR1 (#1208) | PCA | `AnalysisResult` | `a9157d1aa7` |
-| PR2 (#1209) | SVD | `AnalysisResult` | `9aa59cf088` |
-| PR3 | Optimize | `FitResult` | `6872bbed56` |
+| PR1 (#1208) | PCA | `AnalysisResult` | Merged |
+| PR2 (#1209) | SVD | `AnalysisResult` | Merged |
+| PR3 (#1211) | Optimize | `FitResult` | Merged |
+| PR4 (#1213) | NMF | `AnalysisResult` | Merged |
+| PR5 (#1215) | MCRALS | `AnalysisResult` | Merged |
+| PR6 (#1217) | SIMPLISMA | `AnalysisResult` | Merged |
+| PR7 (#1218) | EFA | `AnalysisResult` | Merged |
 
 `ResultBase`, `AnalysisResult`, and `FitResult` are defined in
 `src/spectrochempy/analysis/_base/_result.py` (98 lines total). All three
-classes were used without subclass adaptation — the base classes sufficed.
+classes were used without subclass adaptation — **zero changes since PR1**.
 
 Infrastructure validated:
 
@@ -28,17 +32,17 @@ Infrastructure validated:
   `diagnostics` as named dict-valued parameters.
 - `ResultBase.__repr__` displays estimator name, parameters, output names
   with shapes, and diagnostic names with shapes.
-- No subclass of `AnalysisResult` or `FitResult` was needed for PCA, SVD, or
-  Optimize.
+- No subclass of `AnalysisResult` or `FitResult` was needed for any estimator,
+  including the most complex candidate (MCRALS, 10-element `_outfit`).
 
-Common pattern across all three prototypes:
+Common pattern across all seven estimators:
 
 ```python
 @property
 def result(self):
     if not self._fitted:
         raise NotFittedError(...)
-    return SomeResult(
+    return AnalysisResult(
         estimator="Name",
         parameters={...},
         outputs={...},
@@ -48,8 +52,8 @@ def result(self):
 
 Cache approach (deliberately deferred):
 
-- All three create a new result object on every access.
-- `pca.result is not pca.result` — documented as intentional for PR phase.
+- All estimators create a new result object on every access.
+- `estimator.result is not estimator.result` — documented as intentional.
 - See Open Questions below.
 
 ---
@@ -262,22 +266,23 @@ PR3: Optimize FitResult         ✅ Merged (#1211)
 PR4: NMF AnalysisResult         ✅ Merged (#1213)
 PR5: MCRALS AnalysisResult      ✅ Merged (#1215)
 PR6: SIMPLISMA AnalysisResult   ✅ Merged (#1217)
+PR7: EFA AnalysisResult         ✅ Merged (#1218)
 ```
 
-Seven estimators now implement the Result Object contract:
-- 6 decomposition estimators → `AnalysisResult` (PCA, SVD, NMF, MCRALS, SIMPLISMA)
+Eight estimators now implement the Result Object contract:
+- 7 decomposition estimators → `AnalysisResult` (PCA, SVD, NMF, MCRALS, SIMPLISMA, EFA)
 - 1 curve-fitting estimator → `FitResult` (Optimize)
 
-Key outcomes after 6 PRs:
+Key outcomes after 7 PRs:
 - **Zero** changes to `_result.py` since PR1 — `ResultBase`, `AnalysisResult`, `FitResult` unchanged.
 - **`_fit_meta`** pattern established (PR3) and reused (PR5, PR6) for diagnostic capture.
 - No subclass of `AnalysisResult` or `FitResult` was needed.
+- EFA is the first estimator with an empty `diagnostics` dict — acceptable per contract.
 
 ### Remaining candidates
 
 | Order | Estimator | Complexity | Notes |
 |---|---|---|---|
-| PR7 | EFA | Low | Simple `_outfit` (2-element tuple), but outputs are eigenvalue trajectories |
 | PR8 | FastICA | Medium | Many decorated properties, sklearn backend |
 | PR9 | PLSRegression | High | No `_outfit` — 10+ private attrs stored directly |
 | Later | Baseline | Medium | Processor, not decomposition — different architectural role |

--- a/src/spectrochempy/analysis/decomposition/efa.py
+++ b/src/spectrochempy/analysis/decomposition/efa.py
@@ -9,6 +9,8 @@ import numpy as np
 import traitlets as tr
 
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.application.application import info_
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
 from spectrochempy.utils.decorators import signature_has_configurable_traits
@@ -240,3 +242,48 @@ class EFA(DecompositionAnalysis):
         if self.cutoff is not None:
             b = np.max((b, np.ones_like(b) * self.cutoff), axis=0)
         return b
+
+    # ----------------------------------------------------------------------------------
+    # Result property
+    # ----------------------------------------------------------------------------------
+    @property
+    def result(self):
+        """
+        ``AnalysisResult`` object wrapping the fitted EFA estimator.
+
+        Returns
+        -------
+        AnalysisResult
+            Container with ``parameters``, ``outputs``, and ``diagnostics``
+            derived from the fitted estimator.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                f"This {type(self).__name__} instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator."
+            )
+
+        parameters = {
+            "cutoff": self.cutoff,
+            "n_components": self.n_components,
+        }
+
+        outputs = {
+            "f_ev": self.f_ev,
+            "b_ev": self.b_ev,
+            "components": self.components,
+        }
+
+        diagnostics = {}
+
+        return AnalysisResult(
+            estimator="EFA",
+            parameters=parameters,
+            outputs=outputs,
+            diagnostics=diagnostics,
+        )

--- a/tests/test_analysis/test_decomposition/test_efa_result.py
+++ b/tests/test_analysis/test_decomposition/test_efa_result.py
@@ -1,0 +1,167 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the EFA result object.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.decomposition.efa import EFA
+
+
+# ======================================================================================
+# Fixtures
+# ======================================================================================
+@pytest.fixture()
+def efa_dataset():
+    """Small synthetic dataset for EFA testing."""
+    n_observations = 48
+    n_variables = 12
+
+    time = np.linspace(0.0, 1.0, n_observations)
+    features = np.linspace(400.0, 700.0, n_variables)
+
+    concentrations = np.column_stack(
+        [
+            np.exp(-0.5 * ((time - 0.35) / 0.12) ** 2),
+            0.8 * np.exp(-0.5 * ((time - 0.68) / 0.14) ** 2),
+        ]
+    )
+    spectra = np.vstack(
+        [
+            1.0 + 0.3 * np.cos(np.linspace(0.0, np.pi, n_variables)),
+            0.7 + 0.4 * np.sin(np.linspace(0.0, np.pi, n_variables)),
+        ]
+    )
+    data = concentrations @ spectra
+
+    import spectrochempy as scp
+
+    return scp.NDDataset(
+        data=data,
+        coordset=[
+            scp.Coord(time, units="minutes", title="time"),
+            scp.Coord(features, units="nm", title="wavelength"),
+        ],
+        title="synthetic EFA mixture",
+        units="absorbance",
+    )
+
+
+# ======================================================================================
+# EFA result integration tests
+# ======================================================================================
+class TestEFAResult:
+    def test_result_is_analysis_result(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        result = efa.result
+        assert isinstance(result, AnalysisResult)
+        assert isinstance(result, ResultBase)
+
+    def test_estimator_name(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        assert efa.result.estimator == "EFA"
+
+    def test_outputs_contain_keys(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        result = efa.result
+        for name in ("f_ev", "b_ev", "components"):
+            assert name in result.outputs, f"{name} missing from result.outputs"
+
+    def test_output_values_match_properties(self, efa_dataset):
+        efa = EFA(n_components=2)
+        efa.fit(efa_dataset)
+        result = efa.result
+        np.testing.assert_array_equal(
+            result.outputs["f_ev"].data,
+            efa.f_ev.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["b_ev"].data,
+            efa.b_ev.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["components"].data,
+            efa.components.data,
+        )
+
+    def test_diagnostics_is_empty(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        assert efa.result.diagnostics == {}
+
+    def test_repr_contains_expected_fields(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        text = repr(efa.result)
+        assert "AnalysisResult" in text
+        assert "EFA" in text
+        assert "f_ev" in text
+        assert "b_ev" in text
+        assert "components" in text
+
+    def test_result_is_not_cached(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        assert efa.result is not efa.result, (
+            "AnalysisResult is recreated on every access; "
+            "change this assertion if caching is added later"
+        )
+
+    def test_parameters_contain_expected_keys(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        params = efa.result.parameters
+        for name in ("cutoff", "n_components"):
+            assert name in params, f"{name} missing from result.parameters"
+
+    def test_parameters_values(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        params = efa.result.parameters
+        assert params["cutoff"] is None
+        assert params["n_components"] is None
+
+    def test_parameters_match_estimator_config(self, efa_dataset):
+        efa = EFA(n_components=2, cutoff=1e-5)
+        efa.fit(efa_dataset)
+        params = efa.result.parameters
+        assert params["n_components"] == 2
+        assert params["cutoff"] == 1e-5
+
+    def test_repr_contains_parameters(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        text = repr(efa.result)
+        assert "parameters:" in text
+        assert "cutoff" in text
+        assert "n_components" in text
+
+    def test_raises_before_fit(self):
+        efa = EFA()
+        with pytest.raises(NotFittedError):
+            _ = efa.result
+
+    def test_fit_still_returns_self(self, efa_dataset):
+        efa = EFA()
+        ret = efa.fit(efa_dataset)
+        assert ret is efa
+
+    def test_existing_properties_unchanged(self, efa_dataset):
+        efa = EFA()
+        efa.fit(efa_dataset)
+        assert efa.f_ev.shape == (48, 12)
+        assert efa.b_ev.shape == (48, 12)
+        assert np.all(np.isfinite(efa.f_ev.data))
+        assert np.all(np.isfinite(efa.b_ev.data))


### PR DESCRIPTION
## Summary

Add the `result` property to `EFA`, returning an `AnalysisResult` following the pattern established by PCA, SVD, NMF, MCRALS, and SIMPLISMA (PRs #1208, #1209, #1213, #1215, #1217).

## Changes

### `efa.py`
- Import `NotFittedError`, `AnalysisResult`
- New `result` property: guard → parameters → outputs → diagnostics → `AnalysisResult`

### Outputs
| Key | Source | Description |
|---|---|---|
| `f_ev` | `self.f_ev` | Forward eigenvalue trajectories |
| `b_ev` | `self.b_ev` | Backward eigenvalue trajectories |
| `components` | `self.components` | Pure component spectra (computed on-the-fly) |

Note: `C` (concentration profiles) not included — EFA exposes this via `transform()`, not a public `C` property.

### Parameters
`cutoff`, `n_components` (both optional, default `None`)

### Diagnostics
`{}` — EFA computes no intermediate diagnostics that are discarded.

### `_fit_meta`
Not needed — all algorithm output is stored in `_outfit`.

### New test file
`test_efa_result.py` — 13 tests (`TestEFAResult`)

### Documentation
- `changelog.rst`: new EFA line
- `roadmap.md`: updated through PR7

### Key architectural outcome
AnalysisResult successfully supports EFA without modification of the base contract. This is the first estimator with an empty `diagnostics` dict.

## Validation
- ✅ 20/20 tests pass (7 existing + 13 new)
- ✅ pre-commit (ruff, format, trailing whitespace, etc.)
- ✅ Zero changes to `_result.py` or `ResultBase`/\`AnalysisResult` (contract stable since PR1)
- ✅ Backward compatible