### PR TITLE
MAINT: add AnalysisResult support for FastICA (#1219)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,8 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
+  ``whiten=False``. (:pr:`1219`)
 - FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.
@@ -83,10 +85,7 @@ Developer
   (:pr:`1208`)
 
 - MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
-  MCRALS, and SIMPLISMA, providing unified access to analysis and
-  fitting outputs while preserving backward compatibility.
-  (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`, :pr:`1217`)
-
-- MAINT: extend Result Object support to SIMPLISMA. (:pr:`1217`)
-
-- MAINT: extend Result Object support to EFA. (:pr:`1218`)
+  MCRALS, SIMPLISMA, EFA, and FastICA, providing unified access to
+  analysis and fitting outputs while preserving backward compatibility.
+  (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`,
+  :pr:`1217`, :pr:`1218`, :pr:`1219`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,8 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
+  ``whiten=False``. (:pr:`1219`)
 - FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.
@@ -48,10 +50,7 @@ Developer
   (:pr:`1208`)
 
 - MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
-  MCRALS, and SIMPLISMA, providing unified access to analysis and
-  fitting outputs while preserving backward compatibility.
-  (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`, :pr:`1217`)
-
-- MAINT: extend Result Object support to SIMPLISMA. (:pr:`1217`)
-
-- MAINT: extend Result Object support to EFA. (:pr:`1218`)
+  MCRALS, SIMPLISMA, EFA, and FastICA, providing unified access to
+  analysis and fitting outputs while preserving backward compatibility.
+  (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`,
+  :pr:`1217`, :pr:`1218`, :pr:`1219`)

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -267,23 +267,23 @@ PR4: NMF AnalysisResult         ✅ Merged (#1213)
 PR5: MCRALS AnalysisResult      ✅ Merged (#1215)
 PR6: SIMPLISMA AnalysisResult   ✅ Merged (#1217)
 PR7: EFA AnalysisResult         ✅ Merged (#1218)
+PR8: FastICA AnalysisResult     ✅ Merged (#1219)
 ```
 
-Eight estimators now implement the Result Object contract:
-- 7 decomposition estimators → `AnalysisResult` (PCA, SVD, NMF, MCRALS, SIMPLISMA, EFA)
+Nine estimators now implement the Result Object contract:
+- 8 decomposition estimators → `AnalysisResult` (PCA, SVD, NMF, MCRALS, SIMPLISMA, EFA, FastICA)
 - 1 curve-fitting estimator → `FitResult` (Optimize)
 
-Key outcomes after 7 PRs:
+Key outcomes after 8 PRs:
 - **Zero** changes to `_result.py` since PR1 — `ResultBase`, `AnalysisResult`, `FitResult` unchanged.
 - **`_fit_meta`** pattern established (PR3) and reused (PR5, PR6) for diagnostic capture.
 - No subclass of `AnalysisResult` or `FitResult` was needed.
-- EFA is the first estimator with an empty `diagnostics` dict — acceptable per contract.
+- No estimator has required any change to the base contract.
 
 ### Remaining candidates
 
 | Order | Estimator | Complexity | Notes |
 |---|---|---|---|
-| PR8 | FastICA | Medium | Many decorated properties, sklearn backend |
 | PR9 | PLSRegression | High | No `_outfit` — 10+ private attrs stored directly |
 | Later | Baseline | Medium | Processor, not decomposition — different architectural role |
 | Later | LSTSQ / NNLS | Low | Thin sklearn wrappers — `FitResult`?

--- a/src/spectrochempy/analysis/decomposition/fast_ica.py
+++ b/src/spectrochempy/analysis/decomposition/fast_ica.py
@@ -10,7 +10,9 @@ from numpy.random import RandomState
 from sklearn import decomposition
 
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
+from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.utils.decorators import signature_has_configurable_traits
 from spectrochempy.utils.traits import NDDatasetType
 
@@ -335,18 +337,82 @@ array of values drawn from a normal distribution is used."""
         """
         Number of iterations.
 
-        If the algorithm is “deflation”, n_iter is the maximum number of iterations run
+        If the algorithm is "deflation", n_iter is the maximum number of iterations run
         across all components. Else they are just the number of iterations taken to
         converge.
         """
         return self._fast_ica.n_iter_
 
+    # ----------------------------------------------------------------------------------
+    # Result property
+    # ----------------------------------------------------------------------------------
     @property
+    def result(self):
+        """
+        ``AnalysisResult`` object wrapping the fitted FastICA estimator.
+
+        Returns
+        -------
+        AnalysisResult
+            Container with ``parameters``, ``outputs``, and ``diagnostics``
+            derived from the fitted estimator.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                f"This {type(self).__name__} instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator."
+            )
+
+        parameters = {
+            "n_components": self.n_components,
+            "algorithm": self.algorithm,
+            "whiten": self.whiten,
+            "fun": ("<callable>" if callable(self.fun) else self.fun),
+            "fun_args": self.fun_args,
+            "tol": self.tol,
+            "max_iter": self.max_iter,
+            "w_init": (
+                f"<NDDataset shape={self.w_init.shape}>"
+                if hasattr(self.w_init, "shape")
+                else self.w_init
+            ),
+            "whiten_solver": self.whiten_solver,
+            "random_state": self.random_state,
+        }
+
+        outputs = {
+            "components": self.components,
+            "mixing": self.mixing,
+            "St": self.St,
+            "A": self.A,
+        }
+
+        diagnostics = {
+            "n_iter": self.n_iter,
+        }
+
+        return AnalysisResult(
+            estimator="FastICA",
+            parameters=parameters,
+            outputs=outputs,
+            diagnostics=diagnostics,
+        )
+
     @_wrap_ndarray_output_to_nddataset(
         units=None,
         title=None,
         typey="components",
     )
+    def _whitening_wrapped(self):
+        """Return the whitening matrix as an NDDataset (decorated)."""
+        return self._fast_ica.whitening_
+
+    @property
     def whitening(self):
         """
         NDDataset of shape (n_components, n_features).
@@ -354,6 +420,6 @@ array of values drawn from a normal distribution is used."""
         Only set if whiten is not None. This is the pre-whitening matrix that projects
         data onto the first n_components principal components.
         """
-        if self.whiten:
-            return self._fast_ica.whitening_
-        return None
+        if not self.whiten:
+            return None
+        return self._whitening_wrapped()

--- a/tests/test_analysis/test_decomposition/test_fast_ica.py
+++ b/tests/test_analysis/test_decomposition/test_fast_ica.py
@@ -153,3 +153,10 @@ def test_fastica_3d_raises():
 
     with pytest.raises(ValueError, match="Found array with dim 3"):
         scp_ICA(n_components=2).fit(ds_3d)
+
+
+def test_whitening_returns_none_when_whiten_false(fastica_dataset):
+    """Regression: whitening property should return None when whiten=False."""
+    ica = scp_ICA(n_components=4, random_state=123, whiten=False)
+    ica.fit(fastica_dataset)
+    assert ica.whitening is None

--- a/tests/test_analysis/test_decomposition/test_fast_ica_result.py
+++ b/tests/test_analysis/test_decomposition/test_fast_ica_result.py
@@ -1,0 +1,175 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the FastICA result object.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.decomposition.fast_ica import FastICA
+
+
+# ======================================================================================
+# FastICA result integration tests
+# ======================================================================================
+class TestFastICAResult:
+    def test_result_is_analysis_result(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        result = ica.result
+        assert isinstance(result, AnalysisResult)
+        assert isinstance(result, ResultBase)
+
+    def test_estimator_name(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        assert ica.result.estimator == "FastICA"
+
+    def test_outputs_contain_keys(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        result = ica.result
+        for name in ("components", "mixing", "St", "A"):
+            assert name in result.outputs, f"{name} missing from result.outputs"
+
+    def test_output_values_match_properties(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        result = ica.result
+        np.testing.assert_array_equal(
+            result.outputs["components"].data,
+            ica.components.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["mixing"].data,
+            ica.mixing.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["St"].data,
+            ica.St.data,
+        )
+        np.testing.assert_array_equal(
+            result.outputs["A"].data,
+            ica.A.data,
+        )
+
+    def test_diagnostics_contain_keys(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        result = ica.result
+        for name in ("n_iter",):
+            assert name in result.diagnostics, f"{name} missing from result.diagnostics"
+
+    def test_diagnostic_values(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        result = ica.result
+        assert result.diagnostics["n_iter"] == ica.n_iter
+        assert isinstance(result.diagnostics["n_iter"], int)
+        assert result.diagnostics["n_iter"] > 0
+
+    def test_repr_contains_expected_fields(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        text = repr(ica.result)
+        assert "AnalysisResult" in text
+        assert "FastICA" in text
+        assert "components" in text
+        assert "mixing" in text
+        assert "n_iter" in text
+
+    def test_result_is_not_cached(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        assert ica.result is not ica.result, (
+            "AnalysisResult is recreated on every access; "
+            "change this assertion if caching is added later"
+        )
+
+    def test_parameters_contain_expected_keys(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        params = ica.result.parameters
+        for name in (
+            "n_components",
+            "algorithm",
+            "whiten",
+            "fun",
+            "fun_args",
+            "tol",
+            "max_iter",
+            "w_init",
+            "whiten_solver",
+            "random_state",
+        ):
+            assert name in params, f"{name} missing from result.parameters"
+
+    def test_parameters_values(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        params = ica.result.parameters
+        assert params["n_components"] == 4
+        assert params["algorithm"] == "parallel"
+        assert params["whiten"] == "unit-variance"
+        assert params["fun"] == "logcosh"
+        assert params["fun_args"] is None
+        assert params["tol"] == 1e-4
+        assert params["max_iter"] == 200
+        assert params["w_init"] is None
+        assert params["whiten_solver"] == "svd"
+        assert params["random_state"] == 123
+
+    def test_parameters_match_estimator_config(self, fastica_dataset):
+        ica = FastICA(
+            n_components=3,
+            algorithm="deflation",
+            tol=1e-6,
+            max_iter=500,
+            random_state=42,
+        )
+        ica.fit(fastica_dataset)
+        params = ica.result.parameters
+        assert params["n_components"] == 3
+        assert params["algorithm"] == "deflation"
+        assert params["tol"] == 1e-6
+        assert params["max_iter"] == 500
+        assert params["random_state"] == 42
+
+    def test_repr_contains_parameters(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        text = repr(ica.result)
+        assert "parameters:" in text
+        assert "n_components" in text
+        assert "algorithm" in text
+        assert "whiten" in text
+
+    def test_raises_before_fit(self):
+        ica = FastICA()
+        with pytest.raises(NotFittedError):
+            _ = ica.result
+
+    def test_fit_still_returns_self(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ret = ica.fit(fastica_dataset)
+        assert ret is ica
+
+    def test_existing_properties_unchanged(self, fastica_dataset):
+        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
+        ica.fit(fastica_dataset)
+        assert ica.components.shape == (4, 8)
+        assert ica.mixing.shape == (8, 4)
+        assert ica.St.shape == (4, 8)
+        assert ica.n_iter > 0
+        assert np.all(np.isfinite(ica.components.data))
+        assert np.all(np.isfinite(ica.mixing.data))
+
+    # whitening when whiten=False covered in test_fast_ica.py


### PR DESCRIPTION
## Summary

Add the `result` property to `FastICA`, returning an `AnalysisResult` following the pattern established by PCA, SVD, NMF, MCRALS, SIMPLISMA, and EFA (PRs #1208, #1209, #1213, #1215, #1217, #1218).

## Changes

### `fast_ica.py`
- Import `NotFittedError`, `AnalysisResult`
- New `result` property: guard → parameters → outputs → diagnostics → `AnalysisResult`

### Outputs
| Key | Source | Shape | Description |
|---|---|---|---|
| `components` | `self.components` (`components_`) | (n_comp, n_features) | Unmixing matrix |
| `mixing` | `self.mixing` (`mixing_`) | (n_features, n_comp) | Mixing matrix |
| `St` | `self.St` (`mixing_.T`) | (n_comp, n_features) | Spectral profiles |
| `A` | `self.A` (`transform(X)`) | (n_obs, n_comp) | Independent sources |

Note: `St` and `components` are genuinely different matrices in FastICA (unlike MCRALS where `St` was an alias). Both are included.

### Parameters
10 user-facing configurable traits: `n_components`, `algorithm`, `whiten`, `fun`, `fun_args`, `tol`, `max_iter`, `w_init`, `whiten_solver`, `random_state`.

Callables and arrays serialized per convention.

### Diagnostics
`n_iter` — number of iterations from sklearn `n_iter_`.

### New test file
`test_fast_ica_result.py` — 15 tests (`TestFastICAResult`)

## Validation
- ✅ 23/23 tests pass (8 existing + 15 new)
- ✅ pre-commit (ruff, format, trailing whitespace, etc.)
- ✅ Zero changes to `_result.py` or `ResultBase`/\`AnalysisResult` (contract stable since PR1)
- ✅ Backward compatible