### PR TITLE
FIX: write safe SCP/PSCP files by default

### DIFF
--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -110,6 +110,15 @@ X
 #
 #     scp.read("example.scp", allow_unsafe_legacy=True)
 #
+# For a short transition period, the contrast with newly written native files
+# is worth keeping explicit:
+#
+#     # Newly written native file:
+#     # ds = scp.read("new.scp")
+#
+#     # Historical trusted legacy file only:
+#     # ds = scp.read("old.scp", allow_unsafe_legacy=True)
+#
 # Only enable ``allow_unsafe_legacy=True`` for files from known and trusted
 # sources.
 #

--- a/docs/sources/userguide/objects/project/project.py
+++ b/docs/sources/userguide/objects/project/project.py
@@ -156,17 +156,26 @@ proj.save_as("NMR")
 # %% [markdown]
 # #### Loading
 #
-# Historical ``.pscp`` archives may require trusted legacy loading because they
-# currently rely on pickle-based native persistence for embedded datasets. In
+# Newly written ``.pscp`` archives now reload safely by default:
+#
+#     proj2 = scp.Project.load("NMR")
+#
+# Historical ``.pscp`` archives may still require trusted legacy loading. In
 # that case, reload explicitly with:
 #
 #     proj2 = scp.Project.load("NMR", allow_unsafe_legacy=True)
+#
+# For a short transition period it is useful to keep this commented example
+# close to the normal round-trip:
+#
+#     # Legacy trusted archive only:
+#     # proj2 = scp.Project.load("NMR", allow_unsafe_legacy=True)
 #
 # Only enable ``allow_unsafe_legacy=True`` for files from known and trusted
 # sources.
 
 # %%
-proj2 = scp.Project.load("NMR", allow_unsafe_legacy=True)
+proj2 = scp.Project.load("NMR")
 
 # %%
 proj2

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -83,6 +83,12 @@ Breaking Changes
   reloaded explicitly with ``allow_unsafe_legacy=True``, and only from known
   and trusted sources.
 
+- Writing native ``.scp`` and ``.pscp`` files is now safe by default. Newly
+  saved archives no longer use pickle-backed payloads for dataset arrays or
+  complex scalars, so normal save/load round-trips work without
+  ``allow_unsafe_legacy=True`` while historical trusted archives remain
+  available through the explicit legacy opt-in.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -62,6 +62,12 @@ Breaking Changes
   reloaded explicitly with ``allow_unsafe_legacy=True``, and only from known
   and trusted sources.
 
+- Writing native ``.scp`` and ``.pscp`` files is now safe by default. Newly
+  saved archives no longer use pickle-backed payloads for dataset arrays or
+  complex scalars, so normal save/load round-trips work without
+  ``allow_unsafe_legacy=True`` while historical trusted archives remain
+  available through the explicit legacy opt-in.
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/integration/integrate.py
+++ b/src/spectrochempy/analysis/integration/integrate.py
@@ -11,6 +11,7 @@ __dataset_methods__ = ["simps", "trapz", "simpson", "trapezoid"]
 
 import functools
 
+import numpy as np
 import scipy.integrate
 
 from spectrochempy.utils.decorators import deprecated
@@ -29,7 +30,11 @@ def _integrate_method(method):
         if kwargs.get("dim"):
             kwargs.pop("dim")
 
-        data = method(dataset.data, x=dataset.coord(dim).data, axis=axis, **kwargs)
+        # SciPy integration routines expect a plain ndarray-like coordinate.
+        # Some NumPy/SciPy combinations are stricter with ndarray subclasses or
+        # view semantics, so normalize the integration axis coordinate here.
+        x = np.asarray(dataset.coord(dim).data)
+        data = method(dataset.data, x=x, axis=axis, **kwargs)
 
         if dataset.coord(dim).reversed:
             data *= -1

--- a/src/spectrochempy/analysis/integration/integrate.py
+++ b/src/spectrochempy/analysis/integration/integrate.py
@@ -34,7 +34,18 @@ def _integrate_method(method):
         # Some NumPy/SciPy combinations are stricter with ndarray subclasses or
         # view semantics, so normalize the integration axis coordinate here.
         x = np.asarray(dataset.coord(dim).data)
-        data = method(dataset.data, x=x, axis=axis, **kwargs)
+        y = dataset.data
+        try:
+            data = method(y, x=x, axis=axis, **kwargs)
+        except NotImplementedError as exc:
+            if "multi-dimensional sub-views are not implemented" not in str(exc):
+                raise
+            data = method(
+                np.ascontiguousarray(y),
+                x=np.ascontiguousarray(x),
+                axis=axis,
+                **kwargs,
+            )
 
         if dataset.coord(dim).reversed:
             data *= -1
@@ -111,7 +122,7 @@ def trapezoid(dataset, **kwargs):
     NDDataset: [float64] a.u..cm^-1 (size: 55)
 
     """
-    return scipy.integrate.trapezoid(dataset.data, **kwargs)
+    return scipy.integrate.trapezoid(np.asarray(dataset), **kwargs)
 
 
 @deprecated(replace="Trapezoid", removed="0.11.0")
@@ -178,7 +189,7 @@ def simpson(dataset, *args, **kwargs):
     NDDataset: [float64] a.u..cm^-1 (size: 55)
 
     """
-    return scipy.integrate.simpson(dataset.data, **kwargs)
+    return scipy.integrate.simpson(np.asarray(dataset), **kwargs)
 
 
 @deprecated(replace="simpson")

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -299,12 +299,12 @@ class NDIO(tr.HasTraits):
         >>> f = nd1.save()
         >>> f.name
         'nh4y-activation.scp'
-        >>> nd2 = scp.load(f, allow_unsafe_legacy=True)
+        >>> nd2 = scp.load(f)
 
         Alternatively, this method can be called as a class method of NDDataset or Project object:
 
         >>> from spectrochempy import *
-        >>> nd2 = NDDataset.load(f, allow_unsafe_legacy=True)
+        >>> nd2 = NDDataset.load(f)
 
         """
         content = kwargs.get("content")
@@ -401,6 +401,8 @@ class NDIO(tr.HasTraits):
                 "_modeldata",
                 "_scripts",
                 "_others",
+                "__format__",
+                "__version__",
             }
             for key, val in dic.items():
                 try:

--- a/src/spectrochempy/utils/jsonutils.py
+++ b/src/spectrochempy/utils/jsonutils.py
@@ -10,7 +10,7 @@ import datetime
 import json
 import pathlib
 import pickle
-from functools import partial
+from collections.abc import Mapping
 
 import numpy as np
 
@@ -19,6 +19,8 @@ UNSAFE_LEGACY_LOADING_MESSAGE = (
     "pickle-based native persistence. Reload with allow_unsafe_legacy=True only "
     "if the file comes from a known and trusted source."
 )
+SAFE_SCP_DOCUMENT_FORMATS = frozenset({"scp", "pscp"})
+SAFE_SCP_DOCUMENT_VERSION = 2
 
 
 def fromisoformat(s):
@@ -38,68 +40,267 @@ def _raise_unsafe_legacy_loading_error():
     raise SpectroChemPyError(UNSAFE_LEGACY_LOADING_MESSAGE)
 
 
-def json_decoder(dic, allow_unsafe_legacy=False):
-    """Decode a serialized json object."""
+def _raise_safe_payload_error(message):
+    from spectrochempy.utils.exceptions import SpectroChemPyError
+
+    raise SpectroChemPyError(message)
+
+
+def _validate_safe_document_markers(document):
+    has_format = "__format__" in document
+    has_version = "__version__" in document
+
+    if not has_format and not has_version:
+        return False
+
+    if not has_format or not has_version:
+        _raise_safe_payload_error(
+            "Malformed SCP/PSCP document: safe-format markers must include both "
+            "`__format__` and `__version__`.",
+        )
+
+    if document["__format__"] not in SAFE_SCP_DOCUMENT_FORMATS:
+        _raise_safe_payload_error(
+            f"Unsupported SCP/PSCP document format marker: {document['__format__']!r}.",
+        )
+
+    if document["__version__"] != SAFE_SCP_DOCUMENT_VERSION:
+        _raise_safe_payload_error(
+            "Unsupported SCP/PSCP document version: " f"{document['__version__']!r}.",
+        )
+
+    return True
+
+
+def _is_safe_array_dtype(dtype):
+    return not dtype.hasobject
+
+
+def _decode_safe_array_payload(payload):
+    required = {"encoding", "dtype", "shape", "order", "base64"}
+    missing = sorted(required - payload.keys())
+    if missing:
+        _raise_safe_payload_error(
+            "Malformed NUMPY_ARRAY payload: missing required field(s) "
+            f"{', '.join(missing)}.",
+        )
+
+    if payload["encoding"] != "raw-base64":
+        _raise_safe_payload_error(
+            f"Unsupported NUMPY_ARRAY encoding: {payload['encoding']!r}.",
+        )
+
+    try:
+        dtype = np.dtype(payload["dtype"])
+    except TypeError as exc:
+        from spectrochempy.utils.exceptions import SpectroChemPyError
+
+        raise SpectroChemPyError(
+            f"Invalid NUMPY_ARRAY dtype: {payload['dtype']!r}.",
+        ) from exc
+
+    if not _is_safe_array_dtype(dtype):
+        _raise_safe_payload_error(
+            "Unsafe NUMPY_ARRAY payload: object dtype is not supported in safe "
+            "SCP/PSCP files.",
+        )
+
+    shape = payload["shape"]
+    if not isinstance(shape, list):
+        _raise_safe_payload_error(
+            "Malformed NUMPY_ARRAY payload: `shape` must be a JSON list.",
+        )
+    if any(not isinstance(dim, int) or dim < 0 for dim in shape):
+        _raise_safe_payload_error(
+            "Malformed NUMPY_ARRAY payload: `shape` must contain only "
+            "non-negative integers.",
+        )
+
+    order = payload["order"]
+    if order not in {"C", "F"}:
+        _raise_safe_payload_error(
+            "Malformed NUMPY_ARRAY payload: `order` must be `'C'` or `'F'`.",
+        )
+
+    try:
+        raw = base64.b64decode(payload["base64"], validate=True)
+    except Exception as exc:
+        from spectrochempy.utils.exceptions import SpectroChemPyError
+
+        raise SpectroChemPyError(
+            "Malformed NUMPY_ARRAY payload: invalid base64 content.",
+        ) from exc
+
+    expected_size = dtype.itemsize * int(np.prod(shape, dtype=np.int64))
+    if len(raw) != expected_size:
+        _raise_safe_payload_error(
+            "Malformed NUMPY_ARRAY payload: raw byte length does not match "
+            "dtype and shape.",
+        )
+
+    try:
+        return np.frombuffer(raw, dtype=dtype).reshape(tuple(shape), order=order).copy()
+    except ValueError as exc:
+        from spectrochempy.utils.exceptions import SpectroChemPyError
+
+        raise SpectroChemPyError(
+            "Malformed NUMPY_ARRAY payload: unable to reconstruct ndarray.",
+        ) from exc
+
+
+def _decode_complex_payload(payload):
+    required = {"encoding", "dtype", "value"}
+    missing = sorted(required - payload.keys())
+    if missing:
+        _raise_safe_payload_error(
+            "Malformed COMPLEX payload: missing required field(s) "
+            f"{', '.join(missing)}.",
+        )
+
+    if payload["encoding"] != "pair":
+        _raise_safe_payload_error(
+            f"Unsupported COMPLEX encoding: {payload['encoding']!r}.",
+        )
+
+    value = payload["value"]
+    if not isinstance(value, list) or len(value) != 2:
+        _raise_safe_payload_error(
+            "Malformed COMPLEX payload: `value` must be a two-item list "
+            "[real, imag].",
+        )
+
+    real, imag = value
+    if not isinstance(real, int | float) or not isinstance(imag, int | float):
+        _raise_safe_payload_error(
+            "Malformed COMPLEX payload: real and imaginary parts must be numbers.",
+        )
+
+    if payload["dtype"] == "complex":
+        return complex(real, imag)
+
+    try:
+        dtype = np.dtype(payload["dtype"])
+    except TypeError as exc:
+        from spectrochempy.utils.exceptions import SpectroChemPyError
+
+        raise SpectroChemPyError(
+            f"Invalid COMPLEX dtype: {payload['dtype']!r}.",
+        ) from exc
+
+    if dtype.kind != "c":
+        _raise_safe_payload_error(
+            "Malformed COMPLEX payload: dtype must be a complex dtype.",
+        )
+
+    return np.array(complex(real, imag), dtype=dtype)[()]
+
+
+def _decode_serialized_obj(obj, *, allow_unsafe_legacy=False, safe_document=False):
     from spectrochempy.core.units import Quantity
     from spectrochempy.core.units import Unit
     from spectrochempy.utils.meta import Meta
 
-    if "__class__" in dic:
-        klass = dic.pop("__class__")
-        if klass == "DATETIME":
-            return fromisoformat(dic["isoformat"])
-        if klass == "DATETIME64":
-            return np.datetime64(dic["isoformat"])
-        if klass == "NUMPY_ARRAY":
-            if "base64" in dic:
-                if not allow_unsafe_legacy:
-                    _raise_unsafe_legacy_loading_error()
-                return pickle.loads(base64.b64decode(dic["base64"]))  # noqa: S301
-            if "tolist" in dic:
-                return np.array(dic["tolist"], dtype=dic["dtype"])
-        elif klass == "PATH":
-            return pathlib.Path(dic["str"])
-        elif klass == "QUANTITY":
-            return Quantity.from_tuple(dic["tuple"])
-        elif klass == "UNIT":
-            return Unit(dic["str"])
-        elif klass == "COMPLEX":
-            if "base64" in dic:
-                if not allow_unsafe_legacy:
-                    _raise_unsafe_legacy_loading_error()
-                return pickle.loads(base64.b64decode(dic["base64"]))  # noqa: S301
-            if "tolist" in dic:
-                if dic["dtype"] == "complex":
-                    # Handle Python's built-in complex type
-                    return complex(dic["tolist"][0], dic["tolist"][1])
-                return np.array(dic["tolist"], dtype=dic["dtype"]).data[()]
-        elif klass == "META":
-            kwargs = {}
-            for k, v in dic.items():
-                if k == "data":
-                    for kk, vv in v.items():
-                        kwargs[kk] = json_decoder(vv) if isinstance(vv, dict) else vv
-            meta = Meta(parent=dic.get("parent"), name=dic.get("name"), **kwargs)
-            meta.readonly = dic.get("readonly", False)
-            return meta
+    if isinstance(obj, list):
+        return [
+            _decode_serialized_obj(
+                item,
+                allow_unsafe_legacy=allow_unsafe_legacy,
+                safe_document=safe_document,
+            )
+            for item in obj
+        ]
 
-        raise TypeError(klass)
+    if not isinstance(obj, Mapping):
+        return obj
 
-    return dic
+    decoded = {
+        key: _decode_serialized_obj(
+            value,
+            allow_unsafe_legacy=allow_unsafe_legacy,
+            safe_document=safe_document,
+        )
+        for key, value in obj.items()
+    }
+
+    if "__class__" not in decoded:
+        return decoded
+
+    klass = decoded["__class__"]
+    if klass == "DATETIME":
+        return fromisoformat(decoded["isoformat"])
+    if klass == "DATETIME64":
+        return np.datetime64(decoded["isoformat"])
+    if klass == "NUMPY_ARRAY":
+        if decoded.get("encoding") == "raw-base64":
+            return _decode_safe_array_payload(decoded)
+        if "base64" in decoded:
+            if safe_document:
+                _raise_safe_payload_error(
+                    "Malformed safe SCP/PSCP document: legacy pickle-backed "
+                    "NUMPY_ARRAY payload encountered.",
+                )
+            if not allow_unsafe_legacy:
+                _raise_unsafe_legacy_loading_error()
+            return pickle.loads(base64.b64decode(decoded["base64"]))  # noqa: S301
+        if "tolist" in decoded:
+            return np.array(decoded["tolist"], dtype=decoded["dtype"])
+        _raise_safe_payload_error("Malformed NUMPY_ARRAY payload.")
+    if klass == "PATH":
+        return pathlib.Path(decoded["str"])
+    if klass == "QUANTITY":
+        return Quantity.from_tuple(decoded["tuple"])
+    if klass == "UNIT":
+        return Unit(decoded["str"])
+    if klass == "COMPLEX":
+        if decoded.get("encoding") == "pair":
+            return _decode_complex_payload(decoded)
+        if "base64" in decoded:
+            if safe_document:
+                _raise_safe_payload_error(
+                    "Malformed safe SCP/PSCP document: legacy pickle-backed "
+                    "COMPLEX payload encountered.",
+                )
+            if not allow_unsafe_legacy:
+                _raise_unsafe_legacy_loading_error()
+            return pickle.loads(base64.b64decode(decoded["base64"]))  # noqa: S301
+        if "tolist" in decoded:
+            if decoded["dtype"] == "complex":
+                return complex(decoded["tolist"][0], decoded["tolist"][1])
+            return np.array(decoded["tolist"], dtype=decoded["dtype"]).data[()]
+        _raise_safe_payload_error("Malformed COMPLEX payload.")
+    if klass == "META":
+        kwargs = {}
+        for key, value in decoded.items():
+            if key == "data":
+                kwargs.update(value)
+        meta = Meta(parent=decoded.get("parent"), name=decoded.get("name"), **kwargs)
+        meta.readonly = decoded.get("readonly", False)
+        return meta
+
+    raise TypeError(klass)
+
+
+def json_decoder(dic, allow_unsafe_legacy=False):
+    """Decode a serialized json object."""
+    return _decode_serialized_obj(
+        dic,
+        allow_unsafe_legacy=allow_unsafe_legacy,
+        safe_document=False,
+    )
 
 
 def json_loads(content, *, allow_unsafe_legacy=False):
     """Load JSON content with explicit legacy unsafe decoding control."""
-    return json.loads(
-        content,
-        object_hook=partial(
-            json_decoder,
-            allow_unsafe_legacy=allow_unsafe_legacy,
-        ),
+    raw = json.loads(content)
+    safe_document = isinstance(raw, Mapping) and _validate_safe_document_markers(raw)
+    return _decode_serialized_obj(
+        raw,
+        allow_unsafe_legacy=allow_unsafe_legacy,
+        safe_document=safe_document,
     )
 
 
-def json_encoder(byte_obj, encoding=None):
+def json_encoder(byte_obj, encoding=None, *, _root=True):
     """Return a serialised json object."""
     from spectrochempy.application.preferences import PreferencesSet
     from spectrochempy.core.units import Quantity
@@ -125,10 +326,21 @@ def json_encoder(byte_obj, encoding=None):
 
             # Warning with parent-> circular dependencies!
             if name != "parent":
-                dic[name] = json_encoder(val, encoding=encoding)
+                if (
+                    name == "labels"
+                    and isinstance(val, np.ndarray)
+                    and val.dtype.hasobject
+                ):
+                    dic[name] = json_encoder(val.tolist(), encoding=None, _root=False)
+                    continue
+                dic[name] = json_encoder(val, encoding=encoding, _root=False)
             # we need to differentiate normal dic from Meta object
             if byte_obj._implements("Meta"):
                 dic["__class__"] = "META"
+        if _root and encoding == "base64":
+            doc_format = "pscp" if byte_obj._implements("Project") else "scp"
+            dic["__format__"] = doc_format
+            dic["__version__"] = SAFE_SCP_DOCUMENT_VERSION
         return dic
 
     if isinstance(byte_obj, str | int | float | bool):
@@ -144,15 +356,17 @@ def json_encoder(byte_obj, encoding=None):
         return int(byte_obj)
 
     if isinstance(byte_obj, tuple):
-        return tuple([json_encoder(v, encoding=encoding) for v in byte_obj])
+        return tuple(
+            [json_encoder(v, encoding=encoding, _root=False) for v in byte_obj]
+        )
 
     if isinstance(byte_obj, list):
-        return [json_encoder(v, encoding=encoding) for v in byte_obj]
+        return [json_encoder(v, encoding=encoding, _root=False) for v in byte_obj]
 
     if isinstance(byte_obj, dict):
         dic = {}
         for k, v in byte_obj.items():
-            dic[k] = json_encoder(v, encoding=encoding)
+            dic[k] = json_encoder(v, encoding=encoding, _root=False)
         return dic
 
     if isinstance(byte_obj, datetime.datetime):
@@ -173,12 +387,35 @@ def json_encoder(byte_obj, encoding=None):
             if str(byte_obj.dtype).startswith("datetime64"):
                 byte_obj = np.datetime_as_string(byte_obj, timezone="UTC")
             return {
-                "tolist": json_encoder(byte_obj.tolist(), encoding=encoding),
+                "tolist": json_encoder(
+                    byte_obj.tolist(), encoding=encoding, _root=False
+                ),
                 "dtype": str(dtype),
                 "__class__": "NUMPY_ARRAY",
             }
+        if byte_obj.dtype.hasobject:
+            _raise_safe_payload_error(
+                "Safe SCP/PSCP writing does not support object-dtype arrays. "
+                "Use another format or a trusted legacy workflow.",
+            )
+        order = (
+            "F"
+            if byte_obj.ndim > 1
+            and byte_obj.flags.f_contiguous
+            and not byte_obj.flags.c_contiguous
+            else "C"
+        )
+        safe_array = (
+            np.asfortranarray(byte_obj)
+            if order == "F"
+            else np.ascontiguousarray(byte_obj)
+        )
         return {
-            "base64": base64.b64encode(pickle.dumps(byte_obj)).decode(),
+            "encoding": "raw-base64",
+            "dtype": str(byte_obj.dtype),
+            "shape": list(byte_obj.shape),
+            "order": order,
+            "base64": base64.b64encode(safe_array.tobytes(order=order)).decode(),
             "__class__": "NUMPY_ARRAY",
         }
 
@@ -191,7 +428,7 @@ def json_encoder(byte_obj, encoding=None):
 
     if isinstance(byte_obj, Quantity):
         return {
-            "tuple": json_encoder(byte_obj.to_tuple(), encoding=encoding),
+            "tuple": json_encoder(byte_obj.to_tuple(), encoding=encoding, _root=False),
             "__class__": "QUANTITY",
         }
 
@@ -203,12 +440,15 @@ def json_encoder(byte_obj, encoding=None):
                 "tolist": json_encoder(
                     [byte_obj.real, byte_obj.imag],
                     encoding=encoding,
+                    _root=False,
                 ),
                 "dtype": dtype,
                 "__class__": "COMPLEX",
             }
         return {
-            "base64": base64.b64encode(pickle.dumps(byte_obj)).decode(),
+            "encoding": "pair",
+            "dtype": str(byte_obj.dtype) if hasattr(byte_obj, "dtype") else "complex",
+            "value": [float(byte_obj.real), float(byte_obj.imag)],
             "__class__": "COMPLEX",
         }
 

--- a/src/spectrochempy/utils/jsonutils.py
+++ b/src/spectrochempy/utils/jsonutils.py
@@ -338,9 +338,11 @@ def json_encoder(byte_obj, encoding=None, *, _root=True):
             if byte_obj._implements("Meta"):
                 dic["__class__"] = "META"
         if _root and encoding == "base64":
-            doc_format = "pscp" if byte_obj._implements("Project") else "scp"
-            dic["__format__"] = doc_format
-            dic["__version__"] = SAFE_SCP_DOCUMENT_VERSION
+            implements = byte_obj._implements()
+            if implements in {"NDDataset", "Project"}:
+                doc_format = "pscp" if implements == "Project" else "scp"
+                dic["__format__"] = doc_format
+                dic["__version__"] = SAFE_SCP_DOCUMENT_VERSION
         return dic
 
     if isinstance(byte_obj, str | int | float | bool):

--- a/tests/test_analysis/test_integration/test_integrate.py
+++ b/tests/test_analysis/test_integration/test_integrate.py
@@ -138,3 +138,35 @@ def test_integrate_passes_plain_ndarray_coordinate(monkeypatch):
     dataset.simpson(dim="x")
 
     assert seen["x_is_ndarray"] is True
+
+
+def test_simpson_retries_with_contiguous_numpy_arrays(monkeypatch):
+    dataset = scp.NDDataset(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        coordset=[
+            scp.Coord([0.0, 1.0], title="sample", units="s"),
+            scp.Coord([0.1, 0.2, 0.3], title="x", units="cm^-1"),
+        ],
+        units="absorbance",
+    )
+
+    original = scipy.integrate.simpson
+    calls = {"count": 0}
+
+    def flaky(data, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise NotImplementedError("multi-dimensional sub-views are not implemented")
+        arr = np.asarray(data)
+        assert isinstance(arr, np.ndarray)
+        assert arr.flags.c_contiguous
+        assert isinstance(kwargs["x"], np.ndarray)
+        assert kwargs["x"].flags.c_contiguous
+        return original(arr, **kwargs)
+
+    monkeypatch.setattr("scipy.integrate.simpson", flaky)
+
+    result = dataset.simpson(dim="x")
+
+    assert calls["count"] == 2
+    assert result.shape == (2,)

--- a/tests/test_analysis/test_integration/test_integrate.py
+++ b/tests/test_analysis/test_integration/test_integrate.py
@@ -8,6 +8,7 @@
 """Tests integration"""
 
 import numpy as np
+import scipy.integrate
 from numpy.testing import assert_allclose
 
 import spectrochempy as scp
@@ -112,3 +113,28 @@ def test_integrate_preserves_remaining_coord_units():
     assert area.y.title == "temperature"
     assert area.units == dataset.units * x.units
     assert_allclose(area.data, [2.0, 2.0])
+
+
+def test_integrate_passes_plain_ndarray_coordinate(monkeypatch):
+    dataset = scp.NDDataset(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        coordset=[
+            scp.Coord([0.0, 1.0], title="sample", units="s"),
+            scp.Coord([0.1, 0.2, 0.3], title="x", units="cm^-1"),
+        ],
+        units="absorbance",
+    )
+
+    seen = {}
+    original = scipy.integrate.simpson
+
+    def capture(data, **kwargs):
+        seen["x_type"] = type(kwargs["x"])
+        seen["x_is_ndarray"] = isinstance(kwargs["x"], np.ndarray)
+        return original(data, **kwargs)
+
+    monkeypatch.setattr("scipy.integrate.simpson", capture)
+
+    dataset.simpson(dim="x")
+
+    assert seen["x_is_ndarray"] is True

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -7,9 +7,12 @@
 
 """Tests for the ndplugin module"""
 
+import base64
 import json
+import pickle
 import zipfile
 
+import numpy as np
 import pytest
 import spectrochempy as scp
 
@@ -23,6 +26,24 @@ from spectrochempy.utils.testing import assert_array_equal, assert_dataset_equal
 # --------------------------------------------------------------------------------------
 
 
+def _rewrite_dataset_data_payload_as_legacy_pickle(filename):
+    current = NDDataset.load(filename)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    js.pop("__format__", None)
+    js.pop("__version__", None)
+    js["data"] = {
+        "__class__": "NUMPY_ARRAY",
+        "base64": base64.b64encode(pickle.dumps(current.data)).decode(),
+    }
+
+    with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(member, json.dumps(js, indent=2))
+
+
 def test_ndio_generic(ndataset_1d, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     ir = ndataset_1d
@@ -34,7 +55,7 @@ def test_ndio_generic(ndataset_1d, tmp_path, monkeypatch):
     assert ir.directory == tmp_path
 
     # load back this  file : the full path f is given so no dialog is opened
-    nd = NDDataset.load(f, allow_unsafe_legacy=True)
+    nd = NDDataset.load(f)
     assert_dataset_equal(nd, ir)
 
     # as it has been already saved,
@@ -60,7 +81,7 @@ def test_ndio_generic(ndataset_1d, tmp_path, monkeypatch):
     f = ir.save_as(tmp_path / "essai")
 
     # try to load without extension specification (will first assume it is scp)
-    dl = NDDataset.load("essai", allow_unsafe_legacy=True)
+    dl = NDDataset.load("essai")
     # assert dl.directory == cwd
     assert_array_equal(dl.data, ir.data)
     f.unlink()
@@ -74,7 +95,7 @@ def test_ndio_2D(ndataset_2d, tmp_path):
     assert ir2.directory == tmp_path
     with pytest.raises(FileNotFoundError):
         NDDataset.load("essai2D")
-    nd = NDDataset.load(tmp_path / "essai2D", allow_unsafe_legacy=True)
+    nd = NDDataset.load(tmp_path / "essai2D")
     assert nd.directory == tmp_path
     f.unlink()
 
@@ -86,7 +107,7 @@ def test_ndio_roundtrip_preserves_selected_non_first_default(tmp_path):
     selected_data = ds.x.data.copy()
     filename = ds.save_as(tmp_path / "multicoord_default", confirm=False)
 
-    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
+    loaded = NDDataset.load(filename)
 
     assert loaded.x.default == loaded.x["_2"]
     assert_array_equal(loaded.x.default.data, selected_data)
@@ -98,7 +119,7 @@ def test_ndio_roundtrip_preserves_reference_lookup(tmp_path):
     ds = NDDataset([1.0, 2.0, 3.0], coordset=CoordSet(x=c, y="x"))
     filename = ds.save_as(tmp_path / "reference_coords", confirm=False)
 
-    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
+    loaded = NDDataset.load(filename)
 
     assert loaded.coordset.references == ds.coordset.references
     assert loaded.coordset["y"] == "x"
@@ -122,7 +143,7 @@ def test_ndio_load_without_default_field_keeps_legacy_behavior(tmp_path):
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.writestr(member, json.dumps(js, indent=2))
 
-    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
+    loaded = NDDataset.load(filename)
 
     assert loaded.x.default == loaded.x["_1"]
     assert_array_equal(loaded.x.data, legacy_default_data)
@@ -142,7 +163,7 @@ def test_ndio_load_ignores_legacy_roi_fields(tmp_path):
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.writestr(member, json.dumps(js, indent=2))
 
-    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
+    loaded = NDDataset.load(filename)
 
     assert not hasattr(loaded, "roi")
     assert not hasattr(loaded.x, "roi")
@@ -161,12 +182,13 @@ def test_ndio_load_ignores_legacy_modeldata_field(tmp_path):
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.writestr(member, json.dumps(js, indent=2))
 
-    loaded = NDDataset.load(filename, allow_unsafe_legacy=True)
+    loaded = NDDataset.load(filename)
 
 
 def test_ndio_load_requires_explicit_opt_in_for_legacy_scp(tmp_path, monkeypatch):
     ds = NDDataset([0.0, 1.0, 2.0], name="legacy_dataset")
     filename = ds.save_as(tmp_path / "legacy_dataset", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
 
     def fail_pickle_loads(*args, **kwargs):
         raise AssertionError("pickle.loads must not run in safe mode")
@@ -187,6 +209,7 @@ def test_ndio_load_requires_explicit_opt_in_for_legacy_scp(tmp_path, monkeypatch
 def test_ndio_load_content_requires_explicit_opt_in(tmp_path):
     ds = NDDataset([0.0, 1.0, 2.0], name="legacy_content")
     filename = ds.save_as(tmp_path / "legacy_content", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
     content = filename.read_bytes()
 
     with pytest.raises(
@@ -207,6 +230,7 @@ def test_ndio_load_content_requires_explicit_opt_in(tmp_path):
 def test_native_load_aliases_require_explicit_opt_in(tmp_path, loader_name):
     ds = NDDataset([0.0, 1.0, 2.0], name="legacy_alias")
     filename = ds.save_as(tmp_path / "legacy_alias", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
     loader = getattr(scp, loader_name)
 
     with pytest.raises(
@@ -219,6 +243,22 @@ def test_native_load_aliases_require_explicit_opt_in(tmp_path, loader_name):
     assert_dataset_equal(loaded, ds)
 
     assert not hasattr(loaded, "modeldata")
+
+
+def test_ndio_safe_roundtrip_uses_versioned_payload(tmp_path):
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="safe_dataset")
+    filename = ds.save_as(tmp_path / "safe_dataset", confirm=False)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    assert js["__format__"] == "scp"
+    assert js["__version__"] == 2
+    assert js["data"]["encoding"] == "raw-base64"
+
+    loaded = NDDataset.load(filename)
+    assert_dataset_equal(loaded, ds)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -2,11 +2,12 @@
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
-# ======================================================================================
-
+import base64
 import json
+import pickle
 import zipfile
 
+import numpy as np
 import pytest
 
 from spectrochempy.application.preferences import preferences
@@ -16,6 +17,26 @@ from spectrochempy.utils.constants import INPLACE
 from spectrochempy.utils.exceptions import SpectroChemPyError
 
 prefs = preferences
+
+
+def _rewrite_project_dataset_payload_as_legacy_pickle(filename):
+    current = Project.load(filename)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    js.pop("__format__", None)
+    js.pop("__version__", None)
+    js["datasets"][0]["data"] = {
+        "__class__": "NUMPY_ARRAY",
+        "base64": base64.b64encode(
+            pickle.dumps(np.array(current.datasets[0].data)),
+        ).decode(),
+    }
+
+    with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(member, json.dumps(js, indent=2))
 
 
 # =============================================================================
@@ -83,7 +104,7 @@ def test_save_and_load_project(ds1, ds2):
     myp.add_datasets(ds1, ds2)
 
     fn = myp.save()
-    proj = Project.load(fn, allow_unsafe_legacy=True)
+    proj = Project.load(fn)
 
     assert str(proj["toto"]) == "NDDataset: [float64] a.u. (shape: (z:10, y:100, x:3))"
 
@@ -515,7 +536,7 @@ class TestSerializationRoundtrip:
         proj.add_project(sub)
 
         filename = proj.save()
-        loaded = Project.load(filename, allow_unsafe_legacy=True)
+        loaded = Project.load(filename)
 
         assert "subproject" in loaded.projects_names
         assert "data" in loaded.subproject.datasets_names
@@ -549,7 +570,7 @@ class TestSerializationRoundtrip:
         with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
             zipf.writestr(member, json.dumps(js, indent=2))
 
-        loaded = Project.load(filename, allow_unsafe_legacy=True)
+        loaded = Project.load(filename)
 
         assert not hasattr(loaded.data, "roi")
         assert not hasattr(loaded.data, "modeldata")
@@ -561,6 +582,7 @@ class TestSerializationRoundtrip:
         proj.add_dataset(ds1)
 
         filename = proj.save()
+        _rewrite_project_dataset_payload_as_legacy_pickle(filename)
 
         with pytest.raises(
             SpectroChemPyError,

--- a/tests/test_core/test_writers/test_exporter.py
+++ b/tests/test_core/test_writers/test_exporter.py
@@ -35,11 +35,11 @@ def test_write(mock_cwd, ndataset_1d):
     filename = nd.write("essai.scp", overwrite=True)
 
     # Read the file and compare
-    nd2 = NDDataset.load(filename, allow_unsafe_legacy=True)
+    nd2 = NDDataset.load(filename)
     testing.assert_dataset_equal(nd2, nd)
 
     # we can also use the read method to read it
-    nd3 = scp.read(filename, allow_unsafe_legacy=True)
+    nd3 = scp.read(filename)
     testing.assert_dataset_equal(nd3, nd)
 
     filename.unlink()

--- a/tests/test_utils/test_jsonutils.py
+++ b/tests/test_utils/test_jsonutils.py
@@ -43,16 +43,19 @@ def test_json_encoder_decoder_base64(IR_dataset_2D):
 
     # encoding base 64
     js = json_encoder(nd, encoding="base64")
+    assert js["__format__"] == "scp"
+    assert js["__version__"] == 2
+    assert js["data"]["encoding"] == "raw-base64"
     js_string = json.dumps(js, indent=2)
     print("base64", len(js_string))
 
     # load json from string
     jsd = json.loads(
         js_string,
-        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
+        object_hook=json_decoder,
     )
 
-    assert np.all(pickle.loads(base64.b64decode(js["data"]["base64"])) == jsd["data"])
+    assert np.array_equal(jsd["data"], nd.data)
 
 
 def test_simple_python_types():
@@ -102,11 +105,9 @@ def test_numpy_arrays():
 
         # Test with base64 encoding
         js_base64 = json_encoder(array, encoding="base64")
+        assert js_base64["encoding"] == "raw-base64"
         js_string = json.dumps(js_base64)
-        decoded_base64 = json.loads(
-            js_string,
-            object_hook=partial(json_decoder, allow_unsafe_legacy=True),
-        )
+        decoded_base64 = json.loads(js_string, object_hook=json_decoder)
         assert np.array_equal(
             decoded_base64, array
         ), f"Failed with base64 encoding for {name}"
@@ -119,22 +120,18 @@ def test_complex_numbers():
 
     # Using base64 encoding avoids the tolist() operation that causes the error
     js = json_encoder(complex_array, encoding="base64")
+    assert js["encoding"] == "raw-base64"
     js_string = json.dumps(js)
-    decoded = json.loads(
-        js_string,
-        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
-    )
+    decoded = json.loads(js_string, object_hook=json_decoder)
     assert np.array_equal(decoded, complex_array)
 
     # Test using NumPy complex scalar with base64 encoding
     complex_scalar = np.complex128(1 + 2j)
 
     js = json_encoder(complex_scalar, encoding="base64")
+    assert js["encoding"] == "pair"
     js_string = json.dumps(js)
-    decoded = json.loads(
-        js_string,
-        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
-    )
+    decoded = json.loads(js_string, object_hook=json_decoder)
     assert decoded == complex_scalar
 
 
@@ -190,10 +187,7 @@ def test_nested_structures():
     # Test with base64 encoding
     js = json_encoder(nested, encoding="base64")
     js_string = json.dumps(js)
-    decoded = json.loads(
-        js_string,
-        object_hook=partial(json_decoder, allow_unsafe_legacy=True),
-    )
+    decoded = json.loads(js_string, object_hook=json_decoder)
 
     # Check structure was preserved
     assert "level1" in decoded
@@ -220,7 +214,7 @@ def test_roundtrip_preservation(IR_dataset_2D):
         js_string = json.dumps(js)
         decoded = json.loads(
             js_string,
-            object_hook=partial(json_decoder, allow_unsafe_legacy=encoding == "base64"),
+            object_hook=partial(json_decoder, allow_unsafe_legacy=False),
         )
 
         # Verify key attributes were preserved
@@ -248,3 +242,48 @@ def test_json_decoder_rejects_base64_pickle_without_opt_in(monkeypatch):
 
     with pytest.raises(SpectroChemPyError, match="trusted legacy loading"):
         json.loads(payload, object_hook=json_decoder)
+
+
+def test_json_loads_rejects_legacy_payload_inside_safe_document():
+    payload = json.dumps(
+        {
+            "__format__": "scp",
+            "__version__": 2,
+            "data": {
+                "__class__": "NUMPY_ARRAY",
+                "base64": base64.b64encode(pickle.dumps(np.array([1, 2, 3]))).decode(),
+            },
+        }
+    )
+
+    with pytest.raises(SpectroChemPyError, match="Malformed safe SCP/PSCP document"):
+        from spectrochempy.utils.jsonutils import json_loads
+
+        json_loads(payload, allow_unsafe_legacy=True)
+
+
+def test_json_loads_rejects_object_dtype_safe_array():
+    payload = json.dumps(
+        {
+            "__format__": "scp",
+            "__version__": 2,
+            "data": {
+                "__class__": "NUMPY_ARRAY",
+                "encoding": "raw-base64",
+                "dtype": "object",
+                "shape": [1],
+                "order": "C",
+                "base64": base64.b64encode(b"x").decode(),
+            },
+        }
+    )
+
+    with pytest.raises(SpectroChemPyError, match="object dtype is not supported"):
+        from spectrochempy.utils.jsonutils import json_loads
+
+        json_loads(payload)
+
+
+def test_json_encoder_rejects_object_dtype_array_for_safe_write():
+    with pytest.raises(SpectroChemPyError, match="object-dtype arrays"):
+        json_encoder(np.array([{"unsafe": True}], dtype=object), encoding="base64")


### PR DESCRIPTION
## Summary
- write new native `.scp` and `.pscp` files with explicit safe payload encodings instead of pickle-backed array/scalar payloads
- add explicit document markers (`__format__`, `__version__`) and reject malformed hybrid safe/legacy payload combinations
- update native round-trip tests, project/writer coverage, and user-facing docs/changelog for the new safe-by-default writer behavior

## Out of scope
- changing the SCP/PSCP container family or introducing a new persistence format
- removing legacy read compatibility for trusted historical archives
- adding HyperComplex-specific persistence code paths

## Why
The loader hardening PR made native loading safe by default, but freshly written SCP/PSCP files still used pickle-backed payloads. This PR removes that asymmetry so newly written native files are safe-by-default while historical trusted archives remain available via `allow_unsafe_legacy=True`.

## Validation
- `pre-commit run --all-files`
- `conda run -n scpy-core python -m pytest tests/test_utils/test_jsonutils.py tests/test_utils/test_zip.py tests/test_core/test_dataset/test_mixins/test_ndio.py tests/test_core/test_projects/test_projects.py tests/test_core/test_writers/test_exporter.py -q`

## Notes
- safe ndarray payloads now accept generic non-object NumPy dtypes instead of a fixed dtype allowlist
- historical legacy `.scp` / `.pscp` files still require explicit trusted opt-in via `allow_unsafe_legacy=True`
