### PR TITLE
FIX: annotate savgol(deriv=n) output title and preserve metadata (#1095)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -37,6 +37,14 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- FIX: ``savgol(..., deriv=n)`` now annotates the output ``title`` with
+  the derivative order (e.g. ``"intensity (1st derivative)"``) so a
+  derived quantity is clearly identified. Units are kept as-is and
+  coordinates are preserved, consistent with the index-based
+  Savitzky-Golay path that does not validate even spacing.
+  (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
+
+
 - FIX: application startup now removes invalid JSON preference files only
   after closing them first, avoiding a Windows ``PermissionError`` during
   configuration initialisation when a stale file such as ``CP.json`` is

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -30,6 +30,14 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- FIX: ``savgol(..., deriv=n)`` now annotates the output ``title`` with
+  the derivative order (e.g. ``"intensity (1st derivative)"``) so a
+  derived quantity is clearly identified. Units are kept as-is and
+  coordinates are preserved, consistent with the index-based
+  Savitzky-Golay path that does not validate even spacing.
+  (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
+
+
 - FIX: application startup now removes invalid JSON preference files only
   after closing them first, avoiding a Windows ``PermissionError`` during
   configuration initialisation when a stale file such as ``CP.json`` is

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -179,6 +179,11 @@ and ‘nearest’.
             "cval": self.cval,
         }
 
+        # Reset the output-title annotation: only the Savitzky-Golay derivative
+        # path sets it, so every other method (and deriv=0) leaves the title as
+        # that of the input data.
+        self._output_title_suffix = None
+
         # smooth with moving average
         # --------------------------
         if self.method == "avg":
@@ -217,6 +222,17 @@ and ‘nearest’.
             # Change derived data sign if we have reversed coordinate axis
             if self._reversed and self.deriv:
                 data = data * (-1) ** self.deriv
+
+            # Annotate the output title so a derivative quantity is clearly
+            # identified. Units are intentionally kept as-is (the Savitzky-Golay
+            # path is index-based and does not validate even spacing, so we do
+            # not claim physically transformed units) and coordinates are
+            # preserved by the output wrapping.
+            if self.deriv:
+                ordinal = {1: "1st", 2: "2nd", 3: "3rd"}.get(
+                    self.deriv, f"{self.deriv}th"
+                )
+                self._output_title_suffix = f"({ordinal} derivative)"
 
         # Whittaker-Eilers filter
         # -----------------------

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -487,6 +487,12 @@ class _set_output:
                     X_transf.title = X.title
                 else:
                     X_transf.title = self.title
+                # Allow a processing method to annotate the output title (e.g. to
+                # flag a derived quantity) by exposing ``_output_title_suffix``
+                # on the instance, without having to override this decorator.
+                suffix = getattr(obj, "_output_title_suffix", None)
+                if suffix and X_transf.title:
+                    X_transf.title = f"{X_transf.title} {suffix}"
             # make coordset
             M, N = X.shape
 

--- a/tests/test_processing/test_filter/test_filter_shape.py
+++ b/tests/test_processing/test_filter/test_filter_shape.py
@@ -96,3 +96,50 @@ class TestFilterEdgeCases:
             dataset_2d_single_row
         )
         assert result.title == "IR spectrum", "Title should be preserved"
+
+
+class TestSavgolDerivativeMetadata:
+    """
+    Metadata contract for ``savgol(..., deriv=n)`` (issue #1095).
+
+    The Savitzky-Golay path is index-based and does not validate even spacing,
+    so the derivative output keeps the original units (no physically
+    transformed units are claimed), preserves the coordinate metadata, and its
+    title is annotated to make the derivative explicit.
+    """
+
+    @pytest.fixture
+    def dataset_2d_with_meta(self):
+        ds = NDDataset(np.random.rand(3, 100), title="intensity", units="absorbance")
+        ds.set_coordset(
+            x=scp.Coord(np.linspace(4000, 800, 100), title="wavenumber"),
+            y=scp.Coord([0, 1, 2], title="spectrum"),
+        )
+        return ds
+
+    @pytest.mark.parametrize("deriv, label", [(1, "1st"), (2, "2nd"), (3, "3rd")])
+    def test_deriv_title_is_explicit(self, dataset_2d_with_meta, deriv, label):
+        result = scp.savgol(dataset_2d_with_meta, size=7, order=3, deriv=deriv)
+        assert result.title == f"intensity ({label} derivative)", result.title
+
+    def test_deriv_higher_order_title(self, dataset_2d_with_meta):
+        result = scp.savgol(dataset_2d_with_meta, size=11, order=5, deriv=4)
+        assert result.title == "intensity (4th derivative)", result.title
+
+    def test_deriv_zero_keeps_title_unannotated(self, dataset_2d_with_meta):
+        result = scp.savgol(dataset_2d_with_meta, size=7, order=3, deriv=0)
+        assert result.title == "intensity", result.title
+
+    def test_deriv_preserves_coordinates(self, dataset_2d_with_meta):
+        result = scp.savgol(dataset_2d_with_meta, size=7, order=3, deriv=1)
+        assert result.coordset is not None
+        assert result.dims == ["y", "x"]
+        np.testing.assert_array_equal(
+            result.coord("x").data, dataset_2d_with_meta.coord("x").data
+        )
+
+    def test_deriv_keeps_original_units(self, dataset_2d_with_meta):
+        # Conservative: index-based derivative scaling is not tied to a
+        # validated physical spacing, so units are unchanged.
+        result = scp.savgol(dataset_2d_with_meta, size=7, order=3, deriv=1)
+        assert result.units == "absorbance", result.units


### PR DESCRIPTION
Fixes #1095.

## Summary

For `savgol(..., deriv=n)`, the output `NDDataset` title was an unchanged copy of the input title, so a derivative quantity was indistinguishable from the original data. This implements the focused metadata handling requested in #1095 — no new public derivative API is introduced.

## What changed

- **Title (the actual fix):** when `deriv > 0`, the output title is annotated with the derivative order, e.g. `"intensity (1st derivative)"` (1st/2nd/3rd, then `Nth`). `deriv = 0` and all non-savgol filter methods keep the input title unchanged.
- **Coordinates:** already preserved by the existing output wrapping (`_wrap_ndarray_output_to_nddataset` copies the coordset when the shape is unchanged); the new tests pin this so it doesn't regress.
- **Units — conservative, as discussed in #1095:** the Savitzky-Golay path is index-based and does not validate even spacing (the `savgol` docstring already states this). Since the derivative scaling is therefore not tied to a validated physical spacing/delta, the output **keeps the original units** rather than claiming physically transformed `U / X**n` units. This behavior is now documented by the regression tests.

## How

A small, generic output-title-suffix hook on `_wrap_ndarray_output_to_nddataset`: if the processing instance exposes `_output_title_suffix`, it is appended to the (kept) title. `Filter._transform` resets it to `None` at the top and the savgol branch sets it only when `deriv > 0`. The decorator already reads other instance attributes the same way (`obj.name`, `obj._restore_masked_data`, `getattr(obj, "_X_original_ndim", 2)`), so this is consistent with the existing pattern and touches no other method.

## Verification

- New `TestSavgolDerivativeMetadata` class: derivative title for `deriv = 1/2/3/4`, `deriv = 0` keeps the title unannotated, coordinates are preserved, and original units are kept.
- RED→GREEN confirmed: the title assertions fail on current `master` (title not annotated) and pass with this change; the coordinate/units assertions already pass (pinning the preserved behavior).
- `tests/test_processing/test_filter/` — **16 passed, 2 skipped**; the broader `tests/test_processing/` tree — **96 passed, 21 skipped**, no regressions from the shared-decorator change.
- `ruff check` clean on all changed files (no new lint errors introduced; pre-existing ones in `decorators.py` are untouched).
- Added a `Bug Fixes` entry to `changelog.rst` (per the repo's whatsnew convention).

This pull request was prepared with the assistance of AI, under my direction and review.
