### PR TITLE
SEC: make SCP/PSCP loading safe by default

### DIFF
--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -104,6 +104,15 @@ X
 # The `read_dir` function scans a directory and reads all supported files,
 # returning a list of `NDDataset` objects.
 #
+# Historical ``.scp`` and ``.pscp`` files are trusted native persistence
+# archives. If such a file requires legacy pickle-based decoding, load it
+# explicitly with:
+#
+#     scp.read("example.scp", allow_unsafe_legacy=True)
+#
+# Only enable ``allow_unsafe_legacy=True`` for files from known and trusted
+# sources.
+#
 # Other reader functions return either a single `NDDataset` or multiple `NDDataset`
 # objects, depending on the file type and content.
 #

--- a/docs/sources/userguide/objects/project/project.py
+++ b/docs/sources/userguide/objects/project/project.py
@@ -155,9 +155,18 @@ proj.save_as("NMR")
 
 # %% [markdown]
 # #### Loading
+#
+# Historical ``.pscp`` archives may require trusted legacy loading because they
+# currently rely on pickle-based native persistence for embedded datasets. In
+# that case, reload explicitly with:
+#
+#     proj2 = scp.Project.load("NMR", allow_unsafe_legacy=True)
+#
+# Only enable ``allow_unsafe_legacy=True`` for files from known and trusted
+# sources.
 
 # %%
-proj2 = scp.Project.load("NMR")
+proj2 = scp.Project.load("NMR", allow_unsafe_legacy=True)
 
 # %%
 proj2

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- FIX: application startup now removes invalid JSON preference files only
+  after closing them first, avoiding a Windows ``PermissionError`` during
+  configuration initialisation when a stale file such as ``CP.json`` is
+  encountered.
+
 - FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
   ``whiten=False``. (:pr:`1219`)
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -73,6 +73,11 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
 
+- Loading native ``.scp`` and ``.pscp`` files is now safe by default.
+  Historical archives that require pickle-based native persistence must be
+  reloaded explicitly with ``allow_unsafe_legacy=True``, and only from known
+  and trusted sources.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,11 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- FIX: application startup now removes invalid JSON preference files only
+  after closing them first, avoiding a Windows ``PermissionError`` during
+  configuration initialisation when a stale file such as ``CP.json`` is
+  encountered.
+
 - FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
   ``whiten=False``. (:pr:`1219`)
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -49,6 +49,14 @@ Bug Fixes
   variable instead of a literal string; and invalid ``return_ifg`` values
   now produce a clear warning. (PR by @gaoflow)
 
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- Loading native ``.scp`` and ``.pscp`` files is now safe by default.
+  Historical archives that require pickle-based native persistence must be
+  reloaded explicitly with ``allow_unsafe_legacy=True``, and only from known
+  and trusted sources.
+
 Developer
 ~~~~~~~~~
 

--- a/maintainers/rfcs/trusted-and-portable-persistence.md
+++ b/maintainers/rfcs/trusted-and-portable-persistence.md
@@ -584,4 +584,3 @@ SpectroChemPy must make explicit what SCP/PSCP formats are and what they promise
 5. **Sequenced follow-up RFCs** to address security, portable formats, Result persistence, Project membership, and plugin governance.
 
 The goal is not to redesign persistence immediately, but to clarify the foundation so that future decisions can be coherent, well-informed, and aligned with SpectroChemPy's commitment to scientific reproducibility, safety, and long-term compatibility.
-

--- a/src/spectrochempy/application/application.py
+++ b/src/spectrochempy/application/application.py
@@ -299,12 +299,15 @@ class SpectroChemPy(Application):
                         jsonname.unlink()
                     else:
                         # check integrity of the file
+                        invalid_json = False
                         with jsonname.open() as f:
                             try:
                                 json.load(f)
                             except json.JSONDecodeError:
-                                jsonname.unlink()
-                                continue
+                                invalid_json = True
+                        if invalid_json:
+                            jsonname.unlink()
+                            continue
                         configfiles.append(jsonname)
 
             for cfgname in configfiles:

--- a/src/spectrochempy/core/dataset/_coordgroup.py
+++ b/src/spectrochempy/core/dataset/_coordgroup.py
@@ -206,7 +206,9 @@ def _coord_from_legacy_state(state: dict) -> Coord:
         if key == "__class__":
             continue
         decoded = (
-            json_decoder(cpy.deepcopy(value)) if isinstance(value, dict) else value
+            json_decoder(cpy.deepcopy(value), allow_unsafe_legacy=True)
+            if isinstance(value, dict)
+            else value
         )
         setattr(coord, key if key == "name" else f"_{key}", decoded)
     return coord

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -279,6 +279,10 @@ class NDIO(tr.HasTraits):
         ----------------
         content : str, optional
              The optional content of the file(s) to be loaded as a binary string.
+        allow_unsafe_legacy : bool, optional, default=False
+             Allow loading legacy SCP/PSCP payloads that require pickle-based
+             native persistence. Enable this only for files from known and
+             trusted sources.
 
         See Also
         --------
@@ -295,17 +299,19 @@ class NDIO(tr.HasTraits):
         >>> f = nd1.save()
         >>> f.name
         'nh4y-activation.scp'
-        >>> nd2 = scp.load(f)
+        >>> nd2 = scp.load(f, allow_unsafe_legacy=True)
 
         Alternatively, this method can be called as a class method of NDDataset or Project object:
 
         >>> from spectrochempy import *
-        >>> nd2 = NDDataset.load(f)
+        >>> nd2 = NDDataset.load(f, allow_unsafe_legacy=True)
 
         """
         content = kwargs.get("content")
+        allow_unsafe_legacy = kwargs.get("allow_unsafe_legacy", False)
+        resolved_filename = None
 
-        if content:
+        if content is not None:
             fid = io.BytesIO(content)
         else:
             # be sure to convert filename to a pathlib object with the
@@ -319,10 +325,11 @@ class NDIO(tr.HasTraits):
                 raise FileNotFoundError(f"No file with name {filename} could be found.")
                 # filename = check_filenames(filename, **kwargs)[0]
             fid = open(filename, "rb")  # noqa: SIM115
+            resolved_filename = filename
 
         # get zip file
         try:
-            obj = ScpFile(fid)
+            obj = ScpFile(fid, allow_unsafe_legacy=allow_unsafe_legacy)
         except FileNotFoundError as e:
             raise exceptions.SpectroChemPyError(
                 f"File {filename} doesn't exist!",
@@ -334,18 +341,16 @@ class NDIO(tr.HasTraits):
                 ) from e
             raise exceptions.SpectroChemPyError("Undefined error!") from e
 
-        js = obj[obj.files[0]]
+        with obj:
+            js = obj[obj.files[0]]
         if kwargs.get("json", False):
             return js
 
         new = cls.loads(js)
 
-        fid.close()
-
-        if filename:
-            filename = pathclean(filename)
-            new._filename = filename
-            new.name = filename.stem
+        if resolved_filename is not None:
+            new._filename = resolved_filename
+            new.name = resolved_filename.stem
 
         return new
 
@@ -511,4 +516,14 @@ class NDIO(tr.HasTraits):
         return filename
 
 
-load = NDIO.load  # make load accessible directly from the scp API
+def load(filename: str | pathlib.Path | BinaryIO, **kwargs: Any) -> Any:
+    """Load a native SpectroChemPy dataset or project from a `.scp` / `.pscp` file."""
+    from spectrochempy.core.dataset.nddataset import NDDataset
+    from spectrochempy.core.project.project import Project
+
+    if isinstance(filename, str | pathlib.Path):
+        suffix = pathclean(filename).suffix.lower()
+        if suffix == ".pscp":
+            return Project.load(filename, **kwargs)
+
+    return NDDataset.load(filename, **kwargs)

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -27,6 +27,7 @@ from spectrochempy.utils._logging import debug_
 from spectrochempy.utils._logging import info_
 from spectrochempy.utils._logging import warning_
 from spectrochempy.utils.exceptions import ProtocolError
+from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.file import check_filename_to_open
 from spectrochempy.utils.file import get_directory_name
 from spectrochempy.utils.file import get_filenames
@@ -223,6 +224,8 @@ class Importer(HasTraits):
                     warning_(str(e))
 
             except Exception as e:
+                if isinstance(e, SpectroChemPyError):
+                    raise
                 warning_(str(e))
 
             if dataset is not None:

--- a/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
@@ -14,23 +14,28 @@ either from local or remote files.
 
 # %%
 # First we need to import the spectrochempy API package
+import os
+from pathlib import Path
+
 import spectrochempy as scp
+
+TEST_FILE = Path(os.environ.get("TEST_FILE", "irdata/nh4y-activation.spg"))
+TEST_FOLDER = Path(os.environ.get("TEST_FOLDER", "irdata"))
 
 # %%
 # Import dataset from local files
 # -------------------------------
 # Read a IR data recorded in Omnic format (``.spg`` extension).
 # We just pass the file name as parameter.
-dataset = scp.read("irdata/nh4y-activation.spg")
+dataset = scp.read(TEST_FILE)
 print(dataset)
 
 # %%
-_ = dataset.plot(style="paper")
+if dataset is not None:
+    _ = dataset.plot(style="paper")
 # %%
 # When using `read`, we can pass filename as a `str` or a `~pathlib.Path` object.
-from pathlib import Path
-
-filename = Path("irdata/nh4y-activation.spg")
+filename = TEST_FILE
 dataset = scp.read(filename)
 
 # %%
@@ -44,8 +49,9 @@ print(datadir)
 # By default, the different files will be merged along the first dimension (y).
 # However, for this to work, the second dimension (x) must be compatible (same size)
 # or else a WARNING appears. To avoid the warning and get individual spectra, you can
-# set ``merge`` to `False` .
-dataset_list = scp.read("irdata", merge=False)
+# set ``merge`` to `False` . This test-data directory may also contain historical
+# trusted native `.scp` archives, which require explicit legacy opt-in.
+dataset_list = scp.read(TEST_FOLDER, merge=False, allow_unsafe_legacy=True)
 print(dataset_list)
 
 # %%

--- a/src/spectrochempy/examples/core/e_project/plot_project.py
+++ b/src/spectrochempy/examples/core/e_project/plot_project.py
@@ -63,5 +63,5 @@ proj.save()
 # %%
 # RELOAD the project from disk as newproj
 
-newproj = scp.Project.load("project_1")
+newproj = scp.Project.load("project_1", allow_unsafe_legacy=True)
 newproj

--- a/src/spectrochempy/utils/jsonutils.py
+++ b/src/spectrochempy/utils/jsonutils.py
@@ -7,10 +7,18 @@
 
 import base64
 import datetime
+import json
 import pathlib
 import pickle
+from functools import partial
 
 import numpy as np
+
+UNSAFE_LEGACY_LOADING_MESSAGE = (
+    "This SCP/PSCP file requires trusted legacy loading because it uses "
+    "pickle-based native persistence. Reload with allow_unsafe_legacy=True only "
+    "if the file comes from a known and trusted source."
+)
 
 
 def fromisoformat(s):
@@ -24,7 +32,13 @@ def fromisoformat(s):
 # ======================================================================================
 # JSON UTILITIES
 # ======================================================================================
-def json_decoder(dic):
+def _raise_unsafe_legacy_loading_error():
+    from spectrochempy.utils.exceptions import SpectroChemPyError
+
+    raise SpectroChemPyError(UNSAFE_LEGACY_LOADING_MESSAGE)
+
+
+def json_decoder(dic, allow_unsafe_legacy=False):
     """Decode a serialized json object."""
     from spectrochempy.core.units import Quantity
     from spectrochempy.core.units import Unit
@@ -38,6 +52,8 @@ def json_decoder(dic):
             return np.datetime64(dic["isoformat"])
         if klass == "NUMPY_ARRAY":
             if "base64" in dic:
+                if not allow_unsafe_legacy:
+                    _raise_unsafe_legacy_loading_error()
                 return pickle.loads(base64.b64decode(dic["base64"]))  # noqa: S301
             if "tolist" in dic:
                 return np.array(dic["tolist"], dtype=dic["dtype"])
@@ -49,6 +65,8 @@ def json_decoder(dic):
             return Unit(dic["str"])
         elif klass == "COMPLEX":
             if "base64" in dic:
+                if not allow_unsafe_legacy:
+                    _raise_unsafe_legacy_loading_error()
                 return pickle.loads(base64.b64decode(dic["base64"]))  # noqa: S301
             if "tolist" in dic:
                 if dic["dtype"] == "complex":
@@ -65,9 +83,20 @@ def json_decoder(dic):
             meta.readonly = dic.get("readonly", False)
             return meta
 
-        raise TypeError(dic["__class__"])
+        raise TypeError(klass)
 
     return dic
+
+
+def json_loads(content, *, allow_unsafe_legacy=False):
+    """Load JSON content with explicit legacy unsafe decoding control."""
+    return json.loads(
+        content,
+        object_hook=partial(
+            json_decoder,
+            allow_unsafe_legacy=allow_unsafe_legacy,
+        ),
+    )
 
 
 def json_encoder(byte_obj, encoding=None):

--- a/src/spectrochempy/utils/zip.py
+++ b/src/spectrochempy/utils/zip.py
@@ -3,7 +3,6 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-import json
 import os
 from collections.abc import Mapping
 
@@ -69,11 +68,12 @@ class ScpFile(Mapping):  # lgtm[py/missing-equals]
 
     """
 
-    def __init__(self, fid):
+    def __init__(self, fid, *, allow_unsafe_legacy=False):
         _zip = make_zipfile(fid)
 
         self.files = _zip.namelist()
         self.zip = _zip
+        self.allow_unsafe_legacy = allow_unsafe_legacy
 
         if hasattr(fid, "close"):
             self.fid = fid
@@ -111,7 +111,9 @@ class ScpFile(Mapping):  # lgtm[py/missing-equals]
         return len(self.files)
 
     def __getitem__(self, key):
-        from spectrochempy.utils.jsonutils import json_decoder
+        from spectrochempy.utils.exceptions import SpectroChemPyError
+        from spectrochempy.utils.jsonutils import UNSAFE_LEGACY_LOADING_MESSAGE
+        from spectrochempy.utils.jsonutils import json_loads
 
         member = False
         ext = None
@@ -122,18 +124,32 @@ class ScpFile(Mapping):  # lgtm[py/missing-equals]
 
         if member and ext in [".npy"]:
             f = self.zip.open(key)
-            return read_array(f, allow_pickle=True)
+            try:
+                return read_array(f, allow_pickle=self.allow_unsafe_legacy)
+            except ValueError as exc:
+                if not self.allow_unsafe_legacy and "allow_pickle=False" in str(exc):
+                    raise SpectroChemPyError(
+                        UNSAFE_LEGACY_LOADING_MESSAGE,
+                    ) from exc
+                raise
 
         if member and ext in [".scp"]:
             from spectrochempy.core.dataset.nddataset import NDDataset
 
             # f = io.BytesIO(self.zip.read(key))
             content = self.zip.read(key)
-            return NDDataset.load(key, content=content)
+            return NDDataset.load(
+                key,
+                content=content,
+                allow_unsafe_legacy=self.allow_unsafe_legacy,
+            )
 
         if member and ext in [".json"]:
             content = self.zip.read(key)
-            return json.loads(content, object_hook=json_decoder)
+            return json_loads(
+                content,
+                allow_unsafe_legacy=self.allow_unsafe_legacy,
+            )
 
         if member:
             return self.zip.read(key)

--- a/tests/test_application/test_application.py
+++ b/tests/test_application/test_application.py
@@ -9,6 +9,7 @@ import logging
 import pytest
 from pathlib import Path
 import spectrochempy as scp
+from spectrochempy.application.application import SpectroChemPy
 from spectrochempy.application.application import app
 from unittest.mock import patch
 import subprocess
@@ -81,6 +82,19 @@ def test_datadir():
     assert DATADIR.exists()
     assert DATADIR.is_dir()
     assert DATADIR.name == "testdata"
+
+
+def test_invalid_json_config_is_removed_after_close(tmp_path):
+    """Invalid JSON config files should be removed without blocking startup."""
+    invalid = tmp_path / "CP.json"
+    invalid.write_text("{not valid json", encoding="utf-8")
+
+    app = SpectroChemPy(config_dir=tmp_path, log_level=logging.WARNING)
+    app._init_all_preferences()
+
+    assert not invalid.exists()
+    assert app.general_preferences is not None
+    assert app.plot_preferences is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core/test_dataset/test_dataset_regressions.py
+++ b/tests/test_core/test_dataset/test_dataset_regressions.py
@@ -45,7 +45,7 @@ def test_nddataset_bug_462():
     A = scp.random((10, 100))
     A.x = scp.Coord(np.arange(0.0, 100.0, 1), title="coord1")
     af = A.write("A.scp", overwrite=True)
-    B = scp.read("A.scp")
+    B = scp.read("A.scp", allow_unsafe_legacy=True)
     assert B.x == A.x
 
     C = scp.random((10, 100))
@@ -54,7 +54,7 @@ def test_nddataset_bug_462():
         scp.Coord(np.arange(0.0, 1000.0, 10), title="coord2"),
     ]
     cf = C.write("C.scp", overwrite=True)
-    D = scp.read("C.scp")
+    D = scp.read("C.scp", allow_unsafe_legacy=True)
     assert len(D.x) == 2, "incorrect encoding/decoding"
 
     af.unlink()

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -11,10 +11,12 @@ import json
 import zipfile
 
 import pytest
+import spectrochempy as scp
 
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
+from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.testing import assert_array_equal, assert_dataset_equal
 
 # Basic
@@ -32,7 +34,7 @@ def test_ndio_generic(ndataset_1d, tmp_path, monkeypatch):
     assert ir.directory == tmp_path
 
     # load back this  file : the full path f is given so no dialog is opened
-    nd = NDDataset.load(f)
+    nd = NDDataset.load(f, allow_unsafe_legacy=True)
     assert_dataset_equal(nd, ir)
 
     # as it has been already saved,
@@ -58,7 +60,7 @@ def test_ndio_generic(ndataset_1d, tmp_path, monkeypatch):
     f = ir.save_as(tmp_path / "essai")
 
     # try to load without extension specification (will first assume it is scp)
-    dl = NDDataset.load("essai")
+    dl = NDDataset.load("essai", allow_unsafe_legacy=True)
     # assert dl.directory == cwd
     assert_array_equal(dl.data, ir.data)
     f.unlink()
@@ -72,7 +74,7 @@ def test_ndio_2D(ndataset_2d, tmp_path):
     assert ir2.directory == tmp_path
     with pytest.raises(FileNotFoundError):
         NDDataset.load("essai2D")
-    nd = NDDataset.load(tmp_path / "essai2D")
+    nd = NDDataset.load(tmp_path / "essai2D", allow_unsafe_legacy=True)
     assert nd.directory == tmp_path
     f.unlink()
 
@@ -84,7 +86,7 @@ def test_ndio_roundtrip_preserves_selected_non_first_default(tmp_path):
     selected_data = ds.x.data.copy()
     filename = ds.save_as(tmp_path / "multicoord_default", confirm=False)
 
-    loaded = NDDataset.load(filename)
+    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
 
     assert loaded.x.default == loaded.x["_2"]
     assert_array_equal(loaded.x.default.data, selected_data)
@@ -96,7 +98,7 @@ def test_ndio_roundtrip_preserves_reference_lookup(tmp_path):
     ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(x=c, y="x"))
     filename = ds.save_as(tmp_path / "reference_coords", confirm=False)
 
-    loaded = NDDataset.load(filename)
+    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
 
     assert loaded.coordset.references == ds.coordset.references
     assert loaded.coordset["y"] == "x"
@@ -120,7 +122,7 @@ def test_ndio_load_without_default_field_keeps_legacy_behavior(tmp_path):
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.writestr(member, json.dumps(js, indent=2))
 
-    loaded = NDDataset.load(filename)
+    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
 
     assert loaded.x.default == loaded.x["_1"]
     assert_array_equal(loaded.x.data, legacy_default_data)
@@ -140,7 +142,7 @@ def test_ndio_load_ignores_legacy_roi_fields(tmp_path):
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.writestr(member, json.dumps(js, indent=2))
 
-    loaded = NDDataset.load(filename)
+    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
 
     assert not hasattr(loaded, "roi")
     assert not hasattr(loaded.x, "roi")
@@ -159,7 +161,62 @@ def test_ndio_load_ignores_legacy_modeldata_field(tmp_path):
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.writestr(member, json.dumps(js, indent=2))
 
-    loaded = NDDataset.load(filename)
+    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
+
+
+def test_ndio_load_requires_explicit_opt_in_for_legacy_scp(tmp_path, monkeypatch):
+    ds = NDDataset([0.0, 1.0, 2.0], name="legacy_dataset")
+    filename = ds.save_as(tmp_path / "legacy_dataset", confirm=False)
+
+    def fail_pickle_loads(*args, **kwargs):
+        raise AssertionError("pickle.loads must not run in safe mode")
+
+    with monkeypatch.context() as m:
+        m.setattr("spectrochempy.utils.jsonutils.pickle.loads", fail_pickle_loads)
+
+        with pytest.raises(
+            SpectroChemPyError,
+            match="trusted legacy loading",
+        ):
+            NDDataset.load(filename)
+
+    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
+    assert_dataset_equal(loaded, ds)
+
+
+def test_ndio_load_content_requires_explicit_opt_in(tmp_path):
+    ds = NDDataset([0.0, 1.0, 2.0], name="legacy_content")
+    filename = ds.save_as(tmp_path / "legacy_content", confirm=False)
+    content = filename.read_bytes()
+
+    with pytest.raises(
+        SpectroChemPyError,
+        match="allow_unsafe_legacy=True",
+    ):
+        NDDataset.load("legacy_content.scp", content=content)
+
+    loaded = NDDataset.load(
+        "legacy_content.scp",
+        content=content,
+        allow_unsafe_legacy=True,
+    )
+    assert_dataset_equal(loaded, ds)
+
+
+@pytest.mark.parametrize("loader_name", ["load", "read"])
+def test_native_load_aliases_require_explicit_opt_in(tmp_path, loader_name):
+    ds = NDDataset([0.0, 1.0, 2.0], name="legacy_alias")
+    filename = ds.save_as(tmp_path / "legacy_alias", confirm=False)
+    loader = getattr(scp, loader_name)
+
+    with pytest.raises(
+        SpectroChemPyError,
+        match="trusted legacy loading",
+    ):
+        loader(filename)
+
+    loaded = loader(filename, allow_unsafe_legacy=True)
+    assert_dataset_equal(loaded, ds)
 
     assert not hasattr(loaded, "modeldata")
 

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -1046,7 +1046,7 @@ def test_issue417():
             x = X - X[-1]
 
             f = X.write("X.scp")
-            X_r = scp.read("X.scp")
+            X_r = scp.read("X.scp", allow_unsafe_legacy=True)
             f.unlink()
 
             assert_array_equal(X.data, X_r.data)

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -13,6 +13,7 @@ from spectrochempy.application.preferences import preferences
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.project.project import Project
 from spectrochempy.utils.constants import INPLACE
+from spectrochempy.utils.exceptions import SpectroChemPyError
 
 prefs = preferences
 
@@ -82,7 +83,7 @@ def test_save_and_load_project(ds1, ds2):
     myp.add_datasets(ds1, ds2)
 
     fn = myp.save()
-    proj = Project.load(fn)
+    proj = Project.load(fn, allow_unsafe_legacy=True)
 
     assert str(proj["toto"]) == "NDDataset: [float64] a.u. (shape: (z:10, y:100, x:3))"
 
@@ -514,7 +515,7 @@ class TestSerializationRoundtrip:
         proj.add_project(sub)
 
         filename = proj.save()
-        loaded = Project.load(filename)
+        loaded = Project.load(filename, allow_unsafe_legacy=True)
 
         assert "subproject" in loaded.projects_names
         assert "data" in loaded.subproject.datasets_names
@@ -548,11 +549,27 @@ class TestSerializationRoundtrip:
         with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
             zipf.writestr(member, json.dumps(js, indent=2))
 
-        loaded = Project.load(filename)
+        loaded = Project.load(filename, allow_unsafe_legacy=True)
 
         assert not hasattr(loaded.data, "roi")
         assert not hasattr(loaded.data, "modeldata")
         assert not hasattr(loaded, "_others")
+
+    def test_project_load_requires_explicit_opt_in(self, ds1):
+        proj = Project(name="legacy_project")
+        ds1.name = "data"
+        proj.add_dataset(ds1)
+
+        filename = proj.save()
+
+        with pytest.raises(
+            SpectroChemPyError,
+            match="trusted legacy loading",
+        ):
+            Project.load(filename)
+
+        loaded = Project.load(filename, allow_unsafe_legacy=True)
+        assert "data" in loaded.datasets_names
 
 
 class TestArgNamesEdgeCases:

--- a/tests/test_core/test_writers/test_exporter.py
+++ b/tests/test_core/test_writers/test_exporter.py
@@ -35,11 +35,11 @@ def test_write(mock_cwd, ndataset_1d):
     filename = nd.write("essai.scp", overwrite=True)
 
     # Read the file and compare
-    nd2 = NDDataset.load(filename)
+    nd2 = NDDataset.load(filename, allow_unsafe_legacy=True)
     testing.assert_dataset_equal(nd2, nd)
 
     # we can also use the read method to read it
-    nd3 = scp.read(filename)
+    nd3 = scp.read(filename, allow_unsafe_legacy=True)
     testing.assert_dataset_equal(nd3, nd)
 
     filename.unlink()

--- a/tests/test_utils/test_jsonutils.py
+++ b/tests/test_utils/test_jsonutils.py
@@ -8,11 +8,13 @@ import base64
 import json
 import pickle
 from datetime import datetime
+from functools import partial
 
 import numpy as np
 import pytest
 
 from spectrochempy.utils.jsonutils import json_decoder, json_encoder
+from spectrochempy.utils.exceptions import SpectroChemPyError
 
 
 @pytest.mark.data
@@ -26,7 +28,10 @@ def test_json_encoder_decoder_no_encoding(IR_dataset_2D):
     print("no encoding", len(js_string))
 
     # load json from string
-    jsd = json.loads(js_string, object_hook=json_decoder)
+    jsd = json.loads(
+        js_string,
+        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+    )
 
     assert np.all(np.array(js["data"]["tolist"]) == jsd["data"])
 
@@ -42,7 +47,10 @@ def test_json_encoder_decoder_base64(IR_dataset_2D):
     print("base64", len(js_string))
 
     # load json from string
-    jsd = json.loads(js_string, object_hook=json_decoder)
+    jsd = json.loads(
+        js_string,
+        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+    )
 
     assert np.all(pickle.loads(base64.b64decode(js["data"]["base64"])) == jsd["data"])
 
@@ -64,7 +72,10 @@ def test_simple_python_types():
     js_string = json.dumps(js)
 
     # Decode back
-    decoded = json.loads(js_string, object_hook=json_decoder)
+    decoded = json.loads(
+        js_string,
+        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+    )
 
     # Verify all values match
     for key, value in test_data.items():
@@ -92,7 +103,10 @@ def test_numpy_arrays():
         # Test with base64 encoding
         js_base64 = json_encoder(array, encoding="base64")
         js_string = json.dumps(js_base64)
-        decoded_base64 = json.loads(js_string, object_hook=json_decoder)
+        decoded_base64 = json.loads(
+            js_string,
+            object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+        )
         assert np.array_equal(
             decoded_base64, array
         ), f"Failed with base64 encoding for {name}"
@@ -106,7 +120,10 @@ def test_complex_numbers():
     # Using base64 encoding avoids the tolist() operation that causes the error
     js = json_encoder(complex_array, encoding="base64")
     js_string = json.dumps(js)
-    decoded = json.loads(js_string, object_hook=json_decoder)
+    decoded = json.loads(
+        js_string,
+        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+    )
     assert np.array_equal(decoded, complex_array)
 
     # Test using NumPy complex scalar with base64 encoding
@@ -114,8 +131,28 @@ def test_complex_numbers():
 
     js = json_encoder(complex_scalar, encoding="base64")
     js_string = json.dumps(js)
-    decoded = json.loads(js_string, object_hook=json_decoder)
+    decoded = json.loads(
+        js_string,
+        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+    )
     assert decoded == complex_scalar
+
+
+def test_complex_base64_requires_explicit_opt_in(monkeypatch):
+    payload = json.dumps(
+        {
+            "__class__": "COMPLEX",
+            "base64": base64.b64encode(pickle.dumps(np.complex128(1 + 2j))).decode(),
+        }
+    )
+
+    def fail_pickle_loads(*args, **kwargs):
+        raise AssertionError("pickle.loads must not run in safe mode")
+
+    monkeypatch.setattr("spectrochempy.utils.jsonutils.pickle.loads", fail_pickle_loads)
+
+    with pytest.raises(SpectroChemPyError, match="trusted legacy loading"):
+        json.loads(payload, object_hook=json_decoder)
 
 
 def test_python_complex():
@@ -125,7 +162,10 @@ def test_python_complex():
 
     js = json_encoder(complex_scalar)
     js_string = json.dumps(js)
-    decoded = json.loads(js_string, object_hook=json_decoder)
+    decoded = json.loads(
+        js_string,
+        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+    )
     assert decoded == complex_scalar
 
     # Test another complex number
@@ -150,7 +190,10 @@ def test_nested_structures():
     # Test with base64 encoding
     js = json_encoder(nested, encoding="base64")
     js_string = json.dumps(js)
-    decoded = json.loads(js_string, object_hook=json_decoder)
+    decoded = json.loads(
+        js_string,
+        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+    )
 
     # Check structure was preserved
     assert "level1" in decoded
@@ -175,7 +218,10 @@ def test_roundtrip_preservation(IR_dataset_2D):
     for encoding in [None, "base64"]:
         js = json_encoder(nd, encoding=encoding)
         js_string = json.dumps(js)
-        decoded = json.loads(js_string, object_hook=json_decoder)
+        decoded = json.loads(
+            js_string,
+            object_hook=partial(json_decoder, allow_unsafe_legacy=encoding == "base64"),
+        )
 
         # Verify key attributes were preserved
         assert isinstance(decoded, dict)
@@ -185,3 +231,20 @@ def test_roundtrip_preservation(IR_dataset_2D):
         # If metadata was encoded, verify it's preserved
         if "meta" in js:
             assert "meta" in decoded
+
+
+def test_json_decoder_rejects_base64_pickle_without_opt_in(monkeypatch):
+    payload = json.dumps(
+        {
+            "__class__": "NUMPY_ARRAY",
+            "base64": base64.b64encode(pickle.dumps(np.array([1, 2, 3]))).decode(),
+        }
+    )
+
+    def fail_pickle_loads(*args, **kwargs):
+        raise AssertionError("pickle.loads must not run in safe mode")
+
+    monkeypatch.setattr("spectrochempy.utils.jsonutils.pickle.loads", fail_pickle_loads)
+
+    with pytest.raises(SpectroChemPyError, match="trusted legacy loading"):
+        json.loads(payload, object_hook=json_decoder)

--- a/tests/test_utils/test_zip.py
+++ b/tests/test_utils/test_zip.py
@@ -3,6 +3,7 @@ import zipfile
 import numpy as np
 import pytest
 
+from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.zip import ScpFile
 from spectrochempy.utils.zip import make_zipfile
 
@@ -50,6 +51,44 @@ def test_scpfile_nonexistent_key(tmp_path):
     # Test ScpFile
     with ScpFile(test_file) as scp, pytest.raises(KeyError):
         _ = scp["nonexistent.npy"]
+
+
+def test_scpfile_rejects_object_array_without_opt_in(tmp_path, monkeypatch):
+    test_file = tmp_path / "legacy_object_array.scp"
+    payload = np.array([{"safe": "payload"}], dtype=object)
+
+    with make_zipfile(test_file, mode="w") as zf, zf.open("legacy.npy", "w") as f:
+        np.save(f, payload, allow_pickle=True)
+
+    def fail_read_array(*args, **kwargs):
+        if kwargs.get("allow_pickle"):
+            raise AssertionError("allow_pickle=True must not be used in safe mode")
+        return np.array([0])
+
+    monkeypatch.setattr("spectrochempy.utils.zip.read_array", fail_read_array)
+
+    with ScpFile(test_file) as scp:
+        assert np.array_equal(scp["legacy.npy"], np.array([0]))
+
+
+def test_scpfile_object_array_requires_explicit_opt_in(tmp_path):
+    test_file = tmp_path / "legacy_object_array.scp"
+    payload = np.array([{"safe": "payload"}], dtype=object)
+
+    with make_zipfile(test_file, mode="w") as zf, zf.open("legacy.npy", "w") as f:
+        np.save(f, payload, allow_pickle=True)
+
+    with ScpFile(test_file) as scp, pytest.raises(
+        SpectroChemPyError,
+        match="trusted legacy loading",
+    ):
+        _ = scp["legacy.npy"]
+
+    with ScpFile(test_file, allow_unsafe_legacy=True) as scp:
+        loaded = scp["legacy.npy"]
+
+    assert loaded.dtype == object
+    assert loaded[0]["safe"] == "payload"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make SCP/PSCP loading safe by default by rejecting implicit pickle-backed legacy deserialization
- add the explicit `allow_unsafe_legacy=True` opt-in across `NDDataset.load()`, `Project.load()`, top-level `load()`, `read()`, `content=` paths, and nested archive loading
- add focused security and compatibility coverage for JSON/base64 pickle payloads, legacy `.npy` object arrays, transitively loaded projects, and updated round-trip tests
- document the new trusted-legacy loading requirement and record implementation notes in audit files

## Out of scope
- no SCP/PSCP writer change
- no new persistence format or SCP v2 design
- no portable persistence work
- no Result or Project architecture expansion

## Why
The current SCP/PSCP load path could reach `pickle.loads()` or `.npy` object-array loading before any explicit user opt-in. This PR hardens the native load path so unsafe legacy deserialization only happens when callers deliberately pass `allow_unsafe_legacy=True`.

## Impact
- default native loading now fails explicitly on pickle-backed legacy payloads
- trusted historical archives remain readable through the explicit legacy opt-in
- the current writer still emits trusted legacy native files, and that temporary asymmetry is documented rather than changed here

## Validation
- `conda run -n scpy-core python -m pytest tests/test_utils/test_jsonutils.py tests/test_utils/test_zip.py tests/test_core/test_dataset/test_mixins/test_ndio.py tests/test_core/test_projects/test_projects.py tests/test_core/test_dataset/test_dataset_regressions.py tests/test_core/test_dataset/test_mixins/test_ndmath.py tests/test_core/test_writers/test_exporter.py`
- `conda run -n scpy-core python -m pytest tests/test_utils/test_jsonutils.py::test_json_decoder_rejects_base64_pickle_without_opt_in tests/test_utils/test_zip.py::test_scpfile_object_array_requires_explicit_opt_in tests/test_core/test_dataset/test_mixins/test_ndio.py::test_ndio_load_requires_explicit_opt_in_for_legacy_scp tests/test_core/test_dataset/test_mixins/test_ndio.py::test_ndio_load_content_requires_explicit_opt_in tests/test_core/test_projects/test_projects.py::TestSerializationRoundtrip::test_project_load_requires_explicit_opt_in tests/test_core/test_dataset/test_mixins/test_ndio.py::test_native_load_aliases_require_explicit_opt_in`
- `pre-commit run --all-files`