### PR TITLE
DOC: sync maintainer references with local audit policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ tests/figures/
 # Project Specific          #
 ###############################
 /extdata/
+/audit/
 /git_hooks/
 /installed.txt
 thumb.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,10 @@ Prefer incremental migration.
 
 # Audit Policy
 
-Audit files are the authoritative implementation history.
+Audit files are the authoritative implementation history for a campaign, but
+they are not the authoritative source for the current maintained architecture
+or behavior contract unless that content has been promoted into tracked
+maintainer documentation.
 
 Use audit notes for:
 
@@ -107,6 +110,115 @@ Agents must produce or update an audit note after each work session,
 documenting what was done, key decisions, test results, risks, and next
 steps.  For multi-PR projects, maintain dedicated audit files and update
 them before considering a task complete.
+
+---
+
+# Architecture Documentation Lifecycle
+
+Architecture work should normally progress through the following lifecycle:
+
+```text
+Audit
+  ↓
+RFC (optional)
+  ↓
+Implementation
+  ↓
+Architecture Note / Maintainer Reference
+```
+
+The goal is to ensure that durable architectural knowledge does not remain
+exclusively in local audit notes after a campaign is completed.
+
+## Audit
+
+Use audits for:
+
+* exploration;
+* characterization;
+* investigation;
+* design discussion.
+
+Audits are working documents.
+
+Audits are not authoritative by default for current maintained contracts.
+
+## RFC
+
+Use RFCs to:
+
+* define a proposed contract;
+* record decisions;
+* guide implementation.
+
+RFCs may be:
+
+* proposed;
+* accepted;
+* implemented;
+* superseded.
+
+## Architecture Notes
+
+Use architecture notes to:
+
+* describe current architecture;
+* capture stable contracts;
+* document important design decisions;
+* serve as maintainer references.
+
+Architecture notes become the authoritative source once a design stabilizes.
+
+## Promotion Requirement
+
+When a campaign results in:
+
+* an accepted RFC;
+* significant architectural change;
+* multiple implementation PRs;
+* a long-term contract;
+
+the maintainer should evaluate whether part of the audit material must be
+promoted into:
+
+* `maintainers/architecture/`; or
+* `maintainers/rfcs/`
+
+before the campaign is considered complete.
+
+Architectural reasoning should not remain exclusively in audit documents.
+
+## Audit Deliverables
+
+Major architecture audits should end with a final section named:
+
+```text
+Promotion Candidates
+```
+
+That section should identify:
+
+* content suitable for RFCs;
+* content suitable for architecture notes;
+* content that should remain historical only.
+
+Where possible, suggest target filenames.
+
+This requirement applies to major architecture audits, not to minor bug
+investigations or narrow implementation notes.
+
+## Campaign Closure Checklist
+
+Before closing a major architecture campaign, verify:
+
+* RFC status updated;
+* roadmap updated;
+* relevant architecture notes updated or created;
+* promotion candidates reviewed;
+* authoritative documentation synchronized.
+
+This checklist is meant to keep durable knowledge discoverable, not to add
+heavy process.
 
 ---
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -26,7 +26,7 @@ Utiliser ces couches documentaires dans cet ordre :
 |---|---|---|
 | RFCs | Contrats mainteneur, positions, décisions acceptées, et contrats implémentés | [`rfcs/INDEX.md`](rfcs/INDEX.md) |
 | Architecture Notes | Références d'architecture durables, cartes d'implémentation, et contexte technique maintenu | [`architecture/INDEX.md`](architecture/INDEX.md) |
-| Audits | Notes de travail, historique d'implémentation, investigations, et campagnes locales non versionnées par défaut | `audit/~*.md` |
+| Audits | Notes de travail, historique d'implémentation, investigations, et campagnes locales non versionnées par défaut | notes locales sous `audit/`, lorsqu'elles existent |
 | Roadmap | Priorités, sujets terminés, actifs, ou différés | [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md) |
 
 En pratique :

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -18,12 +18,91 @@ contrats RFC, et notes d'architecture durables.
 | [`rfcs/`](rfcs/) | RFC mainteneur et contrats de comportement |
 | [`architecture/`](architecture/) | Audits, notes d'architecture, et cartes de risques durables |
 
+## Documentation Structure
+
+Utiliser ces couches documentaires dans cet ordre :
+
+| Layer | Use for | Look here first |
+|---|---|---|
+| RFCs | Contrats mainteneur, positions, décisions acceptées, et contrats implémentés | [`rfcs/INDEX.md`](rfcs/INDEX.md) |
+| Architecture Notes | Références d'architecture durables, cartes d'implémentation, et contexte technique maintenu | [`architecture/INDEX.md`](architecture/INDEX.md) |
+| Audits | Notes de travail, historique d'implémentation, investigations, et campagnes locales non versionnées par défaut | `audit/~*.md` |
+| Roadmap | Priorités, sujets terminés, actifs, ou différés | [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md) |
+
+En pratique :
+
+- commencer par ce fichier ;
+- puis lire la roadmap ;
+- puis consulter l'index RFC ou l'index architecture selon que la question est
+  normative ou surtout technique ;
+- utiliser les audits locaux seulement pour retrouver le contexte de campagne
+  et l'historique d'implémentation.
+
+### Architecture-Document Lifecycle
+
+Le cycle documentaire typique est :
+
+```text
+Audit
+  ↓
+RFC
+  ↓
+Architecture Note
+```
+
+- les audits sont des analyses de travail et des notes de campagne ;
+- les RFCs portent des contrats proposés, acceptés, ou implémentés ;
+- les notes d'architecture deviennent la référence suivie lorsqu'un design ou
+  une campagne s'est stabilisé.
+
+### Authority Guide
+
+Considérer comme **authoritative** en priorité :
+
+- la roadmap mainteneur ;
+- les notes d'architecture suivies ;
+- les RFCs implémentés ;
+- les contrats et positions acceptés.
+
+Considérer comme **non-authoritative by default** :
+
+- les audits ;
+- les notes d'implémentation ;
+- les journaux de campagne ;
+- les rapports de caractérisation.
+
+En cas de doute, commencer par la roadmap, puis l'index RFC, puis l'index
+architecture.
+
+## Core Architecture Reading Path
+
+Pour un nouveau mainteneur, l'ordre de lecture recommandé est :
+
+1. [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md)
+2. [`rfcs/INDEX.md`](rfcs/INDEX.md)
+3. [`architecture/INDEX.md`](architecture/INDEX.md)
+4. [`rfcs/project-invariants-rfc.md`](rfcs/project-invariants-rfc.md)
+5. [`rfcs/project-copy-semantics-rfc.md`](rfcs/project-copy-semantics-rfc.md)
+6. [`architecture/coordset-storage-architecture.md`](architecture/coordset-storage-architecture.md)
+7. [`architecture/display-architecture.md`](architecture/display-architecture.md)
+8. [`architecture/result-object-contract-rfc.md`](architecture/result-object-contract-rfc.md)
+9. [`architecture/result-object-migration-roadmap.md`](architecture/result-object-migration-roadmap.md)
+10. [`rfcs/metadata-contract.md`](rfcs/metadata-contract.md)
+11. [`architecture/mathematical-semantics-and-metadata-propagation.md`](architecture/mathematical-semantics-and-metadata-propagation.md)
+12. [`architecture/array-class-responsibility.md`](architecture/array-class-responsibility.md)
+13. [`rfcs/coordinate-arithmetic-semantics.md`](rfcs/coordinate-arithmetic-semantics.md)
+14. [`rfcs/trusted-and-portable-persistence.md`](rfcs/trusted-and-portable-persistence.md)
+15. [`rfcs/nddataset-xarray-mapping-specification.md`](rfcs/nddataset-xarray-mapping-specification.md)
+
 ## Key Documents
 
 | Document | Description |
 |---|---|
+| [`rfcs/INDEX.md`](rfcs/INDEX.md) | Index des RFCs mainteneur, de leur statut, et de leur rôle |
+| [`architecture/INDEX.md`](architecture/INDEX.md) | Point d'entrée organisé vers les notes d'architecture suivies |
 | [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md) | Feuille de route légère des sujets d'architecture récents, terminés ou différés |
 | [`rfcs/project-invariants-rfc.md`](rfcs/project-invariants-rfc.md) | Invariants « Project » : ownership, cycle, doublons, identité clé/nom (implémenté) |
+| [`rfcs/project-copy-semantics-rfc.md`](rfcs/project-copy-semantics-rfc.md) | Contrat de copie `Project` et sémantique deep/shallow maintenue |
 | [`rfcs/metadata-contract.md`](rfcs/metadata-contract.md) | Contrat mainteneur pour les métadonnées `NDDataset` |
 | [`rfcs/analysis-fit-result-architecture.md`](rfcs/analysis-fit-result-architecture.md) | RFC draft sur l'architecture actuelle des résultats d'analyse et de fit |
 | [`rfcs/modeldata-semantic-contract.md`](rfcs/modeldata-semantic-contract.md) | Audit et décision sur la suppression de `NDDataset.modeldata` |

--- a/maintainers/architecture/INDEX.md
+++ b/maintainers/architecture/INDEX.md
@@ -1,0 +1,69 @@
+# Architecture Index
+
+This index is the curated entry point for tracked maintainer architecture
+documents.
+
+Use this file when you want to understand which documents define current
+behavior, which ones provide durable technical reference, and which ones remain
+valuable mainly as historical context.
+
+For normative maintainer contracts and position statements, also see the
+[`../rfcs/INDEX.md`](../rfcs/INDEX.md) and the
+[`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md).
+
+These tracked architecture notes are authoritative once a design or campaign
+has stabilized. Local audits, implementation notes, campaign logs, and
+characterization reports remain useful context, but they are not the first
+place to look for the maintained project contract.
+
+## Core Architecture
+
+These documents are the primary tracked references for current maintained
+behavior, durable architecture boundaries, or active maintainer-facing
+contracts.
+
+| File | Description |
+|---|---|
+| [`array-class-responsibility.md`](array-class-responsibility.md) | Responsibility map across the core array classes before any future hierarchy cleanup. |
+| [`coordinate-arithmetic-audit.md`](coordinate-arithmetic-audit.md) | Technical map of the current coordinate-compatibility model used by arithmetic. |
+| [`coordset-storage-architecture.md`](coordset-storage-architecture.md) | Final tracked architecture for the completed `CoordSet` storage redesign. |
+| [`dataset-vs-coord-arithmetic-audit.md`](dataset-vs-coord-arithmetic-audit.md) | Semantic boundary showing why `Coord` is an axis/support object rather than a signal operand. |
+| [`display-architecture.md`](display-architecture.md) | Final post-migration display architecture and semantic HTML model. |
+| [`mathematical-semantics-and-metadata-propagation.md`](mathematical-semantics-and-metadata-propagation.md) | Active maintainer-facing contract draft for operation behavior, result assembly, provenance, and metadata propagation. |
+| [`result-object-contract-rfc.md`](result-object-contract-rfc.md) | Implemented tracked contract for result objects, ownership, serialization boundary, and display scope. |
+| [`result-object-migration-roadmap.md`](result-object-migration-roadmap.md) | Final campaign summary for the completed Result Object migration. |
+
+## Reference Architecture
+
+These documents are useful supporting references, decision-space analyses, or
+durable risk maps that maintainers may still rely on.
+
+| File | Description |
+|---|---|
+| [`coordinate-arithmetic-decision-audit.md`](coordinate-arithmetic-decision-audit.md) | Decision-space analysis for possible future coordinate arithmetic models. |
+| [`ndmath-maintainability-audit.md`](ndmath-maintainability-audit.md) | Risk map for the responsibility concentration inside `NDMath`. |
+| [`plotting-audit.md`](plotting-audit.md) | Baseline architecture review for plotting backend separation and extensibility. |
+| [`tensor-plugin-migration.md`](tensor-plugin-migration.md) | Durable note on the core/plugin boundary after the tensor migration. |
+| [`units-audit.md`](units-audit.md) | Baseline reference for unit handling, quantity propagation, and unit semantics. |
+
+## Historical Context
+
+These documents remain useful for historical understanding, but they are not
+the first place to look for the current maintained contract.
+
+| File | Description |
+|---|---|
+| [`display-architecture-audit.md`](display-architecture-audit.md) | Pre-migration display analysis preserved for history after the final display architecture note. |
+
+## Reading Order
+
+For a quick orientation path, start with:
+
+1. [`../README.md`](../README.md)
+2. [`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md)
+3. [`../rfcs/INDEX.md`](../rfcs/INDEX.md)
+4. [`coordset-storage-architecture.md`](coordset-storage-architecture.md)
+5. [`display-architecture.md`](display-architecture.md)
+6. [`result-object-contract-rfc.md`](result-object-contract-rfc.md)
+7. [`mathematical-semantics-and-metadata-propagation.md`](mathematical-semantics-and-metadata-propagation.md)
+8. [`array-class-responsibility.md`](array-class-responsibility.md)

--- a/maintainers/architecture/README.md
+++ b/maintainers/architecture/README.md
@@ -16,7 +16,7 @@ For campaign ordering and priorities, see
 |---|---|
 | `../rfcs/` | Normative or near-normative behavior contracts and roadmap documents |
 | this directory | Durable audits, implementation maps, design baselines, and draft architecture analyses |
-| `audit/~*.md` | Local working notes that should not be versioned by default |
+| local notes under `audit/` | Local working notes that should not be versioned by default |
 
 ## Reading Guidance
 
@@ -66,7 +66,7 @@ The curated grouping of those documents lives in [`INDEX.md`](INDEX.md).
 |---|---|---|
 | [`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md) | Roadmap | Summarizes completed, active, and deferred architecture topics. |
 | [`../rfcs/analysis-fit-result-architecture.md`](../rfcs/analysis-fit-result-architecture.md) | Draft conceptual RFC | Preserves the broader conceptual analysis of result surfaces and ownership around the implemented Result contract. |
-| [`../rfcs/coordinate-arithmetic-semantics.md`](../rfcs/coordinate-arithmetic-semantics.md) | Draft RFC | Maintainer position on coordinate arithmetic semantics. |
+| [`../rfcs/coordinate-arithmetic-semantics.md`](../rfcs/coordinate-arithmetic-semantics.md) | Accepted RFC | Maintainer position on coordinate arithmetic semantics. |
 | [`../rfcs/metadata-contract.md`](../rfcs/metadata-contract.md) | Draft RFC | Normative direction for `NDDataset` metadata preservation, recomputation, override, merge, and drop behavior. |
 | [`../rfcs/modeldata-semantic-contract.md`](../rfcs/modeldata-semantic-contract.md) | Accepted decision record | Audit and removal decision for orphaned `NDDataset.modeldata`. |
 | [`../rfcs/roi-semantic-contract.md`](../rfcs/roi-semantic-contract.md) | Accepted decision record | Audit and removal decision for orphaned `NDDataset.roi`. |

--- a/maintainers/architecture/README.md
+++ b/maintainers/architecture/README.md
@@ -5,6 +5,10 @@ preserve decisions, invariants, risks, and technical context that should remain
 available after local audit notes are discarded.
 
 For active maintainer contracts and RFCs, also see [`../rfcs/`](../rfcs/).
+For the curated architecture entry point, see [`INDEX.md`](INDEX.md).
+For the RFC inventory, see [`../rfcs/INDEX.md`](../rfcs/INDEX.md).
+For campaign ordering and priorities, see
+[`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md).
 
 ## Placement Guide
 
@@ -13,6 +17,19 @@ For active maintainer contracts and RFCs, also see [`../rfcs/`](../rfcs/).
 | `../rfcs/` | Normative or near-normative behavior contracts and roadmap documents |
 | this directory | Durable audits, implementation maps, design baselines, and draft architecture analyses |
 | `audit/~*.md` | Local working notes that should not be versioned by default |
+
+## Reading Guidance
+
+Within this tracked directory:
+
+- **current** material is the first place to look for maintained technical
+  behavior or durable architecture boundaries;
+- **reference** material provides supporting risk maps, design-space analysis,
+  or implementation context;
+- **historical** material remains useful for migration context but is no longer
+  the primary authority.
+
+The curated grouping of those documents lives in [`INDEX.md`](INDEX.md).
 
 ## Active Draft Architecture Analyses
 

--- a/maintainers/architecture/coordset-storage-architecture.md
+++ b/maintainers/architecture/coordset-storage-architecture.md
@@ -241,24 +241,9 @@ Do not remove them without proving that they are unreachable or redundant.
 
 ## Audit Trail
 
-For detailed campaign history and representative checkpoints, see:
-
-- `audit/~storage-pr1 - tests de contrat public.md`
-- `audit/~coordset-lookup-audit.md`
-- `audit/~coordset-storage-pr12-notes.md`
-- `audit/~coordset-storage-pr13-notes.md`
-- `audit/~coordset-storage-pr14-notes.md`
-- `audit/~coordset-storage-pr15-notes.md`
-- `audit/~coordset-storage-pr16-notes.md`
-- `audit/~coordset-storage-pr17-notes.md`
-- `audit/~coordset-storage-pr18-notes.md`
-- `audit/~coordset-storage-pr19-notes.md`
-- `audit/~coordset-storage-pr20-notes.md`
-- `audit/~coordset-storage-pr21-audit.md`
-- `audit/~coordset-storage-pr22-audit.md`
-- `audit/~coordset-storage-pr23-audit.md`
-- `audit/~coordset-storage-pr24-preparation.md`
-- `audit/~coordset-storage-pr25-independent-audit.md`
+Detailed campaign history and intermediate checkpoints remain in the local
+maintainer audit trail. The tracked references for maintainers are this final
+architecture note and the curated architecture indexes under `maintainers/`.
 
 ### Broader Traitlets Audit
 

--- a/maintainers/architecture/display-architecture.md
+++ b/maintainers/architecture/display-architecture.md
@@ -200,12 +200,6 @@ items.
 
 ## Audit Trail
 
-For retained detailed notes around the completed display campaign and later
-follow-up work, see:
-
-- `audit/~display-architecture-audit.md`
-- `audit/~project-semantic-display-migration.md`
-- `audit/~project-display-navigation-review.md`
-- `audit/~hypercomplex-display-audit.md`
-- `audit/~hypercomplex-display-regression-check.md`
-- `audit/~hypercomplex-display-restoration.md`
+Detailed campaign notes and follow-up investigations remain part of the local
+maintainer audit trail. The tracked references for maintainers are this
+document and [`display-architecture-audit.md`](display-architecture-audit.md).

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -4,7 +4,9 @@
 
 **Related RFC:** `result-object-contract-rfc.md`
 
-**Campaign review:** `audit/~result-object-campaign-closure-review.md`
+**Campaign review context:** This roadmap preserves the tracked maintainer
+summary for the completed campaign; detailed implementation history remains in
+the local audit trail.
 
 ---
 
@@ -197,15 +199,6 @@ Optional follow-up candidates that do not change campaign completion status:
 
 ## 7. Audit Trail
 
-Detailed implementation history remains in the audit files:
-
-- `audit/~result-object-campaign-closure-review.md`
-- `audit/~result-object-contract-pr1-audit.md`
-- `audit/~result-object-contract-pr2-audit.md`
-- `audit/~result-object-contract-pr3-audit.md`
-- `audit/~result-object-contract-pr4-audit.md`
-- `audit/~result-object-contract-pr5-audit.md`
-- `audit/~result-object-contract-pr6-audit.md`
-- `audit/~result-object-contract-pr7-audit.md`
-- `audit/~result-object-contract-pr8-audit.md`
-- `audit/~result-object-contract-pr9-audit.md`
+Detailed implementation history remains in the local audit trail. The tracked
+maintainer references for this completed campaign are this roadmap and
+[`result-object-contract-rfc.md`](result-object-contract-rfc.md).

--- a/maintainers/architecture/tensor-plugin-migration.md
+++ b/maintainers/architecture/tensor-plugin-migration.md
@@ -5,7 +5,7 @@
 Completed architecture note.
 
 This document preserves the durable decisions from the former
-`audit/tensor-plugin-migration.md` note.
+local tensor-plugin migration note.
 
 ## Scope
 

--- a/maintainers/rfcs/INDEX.md
+++ b/maintainers/rfcs/INDEX.md
@@ -1,0 +1,94 @@
+# RFC Index
+
+This index provides a maintainer-facing entry point to the RFC documents stored
+in this directory.
+
+## Purpose
+
+In SpectroChemPy, RFCs record maintainer-level behavior contracts, position
+statements, and proposed architectural boundaries.
+
+They are different from the other documentation layers:
+
+- RFCs define or propose maintainer-facing contracts and decisions.
+- Architecture notes preserve durable implementation maps, risk analyses, and
+  reference context.
+- Audits are working documents and implementation-history notes that may later
+  become outdated, superseded, or purely historical.
+
+Authoritative maintainer references usually live in:
+
+- the roadmap;
+- accepted RFCs;
+- implemented RFCs;
+- tracked architecture notes once a design has stabilized.
+
+Audits, implementation notes, campaign logs, and characterization reports are
+not authoritative by default.
+
+The usual RFC lifecycle is:
+
+```text
+PROPOSED -> ACCEPTED -> IMPLEMENTED
+                 \-> SUPERSEDED
+```
+
+Not every document passes through every stage. Some RFCs are accepted position
+statements or decision records rather than implementation plans.
+
+## Status Definitions
+
+### `PROPOSED`
+
+The document records a proposed maintainer contract or architecture direction.
+It is useful for guidance, but the behavior is not yet fully adopted.
+
+### `ACCEPTED`
+
+The document records an accepted maintainer position or decision. It is
+authoritative even if it is not primarily an implementation roadmap.
+
+### `IMPLEMENTED`
+
+The documented contract has been adopted in merged behavior and should be
+treated as the current maintained reference.
+
+### `SUPERSEDED`
+
+The RFC remains useful for history, but another document is now the primary
+authoritative reference.
+
+## Related Roadmap
+
+For campaign ordering and architecture priorities, see
+[`architecture-roadmap.md`](architecture-roadmap.md).
+
+## RFC Inventory
+
+| File | Title | Status | Short description | Related issue(s) |
+|---|---|---|---|---|
+| [`analysis-fit-result-architecture.md`](analysis-fit-result-architecture.md) | Analysis and Fit Result Architecture | `PROPOSED` | Conceptual background for result ownership, result surfaces, and the role of `NDDataset`; implementation authority moved to the tracked Result contract. | — |
+| [`coord-labels-portable-semantics.md`](coord-labels-portable-semantics.md) | Coord Labels Portable Semantics | `PROPOSED` | Defines which `Coord.labels` usages belong to the portable persistence contract. | — |
+| [`coordinate-arithmetic-semantics.md`](coordinate-arithmetic-semantics.md) | Coordinate Arithmetic Semantics RFC | `ACCEPTED` | Records the current maintainer position on coordinate arithmetic semantics and its future evolution space. | — |
+| [`csdm-position-statement.md`](csdm-position-statement.md) | Current Position on CSDM | `ACCEPTED` | States the current role of CSDM as an optional exchange format rather than native or primary portable persistence. | `#1153` |
+| [`display-representation-model-rfc.md`](display-representation-model-rfc.md) | Display / Representation Model RFC | `SUPERSEDED` | Historical representation-model RFC retained for context; final authority now lives in the tracked display architecture note. | `#843` |
+| [`metadata-contract.md`](metadata-contract.md) | Metadata Contract v1 | `PROPOSED` | Normative direction for `NDDataset` metadata preservation, recomputation, override, merge, and drop behavior. | — |
+| [`modeldata-semantic-contract.md`](modeldata-semantic-contract.md) | modeldata — Semantic Contract RFC | `ACCEPTED` | Decision record for removal of `NDDataset.modeldata` while preserving load compatibility for legacy serialized state. | `#1168` |
+| [`nddataset-xarray-mapping-specification.md`](nddataset-xarray-mapping-specification.md) | NDDataset ↔ xarray Dataset Mapping Specification | `PROPOSED` | Canonical mapping contract between `NDDataset` and `xarray.Dataset` for portable persistence and interchange; a substantial subset is already reflected in current code. | — |
+| [`project-copy-semantics-rfc.md`](project-copy-semantics-rfc.md) | Project Copy Semantics | `IMPLEMENTED` | Defines the maintained `Project.copy()` contract and the deep-copy model used by the completed campaign. | `#1164` |
+| [`project-invariants-rfc.md`](project-invariants-rfc.md) | Project Invariants and Ownership Semantics | `IMPLEMENTED` | Defines the maintained `Project` ownership, parent, cycle, and key/name identity invariants. | `#1164` |
+| [`roi-semantic-contract.md`](roi-semantic-contract.md) | roi — Semantic Contract RFC | `ACCEPTED` | Decision record for removal of orphaned `NDDataset.roi` runtime state while keeping legacy files readable. | — |
+| [`scientific-object-model-and-persistence-boundaries.md`](scientific-object-model-and-persistence-boundaries.md) | Scientific Object Model and Persistence Boundaries | `PROPOSED` | Defines the proposed object-role and persistence-boundary vocabulary for datasets, Projects, results, and extensions. | — |
+| [`trusted-and-portable-persistence.md`](trusted-and-portable-persistence.md) | Trusted and Portable Persistence | `PROPOSED` | Defines the conceptual distinction between trusted native persistence and portable scientific persistence; parts of this framing already guide the current security posture. | — |
+| [`xarray-backed-netcdf-persistence.md`](xarray-backed-netcdf-persistence.md) | xarray-Backed NetCDF Persistence | `PROPOSED` | Defines the proposed NetCDF contract for the xarray-backed portable persistence layer; parts of the portable round-trip path are already implemented. | — |
+
+## Notes
+
+- Status assignments above follow the documentation consolidation audit in
+  [`audit/~documentation-consolidation-audit-2026-06-21.md`](../../audit/~documentation-consolidation-audit-2026-06-21.md).
+- Several `PROPOSED` RFCs already describe behavior that is partially
+  reflected in current code. They remain `PROPOSED` here because the relevant
+  contract is not yet fully adopted or reclassified.
+- `coordinate-arithmetic-semantics.md` is listed as `ACCEPTED` here because it
+  already records the current maintainer position future discussions are
+  expected to start from.

--- a/maintainers/rfcs/INDEX.md
+++ b/maintainers/rfcs/INDEX.md
@@ -84,8 +84,8 @@ For campaign ordering and architecture priorities, see
 
 ## Notes
 
-- Status assignments above follow the documentation consolidation audit in
-  [`audit/~documentation-consolidation-audit-2026-06-21.md`](../../audit/~documentation-consolidation-audit-2026-06-21.md).
+- Status assignments above reflect the current maintainer documentation review
+  and roadmap synchronization work.
 - Several `PROPOSED` RFCs already describe behavior that is partially
   reflected in current code. They remain `PROPOSED` here because the relevant
   contract is not yet fully adopted or reclassified.

--- a/maintainers/rfcs/analysis-fit-result-architecture.md
+++ b/maintainers/rfcs/analysis-fit-result-architecture.md
@@ -2,11 +2,8 @@
 
 **Status:** Draft conceptual RFC
 
-**Audit reference:**
-[`audit/~analysis-fit-result-architecture-audit.md`](../audit/~analysis-fit-result-architecture-audit.md)
-
-**PR9 output semantics reference:**
-[`audit/~pr9-analysis-output-semantics-report.md`](../audit/~pr9-analysis-output-semantics-report.md)
+**Background:** Maintainer analysis and campaign-local audit work informed this
+conceptual RFC.
 
 **Implementation reference:**
 [`maintainers/architecture/result-object-contract-rfc.md`](../architecture/result-object-contract-rfc.md)

--- a/maintainers/rfcs/architecture-roadmap.md
+++ b/maintainers/rfcs/architecture-roadmap.md
@@ -155,6 +155,8 @@ Decision:
 
 Future work is limited to maintenance and follow-up improvements.
 
+Campaign status: Completed.
+
 ---
 
 ### Metadata Propagation
@@ -168,6 +170,9 @@ Decision:
 No immediate redesign work is planned.
 
 Future work should be driven by concrete metadata issues.
+
+Campaign status: Active contract-consolidation topic, not an open migration
+campaign.
 
 ---
 
@@ -209,6 +214,8 @@ Decision:
 
 Future display work should preserve this plugin/core separation.
 
+Campaign status: Completed.
+
 ---
 
 ### NDMath
@@ -223,9 +230,11 @@ Future work should focus on maintainability rather than semantics.
 
 NDMath refactoring is deferred until a concrete maintenance problem appears.
 
+Campaign status: Deferred / future candidate.
+
 ---
 
-# Recently Completed Topics
+# Completed Campaigns
 
 ## CoordSet Storage Redesign
 
@@ -238,20 +247,6 @@ Major outcomes:
 * removal of legacy storage assumptions;
 * stabilization of same-dim behavior;
 * improved architectural consistency.
-
----
-
-## Metadata Contract
-
-Status: Drafted
-
-Major outcomes:
-
-* metadata propagation semantics documented;
-* preservation and recomputation rules clarified;
-* architectural direction established.
-
-Current priority: Low.
 
 ---
 
@@ -309,6 +304,105 @@ for the final architecture.
 Key outcomes: Coord, CoordSet, NDDataset, and Project now use the
 semantic HTML path (`_repr_sections()` → `_render_sections()`). The
 authoritative reference is `display-architecture.md`.
+
+---
+
+## Result Object Architecture
+
+Status: Completed for core estimators
+
+Refer to
+[`maintainers/architecture/result-object-contract-rfc.md`](../architecture/result-object-contract-rfc.md)
+and
+[`maintainers/architecture/result-object-migration-roadmap.md`](../architecture/result-object-migration-roadmap.md)
+for the implemented contract and campaign summary.
+
+Major outcomes:
+
+* stable Result object contract implemented;
+* core estimator migration completed;
+* ownership, provenance boundary, serialization boundary, and display scope
+  clarified.
+
+Current priority: Deferred infrastructure follow-up only.
+
+---
+
+## Project Invariants
+
+Status: Completed
+
+Major outcomes:
+
+* single-parent ownership clarified and enforced;
+* cycle protection clarified;
+* duplicate rejection clarified;
+* key/name identity clarified.
+
+Current priority: Closed except for future broader `Project` role questions.
+
+---
+
+## Project Copy Semantics
+
+Status: Completed
+
+Major outcomes:
+
+* `Project.copy()` contract documented and implemented;
+* detached recursive copy model clarified;
+* stale-parent behavior removed from the maintained contract.
+
+Current priority: Closed.
+
+---
+
+## Portable xarray / NetCDF Persistence
+
+Status: Active partial implementation
+
+Major outcomes:
+
+* canonical RFCs drafted for xarray mapping and NetCDF persistence;
+* portable same-dimension coordinates support merged;
+* portable string-label subset support merged;
+* a substantial subset of the xarray / NetCDF round-trip path now exists.
+
+Current priority: Active follow-up and contract synchronization.
+
+---
+
+## Security / Trusted Persistence
+
+Status: Completed security hardening; active contract clarification
+
+Major outcomes:
+
+* native persistence security hardening completed;
+* safe-writer and trust-boundary work merged;
+* trusted-versus-portable persistence framing documented as the current
+  architectural direction.
+
+Current priority: Documentation and boundary clarification rather than urgent
+implementation work.
+
+---
+
+# Active Documentation and Contract Topics
+
+## Metadata Contract
+
+Status: Active contract
+
+Major outcomes:
+
+* metadata propagation semantics documented;
+* preservation and recomputation rules clarified;
+* architectural direction established.
+
+Current priority: Low.
+This remains an active documentation contract rather than a completed
+implementation campaign.
 
 ---
 
@@ -392,7 +486,7 @@ campaign by default.
 
 ---
 
-# Near-Term Architectural Candidates
+# Active and Near-Term Candidates
 
 The following topics appear to offer the highest architectural value relative to their expected complexity.
 
@@ -414,6 +508,8 @@ Questions include:
 * result assembly consistency across core, processing, analysis, and plugins.
 
 This topic should be addressed before any class hierarchy split.
+
+Status: Active.
 
 ---
 
@@ -438,6 +534,8 @@ Questions that remain open:
 
 Deferred topics documented in the RFC: copy semantics, root-name semantics.
 
+Status: Future candidate.
+
 ---
 
 ## User-Facing Improvements
@@ -454,6 +552,8 @@ Examples include:
 * documentation improvements.
 
 User-facing improvements should generally take precedence when they provide immediate value.
+
+Status: Ongoing parallel priority, not a single architecture campaign.
 
 ---
 

--- a/maintainers/rfcs/architecture-roadmap.md
+++ b/maintainers/rfcs/architecture-roadmap.md
@@ -39,7 +39,6 @@ This document should evolve as the project evolves.
 - Reference: `maintainers/rfcs/analysis-fit-result-architecture.md`
 - Implementation reference: `maintainers/architecture/result-object-contract-rfc.md`
 - Campaign summary: `maintainers/architecture/result-object-migration-roadmap.md`
-- Audit reference: `audit/~analysis-fit-result-architecture-audit.md`
 
 ### Units and Dimensional Semantics Audit
 
@@ -54,7 +53,6 @@ This document should evolve as the project evolves.
 - Minor inconsistency: `PLSRegression.coef` is unitless while
   `LinearRegressionAnalysis.coef` computes explicit `Y/X` unit ratios.
 - No immediate redesign recommended.
-- Audit reference: `audit/~units-and-dimensional-semantics-audit.md`
 
 ### History and Provenance Semantics Characterization
 
@@ -591,11 +589,11 @@ Status: Audited; RFC drafted; partial implementation completed.
 
 Motivation:
 
-Several audits revealed multiple result-construction paths throughout the codebase.
+Several maintainer reviews revealed multiple result-construction paths
+throughout the codebase.
 
 Current state:
 
-- Analysis and Fit Result Architecture audit completed (`audit/~analysis-fit-result-architecture-audit.md`).
 - RFC drafted (`maintainers/rfcs/analysis-fit-result-architecture.md`).
 - Result Object contract implemented and documented in
   `maintainers/architecture/result-object-contract-rfc.md`.

--- a/maintainers/rfcs/coord-labels-portable-semantics.md
+++ b/maintainers/rfcs/coord-labels-portable-semantics.md
@@ -14,8 +14,8 @@ model.
 
 - `maintainers/rfcs/nddataset-xarray-mapping-specification.md`
 - `maintainers/rfcs/xarray-backed-netcdf-persistence.md`
-- `audit/~portable-coordset-enrichment-audit.md`
-- `audit/~portable-same-dim-coords-progress.md`
+- the recent portable `CoordSet` enrichment work and same-dimension coordinate
+  progress reviews
 
 ---
 
@@ -34,7 +34,8 @@ A clear portable semantics decision is needed before implementing, because:
 - several readers (OPUS, JCAMP, Omnic, SPC, CSV) populate labels with
   acquisition metadata that users may expect to survive round-trip;
 - the xarray mapping RFC explicitly lists labels as an open question;
-- the enrichment audit recommends deferring labels to a dedicated RFC.
+- earlier portable-persistence review recommended deferring labels to a
+  dedicated RFC.
 
 This RFC resolves that open question by classifying label usages and defining
 which subset is portable.

--- a/maintainers/rfcs/coordinate-arithmetic-semantics.md
+++ b/maintainers/rfcs/coordinate-arithmetic-semantics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft Maintainer RFC.
+Accepted Maintainer RFC.
 
 This document records the current maintainer position on coordinate arithmetic
 semantics in SpectroChemPy.

--- a/maintainers/rfcs/csdm-position-statement.md
+++ b/maintainers/rfcs/csdm-position-statement.md
@@ -8,8 +8,8 @@ SpectroChemPy.
 **Related issue:**
 [#1153](https://github.com/spectrochempy/spectrochempy/issues/1153)
 
-**Supporting audit:**
-`audit/~csdm-interoperability-and-native-persistence-evaluation.md`
+**Supporting context:** This position is informed by the recent maintainer
+evaluation of CSDM interoperability and native-persistence candidates.
 
 ## Decision
 

--- a/maintainers/rfcs/nddataset-xarray-mapping-specification.md
+++ b/maintainers/rfcs/nddataset-xarray-mapping-specification.md
@@ -13,8 +13,8 @@ mechanics.
 
 - `maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md`
 - `maintainers/rfcs/trusted-and-portable-persistence.md`
-- `audit/~portable-xarray-netcdf-format-architecture-audit.md`
-- `audit/~csdm-native-persistence-candidate-audit.md`
+- the recent portable xarray / NetCDF architecture review
+- the recent CSDM native-persistence candidate review
 
 The key words MUST, SHOULD, and MAY express the intended future contract. They
 do not change current behavior until separately implemented.
@@ -505,7 +505,8 @@ However, based on the CSDM audit:
   whole at this stage;
 - it should not replace the xarray-centered mapping model defined here.
 
-See `audit/~csdm-native-persistence-candidate-audit.md`.
+See the related CSDM position statement and the portable-persistence RFCs for
+the tracked maintainer direction.
 
 ## Recommendations
 

--- a/maintainers/rfcs/project-copy-semantics-rfc.md
+++ b/maintainers/rfcs/project-copy-semantics-rfc.md
@@ -8,7 +8,8 @@
 (PRs #1230–#1234). Copy semantics was explicitly deferred there and is the
 subject of this RFC.
 
-**Prerequisite audit:** `audit/~project-copy-semantics-audit.md`
+**Prerequisite analysis:** This RFC follows the completed maintainer review of
+`Project` copy behavior and ownership invariants.
 
 ## Motivation
 
@@ -22,7 +23,7 @@ because:
 3. It was unclear whether `copy()` should be shallow, deep, or something in
    between.
 
-The audit (`audit/~project-copy-semantics-audit.md`) found that:
+The prerequisite review found that:
 
 - The current behavior is **not the result of an explicit design decision**.
   It is a side effect of how Traitlets type validators interact with

--- a/maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md
+++ b/maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md
@@ -15,7 +15,7 @@ through separately approved work.
 - `maintainers/architecture/result-object-migration-roadmap.md`
 - `maintainers/rfcs/analysis-fit-result-architecture.md`
 - `maintainers/rfcs/metadata-contract.md`
-- `audit/~project-and-serialization-architecture-review.md`
+- recent maintainer review of `Project` and serialization boundaries
 
 ## Motivation
 

--- a/maintainers/rfcs/trusted-and-portable-persistence.md
+++ b/maintainers/rfcs/trusted-and-portable-persistence.md
@@ -9,7 +9,7 @@
 **Related documents:**
 
 - `maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md`
-- `audit/~serialization-security-and-trust-boundary-audit.md`
+- recent maintainer security and trust-boundary review work
 
 ---
 

--- a/maintainers/rfcs/xarray-backed-netcdf-persistence.md
+++ b/maintainers/rfcs/xarray-backed-netcdf-persistence.md
@@ -12,8 +12,7 @@ persistence, Zarr-specific policy, implementation, migration, or API work.
 
 - `maintainers/rfcs/nddataset-xarray-mapping-specification.md`
 - `maintainers/rfcs/trusted-and-portable-persistence.md`
-- `audit/~xarray-prototype-implementation-notes.md`
-- `audit/~portable-xarray-netcdf-format-architecture-audit.md`
+- the earlier xarray / NetCDF prototype and architecture reviews
 
 The key words MUST, SHOULD, and MAY express the intended future contract. They
 do not change current behavior until separately implemented.


### PR DESCRIPTION
Superseded by #1239, which rebased the same documentation-only changes onto a fresh branch and merged cleanly.