### PR TITLE
ENH: portable xarray/NetCDF round-trip — same-dim coords and string labels

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -22,11 +22,17 @@ New Features
 - Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
-  ``name``/``title``, and auxiliary same-dimension ``CoordSet`` coordinates
-  (multiple numeric coordinates sharing a dimension). Auxiliary coordinates
-  are exported as non-dimension coordinates with ``scpy_coord_role`` and
-  ``scpy_owner_dim`` markers and restored on import with the dimension
-  coordinate as default.
+  ``name``/``title``, auxiliary same-dimension ``CoordSet`` coordinates
+  (multiple numeric coordinates sharing a dimension), and portable string
+  labels on coordinates (1D string-only, ``None`` preserved via metadata
+  marker). Auxiliary coordinates are exported as non-dimension coordinates with
+  ``scpy_coord_role`` and ``scpy_owner_dim`` markers and restored on import
+  with the dimension coordinate as default. Portable string labels are
+  exported as non-dimension coordinate variables with
+  ``scpy_coord_role="label"`` and restored on import. Non-exportable labels
+  (mixed types, datetime, multi-row) trigger an explicit
+  :class:`~spectrochempy.utils._logging.warning_` instead of silent
+  omission. (:issue:`1227`)
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,11 +18,17 @@ New Features
 - Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
-  ``name``/``title``, and auxiliary same-dimension ``CoordSet`` coordinates
-  (multiple numeric coordinates sharing a dimension). Auxiliary coordinates
-  are exported as non-dimension coordinates with ``scpy_coord_role`` and
-  ``scpy_owner_dim`` markers and restored on import with the dimension
-  coordinate as default.
+  ``name``/``title``, auxiliary same-dimension ``CoordSet`` coordinates
+  (multiple numeric coordinates sharing a dimension), and portable string
+  labels on coordinates (1D string-only, ``None`` preserved via metadata
+  marker). Auxiliary coordinates are exported as non-dimension coordinates with
+  ``scpy_coord_role`` and ``scpy_owner_dim`` markers and restored on import
+  with the dimension coordinate as default. Portable string labels are
+  exported as non-dimension coordinate variables with
+  ``scpy_coord_role="label"`` and restored on import. Non-exportable labels
+  (mixed types, datetime, multi-row) trigger an explicit
+  :class:`~spectrochempy.utils._logging.warning_` instead of silent
+  omission. (:issue:`1227`)
 
 Bug Fixes
 ~~~~~~~~~

--- a/maintainers/rfcs/coord-labels-portable-semantics.md
+++ b/maintainers/rfcs/coord-labels-portable-semantics.md
@@ -1,0 +1,459 @@
+# Coord Labels Portable Semantics
+
+**Status:** Proposed Maintainer RFC
+
+**Scope:** Semantic classification of `Coord.labels` for portable persistence
+through the existing `NDDataset ↔ xarray.Dataset ↔ NetCDF` chain.
+
+**Out of scope:** Code, PR, API changes, aliases, references, `Coord.meta`,
+numeric same-dimension coordinates (already handled), `Project` persistence,
+`Result` persistence, or backward-incompatible changes to the current label
+model.
+
+**Related documents:**
+
+- `maintainers/rfcs/nddataset-xarray-mapping-specification.md`
+- `maintainers/rfcs/xarray-backed-netcdf-persistence.md`
+- `audit/~portable-coordset-enrichment-audit.md`
+- `audit/~portable-same-dim-coords-progress.md`
+
+---
+
+## Motivation
+
+`Coord.labels` is the last major `CoordSet` feature without a portable
+persistence story. Numeric default coordinates and numeric auxiliary same-
+dimension coordinates are now covered. Labels are different: they are
+semantically heterogeneous, dtype-flexible, often multi-row, and used in ways
+that blur the line between coordinate values, annotations, metadata, and plot
+decorations.
+
+A clear portable semantics decision is needed before implementing, because:
+
+- the current serialization silently drops labels — no warning, no error;
+- several readers (OPUS, JCAMP, Omnic, SPC, CSV) populate labels with
+  acquisition metadata that users may expect to survive round-trip;
+- the xarray mapping RFC explicitly lists labels as an open question;
+- the enrichment audit recommends deferring labels to a dedicated RFC.
+
+This RFC resolves that open question by classifying label usages and defining
+which subset is portable.
+
+---
+
+## Current label model
+
+### Inheritance
+
+- `NDArray` defines `labels` as a trait (property + setter, `ndarray.py:1553`).
+- `Coord` inherits directly (always 1D, labels sliced alongside data on `__getitem__`).
+- `CoordSet.labels` is a read-only list delegating to each stored `Coord`.
+- `NDDataset` has `_labels_allowed = False` — direct labels are disabled.
+  Dataset-level labels live only inside the coordinates of `CoordSet`.
+
+### Storage
+
+`Coord.labels` is stored as a NumPy array of dtype `object`. Its shape is:
+
+- `(N,)` for single-row labels — one label per coordinate point;
+- `(M, N)` for multi-row labels — M rows of N labels.
+
+There is no restriction on element types. Observed values include strings,
+datetimes, `None`, numeric strings, and filenames.
+
+### Construction
+
+Labels are passed as a `labels=` keyword argument to the `Coord` constructor
+or set later via the property setter.
+
+### Display
+
+Labels are displayed in `Coord.__repr__` via `str(self.labels.T).strip()` and
+used as tick labels in 1D and 2D plots (`plot1d.py`, `plot2d.py`).
+
+### Serialization (current)
+
+- **xarray/NetCDF**: silently dropped — `to_xarray()` does not export labels;
+  `from_xarray()` does not reconstruct them.
+- **JSON utils**: special-cased — object-dtype label arrays are converted via
+  `.tolist()` before encoding (`jsonutils.py:330`).
+- **SCP/PSCP native**: labels are preserved through native serialization
+  (trusted path, not portable).
+
+---
+
+## Observed usages
+
+### Category 1: Sample / acquisition identification
+
+Used as point annotations on the y-dimension (or x) to identify individual
+acquisitions. Common patterns:
+
+- acquisition dates and times (OPUS, JCAMP)
+- filenames (OPUS, Omnic)
+- sample names (CSV, download examples)
+- channel names (Quadera)
+- compound / species names (kinetic utilities, PLS)
+
+These are **scientific metadata** — they identify which physical sample or
+acquisition produced a given data point.
+
+### Category 2: Plot labels (synthetic)
+
+Synthetic labels generated for display:
+
+- `f"#{i}"` iteration labels (`decorators.py`)
+- auto-generated labels for plot legends
+
+These are **display conveniences** — they have no scientific meaning outside
+the session.
+
+### Category 3: Multi-field annotations
+
+Multi-row labels where each row carries a different kind of information:
+
+- (acquisition date, title, filename) — OPUS reader
+- (datetime, species name, replicate) — kinetic experiments
+
+These mix semantics within a single `Coord.labels` array.
+
+### Category 4: Target / reference names
+
+Used in analysis contexts:
+
+- PLS target variable names (`pls.py`)
+- Component names in kinetic modeling
+
+These are **structural model metadata** — they identify which output variable
+or component a coordinate value corresponds to.
+
+### Category 5: Coordinate-like numeric labels
+
+Rare: labels used as quasi-coordinate values (e.g., channel indices stored as
+labels rather than as coordinate data). Not recommended but present in legacy
+code.
+
+---
+
+## Label categories
+
+| Category | Scientific value | Structural role | Portability priority |
+|---|---|---|---|
+| 1. Acquisition identifiers | High | Annotation | Should be portable |
+| 2. Synthetic plot labels | None | Display | Not portable |
+| 3. Multi-field annotations | Medium | Annotation | Conditional |
+| 4. Target / reference names | High | Model metadata | Should be portable |
+| 5. Coordinate-like values | Medium | Structural (misplaced) | Out of scope |
+
+---
+
+## Portable semantics
+
+### Guaranteed
+
+A label is portable if it satisfies **all** of:
+
+1. **1D string-only**: labels are a single row of strings (dtype `object`
+   containing only `str` elements), one per coordinate point.
+2. **Same length as the owning coordinate**: `len(labels) == len(coord)`.
+3. **No mixed types**: all elements are `str` (or `None` representing missing).
+
+This subset corresponds to the most common portable case: acquisition
+identifiers, sample names, and target names that are already strings.
+
+### Warning on non-exportable labels
+
+Labels that exist but are not part of the guaranteed portable subset MUST NOT
+disappear silently. When export encounters non-exportable labels, an explicit
+warning MUST be emitted:
+
+```text
+PortableWarning:
+Coord labels were not exported because they are not part of the
+supported portable label subset.
+```
+
+The exact mechanism (Python `warnings.warn` vs structured logging) is an
+implementation detail, but the requirement is behavioural: the user must be
+notified that label information was dropped.
+
+### Best effort
+
+Multi-row string labels where all elements are strings and each row has the
+same length. These could be represented as multiple 1D string coordinates in
+xarray, each with a deterministic naming convention. However, the
+interpretation of each row's semantics is lost without additional metadata.
+
+### Not portable
+
+- Object-dtype arrays containing non-string elements (numeric, mixed).
+- Multi-row labels where rows have different semantic roles.
+- Labels longer than the owning coordinate.
+- Synthetic display-only labels (`f"#{i}"`).
+- Labels used as structural coordinate values.
+
+### Deferred
+
+- **Datetime labels** — previously classified as not portable. Reclassified as
+  deferred because datetime-valued labels (acquisition dates, timestamps) carry
+  genuine scientific metadata and are common in reader output. A future phase
+  could map datetime ↔ ISO 8601 string at export time if a real need is
+  identified. For now, datetime labels trigger the non-exportable warning.
+
+---
+
+## xarray mapping options
+
+### Option A: Labels as 1D string coordinate variable
+
+Export single-row string labels as a non-dimension coordinate variable on the
+owning dimension:
+
+```python
+xds.coords["{dim}_labels"] = xr.DataArray(
+    labels_array,  # string array
+    dims=(dim,),
+    attrs={"scpy_coord_role": "label", "scpy_owner_dim": dim},
+)
+```
+
+**Pros:** natural xarray representation; survives NetCDF as a string variable;
+visible to external tools; reconstructible.
+
+**Cons:** only works for 1D string labels; multi-row needs additional
+convention; NetCDF string variable length limits may apply.
+
+### Option B: Labels as JSON-encoded attr
+
+Store labels as a JSON string in the coordinate's attrs:
+
+```python
+coord_attrs["scpy_labels"] = json.dumps(labels.tolist())
+```
+
+**Pros:** handles multi-row and mixed types; no new variable in xarray; no
+NetCDF dtype issues; works with any shape.
+
+**Cons:** invisible to external tools; opaque; no xarray indexing; fragile for
+large label arrays.
+
+### Option C: Labels as a separate data variable
+
+Store labels as a dedicated data variable in the xarray Dataset:
+
+```python
+xds["{dim}_labels"] = xr.DataArray(
+    labels_array,
+    dims=(dim,) if labels.ndim == 1 else (dim, "label_row"),
+    attrs={"scpy_role": "label", "scpy_owner_dim": dim},
+)
+```
+
+**Pros:** handles multi-row cleanly with an extra dimension; visible to
+external tools; reconstructible.
+
+**Cons:** introduces a synthetic dimension for multi-row labels; not a
+coordinate (does not participate in xarray indexing); more complex
+reconstruction contract.
+
+### Option D: No export (status quo)
+
+Do not export labels. Document that labels are not portable and recommend
+native SCP/PSCP for label preservation.
+
+**Pros:** zero implementation cost; no backward compatibility risk; no xarray
+mapping ambiguity.
+
+**Cons:** silently drops user data; several readers populate labels with
+scientifically meaningful metadata; users lose information on xarray/NetCDF
+round-trip.
+
+### Comparison
+
+| Criterion | A (string coord) | B (JSON attr) | C (separate var) | D (none) |
+|---|---|---|---|---|
+| Scientific visibility | High | Low | High | None |
+| External tool access | Yes | No | Yes | No |
+| Multi-row support | No | Yes | Yes | N/A |
+| Non-string support | No | Yes | No | N/A |
+| Implementation cost | Medium | Low | Medium | Zero |
+| Backward compat risk | Low | Low | Low | None |
+| Reconstruction | Trivial | Trivial | Medium | N/A |
+
+---
+
+## NetCDF constraints
+
+### String arrays
+
+NetCDF3 (scipy engine) supports fixed-length strings. NetCDF4 supports
+variable-length strings. Both can represent 1D string coordinate variables.
+
+Practical limitations:
+
+- very long strings may be truncated by the scipy engine;
+- NetCDF3 does not support variable-length UTF-8 natively;
+- Python object dtype is not supported — arrays must be explicitly converted to
+  string type before writing.
+
+### Multi-dimensional string arrays
+
+xarray can represent multi-dimensional string arrays, but each string dimension
+must be an explicit xarray dimension. For multi-row labels, this means:
+
+```python
+dims = (dim, f"{dim}_label_row")
+```
+
+This introduces a synthetic dimension that has no scientific meaning outside
+SpectroChemPy.
+
+### Object dtype
+
+Object arrays cannot be written directly to NetCDF. They must be converted:
+
+- strings → fixed or variable-length string arrays (xarray handles this);
+- datetimes → numeric or string representation;
+- mixed types → not representable without loss.
+
+### scipy engine compatibility
+
+The current NetCDF prototype defaults to the `scipy` engine (NetCDF3).
+Variable-length strings and multi-dimensional string variables are possible
+but more fragile than numeric arrays.
+
+---
+
+## Round-trip contract
+
+### `NDDataset → xarray → NDDataset` (string labels)
+
+```text
+GUARANTEED:
+    labels = ["a", "b", "c"] (1D, all str, len == N)
+    → survives as string coordinate variable
+    → reconstructed as np.array(["a", "b", "c"], dtype=object)
+```
+
+```text
+BEST EFFORT:
+    labels = [["a1", "b1"], ["a2", "b2"]] (2D, all str)
+    → may survive as multi-dim string variable
+    → reconstruction depends on explicit dimension handling
+```
+
+```text
+NOT GUARANTEED:
+    labels = ["a", 1, None, "b"]  # mixed types
+    labels = ["a", "b"]  # len != N
+```
+
+```text
+DEFERRED:
+    labels = [datetime(2024, 1, 1), datetime(2024, 1, 2)]
+    → not portable today; potential ISO 8601 string representation
+```
+
+### `NDDataset → NetCDF → NDDataset` (string labels)
+
+Same contract as xarray, plus:
+
+```text
+LIMITATIONS:
+    - scipy engine may truncate very long strings
+    - multi-row labels require synthetic dimensions
+    - non-string labels must be converted or rejected
+```
+
+---
+
+## Recommendation
+
+### Phase 2a: String-only 1D labels (Option A — recommended)
+
+**Scope:**
+
+- Export single-row string-only labels as 1D non-dimension coordinate
+  variables with `scpy_coord_role = "label"` and `scpy_owner_dim = <dim>`.
+- Import: detect `scpy_coord_role == "label"`, reconstruct labels as
+  `np.array(..., dtype=object)`.
+- Multi-row labels, non-string labels, datetime labels, and mixed types are
+  **not exported** and MUST trigger a warning (e.g. `PortableWarning`).
+- Labels must NOT disappear silently.
+
+**Rationale:**
+
+- Catches the most common portable case (acquisition identifiers, sample names).
+- Maps cleanly to xarray/NetCDF string variables.
+- External tools can read the labels.
+- Low implementation risk.
+- Clear migration path for Phase 2b.
+
+**Naming convention:**
+
+```text
+{dim}_labels
+e.g., "y_labels", "x_labels"
+```
+
+**Export only when** `labels.ndim == 1` and all elements are `str` or `None`.
+
+### Phase 2b: Multi-row metadata encoding (Option B as fallback)
+
+If multi-row string labels are common enough to justify the complexity:
+
+- Export the primary label row as a 1D string coordinate (Phase 2a);
+- Encode remaining rows as a JSON string in the coordinate attrs under
+  `scpy_labels_extra`;
+- Document that extra rows are best-effort metadata, not portable structural
+  data.
+
+**Rationale:** avoids the synthetic-dimension problem while preserving
+ancillary information for SpectroChemPy round-trip.
+
+### Deferred
+
+- **Datetime labels** — deferred rather than excluded. Datetime-valued labels
+  (acquisition dates, timestamps) carry scientific metadata and are common in
+  reader output. A future phase could map `datetime ↔ ISO 8601 string` at
+  export time if a real need is identified.
+- Non-string labels (numeric, mixed).
+- Multi-row labels as multi-dimensional coordinate variables (Option C).
+- Label-based indexing guarantees through the portable path.
+
+### Excluded
+
+- Synthetic display labels (`f"#{i}"`).
+- Labels used as coordinate values.
+- Full backward compatibility with legacy label serialization edge cases.
+
+---
+
+## Open questions
+
+1. Should a `scpy_label_rows` attr be emitted to record the original number of
+   rows for multi-row labels that get partially exported?
+
+2. Should the warning mechanism use Python `warnings.warn` with a dedicated
+   `PortableWarning` subclass, or use the existing `warning_()` utility?
+
+3. Should `from_xarray()` accept external xarray string coordinate variables
+   (without `scpy_coord_role`) as label candidates, or require explicit markers?
+
+4. Should the Phase 2a naming convention reserve `{dim}_labels` so that a
+   future Phase 2b does not need to rename existing exports?
+
+---
+
+## Conclusion
+
+| Question | Answer |
+|---|---|---|
+| Support labels now? | Yes, for 1D string-only labels (Phase 2a). |
+| Scope? | Single-row `str` elements only. Multi-row and datetime deferred. |
+| Representation? | 1D non-dimension coordinate variable with `scpy_coord_role`. |
+| Limits? | No non-string, no multi-row as variables, no synthetic display labels. |
+| Warning? | Yes — non-exportable labels trigger an explicit warning. |
+
+**Recommended next step:** implement Phase 2a as a short follow-up PR after
+the same-dimension numeric coordinate PR.

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -84,6 +84,41 @@ def _normalize_json_compatible(value: Any) -> Any:
     raise TypeError(f"Value of type {type(value).__name__} is not JSON-compatible")
 
 
+def _is_portable_labels(labels):
+    """Return True if labels are exportable as portable string labels."""
+    if labels is None or labels.ndim != 1 or len(labels) == 0:
+        return False
+    return all(isinstance(v, str) or v is None for v in labels)
+
+
+def _export_labels(coord, dim, aux_vars):
+    """Append label export variables to *aux_vars* or emit a warning."""
+    labels = coord.labels
+    if labels is None or not coord.is_labeled:
+        return
+    if _is_portable_labels(labels):
+        safe = np.array(["" if v is None else v for v in labels])
+        attrs = {"scpy_coord_role": "label", "scpy_owner_dim": dim}
+        none_mask = np.array([v is None for v in labels])
+        if np.any(none_mask):
+            attrs["scpy_label_none_mask"] = json.dumps(
+                none_mask.tolist(), sort_keys=True
+            )
+        aux_vars.append(
+            (
+                f"{dim}_labels",
+                dim,
+                np.asarray(safe, dtype=str),
+                attrs,
+            )
+        )
+    else:
+        warning_(
+            f"Labels on dimension '{dim}' were not exported because they are "
+            "not part of the supported portable label subset.",
+        )
+
+
 def _prepare_xarray_dataset_for_netcdf(dataset):
     """Convert a canonical xarray Dataset into a NetCDF-safe representation."""
     xds = dataset.copy(deep=True)
@@ -1475,6 +1510,11 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         default coordinate and non-dimension coordinates for auxiliary
         coordinates, with ``scpy_coord_role`` and ``scpy_owner_dim`` markers.
 
+        Portable string labels on coordinates (1D string-only labels with no
+        mixed types) are exported as non-dimension coordinate variables with
+        ``scpy_coord_role="label"``. Non-exportable labels trigger a warning.
+
+
         Warning: the xarray library must be available.
 
         Returns
@@ -1531,6 +1571,8 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
                             aux_attrs,
                         )
                     )
+
+                _export_labels(default_coord, dim, aux_vars)
             else:
                 coord_attrs = {"scpy_coord_role": "default", "scpy_default": dim}
                 if coord.units is not None:
@@ -1543,6 +1585,8 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
                     dims=(dim,),
                     attrs=coord_attrs,
                 )
+
+                _export_labels(coord, dim, aux_vars)
 
         meta = {}
         skipped_meta_keys = []
@@ -1650,11 +1694,16 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
 
         This prototype covers numerical data, default coordinates, auxiliary
         same-dimension coordinates, units, masks, JSON-compatible metadata,
-        title, and name.
+        title, name, and portable string labels.
 
         Auxiliary coordinates are detected by ``scpy_coord_role`` and
         ``scpy_owner_dim`` attributes and reassembled into a same-dimension
         ``CoordSet`` with the dimension coordinate as the default.
+
+        Portable string labels are restored from non-dimension coordinates with
+        ``scpy_coord_role="label"`` and associated with the owning dimension's
+        coordinate via ``scpy_owner_dim``.
+
 
         Rich CoordSet semantics and backend-specific persistence are
         intentionally out of scope here.
@@ -1752,6 +1801,30 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
                     if j != inner._default:
                         inner._default = j
                     break
+
+        # Restore portable string labels.
+        for label_name in sorted(dataset.coords):
+            var = dataset.coords[label_name]
+            if var.attrs.get("scpy_coord_role") != "label":
+                continue
+            owner_dim = var.attrs.get("scpy_owner_dim")
+            if owner_dim is None:
+                continue
+            try:
+                idx = result._coordset.names.index(owner_dim)
+            except (ValueError, AttributeError):
+                continue
+            target = result._coordset.coords[idx]
+            if isinstance(target, CoordSet) and target.is_same_dim:
+                target = target.default
+            label_data = np.asarray(var.data, dtype=object)
+            none_mask = var.attrs.get("scpy_label_none_mask")
+            if none_mask is not None:
+                mask = json.loads(none_mask)
+                for i, is_none in enumerate(mask):
+                    if is_none:
+                        label_data[i] = None
+            target.labels = label_data
 
         return result
 

--- a/tests/test_core/test_dataset/test_xarray_mapping.py
+++ b/tests/test_core/test_dataset/test_xarray_mapping.py
@@ -295,3 +295,208 @@ class TestSameDimCoordRoundtrip:
             new_default = rebuilt.coord("x").default
             assert new_default.title == orig_default.title
             assert np.allclose(new_default.data, orig_default.data)
+
+
+def _make_labeled_dataset(labels=None, same_dim=False):
+    """Create a dataset with string labels on the x coord."""
+    if labels is None:
+        labels = ["peak_a", "peak_b", "peak_c", "peak_d", "peak_e"]
+
+    data = np.random.default_rng(42).random((3, 5))
+    coord_y = Coord([10.0, 20.0, 30.0], name="y", title="time", units="s")
+
+    if same_dim:
+        coord_x = Coord(
+            [1000.0, 1100.0, 1200.0, 1300.0, 1400.0],
+            name="x",
+            title="wavenumber",
+            units="cm^-1",
+        )
+        coord_x2 = Coord(
+            [1.0, 1.25, 1.5, 1.75, 2.0], name="x2", title="wavelength", units="µm"
+        )
+        inner_x = CoordSet(coord_x, coord_x2, sorted=False)
+        ds = NDDataset(
+            data, dims=["y", "x"], coordset=[coord_y, inner_x], name="spectra"
+        )
+        ds.coord("x").default.labels = labels
+        return ds
+
+    coord_x = Coord(
+        [1000.0, 1100.0, 1200.0, 1300.0, 1400.0],
+        name="x",
+        title="wavenumber",
+        units="cm^-1",
+    )
+    ds = NDDataset(data, dims=["y", "x"], coordset=[coord_y, coord_x], name="spectra")
+    ds.coord("x").labels = labels
+    return ds
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+class TestLabelExportImport:
+    def test_string_labels_exported_as_coord_variable(self):
+        ds = _make_labeled_dataset()
+        xds = ds.to_xarray()
+        assert "x_labels" in xds.coords
+        assert xds.coords["x_labels"].attrs["scpy_coord_role"] == "label"
+        assert xds.coords["x_labels"].attrs["scpy_owner_dim"] == "x"
+        assert list(xds.coords["x_labels"].values) == [
+            "peak_a",
+            "peak_b",
+            "peak_c",
+            "peak_d",
+            "peak_e",
+        ]
+
+    def test_string_labels_xarray_roundtrip(self):
+        ds = _make_labeled_dataset()
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        assert list(rebuilt.coord("x").labels) == [
+            "peak_a",
+            "peak_b",
+            "peak_c",
+            "peak_d",
+            "peak_e",
+        ]
+
+    def test_string_labels_with_none_xarray_roundtrip(self):
+        labels = ["A", None, "C", None, "E"]
+        ds = _make_labeled_dataset(labels=labels)
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        exported = list(xds.coords["x_labels"].values)
+        assert exported == ["A", "", "C", "", "E"]
+        imported = list(rebuilt.coord("x").labels)
+        assert imported == ["A", None, "C", None, "E"]
+
+    def test_no_labels_unchanged(self):
+        ds = _make_dataset()
+        xds = ds.to_xarray()
+        label_vars = [
+            n
+            for n in xds.coords
+            if xds.coords[n].attrs.get("scpy_coord_role") == "label"
+        ]
+        assert label_vars == []
+
+    def test_mixed_type_labels_emit_warning(self):
+        labels = np.array(["A", 42, "C", "D", "E"], dtype=object)
+        ds = _make_labeled_dataset(labels=labels)
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            xds = ds.to_xarray()
+            label_vars = [
+                n
+                for n in xds.coords
+                if xds.coords[n].attrs.get("scpy_coord_role") == "label"
+            ]
+            assert label_vars == []
+            assert any("not exported" in str(msg.message) for msg in w)
+
+    def test_datetime_labels_emit_warning(self):
+        labels = np.array(
+            [
+                np.datetime64("2024-01-01"),
+                np.datetime64("2024-06-15"),
+                np.datetime64("2024-07-04"),
+                np.datetime64("2024-10-31"),
+                np.datetime64("2025-01-01"),
+            ],
+            dtype=object,
+        )
+        ds = _make_labeled_dataset(labels=labels)
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            xds = ds.to_xarray()
+            label_vars = [
+                n
+                for n in xds.coords
+                if xds.coords[n].attrs.get("scpy_coord_role") == "label"
+            ]
+            assert label_vars == []
+            assert any("not exported" in str(msg.message) for msg in w)
+
+    def test_multi_row_labels_emit_warning(self):
+        ds = NDDataset(
+            np.array([1.0, 2.0, 3.0]),
+            dims=["x"],
+            coordset=[Coord([10.0, 20.0, 30.0], name="x")],
+        )
+        labels = np.array([["A", "B"], ["C", "D"], ["E", "F"]], dtype=object)
+        ds.coord("x").labels = labels
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            xds = ds.to_xarray()
+            label_vars = [
+                n
+                for n in xds.coords
+                if xds.coords[n].attrs.get("scpy_coord_role") == "label"
+            ]
+            assert label_vars == []
+            assert any("not exported" in str(msg.message) for msg in w)
+
+    def test_labels_on_same_dim_default_coord_roundtrip(self):
+        ds = _make_labeled_dataset(same_dim=True)
+        xds = ds.to_xarray()
+        rebuilt = NDDataset.from_xarray(xds)
+        assert list(rebuilt.coord("x").default.labels) == [
+            "peak_a",
+            "peak_b",
+            "peak_c",
+            "peak_d",
+            "peak_e",
+        ]
+
+    def test_labels_on_same_dim_exported_with_scpy_markers(self):
+        ds = _make_labeled_dataset(same_dim=True)
+        xds = ds.to_xarray()
+        assert "x_labels" in xds.coords
+        assert xds.coords["x_labels"].attrs["scpy_coord_role"] == "label"
+        assert xds.coords["x_labels"].attrs["scpy_owner_dim"] == "x"
+
+    def test_netcdf_roundtrip_preserves_string_labels(self, tmp_path):
+        ds = _make_labeled_dataset()
+        filename = tmp_path / "labels.nc"
+        ds.to_netcdf(filename)
+        rebuilt = NDDataset.from_netcdf(filename)
+        assert list(rebuilt.coord("x").labels) == [
+            "peak_a",
+            "peak_b",
+            "peak_c",
+            "peak_d",
+            "peak_e",
+        ]
+
+    def test_netcdf_roundtrip_preserves_labels_with_none(self, tmp_path):
+        labels = ["X", None, "Z"]
+        ds = NDDataset(
+            np.array([1.0, 2.0, 3.0]),
+            dims=["x"],
+            coordset=[Coord([10.0, 20.0, 30.0], name="x")],
+        )
+        ds.coord("x").labels = labels
+        filename = tmp_path / "labels_none.nc"
+        ds.to_netcdf(filename)
+        rebuilt = NDDataset.from_netcdf(filename)
+        assert list(rebuilt.coord("x").labels) == ["X", None, "Z"]
+
+    def test_labels_exported_only_for_labeled_dims(self):
+        coord_x = Coord([1.0, 2.0, 3.0], name="x")
+        coord_y = Coord([10.0, 20.0], name="y")
+        ds = NDDataset(
+            np.ones((2, 3)),
+            dims=["y", "x"],
+            coordset=[coord_y, coord_x],
+        )
+        ds.coord("x").labels = ["A", "B", "C"]
+        xds = ds.to_xarray()
+        assert "x_labels" in xds.coords
+        assert "y_labels" not in xds.coords


### PR DESCRIPTION

## Summary

Extends `NDDataset.to_xarray()` / `from_xarray()` and the NetCDF prototype (`to_netcdf()` / `from_netcdf()`) with support for:

### Phase 1 — Same-dimension numeric coordinates
- Auxiliary numeric coordinates in a `CoordSet` sharing a dimension are exported as non-dimension coordinates with `scpy_coord_role` and `scpy_owner_dim` markers
- Default coordinate identified by data matching on import (avoids CoordSet sorting dependency)
- NetCDF round-trip works without additional changes

### Phase 2a — Portable string labels
- 1D string-only labels (with `None` support) exported as `{dim}_labels` coords with `scpy_coord_role="label"`
- `None` preserved via `scpy_label_none_mask` JSON boolean attribute
- Non-exportable labels (mixed types, datetime, multi-row) emit an explicit warning via `warning_()`

## Changelog

Single consolidated entry under `New Features`.

## Tests

36 tests total (24 xarray + 12 NetCDF), all passing.
