### PR TITLE
DOC: clarify maintainer documentation governance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ tests/figures/
 # Project Specific          #
 ###############################
 /extdata/
+/audit/
 /git_hooks/
 /installed.txt
 thumb.png

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -18,12 +18,91 @@ contrats RFC, et notes d'architecture durables.
 | [`rfcs/`](rfcs/) | RFC mainteneur et contrats de comportement |
 | [`architecture/`](architecture/) | Audits, notes d'architecture, et cartes de risques durables |
 
+## Documentation Structure
+
+Utiliser ces couches documentaires dans cet ordre :
+
+| Layer | Use for | Look here first |
+|---|---|---|
+| RFCs | Contrats mainteneur, positions, décisions acceptées, et contrats implémentés | [`rfcs/INDEX.md`](rfcs/INDEX.md) |
+| Architecture Notes | Références d'architecture durables, cartes d'implémentation, et contexte technique maintenu | [`architecture/INDEX.md`](architecture/INDEX.md) |
+| Audits | Notes de travail, historique d'implémentation, investigations, et campagnes locales non versionnées par défaut | `audit/~*.md` |
+| Roadmap | Priorités, sujets terminés, actifs, ou différés | [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md) |
+
+En pratique :
+
+- commencer par ce fichier ;
+- puis lire la roadmap ;
+- puis consulter l'index RFC ou l'index architecture selon que la question est
+  normative ou surtout technique ;
+- utiliser les audits locaux seulement pour retrouver le contexte de campagne
+  et l'historique d'implémentation.
+
+### Architecture-Document Lifecycle
+
+Le cycle documentaire typique est :
+
+```text
+Audit
+  ↓
+RFC
+  ↓
+Architecture Note
+```
+
+- les audits sont des analyses de travail et des notes de campagne ;
+- les RFCs portent des contrats proposés, acceptés, ou implémentés ;
+- les notes d'architecture deviennent la référence suivie lorsqu'un design ou
+  une campagne s'est stabilisé.
+
+### Authority Guide
+
+Considérer comme **authoritative** en priorité :
+
+- la roadmap mainteneur ;
+- les notes d'architecture suivies ;
+- les RFCs implémentés ;
+- les contrats et positions acceptés.
+
+Considérer comme **non-authoritative by default** :
+
+- les audits ;
+- les notes d'implémentation ;
+- les journaux de campagne ;
+- les rapports de caractérisation.
+
+En cas de doute, commencer par la roadmap, puis l'index RFC, puis l'index
+architecture.
+
+## Core Architecture Reading Path
+
+Pour un nouveau mainteneur, l'ordre de lecture recommandé est :
+
+1. [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md)
+2. [`rfcs/INDEX.md`](rfcs/INDEX.md)
+3. [`architecture/INDEX.md`](architecture/INDEX.md)
+4. [`rfcs/project-invariants-rfc.md`](rfcs/project-invariants-rfc.md)
+5. [`rfcs/project-copy-semantics-rfc.md`](rfcs/project-copy-semantics-rfc.md)
+6. [`architecture/coordset-storage-architecture.md`](architecture/coordset-storage-architecture.md)
+7. [`architecture/display-architecture.md`](architecture/display-architecture.md)
+8. [`architecture/result-object-contract-rfc.md`](architecture/result-object-contract-rfc.md)
+9. [`architecture/result-object-migration-roadmap.md`](architecture/result-object-migration-roadmap.md)
+10. [`rfcs/metadata-contract.md`](rfcs/metadata-contract.md)
+11. [`architecture/mathematical-semantics-and-metadata-propagation.md`](architecture/mathematical-semantics-and-metadata-propagation.md)
+12. [`architecture/array-class-responsibility.md`](architecture/array-class-responsibility.md)
+13. [`rfcs/coordinate-arithmetic-semantics.md`](rfcs/coordinate-arithmetic-semantics.md)
+14. [`rfcs/trusted-and-portable-persistence.md`](rfcs/trusted-and-portable-persistence.md)
+15. [`rfcs/nddataset-xarray-mapping-specification.md`](rfcs/nddataset-xarray-mapping-specification.md)
+
 ## Key Documents
 
 | Document | Description |
 |---|---|
+| [`rfcs/INDEX.md`](rfcs/INDEX.md) | Index des RFCs mainteneur, de leur statut, et de leur rôle |
+| [`architecture/INDEX.md`](architecture/INDEX.md) | Point d'entrée organisé vers les notes d'architecture suivies |
 | [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md) | Feuille de route légère des sujets d'architecture récents, terminés ou différés |
 | [`rfcs/project-invariants-rfc.md`](rfcs/project-invariants-rfc.md) | Invariants « Project » : ownership, cycle, doublons, identité clé/nom (implémenté) |
+| [`rfcs/project-copy-semantics-rfc.md`](rfcs/project-copy-semantics-rfc.md) | Contrat de copie `Project` et sémantique deep/shallow maintenue |
 | [`rfcs/metadata-contract.md`](rfcs/metadata-contract.md) | Contrat mainteneur pour les métadonnées `NDDataset` |
 | [`rfcs/analysis-fit-result-architecture.md`](rfcs/analysis-fit-result-architecture.md) | RFC draft sur l'architecture actuelle des résultats d'analyse et de fit |
 | [`rfcs/modeldata-semantic-contract.md`](rfcs/modeldata-semantic-contract.md) | Audit et décision sur la suppression de `NDDataset.modeldata` |

--- a/maintainers/architecture/INDEX.md
+++ b/maintainers/architecture/INDEX.md
@@ -1,0 +1,69 @@
+# Architecture Index
+
+This index is the curated entry point for tracked maintainer architecture
+documents.
+
+Use this file when you want to understand which documents define current
+behavior, which ones provide durable technical reference, and which ones remain
+valuable mainly as historical context.
+
+For normative maintainer contracts and position statements, also see the
+[`../rfcs/INDEX.md`](../rfcs/INDEX.md) and the
+[`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md).
+
+These tracked architecture notes are authoritative once a design or campaign
+has stabilized. Local audits, implementation notes, campaign logs, and
+characterization reports remain useful context, but they are not the first
+place to look for the maintained project contract.
+
+## Core Architecture
+
+These documents are the primary tracked references for current maintained
+behavior, durable architecture boundaries, or active maintainer-facing
+contracts.
+
+| File | Description |
+|---|---|
+| [`array-class-responsibility.md`](array-class-responsibility.md) | Responsibility map across the core array classes before any future hierarchy cleanup. |
+| [`coordinate-arithmetic-audit.md`](coordinate-arithmetic-audit.md) | Technical map of the current coordinate-compatibility model used by arithmetic. |
+| [`coordset-storage-architecture.md`](coordset-storage-architecture.md) | Final tracked architecture for the completed `CoordSet` storage redesign. |
+| [`dataset-vs-coord-arithmetic-audit.md`](dataset-vs-coord-arithmetic-audit.md) | Semantic boundary showing why `Coord` is an axis/support object rather than a signal operand. |
+| [`display-architecture.md`](display-architecture.md) | Final post-migration display architecture and semantic HTML model. |
+| [`mathematical-semantics-and-metadata-propagation.md`](mathematical-semantics-and-metadata-propagation.md) | Active maintainer-facing contract draft for operation behavior, result assembly, provenance, and metadata propagation. |
+| [`result-object-contract-rfc.md`](result-object-contract-rfc.md) | Implemented tracked contract for result objects, ownership, serialization boundary, and display scope. |
+| [`result-object-migration-roadmap.md`](result-object-migration-roadmap.md) | Final campaign summary for the completed Result Object migration. |
+
+## Reference Architecture
+
+These documents are useful supporting references, decision-space analyses, or
+durable risk maps that maintainers may still rely on.
+
+| File | Description |
+|---|---|
+| [`coordinate-arithmetic-decision-audit.md`](coordinate-arithmetic-decision-audit.md) | Decision-space analysis for possible future coordinate arithmetic models. |
+| [`ndmath-maintainability-audit.md`](ndmath-maintainability-audit.md) | Risk map for the responsibility concentration inside `NDMath`. |
+| [`plotting-audit.md`](plotting-audit.md) | Baseline architecture review for plotting backend separation and extensibility. |
+| [`tensor-plugin-migration.md`](tensor-plugin-migration.md) | Durable note on the core/plugin boundary after the tensor migration. |
+| [`units-audit.md`](units-audit.md) | Baseline reference for unit handling, quantity propagation, and unit semantics. |
+
+## Historical Context
+
+These documents remain useful for historical understanding, but they are not
+the first place to look for the current maintained contract.
+
+| File | Description |
+|---|---|
+| [`display-architecture-audit.md`](display-architecture-audit.md) | Pre-migration display analysis preserved for history after the final display architecture note. |
+
+## Reading Order
+
+For a quick orientation path, start with:
+
+1. [`../README.md`](../README.md)
+2. [`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md)
+3. [`../rfcs/INDEX.md`](../rfcs/INDEX.md)
+4. [`coordset-storage-architecture.md`](coordset-storage-architecture.md)
+5. [`display-architecture.md`](display-architecture.md)
+6. [`result-object-contract-rfc.md`](result-object-contract-rfc.md)
+7. [`mathematical-semantics-and-metadata-propagation.md`](mathematical-semantics-and-metadata-propagation.md)
+8. [`array-class-responsibility.md`](array-class-responsibility.md)

--- a/maintainers/architecture/README.md
+++ b/maintainers/architecture/README.md
@@ -5,6 +5,10 @@ preserve decisions, invariants, risks, and technical context that should remain
 available after local audit notes are discarded.
 
 For active maintainer contracts and RFCs, also see [`../rfcs/`](../rfcs/).
+For the curated architecture entry point, see [`INDEX.md`](INDEX.md).
+For the RFC inventory, see [`../rfcs/INDEX.md`](../rfcs/INDEX.md).
+For campaign ordering and priorities, see
+[`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md).
 
 ## Placement Guide
 
@@ -13,6 +17,19 @@ For active maintainer contracts and RFCs, also see [`../rfcs/`](../rfcs/).
 | `../rfcs/` | Normative or near-normative behavior contracts and roadmap documents |
 | this directory | Durable audits, implementation maps, design baselines, and draft architecture analyses |
 | `audit/~*.md` | Local working notes that should not be versioned by default |
+
+## Reading Guidance
+
+Within this tracked directory:
+
+- **current** material is the first place to look for maintained technical
+  behavior or durable architecture boundaries;
+- **reference** material provides supporting risk maps, design-space analysis,
+  or implementation context;
+- **historical** material remains useful for migration context but is no longer
+  the primary authority.
+
+The curated grouping of those documents lives in [`INDEX.md`](INDEX.md).
 
 ## Active Draft Architecture Analyses
 

--- a/maintainers/rfcs/INDEX.md
+++ b/maintainers/rfcs/INDEX.md
@@ -1,0 +1,94 @@
+# RFC Index
+
+This index provides a maintainer-facing entry point to the RFC documents stored
+in this directory.
+
+## Purpose
+
+In SpectroChemPy, RFCs record maintainer-level behavior contracts, position
+statements, and proposed architectural boundaries.
+
+They are different from the other documentation layers:
+
+- RFCs define or propose maintainer-facing contracts and decisions.
+- Architecture notes preserve durable implementation maps, risk analyses, and
+  reference context.
+- Audits are working documents and implementation-history notes that may later
+  become outdated, superseded, or purely historical.
+
+Authoritative maintainer references usually live in:
+
+- the roadmap;
+- accepted RFCs;
+- implemented RFCs;
+- tracked architecture notes once a design has stabilized.
+
+Audits, implementation notes, campaign logs, and characterization reports are
+not authoritative by default.
+
+The usual RFC lifecycle is:
+
+```text
+PROPOSED -> ACCEPTED -> IMPLEMENTED
+                 \-> SUPERSEDED
+```
+
+Not every document passes through every stage. Some RFCs are accepted position
+statements or decision records rather than implementation plans.
+
+## Status Definitions
+
+### `PROPOSED`
+
+The document records a proposed maintainer contract or architecture direction.
+It is useful for guidance, but the behavior is not yet fully adopted.
+
+### `ACCEPTED`
+
+The document records an accepted maintainer position or decision. It is
+authoritative even if it is not primarily an implementation roadmap.
+
+### `IMPLEMENTED`
+
+The documented contract has been adopted in merged behavior and should be
+treated as the current maintained reference.
+
+### `SUPERSEDED`
+
+The RFC remains useful for history, but another document is now the primary
+authoritative reference.
+
+## Related Roadmap
+
+For campaign ordering and architecture priorities, see
+[`architecture-roadmap.md`](architecture-roadmap.md).
+
+## RFC Inventory
+
+| File | Title | Status | Short description | Related issue(s) |
+|---|---|---|---|---|
+| [`analysis-fit-result-architecture.md`](analysis-fit-result-architecture.md) | Analysis and Fit Result Architecture | `PROPOSED` | Conceptual background for result ownership, result surfaces, and the role of `NDDataset`; implementation authority moved to the tracked Result contract. | — |
+| [`coord-labels-portable-semantics.md`](coord-labels-portable-semantics.md) | Coord Labels Portable Semantics | `PROPOSED` | Defines which `Coord.labels` usages belong to the portable persistence contract. | — |
+| [`coordinate-arithmetic-semantics.md`](coordinate-arithmetic-semantics.md) | Coordinate Arithmetic Semantics RFC | `ACCEPTED` | Records the current maintainer position on coordinate arithmetic semantics and its future evolution space. | — |
+| [`csdm-position-statement.md`](csdm-position-statement.md) | Current Position on CSDM | `ACCEPTED` | States the current role of CSDM as an optional exchange format rather than native or primary portable persistence. | `#1153` |
+| [`display-representation-model-rfc.md`](display-representation-model-rfc.md) | Display / Representation Model RFC | `SUPERSEDED` | Historical representation-model RFC retained for context; final authority now lives in the tracked display architecture note. | `#843` |
+| [`metadata-contract.md`](metadata-contract.md) | Metadata Contract v1 | `PROPOSED` | Normative direction for `NDDataset` metadata preservation, recomputation, override, merge, and drop behavior. | — |
+| [`modeldata-semantic-contract.md`](modeldata-semantic-contract.md) | modeldata — Semantic Contract RFC | `ACCEPTED` | Decision record for removal of `NDDataset.modeldata` while preserving load compatibility for legacy serialized state. | `#1168` |
+| [`nddataset-xarray-mapping-specification.md`](nddataset-xarray-mapping-specification.md) | NDDataset ↔ xarray Dataset Mapping Specification | `PROPOSED` | Canonical mapping contract between `NDDataset` and `xarray.Dataset` for portable persistence and interchange; a substantial subset is already reflected in current code. | — |
+| [`project-copy-semantics-rfc.md`](project-copy-semantics-rfc.md) | Project Copy Semantics | `IMPLEMENTED` | Defines the maintained `Project.copy()` contract and the deep-copy model used by the completed campaign. | `#1164` |
+| [`project-invariants-rfc.md`](project-invariants-rfc.md) | Project Invariants and Ownership Semantics | `IMPLEMENTED` | Defines the maintained `Project` ownership, parent, cycle, and key/name identity invariants. | `#1164` |
+| [`roi-semantic-contract.md`](roi-semantic-contract.md) | roi — Semantic Contract RFC | `ACCEPTED` | Decision record for removal of orphaned `NDDataset.roi` runtime state while keeping legacy files readable. | — |
+| [`scientific-object-model-and-persistence-boundaries.md`](scientific-object-model-and-persistence-boundaries.md) | Scientific Object Model and Persistence Boundaries | `PROPOSED` | Defines the proposed object-role and persistence-boundary vocabulary for datasets, Projects, results, and extensions. | — |
+| [`trusted-and-portable-persistence.md`](trusted-and-portable-persistence.md) | Trusted and Portable Persistence | `PROPOSED` | Defines the conceptual distinction between trusted native persistence and portable scientific persistence; parts of this framing already guide the current security posture. | — |
+| [`xarray-backed-netcdf-persistence.md`](xarray-backed-netcdf-persistence.md) | xarray-Backed NetCDF Persistence | `PROPOSED` | Defines the proposed NetCDF contract for the xarray-backed portable persistence layer; parts of the portable round-trip path are already implemented. | — |
+
+## Notes
+
+- Status assignments above follow the documentation consolidation audit in
+  [`audit/~documentation-consolidation-audit-2026-06-21.md`](../../audit/~documentation-consolidation-audit-2026-06-21.md).
+- Several `PROPOSED` RFCs already describe behavior that is partially
+  reflected in current code. They remain `PROPOSED` here because the relevant
+  contract is not yet fully adopted or reclassified.
+- `coordinate-arithmetic-semantics.md` is listed as `ACCEPTED` here because it
+  already records the current maintainer position future discussions are
+  expected to start from.

--- a/maintainers/rfcs/architecture-roadmap.md
+++ b/maintainers/rfcs/architecture-roadmap.md
@@ -155,6 +155,8 @@ Decision:
 
 Future work is limited to maintenance and follow-up improvements.
 
+Campaign status: Completed.
+
 ---
 
 ### Metadata Propagation
@@ -168,6 +170,9 @@ Decision:
 No immediate redesign work is planned.
 
 Future work should be driven by concrete metadata issues.
+
+Campaign status: Active contract-consolidation topic, not an open migration
+campaign.
 
 ---
 
@@ -209,6 +214,8 @@ Decision:
 
 Future display work should preserve this plugin/core separation.
 
+Campaign status: Completed.
+
 ---
 
 ### NDMath
@@ -223,9 +230,11 @@ Future work should focus on maintainability rather than semantics.
 
 NDMath refactoring is deferred until a concrete maintenance problem appears.
 
+Campaign status: Deferred / future candidate.
+
 ---
 
-# Recently Completed Topics
+# Completed Campaigns
 
 ## CoordSet Storage Redesign
 
@@ -238,20 +247,6 @@ Major outcomes:
 * removal of legacy storage assumptions;
 * stabilization of same-dim behavior;
 * improved architectural consistency.
-
----
-
-## Metadata Contract
-
-Status: Drafted
-
-Major outcomes:
-
-* metadata propagation semantics documented;
-* preservation and recomputation rules clarified;
-* architectural direction established.
-
-Current priority: Low.
 
 ---
 
@@ -309,6 +304,105 @@ for the final architecture.
 Key outcomes: Coord, CoordSet, NDDataset, and Project now use the
 semantic HTML path (`_repr_sections()` → `_render_sections()`). The
 authoritative reference is `display-architecture.md`.
+
+---
+
+## Result Object Architecture
+
+Status: Completed for core estimators
+
+Refer to
+[`maintainers/architecture/result-object-contract-rfc.md`](../architecture/result-object-contract-rfc.md)
+and
+[`maintainers/architecture/result-object-migration-roadmap.md`](../architecture/result-object-migration-roadmap.md)
+for the implemented contract and campaign summary.
+
+Major outcomes:
+
+* stable Result object contract implemented;
+* core estimator migration completed;
+* ownership, provenance boundary, serialization boundary, and display scope
+  clarified.
+
+Current priority: Deferred infrastructure follow-up only.
+
+---
+
+## Project Invariants
+
+Status: Completed
+
+Major outcomes:
+
+* single-parent ownership clarified and enforced;
+* cycle protection clarified;
+* duplicate rejection clarified;
+* key/name identity clarified.
+
+Current priority: Closed except for future broader `Project` role questions.
+
+---
+
+## Project Copy Semantics
+
+Status: Completed
+
+Major outcomes:
+
+* `Project.copy()` contract documented and implemented;
+* detached recursive copy model clarified;
+* stale-parent behavior removed from the maintained contract.
+
+Current priority: Closed.
+
+---
+
+## Portable xarray / NetCDF Persistence
+
+Status: Active partial implementation
+
+Major outcomes:
+
+* canonical RFCs drafted for xarray mapping and NetCDF persistence;
+* portable same-dimension coordinates support merged;
+* portable string-label subset support merged;
+* a substantial subset of the xarray / NetCDF round-trip path now exists.
+
+Current priority: Active follow-up and contract synchronization.
+
+---
+
+## Security / Trusted Persistence
+
+Status: Completed security hardening; active contract clarification
+
+Major outcomes:
+
+* native persistence security hardening completed;
+* safe-writer and trust-boundary work merged;
+* trusted-versus-portable persistence framing documented as the current
+  architectural direction.
+
+Current priority: Documentation and boundary clarification rather than urgent
+implementation work.
+
+---
+
+# Active Documentation and Contract Topics
+
+## Metadata Contract
+
+Status: Active contract
+
+Major outcomes:
+
+* metadata propagation semantics documented;
+* preservation and recomputation rules clarified;
+* architectural direction established.
+
+Current priority: Low.
+This remains an active documentation contract rather than a completed
+implementation campaign.
 
 ---
 
@@ -392,7 +486,7 @@ campaign by default.
 
 ---
 
-# Near-Term Architectural Candidates
+# Active and Near-Term Candidates
 
 The following topics appear to offer the highest architectural value relative to their expected complexity.
 
@@ -414,6 +508,8 @@ Questions include:
 * result assembly consistency across core, processing, analysis, and plugins.
 
 This topic should be addressed before any class hierarchy split.
+
+Status: Active.
 
 ---
 
@@ -438,6 +534,8 @@ Questions that remain open:
 
 Deferred topics documented in the RFC: copy semantics, root-name semantics.
 
+Status: Future candidate.
+
 ---
 
 ## User-Facing Improvements
@@ -454,6 +552,8 @@ Examples include:
 * documentation improvements.
 
 User-facing improvements should generally take precedence when they provide immediate value.
+
+Status: Ongoing parallel priority, not a single architecture campaign.
 
 ---
 

--- a/maintainers/rfcs/coordinate-arithmetic-semantics.md
+++ b/maintainers/rfcs/coordinate-arithmetic-semantics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft Maintainer RFC.
+Accepted Maintainer RFC.
 
 This document records the current maintainer position on coordinate arithmetic
 semantics in SpectroChemPy.


### PR DESCRIPTION
## Motivation

Several architecture campaigns have completed over the last releases. The maintainer documentation structure was clarified, but the authoritative documentation still needed synchronization with the current state of the project. This PR combines the documentation-governance index work and the follow-up status synchronization into one maintainer-focused update.

## Changes

- add maintainer RFC and architecture indexes
- clarify where maintainers should look first for authoritative guidance
- document the maintainer documentation lifecycle (`Audit -> RFC -> Architecture Note`)
- add a concise core architecture reading path for new maintainers
- synchronize the architecture roadmap with the current state of completed, active, and future campaigns
- clean up unambiguous RFC status signaling, including the coordinate arithmetic maintainer position
- ignore local `audit/` content by default so personal working notes stay out of versioned PR scope

## No Functional Changes

Documentation-only PR.

No code changes.
No tests.
No behavioral changes.

## Validation

- documentation review only
- no test run requested for this documentation-only PR
