### PR TITLE
BUG: preserve Coord labels when copying Coord into CoordSet

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -45,7 +45,14 @@ Bug Fixes
   derived quantity is clearly identified. Units are kept as-is and
   coordinates are preserved, consistent with the index-based
   Savitzky-Golay path that does not validate even spacing.
-  (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
+   (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
+
+
+- FIX: ``Coord`` labels are no longer silently dropped when a labeled
+  ``Coord`` is copied into a ``CoordSet`` (e.g.
+  ``CoordSet(labeled_coord)``). The ``CoordSet`` constructor creates a copy
+  via ``Coord(coord, copy=True)``, which now propagates labels from the
+  source coordinate. (:pr:`1229`)
 
 
 - FIX: application startup now removes invalid JSON preference files only

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -38,7 +38,14 @@ Bug Fixes
   derived quantity is clearly identified. Units are kept as-is and
   coordinates are preserved, consistent with the index-based
   Savitzky-Golay path that does not validate even spacing.
-  (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
+   (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
+
+
+- FIX: ``Coord`` labels are no longer silently dropped when a labeled
+  ``Coord`` is copied into a ``CoordSet`` (e.g.
+  ``CoordSet(labeled_coord)``). The ``CoordSet`` constructor creates a copy
+  via ``Coord(coord, copy=True)``, which now propagates labels from the
+  source coordinate. (:pr:`1229`)
 
 
 - FIX: application startup now removes invalid JSON preference files only

--- a/src/spectrochempy/core/dataset/basearrays/ndarray.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndarray.py
@@ -236,6 +236,10 @@ class NDArray(tr.HasTraits):
         if self._labels_allowed:
             self.labels = kwargs.pop("labels", None)
 
+        # Propagate labels from source data when no explicit labels passed.
+        if self._labels is None and isinstance(data, NDArray) and data.is_labeled:
+            self._labels = data._labels.copy() if self._copy else data._labels
+
         self.title = kwargs.pop("title", self.title)
 
         mask = kwargs.pop("mask", NOMASK)

--- a/tests/test_core/test_dataset/test_coord_behavior.py
+++ b/tests/test_core/test_dataset/test_coord_behavior.py
@@ -484,3 +484,21 @@ class TestCoordIndexing:
         c = Coord([10, 20, 30], name="x")
         sliced = c[0:2]
         assert sliced.name == "x"
+
+
+class TestCoordCopyLabels:
+    """Label preservation across Coord copy operations."""
+
+    def test_coord_copy_preserves_labels(self):
+        c = Coord([1, 2, 3], name="x")
+        c.labels = ["a", "b", "c"]
+        c2 = c.copy()
+        assert list(c2.labels) == ["a", "b", "c"]
+
+    def test_coord_copy_labels_independent(self):
+        c = Coord([1, 2, 3], name="x")
+        c.labels = ["a", "b", "c"]
+        c2 = c.copy()
+        c2.labels[0] = "modified"
+        assert c.labels[0] == "a"
+        assert c2.labels[0] == "modified"

--- a/tests/test_core/test_dataset/test_coordset_behavior.py
+++ b/tests/test_core/test_dataset/test_coordset_behavior.py
@@ -739,6 +739,22 @@ class TestCoordSetEdgeCases:
         # labels are returned as list of arrays
         assert len(cs.labels[0]) == 3
 
+    def test_labels_preserved_when_coord_passed_to_coordset(self):
+        """Labels set after Coord construction survive CoordSet copy."""
+        c = Coord([1, 2, 3], name="x")
+        c.labels = ["a", "b", "c"]
+        cs = CoordSet(c)
+        assert cs.is_labeled
+        assert list(cs.labels[0]) == ["a", "b", "c"]
+
+    def test_labels_preserved_in_same_dim_coordset(self):
+        """Labels on a coord in a same-dim CoordSet survive."""
+        c1 = Coord([1, 2, 3], name="a", labels=["x", "y", "z"])
+        c2 = Coord([4, 5, 6], name="b")
+        cs = CoordSet([c1, c2])
+        # After _finalize_child_coordset the default is _1 (sorted)
+        assert cs["x"].is_labeled
+
     def test_select_changes_default(self):
         c1 = Coord([1, 2, 3], name="x")
         c2 = Coord([10, 20], name="y")


### PR DESCRIPTION

## Bug

When a labeled `Coord` is passed to `CoordSet()`, the constructor copies it via `Coord(coord, copy=True)` but does **not** propagate `labels` from the source `Coord`. The labels are silently lost.

## Root Cause

In `NDArray.__init__` (`src/spectrochempy/core/dataset/basearrays/ndarray.py`), the labels setter is called with `kwargs.pop("labels", None)`. When no explicit `labels` kwarg is provided (which is the case when `CoordSet` copies a coord), `self._labels` remains `None` even if the source `data` is a labeled `NDArray`.

## Fix

After the labels setter call, if `self._labels` is still `None` and `data` is a labeled `NDArray` instance, propagate the source labels:



`NDArray.copy()` already preserves labels via the `_attributes_` mechanism — explicit tests confirm this.

## Tests

- `Coord(labels=...) -> CoordSet(coord)` preserves labels
- Labels set after `Coord` construction survive `CoordSet` copy
- Same-dim `CoordSet` preserves labels
- `Coord.copy()` preserves labels
- Copied labels are independent (deep copy isolation)
