### PR TITLE
FIX: support autosub along non-last dimensions

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -51,6 +51,10 @@ Bug Fixes
 
 - FIX: ``PLSRegression.intercept`` no longer crashes when the target
   dataset ``Y`` has no coordinate labels. (:pr:`1220`)
+- FIX: ``autosub()`` now supports subtraction along non-last dimensions
+  consistently with its ``dim`` parameter, and the regression tests now
+  cover both last-axis and non-last-axis synthetic cases. (`#1079
+  <https://github.com/spectrochempy/spectrochempy/issues/1079>`_)
 - FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -44,6 +44,10 @@ Bug Fixes
 
 - FIX: ``PLSRegression.intercept`` no longer crashes when the target
   dataset ``Y`` has no coordinate labels. (:pr:`1220`)
+- FIX: ``autosub()`` now supports subtraction along non-last dimensions
+  consistently with its ``dim`` parameter, and the regression tests now
+  cover both last-axis and non-last-axis synthetic cases. (`#1079
+  <https://github.com/spectrochempy/spectrochempy/issues/1079>`_)
 - FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.

--- a/src/spectrochempy/processing/transformation/autosub.py
+++ b/src/spectrochempy/processing/transformation/autosub.py
@@ -108,24 +108,23 @@ def autosub(
     ranges = tuple(np.array(ranges, dtype=float))
     # must be float to be considered as frequency for instance
 
-    coords = new.coordset[dim]
+    coords = new.coordset[-1]
     xrange = trim_ranges(*ranges, reversed=coords.reversed)
 
     s = []
     r = []
 
-    # TODO: this do not work obviously for axis != -1 - correct this
     for xpair in xrange:
         # determine the slices
 
         sl = slice(*xpair)
-        s.append(dataset[..., sl].data)
+        s.append(new[..., sl].data)
         r.append(ref[..., sl].data)
 
     X_r = np.concatenate((*s,), axis=-1)
     ref_r = np.concatenate((*r,), axis=-1).squeeze()
 
-    indices, _ = list(zip(*np.ndenumerate(X_r[..., 0]), strict=False))  # .squeeze())))
+    indices = list(np.ndindex(X_r.shape[:-1]))
 
     # two methods
     # @jit
@@ -153,7 +152,10 @@ def autosub(
 
     x = _minim()
 
-    new._data -= np.dot(x.reshape(-1, 1), ref.data.reshape(1, -1))
+    ref_data = np.asarray(ref.data).reshape(-1)
+    coef_shape = new.shape[:-1] + (1,)
+    ref_shape = (1,) * (new.ndim - 1) + (ref_data.size,)
+    new._data -= x.reshape(coef_shape) * ref_data.reshape(ref_shape)
 
     if swapped:
         new = new.swapdims(axis, -1)

--- a/tests/test_processing/test_transformation/test_autosub.py
+++ b/tests/test_processing/test_transformation/test_autosub.py
@@ -13,11 +13,28 @@ Tests for the ndplugin module.
 import numpy as np
 import pytest
 
+from spectrochempy import Coord
+from spectrochempy import NDDataset
 from spectrochempy.processing.transformation.autosub import autosub
 from spectrochempy.utils.mplutils import show
 
 # autosub
 # ------
+
+
+def _make_synthetic_autosub_dataset():
+    x = Coord(np.linspace(0.0, 5.0, 6), title="x")
+    y = Coord(np.linspace(0.0, 3.0, 4), title="y")
+
+    ref_x = np.array([0.5, -1.0, 2.0, 1.5, -0.25, 0.75])
+    coef_y = np.array([1.0, 2.0, -0.5, 0.25])
+    data = np.outer(coef_y, ref_x)
+
+    dataset = NDDataset(data, coordset=[y, x])
+    ref_last = NDDataset(ref_x, coordset=[x])
+    ref_first = NDDataset(coef_y, coordset=[y])
+
+    return dataset, ref_last, ref_first
 
 
 @pytest.mark.data
@@ -68,3 +85,36 @@ def test_autosub(IR_dataset_2D):
     # s6.plot()
 
     show()
+
+
+def test_autosub_synthetic_last_dimension():
+    dataset, ref_x, _ = _make_synthetic_autosub_dataset()
+
+    result = dataset.autosub(
+        ref_x,
+        [0.0, 2.0],
+        [3.0, 5.0],
+        dim="x",
+        method="ssdiff",
+        inplace=False,
+    )
+
+    np.testing.assert_allclose(
+        dataset.data, np.outer([1.0, 2.0, -0.5, 0.25], ref_x.data)
+    )
+    np.testing.assert_allclose(result.data, 0.0, atol=1.0e-10)
+
+
+def test_autosub_synthetic_non_last_dimension():
+    dataset, _, ref_y = _make_synthetic_autosub_dataset()
+
+    result = dataset.autosub(
+        ref_y,
+        [0.0, 1.0],
+        [2.0, 3.0],
+        dim="y",
+        method="ssdiff",
+        inplace=False,
+    )
+
+    np.testing.assert_allclose(result.data, 0.0, atol=1.0e-10)


### PR DESCRIPTION
## Summary

- fix `autosub()` so subtraction follows the selected dimension even when it is not the last axis
- generalize the coefficient application step so non-last-dimension subtraction works consistently
- add synthetic regression tests for both last-axis and non-last-axis `dim` usage
- document the user-facing fix in the changelog

## Out of scope

- redesigning the `autosub()` API
- interpolation for mismatched reference coordinates
- broader baseline or transformation cleanup

## Validation

- `conda run -n scpy-core python -m pytest tests/test_processing/test_transformation/test_autosub.py -q`
- `pre-commit run --all-files`

Closes #1079.