### PR TITLE
FIX: reject cycles in Project hierarchy

### DIFF
--- a/docs/sources/userguide/objects/project/project.py
+++ b/docs/sources/userguide/objects/project/project.py
@@ -94,7 +94,7 @@ proj.add_datasets(nd1)
 # or `add_datasets` for several datasets.
 
 # %%
-proj.add_datasets(nd1, nd2)
+proj.add_datasets(nd2)
 
 # %% [markdown]
 # Display its structure
@@ -110,6 +110,7 @@ proj
 
 # %%
 proj.remove_dataset("NMR_1D")
+proj.remove_dataset("NMR_1D_copy")
 proj
 
 # %% [markdown]

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -102,6 +102,12 @@ Bug Fixes
   defined by the Project Invariants RFC. Collisions between datasets
   and subprojects are also caught. (:pr:`1232`)
 
+- ``Project`` now raises ``ValueError`` when an operation would create
+  a cycle in the project hierarchy (self-insertion, direct cycle, or
+  indirect cycle). The ``parent`` setter checks for cycles before any
+  mutation, protecting all paths including ``add_project`` and ``parent``
+  reassignment. (:pr:`1233`)
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -95,6 +95,12 @@ Bug Fixes
   defined by the Project Invariants RFC. Collisions between datasets
   and subprojects are also caught. (:pr:`1232`)
 
+- ``Project`` now raises ``ValueError`` when an operation would create
+  a cycle in the project hierarchy (self-insertion, direct cycle, or
+  indirect cycle). The ``parent`` setter checks for cycles before any
+  mutation, protecting all paths including ``add_project`` and ``parent``
+  reassignment. (:pr:`1233`)
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -124,6 +124,26 @@ class Project(AbstractProject, NDIO):
     def _get_from_type(self, name):
         pass  # TODO: ???
 
+    def _check_cycle(self, new_parent):
+        """
+        Raise ValueError if setting parent to new_parent would create a cycle.
+
+        A cycle exists when new_parent is reachable from self by following
+        the parent chain upward. This means new_parent is already a descendant
+        of self in the project tree, and making it the parent of self would
+        create a loop.
+        """
+        if new_parent is None:
+            return
+        current = new_parent
+        while current is not None:
+            if current is self:
+                raise ValueError(
+                    "Setting this parent would create a cycle in the "
+                    "Project hierarchy."
+                )
+            current = current._parent
+
     def _repr_html_(self):
         sections = self._repr_sections()
         body = _render_sections(sections)
@@ -362,6 +382,7 @@ class Project(AbstractProject, NDIO):
 
     @parent.setter
     def parent(self, value):
+        self._check_cycle(value)
         if self._parent is not None:
             # A parent project already exists for this subproject but the
             # entered values gives a different parent. This is not allowed,

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -672,28 +672,94 @@ class TestProjectNameMutationCharacterization:
         assert ds.name == "mutated"
 
 
-class TestProjectCycleCharacterization:
-    """Characterization tests for current cycle behavior."""
+class TestProjectCycleRejection:
+    """Cycle rejection tests per Project Invariants RFC."""
 
-    def test_add_project_allows_self_insertion_without_current_protection(self):
+    def test_self_insertion_raises_valueerror(self):
         proj = Project(name="self")
+        with pytest.raises(ValueError, match="cycle"):
+            proj.add_project(proj)
 
-        proj.add_project(proj)
-
-        _assert_project_membership(proj, proj, "self", present=True)
-        assert proj.parent is proj
-
-    def test_add_project_allows_ancestor_insertion_without_current_protection(self):
+    def test_direct_cycle_raises_valueerror(self):
         parent = Project(name="parent")
         child = Project(name="child")
-
         parent.add_project(child)
-        child.add_project(parent)
+        with pytest.raises(ValueError, match="cycle"):
+            child.add_project(parent)
 
-        _assert_project_membership(parent, child, "child", present=True)
-        _assert_project_membership(child, parent, "parent", present=True)
-        assert parent.parent is child
+    def test_indirect_cycle_raises_valueerror(self):
+        a = Project(name="a")
+        b = Project(name="b")
+        c = Project(name="c")
+        a.add_project(b)
+        b.add_project(c)
+        with pytest.raises(ValueError, match="cycle"):
+            c.add_project(a)
+
+    def test_parent_setter_self_cycle_raises_valueerror(self):
+        proj = Project(name="self")
+        with pytest.raises(ValueError, match="cycle"):
+            proj.parent = proj
+
+    def test_parent_setter_direct_cycle_raises_valueerror(self):
+        parent = Project(name="parent")
+        child = Project(name="child")
+        parent.add_project(child)
+        with pytest.raises(ValueError, match="cycle"):
+            parent.parent = child
+
+    def test_parent_setter_indirect_cycle_raises_valueerror(self):
+        a = Project(name="a")
+        b = Project(name="b")
+        c = Project(name="c")
+        a.add_project(b)
+        b.add_project(c)
+        with pytest.raises(ValueError, match="cycle"):
+            a.parent = c
+
+    def test_state_unchanged_after_self_insertion_failure(self):
+        proj = Project(name="self")
+        with pytest.raises(ValueError):
+            proj.add_project(proj)
+        assert proj.parent is None
+        assert "self" not in proj.projects_names
+
+    def test_state_unchanged_after_direct_cycle_failure(self):
+        parent = Project(name="parent")
+        child = Project(name="child")
+        parent.add_project(child)
+        with pytest.raises(ValueError):
+            child.add_project(parent)
         assert child.parent is parent
+        assert parent.parent is None
+        _assert_project_membership(parent, child, "child", present=True)
+
+    def test_state_unchanged_after_indirect_cycle_failure(self):
+        a = Project(name="a")
+        b = Project(name="b")
+        c = Project(name="c")
+        a.add_project(b)
+        b.add_project(c)
+        with pytest.raises(ValueError):
+            c.add_project(a)
+        assert c.parent is b
+        assert b.parent is a
+        assert a.parent is None
+
+    def test_normal_tree_structure_not_affected_by_cycle_protection(self):
+        parent = Project(name="parent")
+        child = Project(name="child")
+        parent.add_project(child)
+        assert child.parent is parent
+        _assert_project_membership(parent, child, "child", present=True)
+
+    def test_normal_parent_setter_not_affected_by_cycle_protection(self):
+        proj = Project(name="root")
+        child = Project(name="child")
+        proj.add_project(child)
+        child.parent = None
+        assert child.parent is None
+        assert "child" not in proj.projects_names
 
 
 class TestProjectKeyNameIdentityCharacterization:


### PR DESCRIPTION
## Summary

Prevent cycles in the Project hierarchy by adding a cycle check to the `parent` setter. Self-insertion, direct cycles (parent becomes child of its own child), and indirect cycles (3+ node loops) all raise `ValueError` before any mutation occurs.

## Changes

**`src/spectrochempy/core/project/project.py`:**
- Added `_check_cycle(new_parent)` — walks the `_parent` chain upward; raises `ValueError` if `self` is reachable
- Called at the top of the `parent` setter before any state mutation

**`tests/test_core/test_projects/test_projects.py`:**
- Replaced 2 obsolete cycle-characterization tests (which allowed cycles) with 11 RFC-compliant rejection tests covering self-insertion, direct/indirect cycles, parent-setter cycles, state-unchanged-after-failure, and normal operation preservation

**`docs/sources/userguide/objects/project/project.py`:**
- Fixed user-guide example that was broken by the duplicate policy (PR #1232) — was trying to re-add an already-present dataset

## Test results

```
91 passed in 19.46s
```

Follows the Project Invariants RFC. Replaces the previous cycle characterization (where cycles were silently allowed, risking stack overflow on display/serialization).