### PR TITLE
ENH: add xarray-backed NetCDF prototype

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -192,6 +192,8 @@ Import a NDataset from external source
     read_spc
     read_spg
     read_srs
+    NDDataset.from_xarray
+    NDDataset.from_netcdf
     load_iris
     download_nist_ir
 
@@ -212,6 +214,7 @@ Export a NDDataset
     write_matlab
     write_xls
     to_array
+    to_netcdf
     to_xarray
 
 

--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -116,11 +116,20 @@ X
 #     # Newly written native file:
 #     # ds = scp.read("new.scp")
 #
+#     # Portable NetCDF prototype for NDDataset only:
+#     # ds.to_netcdf("new.nc")
+#     # ds2 = scp.NDDataset.from_netcdf("new.nc")
+#
 #     # Historical trusted legacy file only:
 #     # ds = scp.read("old.scp", allow_unsafe_legacy=True)
 #
 # Only enable ``allow_unsafe_legacy=True`` for files from known and trusted
 # sources.
+#
+# NetCDF is a portable persistence path built on the canonical
+# ``NDDataset ↔ xarray.Dataset`` mapping. It currently covers `NDDataset`
+# only; full `CoordSet` fidelity and `Project` round-trips are not guaranteed
+# by this first prototype.
 #
 # Other reader functions return either a single `NDDataset` or multiple `NDDataset`
 # objects, depending on the file type and content.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,12 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Added a first xarray-backed NetCDF prototype for `NDDataset` portable
+  persistence. The prototype builds strictly on the canonical
+  `NDDataset ↔ xarray.Dataset` mapping and covers numerical data, default
+  coordinates, units, explicit masks, JSON-compatible metadata, and complex
+  datasets through a split real/imag NetCDF convention.
+
 - Added a first ``NDDataset`` ↔ ``xarray`` prototype focused on portable
   dataset exchange. Native ``xarray`` round-trips now cover numerical arrays,
   dimension names/order, default coordinates, units, explicit masks,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,12 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- Added a first xarray-backed NetCDF prototype for `NDDataset` portable
+  persistence. The prototype builds strictly on the canonical
+  `NDDataset ↔ xarray.Dataset` mapping and covers numerical data, default
+  coordinates, units, explicit masks, JSON-compatible metadata, and complex
+  datasets through a split real/imag NetCDF convention.
+
 - Added a first ``NDDataset`` ↔ ``xarray`` prototype focused on portable
   dataset exchange. Native ``xarray`` round-trips now cover numerical arrays,
   dimension names/order, default coordinates, units, explicit masks,

--- a/maintainers/rfcs/xarray-backed-netcdf-persistence.md
+++ b/maintainers/rfcs/xarray-backed-netcdf-persistence.md
@@ -1,0 +1,388 @@
+# xarray-backed NetCDF Persistence
+
+**Status:** Proposed Maintainer RFC
+
+**Scope:** NetCDF persistence rules for the already-defined
+`NDDataset ↔ xarray.Dataset` mapping.
+
+**Out of scope:** New object-model design, `Project` persistence, `Result`
+persistence, Zarr-specific policy, implementation, migration, or API work.
+
+**Related documents:**
+
+- `maintainers/rfcs/nddataset-xarray-mapping-specification.md`
+- `maintainers/rfcs/trusted-and-portable-persistence.md`
+- `audit/~xarray-prototype-implementation-notes.md`
+- `audit/~portable-xarray-netcdf-format-architecture-audit.md`
+
+The key words MUST, SHOULD, and MAY express the intended future contract. They
+do not change current behavior until separately implemented.
+
+## Relation to the xarray RFC
+
+The canonical portable carrier for `NDDataset` is `xarray.Dataset`.
+
+NetCDF is a persistence backend for that carrier, not a replacement object
+model. The persistence chain is therefore:
+
+```text
+NDDataset
+    ↔ xarray.Dataset
+    ↔ NetCDF
+```
+
+and not:
+
+```text
+NDDataset ↔ NetCDF
+```
+
+This distinction is mandatory because:
+
+- xarray remains the canonical portable in-memory model;
+- NetCDF backend constraints must not redefine SpectroChemPy semantics;
+- backend-specific compromises belong at the persistence layer, not at the
+  carrier-model layer.
+
+## Goals
+
+This RFC defines a NetCDF persistence profile for the SpectroChemPy xarray
+mapping with the following goals:
+
+- portable scientific persistence;
+- archival-friendly storage of `NDDataset` content;
+- interoperability with xarray and standard NetCDF tooling;
+- compatibility with broader PyData workflows, including later Dask/Zarr usage.
+
+## Non-goals
+
+This RFC does not define:
+
+- a new canonical representation for `NDDataset`;
+- `Project` portable persistence;
+- `ResultBase`, `AnalysisResult`, or `FitResult` persistence;
+- full `CoordSet` fidelity beyond what the xarray RFC already allows;
+- backend-specific chunking or compression policy;
+- a provenance graph model;
+- HyperComplex persistence guarantees.
+
+## Primary variables
+
+Each persisted NetCDF file MUST represent one logical SpectroChemPy primary
+signal derived from the canonical xarray primary variable.
+
+Required conventions:
+
+- the Dataset MUST carry `scpy_primary_variable`;
+- the referenced primary variable MUST exist;
+- the primary variable MUST use the canonical dimension order already defined by
+  the xarray RFC.
+
+Recommended conventions:
+
+- `scpy_format = "nddataset-xarray"`
+- `scpy_version = 1`
+
+NetCDF readers that do not understand `scpy_*` attrs may still read the file as
+a normal xarray/NetCDF dataset, but SpectroChemPy reconstruction MUST rely on
+these attrs when present.
+
+## Coordinates
+
+### Default coordinates
+
+Default per-dimension coordinates MUST be written as NetCDF coordinate
+variables.
+
+Their persistence SHOULD preserve:
+
+- coordinate values;
+- dimension attachment;
+- `units`;
+- `scpy_title` when present;
+- relevant `scpy_*` attrs required for reconstruction.
+
+### Auxiliary coordinates
+
+Auxiliary same-dimension coordinates SHOULD be written as non-dimension
+coordinate variables when the xarray carrier includes them.
+
+This is a best-effort portability layer:
+
+- SpectroChemPy SHOULD preserve them when possible;
+- third-party tools MAY ignore or drop some non-standard attrs;
+- full `CoordSet` topology is not guaranteed by NetCDF itself.
+
+### Guarantees
+
+Guaranteed:
+
+- default coordinates required for core scientific interpretation.
+
+Best effort:
+
+- auxiliary same-dimension coordinates;
+- richer `CoordSet` metadata carried only in `scpy_*` attrs.
+
+## Masks
+
+### Options considered
+
+Option A: explicit boolean mask variable
+
+Option B: `NaN` / `_FillValue` only
+
+Option C: hybrid approach
+
+### Decision
+
+The recommended NetCDF representation is Option C: hybrid, with the explicit
+boolean mask variable as the canonical reconstruction source.
+
+Concretely:
+
+- SpectroChemPy SHOULD persist a dedicated boolean mask variable aligned with
+  the primary variable dimensions;
+- the Dataset SHOULD carry `scpy_mask_variable` naming that variable;
+- `_FillValue` or `NaN` MAY also be emitted when useful for external-tool
+  compatibility, but they are not the canonical source of truth.
+
+### Rationale
+
+Boolean masks are the most faithful reconstruction mechanism because:
+
+- they work for integer, floating, and complex data;
+- they preserve masked-data semantics without conflating them with ordinary
+  missing-value conventions;
+- they survive round-trip reconstruction more explicitly than `NaN` alone.
+
+### Reconstruction
+
+`NetCDF -> xarray -> NDDataset` reconstruction MUST prefer the explicit mask
+variable when present.
+
+If the explicit mask variable is absent, `_FillValue` or `NaN` MAY be used as a
+fallback hint, but this fallback is best effort only.
+
+## Complex data
+
+### xarray versus NetCDF
+
+The xarray RFC already decided that the canonical xarray carrier preserves
+native NumPy complex dtype.
+
+NetCDF persistence introduces a separate backend constraint:
+
+- canonical xarray representation: native complex dtype;
+- canonical NetCDF representation: split real/imag convention.
+
+### Options considered
+
+Option A: split real/imag variables
+
+Option B: backend-specific opaque encodings
+
+Option C: alternative non-standard conventions
+
+### Decision
+
+Option A is retained.
+
+SpectroChemPy SHOULD persist complex-valued primary data as two aligned real
+variables and MUST store the reconstruction metadata needed to rebuild the
+logical complex signal.
+
+Recommended attrs:
+
+- `scpy_complex_representation = "split-real-imag"`
+- `scpy_complex_real = <real variable name>`
+- `scpy_complex_imag = <imag variable name>`
+- `scpy_primary_variable = <logical primary signal name>`
+
+Recommended variable naming:
+
+- `<primary>__real`
+- `<primary>__imag`
+
+### Reconstruction
+
+`NetCDF -> xarray -> NDDataset` reconstruction MUST:
+
+- detect the split-real-imag convention;
+- rebuild a native NumPy complex array in the xarray carrier;
+- continue the normal xarray-based reconstruction path into `NDDataset`.
+
+Opaque backend-specific encodings MUST NOT be the canonical SpectroChemPy
+NetCDF contract.
+
+## Units
+
+Data and coordinate units MUST be persisted as textual `units` attrs.
+
+This RFC recommends:
+
+- prefer CF-compatible unit strings when feasible;
+- preserve SpectroChemPy unit strings as written when exact CF normalization is
+  not available or would change meaning.
+
+Guaranteed:
+
+- textual unit preservation when the NetCDF/xarray toolchain preserves attrs.
+
+Best effort:
+
+- interpretation by third-party readers that apply their own unit semantics;
+- automatic reconstruction of a particular runtime unit engine outside
+  SpectroChemPy.
+
+Portable persistence is about stable scientific meaning, not about forcing
+external readers to understand every SpectroChemPy unit expression identically.
+
+## Metadata
+
+NetCDF persistence SHOULD export portable scientific metadata, not arbitrary
+Python runtime state.
+
+### Export policy
+
+Portable by default:
+
+- JSON-compatible metadata only;
+- `name`, `title`, `description`, `author`, `origin` when available;
+- `history` as textual metadata;
+- required `scpy_*` attrs.
+
+Not portable by default:
+
+- arbitrary Python objects;
+- callables;
+- implementation-private runtime helpers;
+- non-JSON-compatible metadata values.
+
+### Namespace policy
+
+SpectroChemPy-specific persistence attrs SHOULD use the `scpy_*` namespace.
+
+Typical examples:
+
+- `scpy_format`
+- `scpy_version`
+- `scpy_primary_variable`
+- `scpy_mask_variable`
+- `scpy_complex_representation`
+- `scpy_complex_real`
+- `scpy_complex_imag`
+
+### History
+
+`history` SHOULD be written as textual metadata, not as a new provenance graph.
+
+This RFC does not extend NetCDF persistence into workflow replay or structured
+provenance.
+
+## Round-trip guarantees
+
+The relevant persistence path is:
+
+```text
+NDDataset
+    -> xarray
+    -> NetCDF
+    -> xarray
+    -> NDDataset
+```
+
+### Guaranteed
+
+- primary numerical signal values, except for backend-imposed numeric precision
+  changes;
+- dimension names and order;
+- default coordinate values;
+- unit strings for the primary signal and default coordinates;
+- explicit boolean mask reconstruction when the canonical mask variable is
+  preserved;
+- reconstruction of complex data through the split real/imag NetCDF convention;
+- `scpy_*` attrs required by the persistence profile.
+
+### Best effort
+
+- auxiliary same-dimension coordinates;
+- JSON-compatible metadata not required for core reconstruction;
+- textual `history` preservation through external tools;
+- compatibility through toolchains that rewrite attrs or variable encodings.
+
+### Not guaranteed
+
+- full `CoordSet` topology;
+- aliases and reference identity;
+- non-JSON-compatible metadata;
+- HyperComplex dtype semantics;
+- byte-for-byte file identity;
+- identical behavior across all third-party NetCDF readers;
+- preservation of NetCDF backend-specific encoding choices after arbitrary
+  third-party rewrites.
+
+## External tool compatibility
+
+This profile is designed to remain usable outside SpectroChemPy.
+
+### xarray
+
+xarray compatibility is the primary target. SpectroChemPy-specific attrs SHOULD
+be additive, not disruptive.
+
+### Standard NetCDF readers
+
+Readers that understand dimensions, variables, coordinates, and attrs SHOULD be
+able to inspect the scientific content even if they ignore `scpy_*` attrs.
+
+### Dask
+
+Nothing in this RFC should prevent later lazy-loading or chunked workflows.
+However, chunking policy is not defined here.
+
+### Zarr conversion
+
+Because the canonical carrier remains xarray, later NetCDF ↔ Zarr conversion
+through xarray remains a valid downstream path. This RFC does not define Zarr
+policy, but it should not block it.
+
+### Third-party tools
+
+Third-party tools may:
+
+- ignore `scpy_*` attrs;
+- preserve only standard attrs;
+- flatten or rewrite some encodings.
+
+That is acceptable. SpectroChemPy portability guarantees apply to the defined
+profile, not to arbitrary third-party rewrites.
+
+## Recommendations
+
+This RFC recommends the following persistence profile:
+
+1. Treat xarray as the canonical portable carrier and NetCDF as its backend.
+2. Persist default coordinates as standard NetCDF coordinate variables.
+3. Use a hybrid mask strategy, with an explicit boolean mask variable as the
+   canonical reconstruction source.
+4. Persist complex data in NetCDF via a split real/imag convention, while
+   preserving native complex dtype in the xarray carrier.
+5. Persist units as textual `units` attrs.
+6. Restrict portable metadata to JSON-compatible values plus required
+   scientific and `scpy_*` attrs.
+7. Keep round-trip guarantees explicit and conservative.
+
+## Open questions
+
+- Should `_FillValue` emission be mandatory whenever an explicit mask variable
+  is present, or only recommended?
+- Should auxiliary coordinates be written as coordinates only, or may some of
+  them be downgraded to ordinary variables for tool compatibility?
+- Should future work define a stricter CF-aligned subset of allowed unit
+  strings?
+- Should later RFC work define a separate NetCDF profile for `Project`, or keep
+  NetCDF persistence dataset-only?
+
+Recommended next step: prototype NetCDF write/read on top of the validated
+xarray carrier, without expanding object-model scope.

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -13,6 +13,7 @@ __dataset_methods__ = [  # Methods that can be called as API functions
     "transpose",
     "reshape",
     "to_array",
+    "to_netcdf",
     "to_xarray",
     "take",
     "set_complex",
@@ -81,6 +82,102 @@ def _normalize_json_compatible(value: Any) -> Any:
         return [_normalize_json_compatible(item) for item in value]
 
     raise TypeError(f"Value of type {type(value).__name__} is not JSON-compatible")
+
+
+def _prepare_xarray_dataset_for_netcdf(dataset):
+    """Convert a canonical xarray Dataset into a NetCDF-safe representation."""
+    xds = dataset.copy(deep=True)
+
+    for attr_name in ("scpy_meta", "scpy_skipped_meta_keys"):
+        if attr_name in xds.attrs:
+            xds.attrs[attr_name] = json.dumps(xds.attrs[attr_name], sort_keys=True)
+
+    primary_name = xds.attrs.get("scpy_primary_variable")
+    mask_name = xds.attrs.get("scpy_mask_variable")
+    if mask_name in xds.data_vars:
+        mask_var = xds[mask_name]
+        mask_attrs = dict(mask_var.attrs)
+        mask_attrs["scpy_mask_encoding"] = "bool-as-int8"
+        xds[mask_name] = xds[mask_name].astype(np.int8)
+        xds[mask_name].attrs = mask_attrs
+
+    if primary_name in xds.data_vars and np.iscomplexobj(xds[primary_name].data):
+        xr = import_optional_dependency("xarray")
+        data_var = xds[primary_name]
+        real_name = f"{primary_name}__real"
+        imag_name = f"{primary_name}__imag"
+
+        real_attrs = dict(data_var.attrs)
+        imag_attrs = dict(data_var.attrs)
+        real_attrs["scpy_complex_component"] = "real"
+        imag_attrs["scpy_complex_component"] = "imag"
+
+        xds[real_name] = xr.DataArray(
+            np.asarray(data_var.data).real,
+            dims=data_var.dims,
+            coords=data_var.coords,
+            attrs=real_attrs,
+        )
+        xds[imag_name] = xr.DataArray(
+            np.asarray(data_var.data).imag,
+            dims=data_var.dims,
+            coords=data_var.coords,
+            attrs=imag_attrs,
+        )
+        xds = xds.drop_vars(primary_name)
+        xds.attrs["scpy_complex_representation"] = "split-real-imag"
+        xds.attrs["scpy_complex_real"] = real_name
+        xds.attrs["scpy_complex_imag"] = imag_name
+
+    return xds
+
+
+def _restore_xarray_dataset_from_netcdf(dataset):
+    """Restore the canonical xarray Dataset representation from NetCDF content."""
+    xds = dataset.copy(deep=True)
+
+    for attr_name in ("scpy_meta", "scpy_skipped_meta_keys"):
+        if attr_name in xds.attrs and isinstance(xds.attrs[attr_name], str):
+            xds.attrs[attr_name] = json.loads(xds.attrs[attr_name])
+
+    complex_repr = xds.attrs.get("scpy_complex_representation")
+    primary_name = xds.attrs.get("scpy_primary_variable")
+    if complex_repr == "split-real-imag":
+        xr = import_optional_dependency("xarray")
+        real_name = xds.attrs.get("scpy_complex_real")
+        imag_name = xds.attrs.get("scpy_complex_imag")
+        if real_name in xds.data_vars and imag_name in xds.data_vars:
+            real_var = xds[real_name]
+            imag_var = xds[imag_name]
+            attrs = dict(real_var.attrs)
+            attrs.pop("scpy_complex_component", None)
+            xds[primary_name] = xr.DataArray(
+                np.asarray(real_var.data) + 1j * np.asarray(imag_var.data),
+                dims=real_var.dims,
+                coords=real_var.coords,
+                attrs=attrs,
+            )
+            xds = xds.drop_vars([real_name, imag_name])
+
+    mask_name = xds.attrs.get("scpy_mask_variable")
+    if mask_name in xds.data_vars:
+        xds[mask_name] = xds[mask_name].astype(bool)
+        xds[mask_name].attrs.pop("scpy_mask_encoding", None)
+
+    return xds
+
+
+def _handle_xarray_netcdf_backend_error(exc: Exception):
+    message = str(exc)
+    if (
+        "did not find a match in any of xarray's currently installed IO backends"
+        in message
+    ):
+        raise SpectroChemPyError(
+            "NetCDF I/O requires xarray plus an available NetCDF backend. "
+            "Install xarray and use the scipy backend or another xarray-compatible backend.",
+        ) from exc
+    raise exc
 
 
 # ======================================================================================
@@ -1460,6 +1557,39 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
 
         return xds
 
+    def to_netcdf(self, filename=None, **kwargs):
+        """
+        Persist this dataset to NetCDF using the canonical xarray mapping.
+
+        The NetCDF prototype is intentionally narrow:
+
+        - one `NDDataset`;
+        - default coordinates only;
+        - explicit mask variable support;
+        - JSON-compatible metadata only;
+        - complex data persisted through a split real/imag convention.
+
+        Parameters
+        ----------
+        filename : path-like or file-like, optional
+            Destination path or writable file-like object. If omitted, return
+            the serialized NetCDF bytes produced by xarray.
+        **kwargs
+            Additional keyword arguments forwarded to
+            `xarray.Dataset.to_netcdf()`. The default engine is `scipy`.
+
+        Returns
+        -------
+        object
+            The return value from `xarray.Dataset.to_netcdf()`.
+        """
+        kwargs.setdefault("engine", "scipy")
+        xds = _prepare_xarray_dataset_for_netcdf(self.to_xarray())
+        try:
+            return xds.to_netcdf(path=filename, **kwargs)
+        except Exception as exc:  # pragma: no cover - backend-dependent
+            _handle_xarray_netcdf_backend_error(exc)
+
     @classmethod
     def from_xarray(cls, dataset):
         """
@@ -1526,6 +1656,36 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             kwargs["mask"] = np.asarray(dataset[mask_name].data, dtype=bool)
 
         return cls(np.asarray(data_var.data), **kwargs)
+
+    @classmethod
+    def from_netcdf(cls, filename, **kwargs):
+        """
+        Reconstruct an `NDDataset` from the xarray-backed NetCDF prototype.
+
+        Parameters
+        ----------
+        filename : path-like or file-like
+            Source NetCDF file.
+        **kwargs
+            Additional keyword arguments forwarded to `xarray.open_dataset()`.
+            The default engine is `scipy`.
+
+        Returns
+        -------
+        NDDataset
+            Reconstructed dataset.
+        """
+        xr = import_optional_dependency("xarray")
+        kwargs.setdefault("engine", "scipy")
+
+        try:
+            with xr.open_dataset(filename, **kwargs) as xds:
+                xds.load()
+                restored = _restore_xarray_dataset_from_netcdf(xds)
+        except Exception as exc:  # pragma: no cover - backend-dependent
+            _handle_xarray_netcdf_backend_error(exc)
+
+        return cls.from_xarray(restored)
 
     def transpose(self, *dims, inplace=False):
         """

--- a/src/spectrochempy/lazyimport/dataset_methods.py
+++ b/src/spectrochempy/lazyimport/dataset_methods.py
@@ -33,6 +33,7 @@ _LAZY_DATASETS_IMPORTS = {
     "transpose": "spectrochempy.core.dataset.nddataset",
     "reshape": "spectrochempy.core.dataset.nddataset",
     "to_array": "spectrochempy.core.dataset.nddataset",
+    "to_netcdf": "spectrochempy.core.dataset.nddataset",
     "to_xarray": "spectrochempy.core.dataset.nddataset",
     "take": "spectrochempy.core.dataset.nddataset",
     "set_complex": "spectrochempy.core.dataset.nddataset",

--- a/tests/test_core/test_dataset/test_netcdf_mapping.py
+++ b/tests/test_core/test_dataset/test_netcdf_mapping.py
@@ -1,0 +1,129 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+import spectrochempy.core.dataset.nddataset as ndmodule
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.nddataset import NDDataset
+
+if importlib.util.find_spec("xarray") is not None:
+    import xarray as xr
+else:  # pragma: no cover - depends on optional dependency availability
+    xr = None
+
+
+def _make_dataset(data=None, *, complex_data=False):
+    if data is None:
+        if complex_data:
+            data = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]], dtype=np.complex128)
+        else:
+            data = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    return NDDataset(
+        data,
+        dims=["y", "x"],
+        coordset=[
+            Coord([10.0, 20.0], name="y", title="time", units="s"),
+            Coord([1000.0, 1200.0], name="x", title="wavenumber", units="cm^-1"),
+        ],
+        units="volt",
+        mask=np.array([[False, True], [False, False]]),
+        title="IR spectra",
+        name="spectra",
+        meta={
+            "sample": "demo",
+            "nested": {"temperature": 298.15, "labels": ["a", "b"]},
+            "count": 2,
+        },
+    )
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_simple_float_dataset(tmp_path):
+    ds = _make_dataset()
+    filename = tmp_path / "dataset.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    assert np.array_equal(rebuilt.data, ds.data)
+    assert tuple(rebuilt.dims) == tuple(ds.dims)
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_coordinates_units_mask_and_metadata(tmp_path):
+    ds = _make_dataset()
+    filename = tmp_path / "dataset.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    assert np.array_equal(rebuilt.coord("x").data, ds.coord("x").data)
+    assert np.array_equal(rebuilt.coord("y").data, ds.coord("y").data)
+    assert str(rebuilt.coord("x").units) == str(ds.coord("x").units)
+    assert str(rebuilt.units) == str(ds.units)
+    assert np.array_equal(rebuilt.mask, ds.mask)
+    assert rebuilt.meta["sample"] == "demo"
+    assert rebuilt.meta["nested"]["temperature"] == 298.15
+    assert rebuilt.name == ds.name
+    assert rebuilt.title == ds.title
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_complex_roundtrip_uses_split_real_imag_convention(tmp_path):
+    ds = _make_dataset(complex_data=True)
+    filename = tmp_path / "complex.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    with xr.open_dataset(filename, engine="scipy") as opened:
+        assert opened.attrs["scpy_complex_representation"] == "split-real-imag"
+        assert opened.attrs["scpy_complex_real"] == "spectra__real"
+        assert opened.attrs["scpy_complex_imag"] == "spectra__imag"
+        assert "spectra__real" in opened.data_vars
+        assert "spectra__imag" in opened.data_vars
+        assert "spectra" not in opened.data_vars
+
+    assert rebuilt.data.dtype == np.complex128
+    assert np.array_equal(rebuilt.data, ds.data)
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
+    ds = _make_dataset()
+    filename = tmp_path / "dataset.nc"
+
+    ds.to_netcdf(filename)
+
+    with xr.open_dataset(filename, engine="scipy") as opened:
+        assert opened.attrs["scpy_primary_variable"] == "spectra"
+        assert opened.attrs["scpy_mask_variable"] == "spectra__mask"
+        assert opened["spectra"].dims == ("y", "x")
+        assert opened["spectra__mask"].dims == ("y", "x")
+
+
+def test_netcdf_methods_raise_clear_error_when_xarray_is_missing(monkeypatch, tmp_path):
+    missing = ImportError("Missing optional dependency 'xarray'. Use conda or pip to install xarray.")
+    original_import_optional_dependency = ndmodule.import_optional_dependency
+
+    def fail_import(name, *args, **kwargs):
+        if name == "xarray":
+            raise missing
+        return original_import_optional_dependency(name, *args, **kwargs)
+
+    monkeypatch.setattr(ndmodule, "import_optional_dependency", fail_import)
+
+    ds = _make_dataset()
+    with pytest.raises(ImportError, match="Missing optional dependency 'xarray'"):
+        ds.to_netcdf(tmp_path / "dataset.nc")
+
+    with pytest.raises(ImportError, match="Missing optional dependency 'xarray'"):
+        NDDataset.from_netcdf(tmp_path / "dataset.nc")

--- a/tests/test_core/test_dataset/test_netcdf_mapping.py
+++ b/tests/test_core/test_dataset/test_netcdf_mapping.py
@@ -111,7 +111,9 @@ def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
 
 
 def test_netcdf_methods_raise_clear_error_when_xarray_is_missing(monkeypatch, tmp_path):
-    missing = ImportError("Missing optional dependency 'xarray'. Use conda or pip to install xarray.")
+    missing = ImportError(
+        "Missing optional dependency 'xarray'. Use conda or pip to install xarray."
+    )
     original_import_optional_dependency = ndmodule.import_optional_dependency
 
     def fail_import(name, *args, **kwargs):


### PR DESCRIPTION
## Summary
- add the `xarray-backed NetCDF Persistence` RFC
- implement a first `NDDataset.to_netcdf()` / `NDDataset.from_netcdf()` prototype built strictly on `NDDataset.to_xarray()` and `NDDataset.from_xarray()`
- cover numerical data, dims, default coordinates, units, explicit masks, JSON-compatible metadata, and complex round-trips through a split real/imag NetCDF convention
- update the reference/docs and changelog for the new portable NetCDF prototype

Closes #1152.

## Out of scope
- `Project`
- `ResultBase` / `AnalysisResult` / `FitResult`
- HyperComplex
- Zarr
- advanced `CoordSet` round-trip, aliases, or reference topology
- structured provenance

## Validation
- `pre-commit run --all-files`
- `conda run -n scpy-core python -m py_compile src/spectrochempy/core/dataset/nddataset.py src/spectrochempy/lazyimport/dataset_methods.py tests/test_core/test_dataset/test_netcdf_mapping.py`
- `conda run -n scpy-core python -m pytest tests/test_core/test_dataset/test_netcdf_mapping.py -q`

Note: local targeted pytest produced `1 passed, 4 skipped` because `xarray` is not installed in the local `scpy-core` environment. The explicit missing-dependency path is covered by test; full NetCDF/xarray round-trip coverage is expected in CI with the project test dependencies.
