### PR TITLE
DOC: finalize Project invariants documentation

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -106,7 +106,12 @@ Bug Fixes
   a cycle in the project hierarchy (self-insertion, direct cycle, or
   indirect cycle). The ``parent`` setter checks for cycles before any
   mutation, protecting all paths including ``add_project`` and ``parent``
-  reassignment. (:pr:`1233`)
+   reassignment. (:pr:`1233`)
+
+- ``Project.__setitem__`` replacement now enforces key/name identity:
+  after ``project["x"] = new_value``, ``project["x"].name == "x"``
+  holds for both datasets and subprojects. This closes the last gap in
+  the Project Invariants RFC contract. (:pr:`1234`)
 
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -173,4 +173,8 @@ Developer
   unified access to analysis and fitting outputs while preserving
   backward compatibility.
   (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`,
-  :pr:`1217`, :pr:`1218`, :pr:`1219`, :pr:`1220`)
+   :pr:`1217`, :pr:`1218`, :pr:`1219`, :pr:`1220`)
+
+- MAINT: Update Project docstrings and RFC status to reflect implemented
+  invariants (single-parent ownership, acyclic hierarchy, duplicate rejection,
+  key/name identity).  Close the Project Invariants RFC. (:pr:`1235`)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -99,7 +99,12 @@ Bug Fixes
   a cycle in the project hierarchy (self-insertion, direct cycle, or
   indirect cycle). The ``parent`` setter checks for cycles before any
   mutation, protecting all paths including ``add_project`` and ``parent``
-  reassignment. (:pr:`1233`)
+   reassignment. (:pr:`1233`)
+
+- ``Project.__setitem__`` replacement now enforces key/name identity:
+  after ``project["x"] = new_value``, ``project["x"].name == "x"``
+  holds for both datasets and subprojects. This closes the last gap in
+  the Project Invariants RFC contract. (:pr:`1234`)
 
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -145,4 +145,8 @@ Developer
   unified access to analysis and fitting outputs while preserving
   backward compatibility.
   (:pr:`1208`, :pr:`1209`, :pr:`1211`, :pr:`1213`, :pr:`1215`,
-  :pr:`1217`, :pr:`1218`, :pr:`1219`, :pr:`1220`)
+   :pr:`1217`, :pr:`1218`, :pr:`1219`, :pr:`1220`)
+
+- MAINT: Update Project docstrings and RFC status to reflect implemented
+  invariants (single-parent ownership, acyclic hierarchy, duplicate rejection,
+  key/name identity).  Close the Project Invariants RFC. (:pr:`1235`)

--- a/maintainers/rfcs/project-invariants-rfc.md
+++ b/maintainers/rfcs/project-invariants-rfc.md
@@ -1,6 +1,6 @@
 # Project Invariants and Ownership Semantics
 
-**Status:** Proposed maintainer decision record
+**Status:** Implemented
 
 **Related issue:** `#1164`
 
@@ -158,6 +158,16 @@ Recommended follow-up PR sequence
    insert, replace, move, and load paths.
 6. Revisit deferred topics (`copy()`, root-name semantics) in separate, narrow
    follow-up RFCs or PRs if still needed.
+
+All core invariants (items 1–5) have been implemented.
+
+### Implemented by
+
+* `#1230` — characterization tests
+* `#1231` — stale parent fix
+* `#1232` — duplicate policy alignment
+* `#1233` — cycle protection
+* `#1234` — key/name identity
 
 ## Conclusion
 

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -36,20 +36,32 @@ from spectrochempy.utils.traits import NDDatasetType
 @tr.signature_has_traits
 class Project(AbstractProject, NDIO):
     """
-    A manager for projects and datasets.
+    Lightweight hierarchical container for datasets and subprojects.
 
-    It can handle multiple datasets and subprojects in a main
-    project.
+    ``Project`` owns child objects (``NDDataset`` and nested ``Project``
+    instances) with strict single-parent ownership. It enforces:
+
+    * **Single-parent ownership** — a child has at most one parent, and
+      moving a child between projects is an ownership transfer.
+    * **Acyclic hierarchy** — self-insertion and ancestor insertion are
+      rejected with ``ValueError``.
+    * **Explicit duplicate rejection** — adding a child whose name already
+      exists in the project raises ``ValueError``.
+    * **Key/name identity** — after insertion or replacement,
+      ``project[key].name == key``.
+
+    ``Project`` is a dataset container, not a workspace, workflow engine,
+    provenance graph, or generic object store.
 
     Parameters
     ----------
     *args : Series of objects, optional
         Argument type will be interpreted correctly if they are of type
-        `NDDataset` or `Project` .
+        ``NDDataset`` or ``Project``.
         This is optional, as they can be added later.
     argnames : list, optional
         If not None, this list gives the names associated to each
-        object passed as args. It MUST be the same length that the
+        object passed as args. It MUST be the same length as the
         number of args, or an error will be raised.
         If None, the internal name of each object will be used instead.
     name : str, optional
@@ -258,6 +270,39 @@ class Project(AbstractProject, NDIO):
         raise KeyError(f"{key}: This object name does not exist in this project.")
 
     def __setitem__(self, key, value):
+        """
+        Set ``project[key] = value``, inserting or replacing a child.
+
+        When *key* already exists, the existing child is replaced: its
+        parent is cleared, the new child is attached, and the new child's
+        ``.name`` is set to *key* (enforcing key/name identity).  The
+        old child is detached and its parent becomes ``None``.
+
+        When *key* does not exist, the operation delegates to
+        :meth:`add_dataset` or :meth:`add_project` depending on the value
+        type, with *key* as the entry name.
+
+        Type mismatch between the existing entry and the new value raises
+        ``ValueError``.
+
+        Parameters
+        ----------
+        key : str
+            Project entry key.
+        value : `NDDataset` or `Project`
+            Child object to insert or replace.
+
+        Raises
+        ------
+        KeyError
+            If *key* is not a string.
+        ValueError
+            If *key* exists but for a different type of object.
+        ValueError
+            If replacing would create a cycle (when *value* is a
+            ``Project`` that is an ancestor of this project).
+
+        """
         if not isinstance(key, str):
             raise KeyError("The key must be a string.")
 
@@ -379,7 +424,7 @@ class Project(AbstractProject, NDIO):
 
     @property
     def parent(self):
-        """Instance of the Project which is the parent (if any) of the current project (project)."""
+        """Parent project of this subproject, or ``None`` when this is a root project (project)."""
         return self._parent
 
     @parent.setter
@@ -493,12 +538,20 @@ class Project(AbstractProject, NDIO):
         """
         Add several datasets to the current project.
 
+        Each dataset is added via :meth:`add_dataset`.  If any dataset
+        name collides with an existing entry, a ``ValueError`` is raised
+        and no datasets are added (the first duplicate raises).
+
         Parameters
         ----------
         *datasets : series of `NDDataset`
             Datasets to add to the current project.
-            The name of the entries in the project will be identical to the
-            names of the datasets.
+            Entry keys are the datasets' current names.
+
+        Raises
+        ------
+        ValueError
+            If any dataset name already exists in this project.
 
         See Also
         --------
@@ -521,14 +574,25 @@ class Project(AbstractProject, NDIO):
         """
         Add a single dataset to the current project.
 
+        The dataset is attached to this project as its parent, and its
+        ``.name`` is set to the entry key (matching the key/name identity
+        invariant).  If a child with the same name already exists in the
+        project (datasets and subprojects share a single namespace),
+        a ``ValueError`` is raised.
+
         Parameters
         ----------
         dataset : `NDDataset`
-            Datasets to add.
-            The name of the entry will be the name of the dataset, except
-            if parameter `name` is defined.
+            Dataset to add.
         name : str, optional
-            If provided the name will be used to name the entry in the project.
+            Entry key in the project.  If not provided, defaults to
+            ``dataset.name``.  When provided, ``dataset.name`` is
+            overwritten to match this value.
+
+        Raises
+        ------
+        ValueError
+            If a child named ``name`` already exists in this project.
 
         See Also
         --------
@@ -605,12 +669,26 @@ class Project(AbstractProject, NDIO):
     # ----------------------------------------------------------------------------------
     def add_projects(self, *projects):
         """
-        Add one or a series of projects to the current project.
+        Add one or more subprojects to the current project.
+
+        Each subproject is added via :meth:`add_project`.  If any
+        subproject name collides with an existing entry, a
+        ``ValueError`` is raised.
 
         Parameters
         ----------
-        projects : project instances
-            The projects to add to the current ones.
+        *projects : series of `Project`
+            The subprojects to add.
+            Entry keys are the subprojects' current names.
+
+        Raises
+        ------
+        ValueError
+            If any subproject name already exists in this project.
+
+        See Also
+        --------
+        add_project : Add a single subproject.
 
         """
         for proj in projects:
@@ -618,12 +696,35 @@ class Project(AbstractProject, NDIO):
 
     def add_project(self, proj, name=None):
         """
-        Add one project to the current project.
+        Add a subproject to the current project.
+
+        The subproject is attached to this project as its parent.  Its
+        ``.name`` is set to the entry key when ``name`` differs from the
+        subproject's current name.  If a child with the same name already
+        exists in the project (datasets and subprojects share a single
+        namespace), a ``ValueError`` is raised.
+
+        Self-insertion and ancestor insertion are rejected with
+        ``ValueError`` (cycles are not allowed in the project hierarchy).
 
         Parameters
         ----------
-        proj : a project instance
-            A project to add to the current one.
+        proj : `Project`
+            Subproject to add.
+        name : str, optional
+            Entry key in the project.  If not provided, defaults to
+            ``proj.name``.  When provided (and different from the
+            current name), ``proj.name`` is overwritten to match.
+
+        Raises
+        ------
+        ValueError
+            If a child named ``name`` already exists in this project, or
+            if adding the subproject would create a cycle.
+
+        See Also
+        --------
+        add_projects : Add several subprojects at once.
 
         """
         if name is None:

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -272,11 +272,13 @@ class Project(AbstractProject, NDIO):
             value.parent = self
             self._datasets[key] = value
             old._parent = None
+            value.name = key
         elif key in self.projects_names:
             old = self._projects[key]
             value.parent = self
             self._projects[key] = value
             old._parent = None
+            value.name = key
         else:
             # the key does not exist
             self._set_from_type(value, name=key)

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -578,8 +578,8 @@ class TestProjectReplacementCharacterization:
         assert old not in proj.datasets
         assert new.parent is proj
         assert old.parent is None
-        assert new.name == "replacement"
-        assert proj["item"].name != "item"
+        assert new.name == "item"
+        assert proj["item"].name == "item"
 
     def test_replace_subproject_detaches_old_child_parent(self):
         proj = Project(name="root")
@@ -594,8 +594,8 @@ class TestProjectReplacementCharacterization:
         assert old not in proj.projects
         assert new.parent is proj
         assert old.parent is None
-        assert new.name == "replacement"
-        assert proj["item"].name != "item"
+        assert new.name == "item"
+        assert proj["item"].name == "item"
 
     def test_replace_dataset_old_child_detached_even_with_prior_parent(self):
         proj = Project(name="root")
@@ -760,6 +760,85 @@ class TestProjectCycleRejection:
         child.parent = None
         assert child.parent is None
         assert "child" not in proj.projects_names
+
+
+class TestProjectKeyNameIdentityRFC:
+    """RFC-compliant key/name identity tests."""
+
+    def test_setitem_replacement_enforces_key_name_identity_for_dataset(self):
+        proj = Project(name="test")
+        ds = NDDataset([1, 2, 3], name="original")
+        proj.add_dataset(NDDataset([0], name="existing"))
+        proj["existing"] = ds
+        assert proj["existing"].name == "existing"
+        assert ds.name == "existing"
+
+    def test_setitem_replacement_enforces_key_name_identity_for_project(self):
+        proj = Project(name="test")
+        sub = Project(name="original")
+        proj.add_project(Project(name="existing"))
+        proj["existing"] = sub
+        assert proj["existing"].name == "existing"
+        assert sub.name == "existing"
+
+    def test_setitem_new_key_enforces_identity_via_add_dataset(self):
+        proj = Project(name="test")
+        ds = NDDataset([1, 2, 3], name="original")
+        proj["renamed"] = ds
+        assert proj["renamed"].name == "renamed"
+        assert ds.name == "renamed"
+
+    def test_setitem_new_key_enforces_identity_via_add_project(self):
+        proj = Project(name="test")
+        sub = Project(name="original")
+        proj["renamed"] = sub
+        assert proj["renamed"].name == "renamed"
+        assert sub.name == "renamed"
+
+    def test_move_between_projects_via_add_dataset_preserves_identity(self):
+        source = Project(name="source")
+        dest = Project(name="dest")
+        ds = NDDataset([1, 2, 3], name="data")
+        source.add_dataset(ds)
+        dest.add_dataset(ds)
+        assert dest["data"].name == "data"
+
+    def test_move_between_projects_via_add_project_preserves_identity(self):
+        source = Project(name="source")
+        dest = Project(name="dest")
+        sub = Project(name="child")
+        source.add_project(sub)
+        dest.add_project(sub)
+        assert dest["child"].name == "child"
+
+    def test_constructor_with_argnames_enforces_identity(self):
+        ds = NDDataset([1, 2, 3], name="original")
+        proj = Project(ds, argnames=["renamed"])
+        assert proj["renamed"].name == "renamed"
+        assert ds.name == "renamed"
+
+    def test_parent_setter_moves_child_and_add_project_restores_identity(self):
+        source = Project(name="source")
+        dest = Project(name="dest")
+        sub = Project(name="child")
+        source.add_project(sub)
+        sub.parent = None
+        dest.add_project(sub)
+        assert dest["child"].name == "child"
+
+    def test_ownership_and_duplicate_and_cycle_still_work(self):
+        """Verify prior invariants are not broken by key/name identity changes."""
+        proj = Project(name="root")
+        ds = NDDataset([1], name="data")
+        proj.add_dataset(ds)
+        assert ds.parent is proj
+        assert proj["data"] is ds
+
+        with pytest.raises(ValueError, match="already exists"):
+            proj.add_dataset(NDDataset([2], name="data"))
+
+        with pytest.raises(ValueError, match="cycle"):
+            proj.add_project(proj)
 
 
 class TestProjectKeyNameIdentityCharacterization:


### PR DESCRIPTION
## Summary

Documentation pass to close the Project Invariants RFC.  Update docstrings,
RFC status, and changelog to reflect the implemented invariants.

## Changes

**`src/spectrochempy/core/project/project.py`** — docstring updates:

| Symbol | What changed |
|--------|-------------|
| `Project` class | Now describes the container model, four core invariants, and what `Project` is not |
| `add_dataset` | Documents `ValueError` on duplicate, name mutation, key/name identity |
| `add_datasets` | Documents `ValueError` propagation |
| `add_project` | Documents `ValueError` on duplicate, cycle rejection, name mutation |
| `add_projects` | Documents `ValueError` propagation |
| `__setitem__` | **New docstring** — replacement, identity, type check, cycle protection |
| `parent` | Clarified wording |

**`maintainers/rfcs/project-invariants-rfc.md`:**
- Status: `Implemented`
- Added `Implemented by` section (PRs #1230–#1234)

**`docs/sources/whatsnew/changelog.rst`:**
- Added `MAINT` entry in Developer section

## Audit findings

No outdated user-facing documentation was found describing auto-rename,
silent-overwrite, stale-parent, or no-cycle-detection behavior.

## RFC state

```
Project invariants RFC closed.
Deferred topics (copy, root name) remain open for future work.
```