### PR TITLE
BUG: align duplicate handling across Project children

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -40,7 +40,7 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
-- FIX: ``savgol(..., deriv=n)`` now annotates the output ``title`` with
+- ``savgol(..., deriv=n)`` now annotates the output ``title`` with
   the derivative order (e.g. ``"intensity (1st derivative)"``) so a
   derived quantity is clearly identified. Units are kept as-is and
   coordinates are preserved, consistent with the index-based
@@ -48,52 +48,59 @@ Bug Fixes
    (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
 
 
-- FIX: ``Coord`` labels are no longer silently dropped when a labeled
+- ``Coord`` labels are no longer silently dropped when a labeled
   ``Coord`` is copied into a ``CoordSet`` (e.g.
   ``CoordSet(labeled_coord)``). The ``CoordSet`` constructor creates a copy
   via ``Coord(coord, copy=True)``, which now propagates labels from the
   source coordinate. (:pr:`1229`)
 
 
-- FIX: application startup now removes invalid JSON preference files only
+- application startup now removes invalid JSON preference files only
   after closing them first, avoiding a Windows ``PermissionError`` during
   configuration initialisation when a stale file such as ``CP.json`` is
   encountered.
 
-- FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
+- ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
   ``whiten=False``. (:pr:`1219`)
 
-- FIX: ``PLSRegression.components`` now raises a clear ``AttributeError``
+- ``PLSRegression.components`` now raises a clear ``AttributeError``
   explaining that PLS has no single ``components`` matrix, instead of an
   unhelpful ``NotImplementedError``. (:pr:`1220`)
 
-- FIX: ``PLSRegression.intercept`` no longer crashes when the target
+- ``PLSRegression.intercept`` no longer crashes when the target
   dataset ``Y`` has no coordinate labels. (:pr:`1220`)
-- FIX: ``autosub()`` now supports subtraction along non-last dimensions
+- ``autosub()`` now supports subtraction along non-last dimensions
   consistently with its ``dim`` parameter, and the regression tests now
   cover both last-axis and non-last-axis synthetic cases. (`#1079
   <https://github.com/spectrochempy/spectrochempy/issues/1079>`_)
-- FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
+- handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.
   (:pr:`1210`)
 
-- FIX: pass the ``solver`` configuration parameter to the underlying
+- pass the ``solver`` configuration parameter to the underlying
   ``sklearn.decomposition.NMF`` object. Previously the parameter was
   accepted by the SpectroChemPy ``NMF`` estimator but silently ignored
   during sklearn initialisation, so the default solver was always used
   regardless of the configured value. (:pr:`1212`)
 
-- FIX: correct ``PLSRegression.n_iter`` property attribute name. Previously,
+- correct ``PLSRegression.n_iter`` property attribute name. Previously,
   the property referenced ``self._n_iter_`` instead of the actual stored
   attribute ``self._n_iter``, causing an ``AttributeError`` after a
   successful fit. (:pr:`1216`)
 
-- FIX: ``Project.__setitem__`` no longer leaves a stale ``parent``
+- ``Project.__setitem__`` no longer leaves a stale ``parent``
   reference on the displaced child after replacement. Replacing a dataset
   or subproject via ``project["x"] = new_value`` now correctly sets
   ``old_value.parent = None``, matching the ownership invariant
   established by the Project Invariants RFC. (:pr:`1230`, :pr:`1231`)
+
+- ``Project`` now raises ``ValueError`` when adding a dataset or
+  subproject whose name already exists in the project, instead of
+  auto-renaming datasets or silently overwriting subprojects. Both
+  child types now follow the same explicit-failure duplicate policy
+  defined by the Project Invariants RFC. Collisions between datasets
+  and subprojects are also caught. (:pr:`1232`)
 
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -33,7 +33,7 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
-- FIX: ``savgol(..., deriv=n)`` now annotates the output ``title`` with
+- ``savgol(..., deriv=n)`` now annotates the output ``title`` with
   the derivative order (e.g. ``"intensity (1st derivative)"``) so a
   derived quantity is clearly identified. Units are kept as-is and
   coordinates are preserved, consistent with the index-based
@@ -41,52 +41,59 @@ Bug Fixes
    (`#1095 <https://github.com/spectrochempy/spectrochempy/issues/1095>`_)
 
 
-- FIX: ``Coord`` labels are no longer silently dropped when a labeled
+- ``Coord`` labels are no longer silently dropped when a labeled
   ``Coord`` is copied into a ``CoordSet`` (e.g.
   ``CoordSet(labeled_coord)``). The ``CoordSet`` constructor creates a copy
   via ``Coord(coord, copy=True)``, which now propagates labels from the
   source coordinate. (:pr:`1229`)
 
 
-- FIX: application startup now removes invalid JSON preference files only
+- application startup now removes invalid JSON preference files only
   after closing them first, avoiding a Windows ``PermissionError`` during
   configuration initialisation when a stale file such as ``CP.json`` is
   encountered.
 
-- FIX: ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
+- ``FastICA.whitening`` now returns ``None`` (instead of crashing) when
   ``whiten=False``. (:pr:`1219`)
 
-- FIX: ``PLSRegression.components`` now raises a clear ``AttributeError``
+- ``PLSRegression.components`` now raises a clear ``AttributeError``
   explaining that PLS has no single ``components`` matrix, instead of an
   unhelpful ``NotImplementedError``. (:pr:`1220`)
 
-- FIX: ``PLSRegression.intercept`` no longer crashes when the target
+- ``PLSRegression.intercept`` no longer crashes when the target
   dataset ``Y`` has no coordinate labels. (:pr:`1220`)
-- FIX: ``autosub()`` now supports subtraction along non-last dimensions
+- ``autosub()`` now supports subtraction along non-last dimensions
   consistently with its ``dim`` parameter, and the regression tests now
   cover both last-axis and non-last-axis synthetic cases. (`#1079
   <https://github.com/spectrochempy/spectrochempy/issues/1079>`_)
-- FIX: handle SVD ``compute_uv=False`` outputs consistently. The private
+- handle SVD ``compute_uv=False`` outputs consistently. The private
   ``_outfit`` attribute is now always a ``(U, s, VT)`` tuple, fixing wrong
   values and crashes for all properties when ``compute_uv=False``.
   (:pr:`1210`)
 
-- FIX: pass the ``solver`` configuration parameter to the underlying
+- pass the ``solver`` configuration parameter to the underlying
   ``sklearn.decomposition.NMF`` object. Previously the parameter was
   accepted by the SpectroChemPy ``NMF`` estimator but silently ignored
   during sklearn initialisation, so the default solver was always used
   regardless of the configured value. (:pr:`1212`)
 
-- FIX: correct ``PLSRegression.n_iter`` property attribute name. Previously,
+- correct ``PLSRegression.n_iter`` property attribute name. Previously,
   the property referenced ``self._n_iter_`` instead of the actual stored
   attribute ``self._n_iter``, causing an ``AttributeError`` after a
   successful fit. (:pr:`1216`)
 
-- FIX: ``Project.__setitem__`` no longer leaves a stale ``parent``
+- ``Project.__setitem__`` no longer leaves a stale ``parent``
   reference on the displaced child after replacement. Replacing a dataset
   or subproject via ``project["x"] = new_value`` now correctly sets
   ``old_value.parent = None``, matching the ownership invariant
   established by the Project Invariants RFC. (:pr:`1230`, :pr:`1231`)
+
+- ``Project`` now raises ``ValueError`` when adding a dataset or
+  subproject whose name already exists in the project, instead of
+  auto-renaming datasets or silently overwriting subprojects. Both
+  child types now follow the same explicit-failure duplicate policy
+  defined by the Project Invariants RFC. Collisions between datasets
+  and subprojects are also caught. (:pr:`1232`)
 
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -519,16 +519,15 @@ class Project(AbstractProject, NDIO):
         >>> proj.add_dataset(ds1, name='Toto')
 
         """
-        dataset.parent = self
         if name is None:
             name = dataset.name
 
-        n = 1
-        while name in self.allnames:
-            # this name already exists
-            name = f"{dataset.name}-{n}"
-            n += 1
+        if name in self.allnames:
+            raise ValueError(
+                f"An object named '{name}' already exists in this project."
+            )
 
+        dataset.parent = self
         dataset.name = name
         self._datasets[name] = dataset
 
@@ -604,10 +603,16 @@ class Project(AbstractProject, NDIO):
             A project to add to the current one.
 
         """
-        proj.parent = self
         if name is None:
             name = proj.name
-        else:
+
+        if name in self.allnames:
+            raise ValueError(
+                f"An object named '{name}' already exists in this project."
+            )
+
+        proj.parent = self
+        if name != proj.name:
             proj.name = name
         self._projects[name] = proj
 

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -324,54 +324,79 @@ class TestCopy:
         assert "data" in copied.datasets_names
 
 
-class TestDuplicateNames:
-    """Tests for duplicate name handling."""
+class TestDuplicateNamesRFC:
+    """RFC-compliant duplicate name handling."""
 
-    @pytest.mark.parametrize(
-        "count,expected_name",
-        [
-            (1, "data"),
-            (2, "data-1"),
-            (3, "data-2"),
-        ],
-    )
-    def test_add_dataset_duplicate_names(self, ds1, count, expected_name):
-        proj = Project(name="test")
-        ds1.name = "data"
-        proj.add_dataset(ds1)
-
-        for i in range(1, count):
-            ds = NDDataset([i], name="data")
-            proj.add_dataset(ds)
-
-        assert "data" in proj.datasets_names
-        assert expected_name in proj.datasets_names
-
-    def test_add_dataset_duplicate_names_preserves_parent_membership_reciprocity(self):
+    def test_add_dataset_duplicate_raises_valueerror(self):
         proj = Project(name="test")
         first = NDDataset([1], name="data")
-        second = NDDataset([2], name="data")
-
         proj.add_dataset(first)
-        proj.add_dataset(second)
 
-        _assert_dataset_membership(proj, first, "data", present=True)
-        _assert_dataset_membership(proj, second, "data-1", present=True)
-        assert first.parent is proj
-        assert second.parent is proj
+        second = NDDataset([2], name="data")
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_dataset(second)
 
-    def test_add_project_duplicate_names_overwrites_and_leaves_stale_parent(self):
+    def test_add_project_duplicate_raises_valueerror(self):
         proj = Project(name="root")
         first = Project(name="child")
-        second = Project(name="child")
-
         proj.add_project(first)
-        proj.add_project(second)
 
-        _assert_project_membership(proj, second, "child", present=True)
-        assert proj["child"] is not first
-        assert first not in proj.projects
-        assert second.parent is proj
+        second = Project(name="child")
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_project(second)
+
+    def test_duplicate_dataset_dataset(self):
+        proj = Project(name="test")
+        proj.add_dataset(NDDataset([1], name="data"))
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_dataset(NDDataset([2], name="data"))
+
+    def test_duplicate_project_project(self):
+        proj = Project(name="test")
+        proj.add_project(Project(name="sub"))
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_project(Project(name="sub"))
+
+    def test_duplicate_dataset_project_collision(self):
+        proj = Project(name="test")
+        proj.add_dataset(NDDataset([1], name="shared"))
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_project(Project(name="shared"))
+
+    def test_duplicate_project_dataset_collision(self):
+        proj = Project(name="test")
+        proj.add_project(Project(name="shared"))
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_dataset(NDDataset([1], name="shared"))
+
+    def test_constructor_duplicate_raises_valueerror(self):
+        ds1 = NDDataset([1], name="data")
+        ds2 = NDDataset([2], name="data")
+        with pytest.raises(ValueError, match="already exists"):
+            Project(ds1, ds2)
+
+    def test_duplicate_does_not_modify_ownership_on_failure(self):
+        proj = Project(name="test")
+        ds = NDDataset([1], name="data")
+        proj.add_dataset(ds)
+
+        original_parent = ds.parent
+        with pytest.raises(ValueError):
+            proj.add_dataset(NDDataset([2], name="data"))
+
+        assert ds.parent is original_parent
+        assert ds.name == "data"
+        _assert_dataset_membership(proj, ds, "data", present=True)
+
+    def test_duplicate_does_not_partially_modify_parent_on_failure(self):
+        proj = Project(name="test")
+        first = NDDataset([1], name="data")
+        proj.add_dataset(first)
+
+        with pytest.raises(ValueError):
+            proj.add_dataset(NDDataset([2], name="data"))
+
+        assert len(proj.datasets) == 1
         assert first.parent is proj
 
 


### PR DESCRIPTION
## Summary

`Project` now raises `ValueError` when adding a dataset or subproject
whose name already exists in the project, instead of auto-renaming datasets
or silently overwriting subprojects.

**RFC:** maintainers/rfcs/project-invariants-rfc.md — Duplicate Policy

## What changed

**`src/spectrochempy/core/project/project.py`**

- `add_dataset`: removed auto-rename loop, added duplicate check before
  any mutation → raises `ValueError` if `name in self.allnames`
- `add_project`: added duplicate check before any mutation → raises
  `ValueError` if `name in self.allnames`

Both checks run **before** the parent setter, so on failure no child is
partially modified (transactional correctness).

## Tests

**Removed** (3 tests — obsolete auto-rename/overwrite characterization):

| Test | Reason |
|------|--------|
| `test_add_dataset_duplicate_names` (parametrized ×3) | tested auto-rename |
| `test_add_dataset_duplicate_names_preserves_parent_membership_reciprocity` | tested auto-rename |
| `test_add_project_duplicate_names_overwrites_and_leaves_stale_parent` | tested silent overwrite |

**Added** (9 RFC-compliant tests):

| Test | Verifies |
|------|----------|
| `test_add_dataset_duplicate_raises_valueerror` | dataset → ValueError |
| `test_add_project_duplicate_raises_valueerror` | subproject → ValueError |
| `test_duplicate_dataset_dataset` | same-type collision |
| `test_duplicate_project_project` | same-type collision |
| `test_duplicate_dataset_project_collision` | cross-type (dataset→project) |
| `test_duplicate_project_dataset_collision` | cross-type (project→dataset) |
| `test_constructor_duplicate_raises_valueerror` | constructor collision |
| `test_duplicate_does_not_modify_ownership_on_failure` | ownership preserved after ValueError |
| `test_duplicate_does_not_partially_modify_parent_on_failure` | no partial modification |

## Changelog

Removed `FIX:` prefix from all user-facing entries per CONTRIBUTING.md guidelines.

## Validation

```
82 passed in 21.27s
240 passed (display characterization)
```

## Related

- PR #1230 — characterization tests
- PR #1231 — stale-parent fix
- Issue #1164

## Next

```
Ready for cycle-protection PR
```