### PR TITLE
BUG: fix stale parent references on Project replacement

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -89,6 +89,12 @@ Bug Fixes
   attribute ``self._n_iter``, causing an ``AttributeError`` after a
   successful fit. (:pr:`1216`)
 
+- FIX: ``Project.__setitem__`` no longer leaves a stale ``parent``
+  reference on the displaced child after replacement. Replacing a dataset
+  or subproject via ``project["x"] = new_value`` now correctly sets
+  ``old_value.parent = None``, matching the ownership invariant
+  established by the Project Invariants RFC. (:pr:`1230`, :pr:`1231`)
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -82,6 +82,12 @@ Bug Fixes
   attribute ``self._n_iter``, causing an ``AttributeError`` after a
   successful fit. (:pr:`1216`)
 
+- FIX: ``Project.__setitem__`` no longer leaves a stale ``parent``
+  reference on the displaced child after replacement. Replacing a dataset
+  or subproject via ``project["x"] = new_value`` now correctly sets
+  ``old_value.parent = None``, matching the ownership invariant
+  established by the Project Invariants RFC. (:pr:`1230`, :pr:`1231`)
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -248,11 +248,15 @@ class Project(AbstractProject, NDIO):
             )
 
         if key in self.datasets_names:
+            old = self._datasets[key]
             value.parent = self
             self._datasets[key] = value
+            old._parent = None
         elif key in self.projects_names:
+            old = self._projects[key]
             value.parent = self
             self._projects[key] = value
+            old._parent = None
         else:
             # the key does not exist
             self._set_from_type(value, name=key)

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -243,9 +243,11 @@ class TestSetItem:
         # Create initial items
         if item_type == "dataset":
             proj.add_dataset(NDDataset([1, 2, 3], name="item"))
+            old = proj["item"]
             initial = NDDataset([4, 5, 6], name="item")
         else:
             proj.add_project(Project(name="item"))
+            old = proj["item"]
             initial = Project(name="item")
 
         # Update
@@ -253,6 +255,7 @@ class TestSetItem:
 
         assert proj["item"] is initial
         assert initial.parent == proj
+        assert old.parent is None
 
 
 class TestGetAttr:
@@ -537,7 +540,7 @@ class TestProjectOwnershipCharacterization:
 class TestProjectReplacementCharacterization:
     """Characterization tests for current replacement semantics."""
 
-    def test_replace_dataset_keeps_new_parent_and_leaves_old_parent_stale(self):
+    def test_replace_dataset_detaches_old_child_parent(self):
         proj = Project(name="root")
         old = NDDataset([1, 2, 3], name="item")
         new = NDDataset([4, 5, 6], name="replacement")
@@ -549,11 +552,11 @@ class TestProjectReplacementCharacterization:
         assert proj["item"] is not old
         assert old not in proj.datasets
         assert new.parent is proj
-        assert old.parent is proj
+        assert old.parent is None
         assert new.name == "replacement"
         assert proj["item"].name != "item"
 
-    def test_replace_subproject_keeps_new_parent_and_leaves_old_parent_stale(self):
+    def test_replace_subproject_detaches_old_child_parent(self):
         proj = Project(name="root")
         old = Project(name="item")
         new = Project(name="replacement")
@@ -565,9 +568,63 @@ class TestProjectReplacementCharacterization:
         assert proj["item"] is not old
         assert old not in proj.projects
         assert new.parent is proj
-        assert old.parent is proj
+        assert old.parent is None
         assert new.name == "replacement"
         assert proj["item"].name != "item"
+
+    def test_replace_dataset_old_child_detached_even_with_prior_parent(self):
+        proj = Project(name="root")
+        other = Project(name="other")
+        old = NDDataset([1, 2, 3], name="item")
+        new = NDDataset([4, 5, 6], name="replacement")
+
+        other.add_dataset(old)
+        proj.add_dataset(new)
+        proj["item"] = old
+        proj["item"] = new
+
+        assert new.parent is proj
+        assert old.parent is None
+
+    def test_replace_subproject_old_child_detached_even_with_prior_parent(self):
+        proj = Project(name="root")
+        other = Project(name="other")
+        old = Project(name="item")
+        new = Project(name="replacement")
+
+        other.add_project(old)
+        proj.add_project(new)
+        proj["item"] = old
+        proj["item"] = new
+
+        assert new.parent is proj
+        assert old.parent is None
+
+    def test_replace_dataset_does_not_affect_unrelated_children(self):
+        proj = Project(name="root")
+        old = NDDataset([1, 2, 3], name="item")
+        unrelated = NDDataset([7, 8, 9], name="other")
+        new = NDDataset([4, 5, 6], name="replacement")
+
+        proj.add_dataset(old)
+        proj.add_dataset(unrelated)
+        proj["item"] = new
+
+        assert old.parent is None
+        assert unrelated.parent is proj
+
+    def test_replace_subproject_does_not_affect_unrelated_children(self):
+        proj = Project(name="root")
+        old = Project(name="item")
+        unrelated = Project(name="other")
+        new = Project(name="replacement")
+
+        proj.add_project(old)
+        proj.add_project(unrelated)
+        proj["item"] = new
+
+        assert old.parent is None
+        assert unrelated.parent is proj
 
 
 class TestProjectNameMutationCharacterization:


### PR DESCRIPTION
## Summary

When an existing member is replaced via `project["x"] = new_child`,
the displaced child no longer retains a stale `parent` pointer to the
project.  The old child's `parent` is now correctly set to `None`.

**RFC:** `maintainers/rfcs/project-invariants-rfc.md` — Ownership
invariant 4: "A child must never retain an obsolete parent reference
after replacement, removal, or move."

## Scope

- Dataset replacement via `__setitem__`
- Subproject replacement via `__setitem__`

## What changed

`src/spectrochempy/core/project/project.py` — `__setitem__` now saves
the old child reference before replacement and sets `old._parent = None`
after the dict entry is updated, matching the pattern used by
`remove_dataset` / `remove_project`.

Preserved:
- existing replacement behavior
- type checking (existing key with different type → `ValueError`)
- API
- persistence

## Tests

- Updated 2 characterization tests to reflect the corrected behavior
  (`old.parent is proj` → `old.parent is None`)
- Extended `test_setitem_update_existing` to verify `old.parent is None`
- Added 4 new tests: old child with prior parent, unrelated children
  unaffected

## Validation

```
78 passed in 17.11s
```

## Related

- PR #1230 — characterization tests
- Issue #1164
- RFC: `maintainers/rfcs/project-invariants-rfc.md`

## Next

```
Ready for duplicate-policy PR
```