### PR TITLE
ENH: add NDDataset xarray mapping prototype

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,11 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Added a first ``NDDataset`` ↔ ``xarray`` prototype focused on portable
+  dataset exchange. Native ``xarray`` round-trips now cover numerical arrays,
+  dimension names/order, default coordinates, units, explicit masks,
+  ``name``/``title``, and JSON-compatible metadata, while richer ``CoordSet``
+  semantics remain outside this first implementation.
 
 .. section
 
@@ -77,6 +82,10 @@ Dependency Updates
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
+
+- ``NDDataset.to_xarray()`` now returns a canonical ``xarray.Dataset`` instead
+  of a bare ``xarray.DataArray``, aligning the API with the new portable
+  mapping RFC and the future NetCDF/Zarr-oriented interchange model.
 
 - Loading native ``.scp`` and ``.pscp`` files is now safe by default.
   Historical archives that require pickle-based native persistence must be

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,15 @@ What's New in Revision 0.10.1.dev
 These are the changes in SpectroChemPy-0.10.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+New Features
+~~~~~~~~~~~~
+
+- Added a first ``NDDataset`` ↔ ``xarray`` prototype focused on portable
+  dataset exchange. Native ``xarray`` round-trips now cover numerical arrays,
+  dimension names/order, default coordinates, units, explicit masks,
+  ``name``/``title``, and JSON-compatible metadata, while richer ``CoordSet``
+  semantics remain outside this first implementation.
+
 Bug Fixes
 ~~~~~~~~~
 
@@ -56,6 +65,10 @@ Bug Fixes
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
+
+- ``NDDataset.to_xarray()`` now returns a canonical ``xarray.Dataset`` instead
+  of a bare ``xarray.DataArray``, aligning the API with the new portable
+  mapping RFC and the future NetCDF/Zarr-oriented interchange model.
 
 - Loading native ``.scp`` and ``.pscp`` files is now safe by default.
   Historical archives that require pickle-based native persistence must be

--- a/environments/environment_dev.yml
+++ b/environments/environment_dev.yml
@@ -64,6 +64,7 @@ dependencies:
     - pytest-mock
     - pytest-xdist
     - numpydoc
+    - xarray
     # docs
     - ipykernel=6.29.5
     - ipywidgets=8.1.5

--- a/environments/environment_test.yml
+++ b/environments/environment_test.yml
@@ -53,3 +53,4 @@ dependencies:
     - pytest-mock
     - pytest-xdist
     - numpydoc
+    - xarray

--- a/maintainers/rfcs/nddataset-xarray-mapping-specification.md
+++ b/maintainers/rfcs/nddataset-xarray-mapping-specification.md
@@ -1,0 +1,545 @@
+# NDDataset ↔ xarray Dataset Mapping Specification
+
+**Status:** Proposed Maintainer RFC
+
+**Scope:** Canonical conceptual mapping between `NDDataset` and `xarray` for
+future portable persistence and interchange work.
+
+**Out of scope:** Code, API changes, SCP/PSCP changes, `Project` persistence,
+result persistence, plugin persistence, backend selection details, or migration
+mechanics.
+
+**Related documents:**
+
+- `maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md`
+- `maintainers/rfcs/trusted-and-portable-persistence.md`
+- `audit/~portable-xarray-netcdf-format-architecture-audit.md`
+- `audit/~csdm-native-persistence-candidate-audit.md`
+
+The key words MUST, SHOULD, and MAY express the intended future contract. They
+do not change current behavior until separately implemented.
+
+## Motivation
+
+SpectroChemPy now distinguishes two persistence roles:
+
+- SCP/PSCP is trusted native persistence.
+- xarray-backed portable persistence is the leading candidate for scientific
+  interchange and archive-oriented storage.
+
+This distinction matters because the future portable path must support modern
+scientific interoperability with:
+
+- xarray;
+- NetCDF;
+- Zarr;
+- Dask;
+- the broader PyData ecosystem.
+
+At the same time, SpectroChemPy must not collapse its own scientific object
+model into a thin wrapper around xarray internals. `NDDataset` remains the
+primary SpectroChemPy scientific data object. xarray is the canonical portable
+carrier, not the source of truth for SpectroChemPy semantics.
+
+This RFC defines the mapping contract precisely enough that a future
+implementation should not need to reopen core architectural decisions.
+
+## Canonical representation
+
+### Decision
+
+The canonical portable representation of one `NDDataset` MUST be an
+`xarray.Dataset`, not a bare `xarray.DataArray`.
+
+### Rationale
+
+`xarray.Dataset` is retained because it can represent:
+
+- one primary data variable;
+- auxiliary coordinate variables;
+- mask variables;
+- portable metadata at dataset and variable level;
+- future extension points without changing the top-level carrier model.
+
+A `DataArray` view MAY still be exposed as a convenience in a future API, but
+it is not the canonical round-trip representation.
+
+### Primary variable convention
+
+An exported `xarray.Dataset` MUST contain exactly one primary data variable
+representing the numerical signal of the `NDDataset`.
+
+The canonical convention is:
+
+- the dataset-level attribute `scpy_primary_variable` identifies the primary
+  variable name;
+- the primary variable stores the actual numerical data;
+- global dataset attrs carry SpectroChemPy container-level metadata;
+- per-variable attrs carry signal-level metadata when appropriate.
+
+The primary variable name SHOULD be:
+
+- `name` when it is stable and non-empty;
+- otherwise `data`.
+
+Consumers MUST NOT assume that the primary variable is always named `data`;
+they MUST consult `scpy_primary_variable` when present.
+
+### Canonical top-level conventions
+
+The canonical exported `xarray.Dataset` SHOULD use:
+
+- `attrs["scpy_format"] = "nddataset-xarray"`
+- `attrs["scpy_version"] = 1`
+- `attrs["scpy_primary_variable"] = <primary variable name>`
+
+These markers define the SpectroChemPy mapping convention. They are distinct
+from any NetCDF, Zarr, or backend-specific versioning.
+
+## Dimensions
+
+### Mapping rule
+
+`NDDataset.dims` MUST map directly to the dimension tuple of the primary
+variable.
+
+Dimension order MUST be preserved exactly.
+
+If `ds.dims == ("y", "x")`, then the primary variable in xarray MUST use
+`("y", "x")` in that same order.
+
+### Naming
+
+Dimension names MUST be explicit strings.
+
+The canonical exported names SHOULD be the SpectroChemPy dimension keys, not
+human-readable titles. Titles are display metadata, not structural identifiers.
+
+This avoids ambiguity during reconstruction and avoids coupling the structural
+schema to presentation labels.
+
+### Reconstruction
+
+`xarray -> NDDataset` reconstruction MUST use the primary variable's dimension
+tuple as the source of truth for `NDDataset.dims`.
+
+Round-trip guarantee:
+
+- `NDDataset -> xarray -> NDDataset` MUST preserve dimension count, names, and
+  order.
+
+No stronger cross-tool guarantee is made if a third-party tool renames or
+reorders dimensions.
+
+## Coordinates
+
+### Default per-dimension coordinate
+
+Each SpectroChemPy dimension SHOULD export one default coordinate as the
+dimension coordinate in xarray.
+
+This default coordinate is the coordinate that SpectroChemPy would consider the
+active coordinate for that dimension.
+
+### Coordinate payload
+
+For each default coordinate, the mapping SHOULD preserve:
+
+- coordinate values;
+- coordinate dimensional attachment;
+- units;
+- title if present;
+- selected coordinate attrs needed for reconstruction.
+
+Coordinate metadata SHOULD live primarily in coordinate variable attrs.
+
+Recommended attrs:
+
+- `units`
+- `scpy_title`
+- `scpy_coord_role = "default"`
+
+### Monotone and non-monotone coordinates
+
+Both monotone and non-monotone coordinates MUST be representable.
+
+The mapping MUST preserve actual coordinate values and MUST NOT infer a linear
+or monotone representation unless that inference is lossless and explicitly
+defined by a future implementation.
+
+Coordinate values are canonical; inferred linear metadata is secondary.
+
+### Coordinate identity
+
+Coordinate titles, display labels, and aliases MUST NOT be used as the sole
+structural identity of a coordinate during reconstruction.
+
+The owning dimension and exported coordinate variable name are the structural
+anchors.
+
+## CoordSet mapping
+
+`CoordSet` is the main richness gap between SpectroChemPy and xarray.
+
+### Default coordinate
+
+For each dimension, one coordinate MUST be designated as the default exported
+dimension coordinate.
+
+That coordinate provides the portable minimum representation.
+
+### Auxiliary same-dimension coordinates
+
+Additional coordinates attached to the same underlying dimension SHOULD be
+exported as auxiliary coordinate variables on the `xarray.Dataset`.
+
+Recommended convention:
+
+- each auxiliary coordinate variable is 1D and indexed by the same dimension;
+- each carries attrs describing its role and owning dimension.
+
+Recommended attrs:
+
+- `scpy_coord_role = "auxiliary"`
+- `scpy_owner_dim = <dimension name>`
+- `scpy_coord_key = <stable exported key>`
+
+### CoordSet completeness
+
+The `CoordSet` round-trip contract is intentionally partial.
+
+Specifically:
+
+- default same-dimension coordinate selection MUST round-trip;
+- auxiliary coordinate values SHOULD round-trip when preserved by the backend;
+- aliases, internal lookup conveniences, and implementation-specific grouping
+  details are best effort only;
+- reference-sharing identity is not guaranteed to round-trip as identity.
+
+### Reference semantics
+
+If multiple SpectroChemPy coordinates historically share values or references,
+the portable mapping MAY reconstruct equivalent values without reconstructing
+the original internal reference topology.
+
+This means:
+
+- scientific coordinate meaning SHOULD be preserved;
+- Python object identity and reference-sharing MUST NOT be guaranteed.
+
+### Overall decision
+
+`CoordSet` round-trip is therefore:
+
+- complete for the default portable coordinate layer;
+- partial for richer same-dimension grouping semantics;
+- best effort for aliases and internal reference topology.
+
+## Units
+
+### Data units
+
+Primary signal units MUST be exported explicitly.
+
+The recommended canonical location is:
+
+- primary variable attr `units`
+
+### Coordinate units
+
+Coordinate units MUST be exported on the corresponding coordinate variable
+attrs using the same `units` key.
+
+### Semantics
+
+This RFC does not require a future implementation to depend on `pint` inside
+xarray or inside a backend. The portable contract is textual unit preservation,
+not runtime unit-engine preservation.
+
+Guarantees:
+
+- unit strings MUST round-trip when preserved by the backend;
+- scientific intent of units SHOULD round-trip;
+- automatic runtime reconstitution of a specific unit engine is an
+  implementation concern, not part of the portable schema contract.
+
+### CF conventions
+
+CF-compatible unit strings SHOULD be preferred when feasible, but this RFC does
+not require full CF normalization.
+
+If SpectroChemPy-specific unit spellings are used, they SHOULD be preserved as
+written rather than silently coerced.
+
+## Masks
+
+### Canonical representation
+
+Masks SHOULD be represented explicitly, not only by injecting `NaN` into the
+primary data variable.
+
+The recommended canonical mapping is:
+
+- primary variable retains the numerical payload;
+- an auxiliary boolean variable stores the SpectroChemPy mask;
+- dataset attr `scpy_mask_variable` identifies that variable.
+
+The mask variable SHOULD share the same dimensions as the primary variable.
+
+### Why not NaN alone
+
+`NaN`-only encoding is insufficient because:
+
+- integer and complex payloads do not map cleanly to `NaN`;
+- missing-data semantics and masked-data semantics are not always identical;
+- explicit masks are easier to reconstruct faithfully.
+
+### Reconstruction
+
+`xarray -> NDDataset` reconstruction MUST prefer the explicit mask variable when
+present.
+
+`_FillValue`, backend-native missing-data markers, or `NaN` MAY be used as
+fallback hints, but they are not the canonical source of truth.
+
+## Complex and HyperComplex data
+
+### Complex
+
+`complex64` and `complex128` are in scope.
+
+The complex-data decision MUST distinguish the xarray model from backend
+constraints:
+
+- canonical xarray representation: native NumPy complex dtype;
+- canonical NetCDF representation: split real/imag convention.
+
+This distinction is required because xarray can naturally carry complex NumPy
+arrays, while NetCDF portability imposes the real/imag split at backend export
+time rather than at the xarray carrier level.
+
+Therefore:
+
+- `NDDataset -> xarray.Dataset` SHOULD preserve native complex dtype;
+- `xarray.Dataset -> NDDataset` SHOULD preserve native complex dtype when
+  present;
+- any future NetCDF mapping SHOULD define an explicit split real/imag
+  convention without changing the canonical xarray carrier model.
+
+The xarray mapping is the canonical portable carrier for SpectroChemPy, not the
+source of truth for SpectroChemPy semantics, and backend-specific export
+constraints MUST NOT unnecessarily degrade the in-memory xarray representation.
+
+### HyperComplex
+
+HyperComplex or quaternion-like payloads are out of scope for guaranteed
+portable round-trip in this RFC.
+
+Current conclusion:
+
+- ordinary NumPy-backed dataset data fits the xarray model;
+- HyperComplex-specific semantics do not currently justify a distinct canonical
+  portable schema here;
+- no guarantee is made for quaternion dtype round-trip through xarray/NetCDF.
+
+Classification:
+
+- complex data: supported by convention;
+- HyperComplex data: partially supported at best, otherwise out of scope for
+  guaranteed portable interchange.
+
+## Metadata and attrs
+
+### Export policy
+
+Portable export SHOULD preserve scientific metadata, not arbitrary runtime
+internals.
+
+Only JSON-compatible metadata are portable by default.
+
+The following SHOULD be exported when present:
+
+- title;
+- name;
+- description;
+- author;
+- origin;
+- date-like creation/update metadata when stable;
+- history;
+- serializable scientific metadata entries from `meta`.
+
+The following are out of portable scope unless a later RFC defines them
+explicitly:
+
+- arbitrary Python objects in `meta`;
+- callable objects;
+- class instances without a JSON-compatible representation;
+- backend-specific opaque objects.
+
+The following MUST NOT be treated as portable schema guarantees:
+
+- live runtime services;
+- backend-specific caches;
+- display-only transient state;
+- Python object identities;
+- implementation-private helper fields.
+
+Portable persistence is not Python object persistence. Metadata that is not
+JSON-compatible MAY remain valid in native trusted persistence, but it is not
+guaranteed by this xarray portable mapping.
+
+### Attr namespace
+
+SpectroChemPy-specific attrs SHOULD use an explicit `scpy_` prefix.
+
+This avoids collisions with:
+
+- xarray conventions;
+- CF conventions;
+- third-party attrs.
+
+Recommended dataset attrs include:
+
+- `scpy_format`
+- `scpy_version`
+- `scpy_primary_variable`
+- `scpy_mask_variable`
+- `scpy_history_format`
+
+### History
+
+History SHOULD be exported explicitly as metadata.
+
+The canonical first-step representation SHOULD be textual and lossless relative
+to the current `NDDataset.history` field, not a new provenance graph.
+
+This RFC does not redefine history into a portable workflow/provenance model.
+
+## Round-trip contract
+
+### `NDDataset -> xarray -> NDDataset`
+
+Guaranteed:
+
+- numerical data values, except for backend-imposed precision changes;
+- native complex dtype preservation on the xarray path;
+- dimension names and order;
+- default per-dimension coordinate values;
+- data units and default coordinate unit strings;
+- explicit mask values when the mask variable is preserved;
+- core exported metadata under the `scpy_` convention and selected scientific
+  attrs;
+- identification of the primary variable.
+
+Best effort:
+
+- auxiliary same-dimension coordinates;
+- coordinate titles and secondary metadata;
+- JSON-compatible `meta` entries;
+- history formatting beyond textual content equivalence.
+
+Not guaranteed:
+
+- object identity;
+- internal `CoordSet` grouping topology;
+- alias tables;
+- shared-reference identity between coordinates;
+- non-JSON-compatible metadata objects;
+- HyperComplex dtype semantics;
+- backend-specific encoding details;
+- byte-for-byte equality.
+
+### `xarray -> NDDataset -> xarray`
+
+Guaranteed only for xarray objects that already follow the SpectroChemPy
+mapping convention defined in this RFC.
+
+Specifically, the future importer MAY reject or partially import generic
+xarray objects that lack:
+
+- a clear primary variable;
+- reconstructible dimension coordinates;
+- compatible unit metadata;
+- supported numeric dtypes;
+- unambiguous mask conventions.
+
+Therefore:
+
+- convention-compliant xarray datasets SHOULD round-trip predictably;
+- arbitrary third-party xarray datasets are import candidates, not guaranteed
+  full-fidelity round-trips.
+
+## Non-goals
+
+This RFC does not define:
+
+- `Project` portable persistence;
+- `ResultBase`, `AnalysisResult`, or `FitResult` persistence;
+- plugin-specific portable schemas;
+- native SCP/PSCP evolution;
+- a migration plan from existing files;
+- a NetCDF-only API;
+- a Zarr-only API;
+- provenance graph design;
+- a complete HyperComplex schema;
+- backend-specific chunking, compression, or dask policy.
+
+## Relation to CSDM
+
+xarray is retained as the primary portable target because it is the strongest
+fit for the broader PyData and scientific interoperability ecosystem:
+
+- mature xarray data model;
+- strong NetCDF and Zarr alignment;
+- wide ecosystem integration;
+- lower adoption risk for general-purpose portable persistence.
+
+CSDM remains architecturally interesting and scientifically credible,
+especially for spectroscopy-oriented interchange and domain-rich dataset
+semantics.
+
+However, based on the CSDM audit:
+
+- CSDM is better positioned as a complementary specialized exchange format;
+- it is not the preferred primary portable carrier for SpectroChemPy as a
+  whole at this stage;
+- it should not replace the xarray-centered mapping model defined here.
+
+See `audit/~csdm-native-persistence-candidate-audit.md`.
+
+## Recommendations
+
+This RFC recommends the following:
+
+1. Canonical representation: `NDDataset` SHOULD map to an `xarray.Dataset`
+   carrying one logical primary signal plus explicit auxiliary variables.
+2. Compatibility target: the mapping SHOULD guarantee strong round-trip for the
+   core numerical signal, dimensions, default coordinates, units, masks, and
+   essential scientific metadata.
+3. Rich-coordinate limit: `CoordSet` semantics beyond the default coordinate
+   layer SHOULD be treated as partial or best-effort portable features, not as
+   a reason to abandon the xarray model.
+4. Complex strategy: xarray mapping SHOULD preserve native complex NumPy dtype,
+   while future NetCDF export SHOULD use an explicit split real/imag
+   convention.
+5. HyperComplex boundary: HyperComplex portable round-trip SHOULD remain out of
+   guaranteed scope until a real scientific need justifies a dedicated schema
+   decision.
+6. Metadata convention: SpectroChemPy-specific mapping metadata SHOULD use the
+   `scpy_` namespace consistently.
+
+## Open questions
+
+- Should the primary variable default name always be `data`, or should stable
+  dataset names be promoted when available?
+- Should labels be exported as auxiliary coordinates by default, or remain
+  metadata unless their semantics are clearly positional?
+- Should future work define a stricter serialized subset of `meta`, or accept
+  only plain JSON-compatible metadata?
+- Should complex split variables use a naming convention, attrs only, or both?
+- Should a future implementation expose both a strict importer and a permissive
+  best-effort importer for generic xarray objects?
+- Should a later RFC define a separate portable mapping for `Project`, or keep
+  portable persistence dataset-only?
+
+Recommended next step: implement prototype `to_xarray()` / `from_xarray()`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ test = [
   "pytest-mock",
   "pytest-xdist",
   "numpydoc",
+  "xarray",
 ]
 
 [project.urls]

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -31,3 +31,4 @@ pytest-ruff
 pytest-mock
 pytest-xdist
 numpydoc
+xarray

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -27,6 +27,7 @@ __dataset_methods__ = [  # Methods that can be called as API functions
 ]
 
 
+import json
 import textwrap
 
 # Lazy import to avoid triggering matplotlib at module load time
@@ -64,6 +65,22 @@ from spectrochempy.utils.print import _render_sections
 from spectrochempy.utils.print import colored_output
 from spectrochempy.utils.system import get_user_and_node
 from spectrochempy.utils.typeutils import is_sequence
+
+
+def _normalize_json_compatible(value: Any) -> Any:
+    """Return a JSON-compatible copy of *value* or raise ``TypeError``."""
+    if isinstance(value, np.generic):
+        return value.item()
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): _normalize_json_compatible(item) for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize_json_compatible(item) for item in value]
+
+    raise TypeError(f"Value of type {type(value).__name__} is not JSON-compatible")
 
 
 # ======================================================================================
@@ -1354,86 +1371,161 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
 
     def to_xarray(self):
         """
-        Convert a NDDataset instance to an `~xarray.DataArray` object.
+        Convert a NDDataset instance to an `~xarray.Dataset` object.
 
         Warning: the xarray library must be available.
 
         Returns
         -------
         object
-            A axrray.DataArray object.
+            An xarray.Dataset object.
 
         """
-        # Information about DataArray from the DataArray docstring
-        #
-        # Attributes
-        # ----------
-        # dims: tuple
-        #     Dimension names associated with this array.
-        # values: np.ndarray
-        #     Access or modify DataArray values as a numpy array.
-        # coords: dict-like
-        #     Dictionary of DataArray objects that label values along each dimension.
-        # name: str or None
-        #     Name of this array.
-        # attrs: OrderedDict
-        #     Dictionary for holding arbitrary metadata.
-        # Init docstring
-        #
-        # Parameters
-        # ----------
-        # data: array_like
-        #     Values for this array. Must be an `numpy.ndarray` , ndarray like,
-        #     or castable to an `~numpy.ndarray` .
-        # coords: sequence or dict of array_like objects, optional
-        #     Coordinates (tick labels) to use for indexing along each dimension.
-        #     If dict-like, should be a mapping from dimension names to the
-        #     corresponding coordinates. If sequence-like, should be a sequence
-        #     of tuples where the first element is the dimension name and the
-        #     second element is the corresponding coordinate array_like object.
-        # dims: str or sequence of str, optional
-        #     Name(s) of the data dimension(s). Must be either a string (only
-        #     for 1D data) or a sequence of strings with length equal to the
-        #     number of dimensions. If this argument is omitted, dimension names
-        #     are taken from `coords` (if possible) and otherwise default to
-        #     `['dim_0', ... 'dim_n']` .
-        # name: str or None, optional
-        #     Name of this array.
-        # attrs: dict_like or None, optional
-        #     Attributes to assign to the new instance. By default, an empty
-        #     attribute dictionary is initialized.
-        # encoding: dict_like or None, optional
-        #     Dictionary specifying how to encode this array's data into a
-        #     serialized format like netCDF4. Currently used keys (for netCDF)
-        #     include '_FillValue', 'scale_factor', 'add_offset', 'dtype',
-        #     'units' and 'calendar' (the later two only for datetime arrays).
-        #     Unrecognized keys are ignored.
-
         xr = import_optional_dependency("xarray")
         if xr is None:
             return None
 
-        x, y = self.x, self.y
-        tx = x.title
-        if y:
-            ty = y.title
-            da = xr.DataArray(
-                np.array(self.data, dtype=np.float64),
-                coords=[(ty, y.data), (tx, x.data)],
+        dims = tuple(self.dims)
+        primary_name = self._name if self._name else "data"
+
+        coords = {}
+        for dim in dims:
+            coord = self.coord(dim)
+            if coord is None or coord.is_empty:
+                continue
+
+            coord_attrs = {"scpy_coord_role": "default"}
+            if coord.units is not None:
+                coord_attrs["units"] = str(coord.units)
+            if coord.title != "<untitled>":
+                coord_attrs["scpy_title"] = coord.title
+
+            coords[dim] = xr.DataArray(
+                np.asarray(coord.data),
+                dims=(dim,),
+                attrs=coord_attrs,
             )
 
-            da.attrs["units"] = self.units
-        else:
-            da = xr.DataArray(
-                np.array(self.data, dtype=np.float64),
-                coords=[(tx, x.data)],
+        meta = {}
+        skipped_meta_keys = []
+        for key, value in self.meta.items():
+            try:
+                meta[key] = _normalize_json_compatible(value)
+            except TypeError:
+                skipped_meta_keys.append(key)
+
+        if skipped_meta_keys:
+            warning_(
+                "Skipping non-JSON-compatible metadata for xarray export: "
+                f"{', '.join(sorted(skipped_meta_keys))}",
             )
 
-            da.attrs["units"] = self.units
+        data_attrs = {}
+        if self.units is not None:
+            data_attrs["units"] = str(self.units)
 
-        da.attrs["title"] = self.title
+        dataset_attrs = {
+            "scpy_format": "nddataset-xarray",
+            "scpy_version": 1,
+            "scpy_primary_variable": primary_name,
+            "scpy_name": self.name,
+            "scpy_title": self.title,
+        }
+        if meta:
+            dataset_attrs["scpy_meta"] = json.loads(json.dumps(meta))
+        if skipped_meta_keys:
+            dataset_attrs["scpy_skipped_meta_keys"] = sorted(skipped_meta_keys)
 
-        return da
+        xds = xr.Dataset(
+            data_vars={
+                primary_name: xr.DataArray(
+                    np.asarray(self.data),
+                    dims=dims,
+                    coords=coords,
+                    attrs=data_attrs,
+                )
+            },
+            attrs=dataset_attrs,
+        )
+
+        if self.is_masked:
+            mask_name = f"{primary_name}__mask"
+            xds[mask_name] = xr.DataArray(
+                np.asarray(self.mask, dtype=bool),
+                dims=dims,
+                coords=coords,
+                attrs={"scpy_role": "mask"},
+            )
+            xds.attrs["scpy_mask_variable"] = mask_name
+
+        return xds
+
+    @classmethod
+    def from_xarray(cls, dataset):
+        """
+        Build a minimal `NDDataset` instance from an `xarray.Dataset`.
+
+        This prototype covers numerical data, default coordinates, units, masks,
+        JSON-compatible metadata, title, and name. Rich CoordSet semantics and
+        backend-specific persistence are intentionally out of scope here.
+        """
+        xr = import_optional_dependency("xarray")
+        if xr is None:
+            return None
+
+        if not isinstance(dataset, xr.Dataset):
+            raise SpectroChemPyError("from_xarray() expects an xarray.Dataset.")
+
+        primary_name = dataset.attrs.get("scpy_primary_variable")
+        if primary_name is None:
+            data_vars = list(dataset.data_vars)
+            if len(data_vars) == 1:
+                primary_name = data_vars[0]
+            else:
+                raise SpectroChemPyError(
+                    "Cannot determine the primary xarray variable for NDDataset reconstruction."
+                )
+
+        if primary_name not in dataset.data_vars:
+            raise SpectroChemPyError(
+                f"Primary xarray variable `{primary_name}` is missing from the dataset."
+            )
+
+        data_var = dataset[primary_name]
+        dims = tuple(data_var.dims)
+
+        coordset = []
+        for dim in dims:
+            if dim in data_var.coords:
+                xr_coord = data_var.coords[dim]
+                kwargs = {"name": dim}
+                units = xr_coord.attrs.get("units")
+                if units is not None:
+                    kwargs["units"] = units
+                title = xr_coord.attrs.get("scpy_title")
+                if title is not None:
+                    kwargs["title"] = title
+                coordset.append(Coord(np.asarray(xr_coord.data), **kwargs))
+            else:
+                coordset.append(None)
+
+        kwargs = {
+            "dims": list(dims),
+            "coordset": coordset,
+            "name": dataset.attrs.get("scpy_name", primary_name),
+            "title": dataset.attrs.get("scpy_title"),
+            "meta": dataset.attrs.get("scpy_meta"),
+        }
+
+        units = data_var.attrs.get("units")
+        if units is not None:
+            kwargs["units"] = units
+
+        mask_name = dataset.attrs.get("scpy_mask_variable")
+        if mask_name in dataset.data_vars:
+            kwargs["mask"] = np.asarray(dataset[mask_name].data, dtype=bool)
+
+        return cls(np.asarray(data_var.data), **kwargs)
 
     def transpose(self, *dims, inplace=False):
         """

--- a/tests/test_core/test_dataset/test_xarray_mapping.py
+++ b/tests/test_core/test_dataset/test_xarray_mapping.py
@@ -1,0 +1,124 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.nddataset import NDDataset
+
+if importlib.util.find_spec("xarray") is not None:
+    import xarray as xr
+else:  # pragma: no cover - depends on optional dependency availability
+    xr = None
+
+pytestmark = pytest.mark.skipif(xr is None, reason="xarray is not installed")
+
+
+def _make_dataset(data=None, *, complex_data=False, unsupported_meta=False):
+    if data is None:
+        if complex_data:
+            data = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]], dtype=np.complex128)
+        else:
+            data = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    meta = {
+        "sample": "demo",
+        "nested": {"temperature": 298.15, "labels": ["a", "b"]},
+        "count": 2,
+    }
+    if unsupported_meta:
+        meta["unsupported"] = object()
+
+    return NDDataset(
+        data,
+        dims=["y", "x"],
+        coordset=[
+            Coord([10.0, 20.0], name="y", title="time", units="s"),
+            Coord([1000.0, 1200.0], name="x", title="wavenumber", units="cm^-1"),
+        ],
+        units="volt",
+        mask=np.array([[False, True], [False, False]]),
+        title="IR spectra",
+        name="spectra",
+        meta=meta,
+    )
+
+
+def test_to_xarray_returns_dataset():
+    ds = _make_dataset()
+
+    xds = ds.to_xarray()
+
+    assert isinstance(xds, xr.Dataset)
+    assert xds.attrs["scpy_primary_variable"] == "spectra"
+
+
+def test_xarray_roundtrip_preserves_numerical_data_dims_and_coordinates():
+    ds = _make_dataset()
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert np.array_equal(rebuilt.data, ds.data)
+    assert tuple(rebuilt.dims) == tuple(ds.dims)
+    assert np.array_equal(rebuilt.coord("x").data, ds.coord("x").data)
+    assert np.array_equal(rebuilt.coord("y").data, ds.coord("y").data)
+
+
+def test_xarray_roundtrip_preserves_units_mask_title_and_name():
+    ds = _make_dataset()
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert str(rebuilt.units) == str(ds.units)
+    assert np.array_equal(rebuilt.mask, ds.mask)
+    assert rebuilt.title == ds.title
+    assert rebuilt.name == ds.name
+    assert str(rebuilt.coord("x").units) == str(ds.coord("x").units)
+    assert rebuilt.coord("x").title == ds.coord("x").title
+
+
+def test_xarray_roundtrip_preserves_json_compatible_metadata():
+    ds = _make_dataset()
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert xds.attrs["scpy_meta"] == {
+        "count": 2,
+        "nested": {"labels": ["a", "b"], "temperature": 298.15},
+        "sample": "demo",
+    }
+    assert rebuilt.meta["sample"] == "demo"
+    assert rebuilt.meta["nested"]["temperature"] == 298.15
+    assert rebuilt.meta["nested"]["labels"] == ["a", "b"]
+
+
+def test_xarray_export_skips_unsupported_metadata():
+    ds = _make_dataset(unsupported_meta=True)
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert xds.attrs["scpy_skipped_meta_keys"] == ["unsupported"]
+    assert "unsupported" not in xds.attrs.get("scpy_meta", {})
+    assert rebuilt.meta["unsupported"] is None
+    assert rebuilt.meta["sample"] == "demo"
+
+
+def test_xarray_roundtrip_preserves_complex_dtype():
+    ds = _make_dataset(complex_data=True)
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert xds["spectra"].dtype == np.complex128
+    assert rebuilt.data.dtype == np.complex128
+    assert np.array_equal(rebuilt.data, ds.data)


### PR DESCRIPTION
## Summary
- add the `NDDataset ↔ xarray Dataset Mapping Specification` RFC
- implement a minimal `NDDataset.to_xarray()` / `NDDataset.from_xarray()` prototype aligned with that RFC
- add focused tests for numerical data, dims, default coordinates, units, masks, JSON-compatible metadata, and complex dtype preservation on the xarray path
- add `xarray` to the `test` extra and update generated requirement/environment files
- document the prototype and user-facing behavior in the changelog

Closes #1154.

## Out of scope
- NetCDF and Zarr backends
- `Project` / `Result` portable persistence
- full `CoordSet` round-trip, aliases, or reference topology
- HyperComplex guarantees

## Validation
- `pre-commit run --all-files`
- local targeted pytest for the new xarray tests currently skips in `scpy-core` because `xarray` was not installed there before this change
- smoke-tested the new conversion path structurally with a minimal fake xarray backend in the local environment
