### PR TITLE
ENH: portable round-trip of same-dimension CoordSet coordinates

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,17 +19,14 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
-- Added a first xarray-backed NetCDF prototype for `NDDataset` portable
-  persistence. The prototype builds strictly on the canonical
-  `NDDataset ↔ xarray.Dataset` mapping and covers numerical data, default
-  coordinates, units, explicit masks, JSON-compatible metadata, and complex
-  datasets through a split real/imag NetCDF convention.
-
-- Added a first ``NDDataset`` ↔ ``xarray`` prototype focused on portable
-  dataset exchange. Native ``xarray`` round-trips now cover numerical arrays,
-  dimension names/order, default coordinates, units, explicit masks,
-  ``name``/``title``, and JSON-compatible metadata, while richer ``CoordSet``
-  semantics remain outside this first implementation.
+- Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
+  numerical data, default coordinates, units, explicit masks,
+  JSON-compatible metadata, complex data (split real/imag convention),
+  ``name``/``title``, and auxiliary same-dimension ``CoordSet`` coordinates
+  (multiple numeric coordinates sharing a dimension). Auxiliary coordinates
+  are exported as non-dimension coordinates with ``scpy_coord_role`` and
+  ``scpy_owner_dim`` markers and restored on import with the dimension
+  coordinate as default.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,17 +15,14 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
-- Added a first xarray-backed NetCDF prototype for `NDDataset` portable
-  persistence. The prototype builds strictly on the canonical
-  `NDDataset ↔ xarray.Dataset` mapping and covers numerical data, default
-  coordinates, units, explicit masks, JSON-compatible metadata, and complex
-  datasets through a split real/imag NetCDF convention.
-
-- Added a first ``NDDataset`` ↔ ``xarray`` prototype focused on portable
-  dataset exchange. Native ``xarray`` round-trips now cover numerical arrays,
-  dimension names/order, default coordinates, units, explicit masks,
-  ``name``/``title``, and JSON-compatible metadata, while richer ``CoordSet``
-  semantics remain outside this first implementation.
+- Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
+  numerical data, default coordinates, units, explicit masks,
+  JSON-compatible metadata, complex data (split real/imag convention),
+  ``name``/``title``, and auxiliary same-dimension ``CoordSet`` coordinates
+  (multiple numeric coordinates sharing a dimension). Auxiliary coordinates
+  are exported as non-dimension coordinates with ``scpy_coord_role`` and
+  ``scpy_owner_dim`` markers and restored on import with the dimension
+  coordinate as default.
 
 Bug Fixes
 ~~~~~~~~~

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -1470,6 +1470,11 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         """
         Convert a NDDataset instance to an `~xarray.Dataset` object.
 
+        Same-dimension ``CoordSet`` coordinates (multiple numeric coordinates
+        sharing a dimension) are exported as a dimension coordinate for the
+        default coordinate and non-dimension coordinates for auxiliary
+        coordinates, with ``scpy_coord_role`` and ``scpy_owner_dim`` markers.
+
         Warning: the xarray library must be available.
 
         Returns
@@ -1486,22 +1491,58 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         primary_name = self._name if self._name else "data"
 
         coords = {}
+        aux_vars = []
         for dim in dims:
             coord = self.coord(dim)
             if coord is None or coord.is_empty:
                 continue
 
-            coord_attrs = {"scpy_coord_role": "default"}
-            if coord.units is not None:
-                coord_attrs["units"] = str(coord.units)
-            if coord.title != "<untitled>":
-                coord_attrs["scpy_title"] = coord.title
+            if isinstance(coord, CoordSet) and coord.is_same_dim:
+                default_coord = coord.default
+                coord_attrs = {"scpy_coord_role": "default", "scpy_default": dim}
+                if default_coord.units is not None:
+                    coord_attrs["units"] = str(default_coord.units)
+                if default_coord.title != "<untitled>":
+                    coord_attrs["scpy_title"] = default_coord.title
 
-            coords[dim] = xr.DataArray(
-                np.asarray(coord.data),
-                dims=(dim,),
-                attrs=coord_attrs,
-            )
+                coords[dim] = xr.DataArray(
+                    np.asarray(default_coord.data),
+                    dims=(dim,),
+                    attrs=coord_attrs,
+                )
+
+                for i, c in enumerate(coord.coords):
+                    if i == coord.default_index:
+                        continue
+                    aux_var = f"{dim}_aux_{i:04d}"
+                    aux_attrs = {
+                        "scpy_coord_role": "auxiliary",
+                        "scpy_owner_dim": dim,
+                    }
+                    if c.units is not None:
+                        aux_attrs["units"] = str(c.units)
+                    if c.title != "<untitled>":
+                        aux_attrs["scpy_title"] = c.title
+                    aux_vars.append(
+                        (
+                            aux_var,
+                            dim,
+                            np.asarray(c.data),
+                            aux_attrs,
+                        )
+                    )
+            else:
+                coord_attrs = {"scpy_coord_role": "default", "scpy_default": dim}
+                if coord.units is not None:
+                    coord_attrs["units"] = str(coord.units)
+                if coord.title != "<untitled>":
+                    coord_attrs["scpy_title"] = coord.title
+
+                coords[dim] = xr.DataArray(
+                    np.asarray(coord.data),
+                    dims=(dim,),
+                    attrs=coord_attrs,
+                )
 
         meta = {}
         skipped_meta_keys = []
@@ -1545,6 +1586,13 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             attrs=dataset_attrs,
         )
 
+        for var_name, var_dim, var_data, var_attrs in aux_vars:
+            xds.coords[var_name] = xr.DataArray(
+                var_data,
+                dims=(var_dim,),
+                attrs=var_attrs,
+            )
+
         if self.is_masked:
             mask_name = f"{primary_name}__mask"
             xds[mask_name] = xr.DataArray(
@@ -1561,10 +1609,15 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         """
         Persist this dataset to NetCDF using the canonical xarray mapping.
 
+        Auxiliary same-dimension coordinates are persisted automatically
+        through the underlying ``to_xarray()`` output.
+
         The NetCDF prototype is intentionally narrow:
 
         - one `NDDataset`;
         - default coordinates only;
+        - auxiliary same-dimension coordinates (``CoordSet`` sharing a
+          dimension);
         - explicit mask variable support;
         - JSON-compatible metadata only;
         - complex data persisted through a split real/imag convention.
@@ -1595,9 +1648,16 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         """
         Build a minimal `NDDataset` instance from an `xarray.Dataset`.
 
-        This prototype covers numerical data, default coordinates, units, masks,
-        JSON-compatible metadata, title, and name. Rich CoordSet semantics and
-        backend-specific persistence are intentionally out of scope here.
+        This prototype covers numerical data, default coordinates, auxiliary
+        same-dimension coordinates, units, masks, JSON-compatible metadata,
+        title, and name.
+
+        Auxiliary coordinates are detected by ``scpy_coord_role`` and
+        ``scpy_owner_dim`` attributes and reassembled into a same-dimension
+        ``CoordSet`` with the dimension coordinate as the default.
+
+        Rich CoordSet semantics and backend-specific persistence are
+        intentionally out of scope here.
         """
         xr = import_optional_dependency("xarray")
         if xr is None:
@@ -1625,6 +1685,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         dims = tuple(data_var.dims)
 
         coordset = []
+        aux_dims = set()
         for dim in dims:
             if dim in data_var.coords:
                 xr_coord = data_var.coords[dim]
@@ -1635,7 +1696,32 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
                 title = xr_coord.attrs.get("scpy_title")
                 if title is not None:
                     kwargs["title"] = title
-                coordset.append(Coord(np.asarray(xr_coord.data), **kwargs))
+                dim_coord = Coord(np.asarray(xr_coord.data), **kwargs)
+
+                aux_coords = []
+                for aux_name in sorted(dataset.coords):
+                    if aux_name == dim:
+                        continue
+                    var = dataset.coords[aux_name]
+                    if (
+                        var.attrs.get("scpy_coord_role") == "auxiliary"
+                        and var.attrs.get("scpy_owner_dim") == dim
+                    ):
+                        kwargs_aux = {"name": aux_name}
+                        units_aux = var.attrs.get("units")
+                        if units_aux is not None:
+                            kwargs_aux["units"] = units_aux
+                        title_aux = var.attrs.get("scpy_title")
+                        if title_aux is not None:
+                            kwargs_aux["title"] = title_aux
+                        aux_coords.append(Coord(np.asarray(var.data), **kwargs_aux))
+
+                if aux_coords:
+                    aux_dims.add(dim)
+                    inner = CoordSet(dim_coord, *aux_coords, sorted=False)
+                    coordset.append(inner)
+                else:
+                    coordset.append(dim_coord)
             else:
                 coordset.append(None)
 
@@ -1655,12 +1741,27 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         if mask_name in dataset.data_vars:
             kwargs["mask"] = np.asarray(dataset[mask_name].data, dtype=bool)
 
-        return cls(np.asarray(data_var.data), **kwargs)
+        result = cls(np.asarray(data_var.data), **kwargs)
+
+        # Identify the default coordinate explicitly for each same-dim CoordSet.
+        for dim in aux_dims:
+            inner = result._coordset.coords[result._coordset.names.index(dim)]
+            dim_data = np.asarray(data_var.coords[dim].data)
+            for j, c in enumerate(inner.coords):
+                if np.array_equal(np.asarray(c.data), dim_data):
+                    if j != inner._default:
+                        inner._default = j
+                    break
+
+        return result
 
     @classmethod
     def from_netcdf(cls, filename, **kwargs):
         """
         Reconstruct an `NDDataset` from the xarray-backed NetCDF prototype.
+
+        Same-dimension ``CoordSet`` auxiliary coordinates are restored
+        automatically from the xarray coordinate attributes.
 
         Parameters
         ----------

--- a/tests/test_core/test_dataset/test_netcdf_mapping.py
+++ b/tests/test_core/test_dataset/test_netcdf_mapping.py
@@ -11,6 +11,7 @@ import pytest
 
 import spectrochempy.core.dataset.nddataset as ndmodule
 from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 
 if importlib.util.find_spec("xarray") is not None:
@@ -108,6 +109,72 @@ def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
         assert opened.attrs["scpy_mask_variable"] == "spectra__mask"
         assert opened["spectra"].dims == ("y", "x")
         assert opened["spectra__mask"].dims == ("y", "x")
+
+
+def _make_same_dim_netcdf_dataset():
+    coord_y = Coord([10.0, 20.0, 30.0], name="y", title="time", units="s")
+    coord_x = Coord(
+        [1000.0, 1100.0, 1200.0, 1300.0, 1400.0],
+        name="x",
+        title="wavenumber",
+        units="cm^-1",
+    )
+    coord_x2 = Coord(
+        [1.0, 1.25, 1.5, 1.75, 2.0], name="x2", title="wavelength", units="µm"
+    )
+    inner_x = CoordSet(coord_x, coord_x2, sorted=False)
+    return NDDataset(
+        np.random.default_rng(42).random((3, 5)),
+        dims=["y", "x"],
+        coordset=[coord_y, inner_x],
+        name="spectra",
+    )
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_same_dim_structure(tmp_path):
+    ds = _make_same_dim_netcdf_dataset()
+    filename = tmp_path / "same_dim.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    inner = rebuilt.coord("x")
+    assert inner.is_same_dim
+    assert len(inner.coords) == 2
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_auxiliary_coord_values(tmp_path):
+    ds = _make_same_dim_netcdf_dataset()
+    filename = tmp_path / "same_dim.nc"
+    orig_inner = ds.coord("x")
+    orig_aux_data = [c.data for c in orig_inner.coords if c is not orig_inner.default][
+        0
+    ]
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    new_inner = rebuilt.coord("x")
+    new_aux_data = [c.data for c in new_inner.coords if c is not new_inner.default][0]
+    assert np.allclose(new_aux_data, orig_aux_data)
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_same_dim_roundtrip_preserves_default_coordinate(tmp_path):
+    ds = _make_same_dim_netcdf_dataset()
+    filename = tmp_path / "same_dim.nc"
+    orig_inner = ds.coord("x")
+    orig_default = orig_inner.default
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    new_inner = rebuilt.coord("x")
+    assert new_inner.default is not None
+    assert new_inner.default.title == orig_default.title
+    assert np.allclose(new_inner.default.data, orig_default.data)
 
 
 def test_netcdf_methods_raise_clear_error_when_xarray_is_missing(monkeypatch, tmp_path):

--- a/tests/test_core/test_dataset/test_xarray_mapping.py
+++ b/tests/test_core/test_dataset/test_xarray_mapping.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 
 if importlib.util.find_spec("xarray") is not None:
@@ -122,3 +123,175 @@ def test_xarray_roundtrip_preserves_complex_dtype():
     assert xds["spectra"].dtype == np.complex128
     assert rebuilt.data.dtype == np.complex128
     assert np.array_equal(rebuilt.data, ds.data)
+
+
+def _make_same_dim_dataset():
+    coord_y = Coord([10.0, 20.0, 30.0], name="y", title="time", units="s")
+    coord_x = Coord(
+        [1000.0, 1100.0, 1200.0, 1300.0, 1400.0],
+        name="x",
+        title="wavenumber",
+        units="cm^-1",
+    )
+    coord_x2 = Coord(
+        [1.0, 1.25, 1.5, 1.75, 2.0], name="x2", title="wavelength", units="µm"
+    )
+    inner_x = CoordSet(coord_x, coord_x2, sorted=False)
+    return NDDataset(
+        np.random.default_rng(42).random((3, 5)),
+        dims=["y", "x"],
+        coordset=[coord_y, inner_x],
+        name="spectra",
+    )
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+class TestSameDimCoordRoundtrip:
+    def test_export_contains_auxiliary_coord(self):
+        ds = _make_same_dim_dataset()
+        xds = ds.to_xarray()
+        aux_names = [
+            n
+            for n in xds.coords
+            if xds.coords[n].attrs.get("scpy_coord_role") == "auxiliary"
+        ]
+        assert len(aux_names) == 1
+        assert aux_names[0] == "x_aux_0001"
+
+    def test_export_auxiliary_coord_has_correct_attrs(self):
+        ds = _make_same_dim_dataset()
+        xds = ds.to_xarray()
+        # Aux coord is _2 = wavenumber (cm⁻¹) — default is _1 = wavelength (µm)
+        aux = xds.coords["x_aux_0001"]
+        assert aux.attrs["scpy_coord_role"] == "auxiliary"
+        assert aux.attrs["scpy_owner_dim"] == "x"
+        assert aux.attrs["units"] == "cm⁻¹"
+        assert aux.attrs["scpy_title"] == "wavenumber"
+
+    def test_export_dim_coord_has_default_marker(self):
+        ds = _make_same_dim_dataset()
+        xds = ds.to_xarray()
+        assert xds.coords["x"].attrs["scpy_coord_role"] == "default"
+        assert xds.coords["x"].attrs["scpy_default"] == "x"
+
+    def test_roundtrip_preserves_same_dim_structure(self):
+        ds = _make_same_dim_dataset()
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        inner = rebuilt.coord("x")
+        assert hasattr(inner, "is_same_dim")
+        assert inner.is_same_dim
+        assert len(inner.coords) == 2
+
+    def test_roundtrip_preserves_default_coordinate(self):
+        ds = _make_same_dim_dataset()
+        orig_inner = ds.coord("x")
+        orig_default = orig_inner.default
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        inner = rebuilt.coord("x")
+        assert inner.default is not None
+        assert inner.default.title == orig_default.title
+        assert str(inner.default.units) == str(orig_default.units)
+        assert np.allclose(inner.default.data, orig_default.data)
+
+    def test_roundtrip_preserves_auxiliary_coordinate_values(self):
+        ds = _make_same_dim_dataset()
+        orig_inner = ds.coord("x")
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        new_inner = rebuilt.coord("x")
+        # Find the aux coord (non-default) in rebuilt and verify values
+        orig_aux_data = [
+            c.data for c in orig_inner.coords if c is not orig_inner.default
+        ][0]
+        new_aux_data = [c.data for c in new_inner.coords if c is not new_inner.default][
+            0
+        ]
+        assert np.allclose(new_aux_data, orig_aux_data)
+
+    def test_roundtrip_preserves_numerical_data(self):
+        ds = _make_same_dim_dataset()
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        assert np.allclose(rebuilt.data, ds.data)
+
+    def test_roundtrip_preserves_aux_coord_ordering(self):
+        coord_x3 = Coord([0.5, 1.0, 1.5, 2.0, 2.5], title="energy", units="eV")
+        inner_x3 = CoordSet(
+            Coord(
+                [1000.0, 1100.0, 1200.0, 1300.0, 1400.0],
+                title="wavenumber",
+                units="cm^-1",
+            ),
+            Coord([1.0, 1.25, 1.5, 1.75, 2.0], title="wavelength", units="µm"),
+            coord_x3,
+            sorted=False,
+        )
+        ds = NDDataset(
+            np.random.default_rng(42).random((3, 5)),
+            dims=["y", "x"],
+            coordset=[
+                Coord([10.0, 20.0, 30.0], title="time", units="s"),
+                inner_x3,
+            ],
+        )
+        orig_titles = {c.title for c in ds.coord("x").coords}
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        new_titles = {c.title for c in rebuilt.coord("x").coords}
+        assert new_titles == orig_titles
+        assert len(new_titles) == 3
+
+    def test_roundtrip_multiple_dims_with_aux(self):
+        coord_y = Coord([10.0, 20.0, 30.0], title="time", units="s")
+        coord_y2 = Coord([0.0, 50.0, 100.0], title="temperature", units="C")
+        inner_y = CoordSet(coord_y2, coord_y, sorted=False)
+        coord_x = Coord(
+            [1000.0, 1100.0, 1200.0, 1300.0, 1400.0], title="wavenumber", units="cm^-1"
+        )
+        coord_x2 = Coord([1.0, 1.25, 1.5, 1.75, 2.0], title="wavelength", units="µm")
+        inner_x = CoordSet(coord_x, coord_x2, sorted=False)
+        ds = NDDataset(
+            np.random.default_rng(42).random((3, 5)),
+            dims=["y", "x"],
+            coordset=[inner_y, inner_x],
+        )
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        for dim in ("y", "x"):
+            orig_inner = ds.coord(dim)
+            new_inner = rebuilt.coord(dim)
+            assert new_inner.is_same_dim
+            assert len(new_inner.coords) == len(orig_inner.coords)
+        assert np.allclose(rebuilt.data, ds.data)
+
+    def test_default_independent_of_construction_order(self):
+        """
+        Default after round-trip is always the xarray dim coord,
+        regardless of the original CoordSet pass order.
+        """
+        coord_y = Coord([10.0, 20.0, 30.0], name="y", title="time", units="s")
+        # Two coords with different names and data values
+        wavenumber = Coord(
+            [1000.0, 1100.0], name="x", title="wavenumber", units="cm^-1"
+        )
+        wavelength = Coord([1.0, 1.25], name="x2", title="wavelength", units="µm")
+        pass_orders = [
+            [wavenumber, wavelength],
+            [wavelength, wavenumber],
+        ]
+        for coords in pass_orders:
+            inner_x = CoordSet(*coords, sorted=False)
+            ds = NDDataset(
+                np.random.default_rng(42).random((3, 2)),
+                dims=["y", "x"],
+                coordset=[coord_y, inner_x],
+            )
+            # Determine which coord became the dim coord (default) in this original
+            orig_default = ds.coord("x").default
+            xds = ds.to_xarray()
+            rebuilt = NDDataset.from_xarray(xds)
+            new_default = rebuilt.coord("x").default
+            assert new_default.title == orig_default.title
+            assert np.allclose(new_default.data, orig_default.data)


### PR DESCRIPTION
Summary of changes
- to_xarray(): exports same-dim CoordSets — default coord as dimension coordinate with scpy_default, auxiliary coords as non-dimension coordinates with scpy_coord_role and scpy_owner_dim
- from_xarray(): detects auxiliary coords by marker attrs, rebuilds same-dim CoordSet, identifies the default by data matching and sets _default explicitly (independent of internal _finalize_child_coordset sorting)
- to_netcdf() / from_netcdf(): unchanged — scpy_* string attrs survive natively
- Changelog and docstrings updated

Intentionally out of scope
- User select() changes are not preserved (default always = the dim coord)
- Non-numeric coords, labels, aliases, Coord.meta