### PR TITLE
MAINT: add AnalysisResult support for PLSRegression

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -28,6 +28,13 @@ Bug Fixes
 
 - FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
   ``whiten=False``. (:pr:`1219`)
+
+- FIX: ``PLSRegression.components`` now raises a clear ``AttributeError``
+  explaining that PLS has no single ``components`` matrix, instead of an
+  unhelpful ``NotImplementedError``. (:pr:`1220`)
+
+- FIX: ``PLSRegression.intercept`` no longer crashes when the target
+  dataset ``Y`` has no coordinate labels. (:pr:`1220`)
 - FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.
@@ -85,7 +92,8 @@ Developer
   (:pr:`1208`)
 
 - MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
-  MCRALS, SIMPLISMA, EFA, and FastICA, providing unified access to
-  analysis and fitting outputs while preserving backward compatibility.
+  MCRALS, SIMPLISMA, EFA, FastICA, and PLSRegression, providing
+  unified access to analysis and fitting outputs while preserving
+  backward compatibility.
   (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`,
-  :pr:`1217`, :pr:`1218`, :pr:`1219`)
+  :pr:`1217`, :pr:`1218`, :pr:`1219`, :pr:`1220`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -17,6 +17,13 @@ Bug Fixes
 
 - FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
   ``whiten=False``. (:pr:`1219`)
+
+- FIX: ``PLSRegression.components`` now raises a clear ``AttributeError``
+  explaining that PLS has no single ``components`` matrix, instead of an
+  unhelpful ``NotImplementedError``. (:pr:`1220`)
+
+- FIX: ``PLSRegression.intercept`` no longer crashes when the target
+  dataset ``Y`` has no coordinate labels. (:pr:`1220`)
 - FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.
@@ -50,7 +57,8 @@ Developer
   (:pr:`1208`)
 
 - MAINT: extend Result Object support to PCA, SVD, NMF, Optimize,
-  MCRALS, SIMPLISMA, EFA, and FastICA, providing unified access to
-  analysis and fitting outputs while preserving backward compatibility.
+  MCRALS, SIMPLISMA, EFA, FastICA, and PLSRegression, providing
+  unified access to analysis and fitting outputs while preserving
+  backward compatibility.
   (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`,
-  :pr:`1217`, :pr:`1218`, :pr:`1219`)
+  :pr:`1217`, :pr:`1218`, :pr:`1219`, :pr:`1220`)

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -268,23 +268,24 @@ PR5: MCRALS AnalysisResult      ✅ Merged (#1215)
 PR6: SIMPLISMA AnalysisResult   ✅ Merged (#1217)
 PR7: EFA AnalysisResult         ✅ Merged (#1218)
 PR8: FastICA AnalysisResult     ✅ Merged (#1219)
+PR9: PLSRegression AnalysisResult ✅ Merged (#1220)
 ```
 
-Nine estimators now implement the Result Object contract:
-- 8 decomposition estimators → `AnalysisResult` (PCA, SVD, NMF, MCRALS, SIMPLISMA, EFA, FastICA)
+Ten estimators now implement the Result Object contract:
+- 9 decomposition/cross-decomposition estimators → `AnalysisResult` (PCA, SVD, NMF, MCRALS, SIMPLISMA, EFA, FastICA, PLSRegression)
 - 1 curve-fitting estimator → `FitResult` (Optimize)
 
-Key outcomes after 8 PRs:
+Key outcomes after 9 PRs:
 - **Zero** changes to `_result.py` since PR1 — `ResultBase`, `AnalysisResult`, `FitResult` unchanged.
 - **`_fit_meta`** pattern established (PR3) and reused (PR5, PR6) for diagnostic capture.
 - No subclass of `AnalysisResult` or `FitResult` was needed.
-- No estimator has required any change to the base contract.
+- No estimator has required any change to the base contract, including
+  the first `_outfit`-free estimator (PLSRegression).
 
 ### Remaining candidates
 
 | Order | Estimator | Complexity | Notes |
 |---|---|---|---|
-| PR9 | PLSRegression | High | No `_outfit` — 10+ private attrs stored directly |
 | Later | Baseline | Medium | Processor, not decomposition — different architectural role |
 | Later | LSTSQ / NNLS | Low | Thin sklearn wrappers — `FitResult`?
 

--- a/src/spectrochempy/analysis/crossdecomposition/pls.py
+++ b/src/spectrochempy/analysis/crossdecomposition/pls.py
@@ -10,9 +10,12 @@ from sklearn import cross_decomposition
 
 from spectrochempy.analysis._base._analysisbase import CrossDecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.application.application import warning_
+from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.utils.decorators import signature_has_configurable_traits
+from spectrochempy.utils.exceptions import NotFittedError
 
 __all__ = ["PLSRegression"]
 __configurables__ = ["PLSRegression"]
@@ -265,16 +268,69 @@ class PLSRegression(CrossDecompositionAnalysis):
         return coef
 
     @property
-    @_wrap_ndarray_output_to_nddataset(
-        meta_from="_Y",
-        typesingle="targets",
-    )
     def intercept(self):
-        return self._intercept
+        intercept = NDDataset(self._intercept)
+        try:
+            coord = self._Y.coordset[0]
+            if coord is not None:
+                if coord.labels is not None:
+                    labels = coord.labels
+                else:
+                    labels = [f"#{i + 1}" for i in range(self._Y.shape[-1])]
+                intercept.dims = ["j"]
+                intercept.set_coordset(
+                    j=Coord(None, labels=labels, title="targets"),
+                )
+        except (TypeError, IndexError, AttributeError):
+            pass
+        return intercept
 
     @property
     def n_iter(self):
         return self._n_iter
+
+    # ----------------------------------------------------------------------------------
+    # Result object
+    # ----------------------------------------------------------------------------------
+    def _get_components(self):
+        raise AttributeError(
+            "PLSRegression has no single 'components' matrix. "
+            "Use the 'x_loadings', 'x_weights', or 'x_rotations' "
+            "property depending on the analysis context."
+        )
+
+    @property
+    def result(self):
+        if not self._fitted:
+            raise NotFittedError(
+                "This PLSRegression instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this property."
+            )
+        return AnalysisResult(
+            estimator="PLSRegression",
+            parameters={
+                "n_components": self.n_components,
+                "scale": self.scale,
+                "max_iter": self.max_iter,
+                "tol": self.tol,
+            },
+            outputs={
+                "x_scores": self.x_scores,
+                "x_loadings": self.x_loadings,
+                "x_weights": self.x_weights,
+                "x_rotations": self.x_rotations,
+                "y_scores": self.y_scores,
+                "y_loadings": self.y_loadings,
+                "y_weights": self.y_weights,
+                "y_rotations": self.y_rotations,
+                "coef": self.coef,
+                "intercept": self.intercept,
+            },
+            diagnostics={
+                "n_iter": self._n_iter,
+                "n_features_in": self._n_feature_in,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis/test_crossdecomposition/test_pls_result.py
+++ b/tests/test_analysis/test_crossdecomposition/test_pls_result.py
@@ -1,0 +1,213 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+"""Tests for the PLSRegression result property."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis.crossdecomposition.pls import PLSRegression
+from spectrochempy.utils.exceptions import NotFittedError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def pls_fitted():
+    """Return a fitted PLSRegression with default parameters."""
+    rng = np.random.default_rng(42)
+    n_obs = 20
+    n_features = 10
+    n_components = 3
+    n_targets = 2
+
+    X = rng.normal(0, 1, (n_obs, n_features))
+    Y = rng.normal(0, 1, (n_obs, n_targets))
+
+    import spectrochempy as scp
+
+    X_nd = scp.NDDataset(X)
+    Y_nd = scp.NDDataset(Y)
+
+    pls = PLSRegression(n_components=n_components)
+    pls.fit(X_nd, Y_nd)
+    return pls
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPLSRegressionResult:
+    """Tests for PLSRegression.result returning AnalysisResult."""
+
+    def test_result_is_analysis_result(self, pls_fitted):
+        result = pls_fitted.result
+        assert isinstance(result, AnalysisResult)
+
+    def test_estimator_name(self, pls_fitted):
+        assert pls_fitted.result.estimator == "PLSRegression"
+
+    def test_outputs_contain_keys(self, pls_fitted):
+        outputs = pls_fitted.result.outputs
+        expected = {
+            "x_scores",
+            "x_loadings",
+            "x_weights",
+            "x_rotations",
+            "y_scores",
+            "y_loadings",
+            "y_weights",
+            "y_rotations",
+            "coef",
+            "intercept",
+        }
+        assert set(outputs.keys()) == expected
+
+    def test_outputs_do_not_contain_components(self, pls_fitted):
+        assert "components" not in pls_fitted.result.outputs
+
+    def test_output_values_match_properties(self, pls_fitted):
+        pls = pls_fitted
+        outputs = pls.result.outputs
+        assert_allclose(outputs["x_scores"].data, pls.x_scores.data)
+        assert_allclose(outputs["x_loadings"].data, pls.x_loadings.data)
+        assert_allclose(outputs["x_weights"].data, pls.x_weights.data)
+        assert_allclose(outputs["x_rotations"].data, pls.x_rotations.data)
+        assert_allclose(outputs["y_scores"].data, pls.y_scores.data)
+        assert_allclose(outputs["y_loadings"].data, pls.y_loadings.data)
+        assert_allclose(outputs["y_weights"].data, pls.y_weights.data)
+        assert_allclose(outputs["y_rotations"].data, pls.y_rotations.data)
+        assert_allclose(outputs["coef"].data, pls.coef.data)
+        assert_allclose(outputs["intercept"].data, pls.intercept.data)
+
+    def test_diagnostics_contain_keys(self, pls_fitted):
+        diagnostics = pls_fitted.result.diagnostics
+        assert "n_iter" in diagnostics
+        assert "n_features_in" in diagnostics
+
+    def test_diagnostics_values(self, pls_fitted):
+        pls = pls_fitted
+        diagnostics = pls.result.diagnostics
+        # sklearn n_iter_ is a list of ints per component
+        assert isinstance(diagnostics["n_iter"], (list, np.ndarray))
+        assert len(diagnostics["n_iter"]) == pls.n_components
+        assert diagnostics["n_features_in"] == 10
+
+    def test_parameters_contain_expected_keys(self, pls_fitted):
+        parameters = pls_fitted.result.parameters
+        expected = {"n_components", "scale", "max_iter", "tol"}
+        assert set(parameters.keys()) == expected
+
+    def test_parameters_values(self, pls_fitted):
+        parameters = pls_fitted.result.parameters
+        assert parameters["n_components"] == 3
+        assert parameters["scale"] is True
+        assert parameters["max_iter"] == 500
+        assert parameters["tol"] == 1.0e-6
+
+    def test_parameters_match_estimator_config(self, pls_fitted):
+        pls = PLSRegression(
+            n_components=2,
+            scale=False,
+            max_iter=100,
+            tol=1.0e-4,
+        )
+        rng = np.random.default_rng(42)
+        X = rng.normal(0, 1, (20, 10))
+        Y = rng.normal(0, 1, (20, 2))
+        import spectrochempy as scp
+
+        pls.fit(scp.NDDataset(X), scp.NDDataset(Y))
+        params = pls.result.parameters
+        assert params["n_components"] == 2
+        assert params["scale"] is False
+        assert params["max_iter"] == 100
+        assert params["tol"] == 1.0e-4
+
+    def test_repr_contains_expected_fields(self, pls_fitted):
+        text = repr(pls_fitted.result)
+        assert "AnalysisResult" in text
+        assert "PLSRegression" in text
+        assert "x_scores" in text
+        assert "x_loadings" in text
+        assert "coef" in text
+        assert "n_iter" in text
+        assert "n_features_in" in text
+
+    def test_repr_contains_parameters(self, pls_fitted):
+        text = repr(pls_fitted.result)
+        assert "parameters:" in text
+        assert "n_components" in text
+
+    def test_result_is_not_cached(self, pls_fitted):
+        assert pls_fitted.result is not pls_fitted.result
+
+    def test_raises_before_fit(self):
+        pls = PLSRegression(n_components=3)
+        with pytest.raises(NotFittedError):
+            _ = pls.result
+
+    def test_fit_still_returns_self(self, pls_fitted):
+        rng = np.random.default_rng(42)
+        X = rng.normal(0, 1, (20, 10))
+        Y = rng.normal(0, 1, (20, 2))
+        import spectrochempy as scp
+
+        pls = PLSRegression(n_components=3)
+        ret = pls.fit(scp.NDDataset(X), scp.NDDataset(Y))
+        assert ret is pls
+
+    def test_existing_properties_unchanged(self, pls_fitted):
+        pls = pls_fitted
+        assert pls._fitted
+        assert pls.n_components == 3
+        assert pls.x_loadings.shape == (3, 10)
+        assert pls.x_scores.shape == (20, 3)
+        assert pls.n_iter is not None
+
+    def test_n_iter_works_after_fit(self, pls_fitted):
+        n_iter = pls_fitted.n_iter
+        assert n_iter is not None
+        assert len(n_iter) == 3
+
+    def test_components_raises_clear_error(self, pls_fitted):
+        with pytest.raises(AttributeError, match="no single 'components' matrix"):
+            _ = pls_fitted.components
+
+    def test_intercept_in_result_is_nddataset(self, pls_fitted):
+        assert hasattr(pls_fitted.result.outputs["intercept"], "shape")
+
+    def test_intercept_property_handles_y_without_coordset(self):
+        rng = np.random.default_rng(42)
+        X = rng.normal(0, 1, (20, 10))
+        Y = rng.normal(0, 1, (20, 2))
+        import spectrochempy as scp
+
+        pls = PLSRegression(n_components=3)
+        pls.fit(scp.NDDataset(X), scp.NDDataset(Y))
+        intercept = pls.intercept
+        assert hasattr(intercept, "shape")
+        assert intercept.shape == (2,)
+
+    def test_result_intercept_matches_property(self, pls_fitted):
+        pls = pls_fitted
+        assert_allclose(
+            pls.result.outputs["intercept"].data,
+            pls.intercept.data,
+        )
+
+    def test_coef_is_nddataset(self, pls_fitted):
+        assert hasattr(pls_fitted.coef, "shape")
+
+    def test_all_outputs_are_nddataset(self, pls_fitted):
+        for key, value in pls_fitted.result.outputs.items():
+            assert hasattr(value, "shape"), f"{key} is not an NDDataset"


### PR DESCRIPTION
## Summary

Add `PLSRegression.result` property returning `AnalysisResult`.

## Changes

- **`pls.py`** (+54 lines): imports, `_get_components` override with clear error, `result` property
- **`test_pls_result.py`** (new, ~220 lines): 23 tests covering outputs, diagnostics, parameters, repr, edge cases
- **`changelog.rst`**: FIX entry for `components` clearer error, MAINT consolidated with PLSRegression
- **`roadmap`**: PR9 = PLSRegression added

## Outputs (10 keys)

`x_scores`, `x_loadings`, `x_weights`, `x_rotations`, `y_scores`, `y_loadings`, `y_weights`, `y_rotations`, `coef`, `intercept`

## Parameters (4 keys)

`n_components`, `scale`, `max_iter`, `tol`

## Diagnostics (2 keys)

`n_iter`, `n_features_in`

## Pre-existing bug fixed

`PLSRegression.intercept` crashed when `_Y` had no coordinate labels (`coordset` was `None`). Replaced the `@_wrap_ndarray_output_to_nddataset` decorator with manual `NDDataset` wrapping that handles missing coordset gracefully.

## Key architectural outcome

`AnalysisResult` successfully supports PLSRegression despite its `_outfit`-free storage pattern, without modification of the base contract. This confirms the migration pattern works regardless of *how* the estimator stores internal state.

## What is intentionally out of scope

- Caching (deferred)
- Serialization / Project / provenance (deferred)
- No changes to `ResultBase`, `AnalysisResult`, `FitResult`, or RFC

## Related

Closes the PLSRegression step of the Result Object migration roadmap.