### PR TITLE
FIX: enforce Project key/name identity

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -106,7 +106,12 @@ Bug Fixes
   a cycle in the project hierarchy (self-insertion, direct cycle, or
   indirect cycle). The ``parent`` setter checks for cycles before any
   mutation, protecting all paths including ``add_project`` and ``parent``
-  reassignment. (:pr:`1233`)
+   reassignment. (:pr:`1233`)
+
+- ``Project.__setitem__`` replacement now enforces key/name identity:
+  after ``project["x"] = new_value``, ``project["x"].name == "x"``
+  holds for both datasets and subprojects. This closes the last gap in
+  the Project Invariants RFC contract. (:pr:`1234`)
 
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -99,7 +99,12 @@ Bug Fixes
   a cycle in the project hierarchy (self-insertion, direct cycle, or
   indirect cycle). The ``parent`` setter checks for cycles before any
   mutation, protecting all paths including ``add_project`` and ``parent``
-  reassignment. (:pr:`1233`)
+   reassignment. (:pr:`1233`)
+
+- ``Project.__setitem__`` replacement now enforces key/name identity:
+  after ``project["x"] = new_value``, ``project["x"].name == "x"``
+  holds for both datasets and subprojects. This closes the last gap in
+  the Project Invariants RFC contract. (:pr:`1234`)
 
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -272,11 +272,13 @@ class Project(AbstractProject, NDIO):
             value.parent = self
             self._datasets[key] = value
             old._parent = None
+            value.name = key
         elif key in self.projects_names:
             old = self._projects[key]
             value.parent = self
             self._projects[key] = value
             old._parent = None
+            value.name = key
         else:
             # the key does not exist
             self._set_from_type(value, name=key)

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -578,8 +578,8 @@ class TestProjectReplacementCharacterization:
         assert old not in proj.datasets
         assert new.parent is proj
         assert old.parent is None
-        assert new.name == "replacement"
-        assert proj["item"].name != "item"
+        assert new.name == "item"
+        assert proj["item"].name == "item"
 
     def test_replace_subproject_detaches_old_child_parent(self):
         proj = Project(name="root")
@@ -594,8 +594,8 @@ class TestProjectReplacementCharacterization:
         assert old not in proj.projects
         assert new.parent is proj
         assert old.parent is None
-        assert new.name == "replacement"
-        assert proj["item"].name != "item"
+        assert new.name == "item"
+        assert proj["item"].name == "item"
 
     def test_replace_dataset_old_child_detached_even_with_prior_parent(self):
         proj = Project(name="root")
@@ -760,6 +760,85 @@ class TestProjectCycleRejection:
         child.parent = None
         assert child.parent is None
         assert "child" not in proj.projects_names
+
+
+class TestProjectKeyNameIdentityRFC:
+    """RFC-compliant key/name identity tests."""
+
+    def test_setitem_replacement_enforces_key_name_identity_for_dataset(self):
+        proj = Project(name="test")
+        ds = NDDataset([1, 2, 3], name="original")
+        proj.add_dataset(NDDataset([0], name="existing"))
+        proj["existing"] = ds
+        assert proj["existing"].name == "existing"
+        assert ds.name == "existing"
+
+    def test_setitem_replacement_enforces_key_name_identity_for_project(self):
+        proj = Project(name="test")
+        sub = Project(name="original")
+        proj.add_project(Project(name="existing"))
+        proj["existing"] = sub
+        assert proj["existing"].name == "existing"
+        assert sub.name == "existing"
+
+    def test_setitem_new_key_enforces_identity_via_add_dataset(self):
+        proj = Project(name="test")
+        ds = NDDataset([1, 2, 3], name="original")
+        proj["renamed"] = ds
+        assert proj["renamed"].name == "renamed"
+        assert ds.name == "renamed"
+
+    def test_setitem_new_key_enforces_identity_via_add_project(self):
+        proj = Project(name="test")
+        sub = Project(name="original")
+        proj["renamed"] = sub
+        assert proj["renamed"].name == "renamed"
+        assert sub.name == "renamed"
+
+    def test_move_between_projects_via_add_dataset_preserves_identity(self):
+        source = Project(name="source")
+        dest = Project(name="dest")
+        ds = NDDataset([1, 2, 3], name="data")
+        source.add_dataset(ds)
+        dest.add_dataset(ds)
+        assert dest["data"].name == "data"
+
+    def test_move_between_projects_via_add_project_preserves_identity(self):
+        source = Project(name="source")
+        dest = Project(name="dest")
+        sub = Project(name="child")
+        source.add_project(sub)
+        dest.add_project(sub)
+        assert dest["child"].name == "child"
+
+    def test_constructor_with_argnames_enforces_identity(self):
+        ds = NDDataset([1, 2, 3], name="original")
+        proj = Project(ds, argnames=["renamed"])
+        assert proj["renamed"].name == "renamed"
+        assert ds.name == "renamed"
+
+    def test_parent_setter_moves_child_and_add_project_restores_identity(self):
+        source = Project(name="source")
+        dest = Project(name="dest")
+        sub = Project(name="child")
+        source.add_project(sub)
+        sub.parent = None
+        dest.add_project(sub)
+        assert dest["child"].name == "child"
+
+    def test_ownership_and_duplicate_and_cycle_still_work(self):
+        """Verify prior invariants are not broken by key/name identity changes."""
+        proj = Project(name="root")
+        ds = NDDataset([1], name="data")
+        proj.add_dataset(ds)
+        assert ds.parent is proj
+        assert proj["data"] is ds
+
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_dataset(NDDataset([2], name="data"))
+
+        with pytest.raises(ValueError, match="cycle"):
+            proj.add_project(proj)
 
 
 class TestProjectKeyNameIdentityCharacterization:


### PR DESCRIPTION
## Summary

Enforce the key/name identity invariant defined by the Project Invariants RFC: after insertion, replacement, or move, `project[key].name == key`.

## Changes

**`src/spectrochempy/core/project/project.py`** (+2 lines):
- `__setitem__` replacement now mutates `value.name = key` for both datasets and subprojects, closing the last gap where `key != child.name` could occur through public API

**`tests/test_core/test_projects/test_projects.py`**:
- Updated 2 assertions in `TestProjectReplacementCharacterization` (from `name != item` to `name == item`)
- Added `TestProjectKeyNameIdentityRFC` (9 tests) covering: setitem replacement, new-key setitem, moves, constructor with argnames, and prior-invariant non-regression

## Test results

```
100 passed in 25.43s
```

## RFC state

```
Project Invariants RFC fully implemented
```