### PR TITLE
MAINT: align Project copy semantics with RFC

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -113,6 +113,16 @@ Bug Fixes
   holds for both datasets and subprojects. This closes the last gap in
   the Project Invariants RFC contract. (:pr:`1234`)
 
+- ``Project.copy()`` now exposes an explicit ``deep`` parameter in the
+  public API. ``project.copy()`` and ``project.copy(deep=True)`` produce a
+  fully detached recursive copy with parent links rebuilt inside the copied
+  tree, while ``project.copy(deep=False)`` creates a new container that
+  shares children without changing their existing ``parent`` pointers.
+  ``copy.copy(project)`` and ``copy.deepcopy(project)`` intentionally follow
+  the recursive detached model as well, matching the Project copy semantics
+  RFC even though this is stronger than Python's usual shallow-copy
+  convention.
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -106,6 +106,16 @@ Bug Fixes
   holds for both datasets and subprojects. This closes the last gap in
   the Project Invariants RFC contract. (:pr:`1234`)
 
+- ``Project.copy()`` now exposes an explicit ``deep`` parameter in the
+  public API. ``project.copy()`` and ``project.copy(deep=True)`` produce a
+  fully detached recursive copy with parent links rebuilt inside the copied
+  tree, while ``project.copy(deep=False)`` creates a new container that
+  shares children without changing their existing ``parent`` pointers.
+  ``copy.copy(project)`` and ``copy.deepcopy(project)`` intentionally follow
+  the recursive detached model as well, matching the Project copy semantics
+  RFC even though this is stronger than Python's usual shallow-copy
+  convention.
+
 - Fixed several inconsistencies in the OMNIC SPA/SPG reader (`#1144
   <https://github.com/spectrochempy/spectrochempy/issues/1144>`_):
   ``read_spg()`` no longer advertises the ``spa`` protocol; swapped error

--- a/maintainers/rfcs/project-copy-semantics-rfc.md
+++ b/maintainers/rfcs/project-copy-semantics-rfc.md
@@ -1,6 +1,6 @@
 # Project Copy Semantics
 
-**Status:** Proposed maintainer decision record
+**Status:** Implemented
 
 **Related issue:** `#1164`
 

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -379,13 +379,57 @@ class Project(AbstractProject, NDIO):
             "projects",
         ]
 
-    def __copy__(self):
+    def _copy(self, deep=True, memo=None):
+        """
+        Create a copy of this project.
+
+        Parameters
+        ----------
+        deep : bool
+            If True, recursively copy all children (deep / detached copy).
+            If False, create a new container with shared children (shallow copy).
+        memo : dict or None
+            Memo dictionary for ``deepcopy`` support.
+
+        Returns
+        -------
+        Project
+        """
         new = Project()
-        for item in self._attributes_():
-            item = "_" + item
-            data = getattr(self, item)
-            setattr(new, item, cpy.copy(data))
+
+        if memo is not None:
+            memo[id(self)] = new
+
+        new._name = self._name
+        new._explicit_name = self._explicit_name
+        new._meta = cpy.deepcopy(self._meta, memo=memo)
+
+        if deep:
+            for name, ds in self._datasets.items():
+                new.add_dataset(cpy.deepcopy(ds, memo=memo), name=name)
+            for name, sub in self._projects.items():
+                new.add_project(cpy.deepcopy(sub, memo=memo), name=name)
+        else:
+            new._datasets = cpy.copy(self._datasets)
+            new._projects = cpy.copy(self._projects)
+
         return new
+
+    def __copy__(self):
+        """
+        Return a fully independent copy (recursive detached).
+
+        .. note::
+
+            Unlike Python's default shallow ``copy.copy``, this method
+            produces a deep copy identical to ``copy.deepcopy``.  See
+            :meth:`copy` for details.
+        """
+        return self._copy(deep=True)
+
+    def __deepcopy__(self, memo):
+        """Return a fully independent copy with deepcopy memo support."""
+        return self._copy(deep=True, memo=memo)
 
     # ----------------------------------------------------------------------------------
     # properties
@@ -527,9 +571,38 @@ class Project(AbstractProject, NDIO):
             return "Project"
         return name == "Project"
 
-    def copy(self):
-        """Make an exact copy of the current project."""
-        return self.__copy__()
+    def copy(self, deep=True):
+        """
+        Make a copy of the current project.
+
+        This method produces a recursive detached copy (every child is a new
+        independent object) when called without arguments (``deep=True``).
+        In that mode, copied children are re-attached inside the copied tree,
+        so nested datasets and subprojects point to their copied parent.
+        With ``deep=False`` it creates a new container whose children are
+        shared references to the original — the children's ``parent`` pointers
+        remain unchanged.
+
+        .. note::
+
+            ``copy.copy(project)`` and ``copy.deepcopy(project)`` both
+            produce a deep copy, matching the default ``copy(deep=True)``
+            behavior.  This is intentional per the project copy semantics
+            RFC (``maintainers/rfcs/project-copy-semantics-rfc.md``) and
+            differs from Python's default shallow ``copy.copy`` semantics.
+
+        Parameters
+        ----------
+        deep : bool, optional
+            If True (default), a recursive detached copy is made
+            where every child is a new independent object.
+            If False, a new container is created with shared children.
+
+        Returns
+        -------
+        Project
+        """
+        return self._copy(deep=deep)
 
     # ----------------------------------------------------------------------------------
     # dataset items

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -316,12 +316,78 @@ class TestCopy:
         del copied._datasets["data"]
         assert "data" in proj.datasets_names
 
-    def test_copy_method(self, ds1):
+    def test_copy_method_default_is_deep(self, ds1):
         ds1.name = "data"
         proj = Project(ds1, name="original")
         copied = proj.copy()
         assert copied.name == "original"
         assert "data" in copied.datasets_names
+        assert copied["data"] is not ds1
+
+    def test_copy_deep(self, ds1):
+        ds1.name = "data"
+        sub = Project(name="sub")
+        sub.add_dataset(ds1)
+        proj = Project(name="root")
+        proj.add_project(sub)
+
+        copied = proj.copy(deep=True)
+
+        assert copied.name == "root"
+        assert "sub" in copied.projects_names
+        assert copied["sub"] is not sub
+        assert copied["sub"]["data"] is not ds1
+        assert copied.parent is None
+        assert copied["sub"].parent is copied
+        assert copied["sub"]["data"].parent is copied["sub"]
+
+    def test_copy_shallow(self, ds1):
+        ds1.name = "data"
+        sub = Project(name="sub")
+        sub.add_dataset(ds1)
+        proj = Project(name="root")
+        proj.add_project(sub)
+
+        copied = proj.copy(deep=False)
+
+        assert copied is not proj
+        assert copied.name == "root"
+        assert copied["sub"] is sub
+        assert copied["sub"]["data"] is ds1
+        # shallow copy parent is also detached
+        assert copied.parent is None
+        # original parent is preserved on original children
+        assert copied["sub"].parent is proj
+
+    def test_copy_empty(self):
+        proj = Project(name="empty")
+        copied = proj.copy()
+        assert copied.name == "empty"
+        assert copied.datasets_names == []
+        assert copied.projects_names == []
+
+    def test_copy_preserves_meta(self):
+        proj = Project(name="with_meta")
+        proj.meta["key"] = "value"
+        copied = proj.copy()
+        assert copied.meta["key"] == "value"
+
+    def test_copy_module(self, ds1):
+        import copy as cpy
+
+        ds1.name = "data"
+        proj = Project(ds1, name="original")
+
+        # Per RFC: copy(proj) == deepcopy(proj) — fully independent
+        shallow = cpy.copy(proj)
+        deep = cpy.deepcopy(proj)
+
+        for copied in (shallow, deep):
+            assert copied.name == "original"
+            assert "data" in copied.datasets_names
+            assert copied["data"] is not ds1
+            assert copied["data"].parent is copied
+            assert copied.parent is None
 
 
 class TestDuplicateNamesRFC:
@@ -879,30 +945,80 @@ class TestProjectKeyNameIdentityCharacterization:
         assert loaded["sub/nested"].name == "nested"
 
 
-class TestProjectCopyCharacterization:
-    """Characterization tests for current shallow-copy semantics."""
+class TestProjectCopyRFC:
+    """RFC-compliant copy semantics (per project-copy-semantics-rfc.md)."""
 
-    def test_copy_duplicates_dataset_child_and_resets_parent_pointer(self):
+    def test_copy_default_is_recursive_detached(self):
+        proj = Project(name="root")
+        ds = NDDataset([1, 2, 3], name="data")
+        sub = Project(name="child")
+        sub.add_dataset(ds)
+        proj.add_project(sub)
+
+        copied = proj.copy()
+
+        # All children are new independent objects
+        assert copied["child"] is not sub
+        assert copied["child"]["data"] is not ds
+        # Root is detached, nested copies are re-parented inside the copy
+        assert copied.parent is None
+        assert copied["child"].parent is copied
+        assert copied["child"]["data"].parent is copied["child"]
+
+    def test_copy_shallow_shares_children(self):
+        proj = Project(name="root")
+        ds = NDDataset([1, 2, 3], name="data")
+        sub = Project(name="child")
+        sub.add_dataset(ds)
+        proj.add_project(sub)
+
+        copied = proj.copy(deep=False)
+
+        assert copied["child"] is sub
+        assert copied["child"]["data"] is ds
+        # Container parent is None
+        assert copied.parent is None
+        # Original parent references preserved on shared children
+        assert copied["child"].parent is proj
+        assert copied["child"]["data"].parent is sub
+
+    def test_copy_and_deepcopy_equivalence(self):
+        import copy as cpy
+
         proj = Project(name="root")
         ds = NDDataset([1, 2, 3], name="data")
         proj.add_dataset(ds)
 
-        copied = proj.copy()
+        shallow = cpy.copy(proj)
+        deep = cpy.deepcopy(proj)
 
-        assert copied["data"] is not ds
-        assert copied["data"].name == ds.name
-        assert copied["data"].parent is None
+        # Both produce fully independent results (RFC: copy == deepcopy)
+        assert shallow["data"] is not deep["data"]
+        assert shallow["data"].parent is shallow
+        assert deep["data"].parent is deep
+        assert shallow.name == deep.name
 
-    def test_copy_shares_subprojects_and_keeps_parent_on_original(self):
+    def test_deep_copy_preserves_nested_structure(self):
         proj = Project(name="root")
-        child = Project(name="child")
-        proj.add_project(child)
+        inner = Project(name="inner")
+        deep_inner = Project(name="deep_inner")
+        ds = NDDataset([1], name="data")
+        deep_inner.add_dataset(ds)
+        inner.add_project(deep_inner)
+        proj.add_project(inner)
 
-        copied = proj.copy()
+        copied = proj.copy(deep=True)
 
-        assert copied["child"] is child
-        assert copied["child"].parent is proj
-        assert copied["child"].parent is not copied
+        assert copied.name == "root"
+        assert copied["inner"] is not inner
+        assert copied["inner"]["deep_inner"] is not deep_inner
+        assert copied["inner"]["deep_inner"]["data"] is not ds
+        assert copied["inner"].parent is copied
+        assert copied["inner"]["deep_inner"].parent is copied["inner"]
+        assert (
+            copied["inner"]["deep_inner"]["data"].parent
+            is copied["inner"]["deep_inner"]
+        )
 
 
 class TestImplements:


### PR DESCRIPTION
## Summary
Implement the RFC-defined Project copy semantics and document the resulting public API.

## What changed
- make `Project.copy()` expose explicit `deep=True` and `deep=False` semantics
- make deep copies rebuild parent links inside the copied tree
- keep `copy(deep=False)` as a container-only copy that shares children without mutating their existing `parent` pointers
- make `copy.copy(project)` and `copy.deepcopy(project)` intentionally follow the recursive detached model
- update the Project copy RFC status to `Implemented`
- refresh changelog/docstrings/tests accordingly

## Why
The prior behavior around Project copying was incomplete and inconsistent with the RFC, especially for nested parent links and the distinction between detached deep copies and shared-child shallow copies.

## Validation
- `conda run -n scpy-core python -m pytest tests/test_core/test_projects/test_projects.py -k copy`
- `pre-commit run --all-files`
