### PR TITLE
DOC: sync maintainer references with local audit policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,10 @@ Prefer incremental migration.
 
 # Audit Policy
 
-Audit files are the authoritative implementation history.
+Audit files are the authoritative implementation history for a campaign, but
+they are not the authoritative source for the current maintained architecture
+or behavior contract unless that content has been promoted into tracked
+maintainer documentation.
 
 Use audit notes for:
 
@@ -107,6 +110,115 @@ Agents must produce or update an audit note after each work session,
 documenting what was done, key decisions, test results, risks, and next
 steps.  For multi-PR projects, maintain dedicated audit files and update
 them before considering a task complete.
+
+---
+
+# Architecture Documentation Lifecycle
+
+Architecture work should normally progress through the following lifecycle:
+
+```text
+Audit
+  ↓
+RFC (optional)
+  ↓
+Implementation
+  ↓
+Architecture Note / Maintainer Reference
+```
+
+The goal is to ensure that durable architectural knowledge does not remain
+exclusively in local audit notes after a campaign is completed.
+
+## Audit
+
+Use audits for:
+
+* exploration;
+* characterization;
+* investigation;
+* design discussion.
+
+Audits are working documents.
+
+Audits are not authoritative by default for current maintained contracts.
+
+## RFC
+
+Use RFCs to:
+
+* define a proposed contract;
+* record decisions;
+* guide implementation.
+
+RFCs may be:
+
+* proposed;
+* accepted;
+* implemented;
+* superseded.
+
+## Architecture Notes
+
+Use architecture notes to:
+
+* describe current architecture;
+* capture stable contracts;
+* document important design decisions;
+* serve as maintainer references.
+
+Architecture notes become the authoritative source once a design stabilizes.
+
+## Promotion Requirement
+
+When a campaign results in:
+
+* an accepted RFC;
+* significant architectural change;
+* multiple implementation PRs;
+* a long-term contract;
+
+the maintainer should evaluate whether part of the audit material must be
+promoted into:
+
+* `maintainers/architecture/`; or
+* `maintainers/rfcs/`
+
+before the campaign is considered complete.
+
+Architectural reasoning should not remain exclusively in audit documents.
+
+## Audit Deliverables
+
+Major architecture audits should end with a final section named:
+
+```text
+Promotion Candidates
+```
+
+That section should identify:
+
+* content suitable for RFCs;
+* content suitable for architecture notes;
+* content that should remain historical only.
+
+Where possible, suggest target filenames.
+
+This requirement applies to major architecture audits, not to minor bug
+investigations or narrow implementation notes.
+
+## Campaign Closure Checklist
+
+Before closing a major architecture campaign, verify:
+
+* RFC status updated;
+* roadmap updated;
+* relevant architecture notes updated or created;
+* promotion candidates reviewed;
+* authoritative documentation synchronized.
+
+This checklist is meant to keep durable knowledge discoverable, not to add
+heavy process.
 
 ---
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -26,7 +26,7 @@ Utiliser ces couches documentaires dans cet ordre :
 |---|---|---|
 | RFCs | Contrats mainteneur, positions, décisions acceptées, et contrats implémentés | [`rfcs/INDEX.md`](rfcs/INDEX.md) |
 | Architecture Notes | Références d'architecture durables, cartes d'implémentation, et contexte technique maintenu | [`architecture/INDEX.md`](architecture/INDEX.md) |
-| Audits | Notes de travail, historique d'implémentation, investigations, et campagnes locales non versionnées par défaut | `audit/~*.md` |
+| Audits | Notes de travail, historique d'implémentation, investigations, et campagnes locales non versionnées par défaut | notes locales sous `audit/`, lorsqu'elles existent |
 | Roadmap | Priorités, sujets terminés, actifs, ou différés | [`rfcs/architecture-roadmap.md`](rfcs/architecture-roadmap.md) |
 
 En pratique :

--- a/maintainers/architecture/README.md
+++ b/maintainers/architecture/README.md
@@ -16,7 +16,7 @@ For campaign ordering and priorities, see
 |---|---|
 | `../rfcs/` | Normative or near-normative behavior contracts and roadmap documents |
 | this directory | Durable audits, implementation maps, design baselines, and draft architecture analyses |
-| `audit/~*.md` | Local working notes that should not be versioned by default |
+| local notes under `audit/` | Local working notes that should not be versioned by default |
 
 ## Reading Guidance
 
@@ -66,7 +66,7 @@ The curated grouping of those documents lives in [`INDEX.md`](INDEX.md).
 |---|---|---|
 | [`../rfcs/architecture-roadmap.md`](../rfcs/architecture-roadmap.md) | Roadmap | Summarizes completed, active, and deferred architecture topics. |
 | [`../rfcs/analysis-fit-result-architecture.md`](../rfcs/analysis-fit-result-architecture.md) | Draft conceptual RFC | Preserves the broader conceptual analysis of result surfaces and ownership around the implemented Result contract. |
-| [`../rfcs/coordinate-arithmetic-semantics.md`](../rfcs/coordinate-arithmetic-semantics.md) | Draft RFC | Maintainer position on coordinate arithmetic semantics. |
+| [`../rfcs/coordinate-arithmetic-semantics.md`](../rfcs/coordinate-arithmetic-semantics.md) | Accepted RFC | Maintainer position on coordinate arithmetic semantics. |
 | [`../rfcs/metadata-contract.md`](../rfcs/metadata-contract.md) | Draft RFC | Normative direction for `NDDataset` metadata preservation, recomputation, override, merge, and drop behavior. |
 | [`../rfcs/modeldata-semantic-contract.md`](../rfcs/modeldata-semantic-contract.md) | Accepted decision record | Audit and removal decision for orphaned `NDDataset.modeldata`. |
 | [`../rfcs/roi-semantic-contract.md`](../rfcs/roi-semantic-contract.md) | Accepted decision record | Audit and removal decision for orphaned `NDDataset.roi`. |

--- a/maintainers/architecture/coordset-storage-architecture.md
+++ b/maintainers/architecture/coordset-storage-architecture.md
@@ -241,24 +241,9 @@ Do not remove them without proving that they are unreachable or redundant.
 
 ## Audit Trail
 
-For detailed campaign history and representative checkpoints, see:
-
-- `audit/~storage-pr1 - tests de contrat public.md`
-- `audit/~coordset-lookup-audit.md`
-- `audit/~coordset-storage-pr12-notes.md`
-- `audit/~coordset-storage-pr13-notes.md`
-- `audit/~coordset-storage-pr14-notes.md`
-- `audit/~coordset-storage-pr15-notes.md`
-- `audit/~coordset-storage-pr16-notes.md`
-- `audit/~coordset-storage-pr17-notes.md`
-- `audit/~coordset-storage-pr18-notes.md`
-- `audit/~coordset-storage-pr19-notes.md`
-- `audit/~coordset-storage-pr20-notes.md`
-- `audit/~coordset-storage-pr21-audit.md`
-- `audit/~coordset-storage-pr22-audit.md`
-- `audit/~coordset-storage-pr23-audit.md`
-- `audit/~coordset-storage-pr24-preparation.md`
-- `audit/~coordset-storage-pr25-independent-audit.md`
+Detailed campaign history and intermediate checkpoints remain in the local
+maintainer audit trail. The tracked references for maintainers are this final
+architecture note and the curated architecture indexes under `maintainers/`.
 
 ### Broader Traitlets Audit
 

--- a/maintainers/architecture/display-architecture.md
+++ b/maintainers/architecture/display-architecture.md
@@ -200,12 +200,6 @@ items.
 
 ## Audit Trail
 
-For retained detailed notes around the completed display campaign and later
-follow-up work, see:
-
-- `audit/~display-architecture-audit.md`
-- `audit/~project-semantic-display-migration.md`
-- `audit/~project-display-navigation-review.md`
-- `audit/~hypercomplex-display-audit.md`
-- `audit/~hypercomplex-display-regression-check.md`
-- `audit/~hypercomplex-display-restoration.md`
+Detailed campaign notes and follow-up investigations remain part of the local
+maintainer audit trail. The tracked references for maintainers are this
+document and [`display-architecture-audit.md`](display-architecture-audit.md).

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -4,7 +4,9 @@
 
 **Related RFC:** `result-object-contract-rfc.md`
 
-**Campaign review:** `audit/~result-object-campaign-closure-review.md`
+**Campaign review context:** This roadmap preserves the tracked maintainer
+summary for the completed campaign; detailed implementation history remains in
+the local audit trail.
 
 ---
 
@@ -197,15 +199,6 @@ Optional follow-up candidates that do not change campaign completion status:
 
 ## 7. Audit Trail
 
-Detailed implementation history remains in the audit files:
-
-- `audit/~result-object-campaign-closure-review.md`
-- `audit/~result-object-contract-pr1-audit.md`
-- `audit/~result-object-contract-pr2-audit.md`
-- `audit/~result-object-contract-pr3-audit.md`
-- `audit/~result-object-contract-pr4-audit.md`
-- `audit/~result-object-contract-pr5-audit.md`
-- `audit/~result-object-contract-pr6-audit.md`
-- `audit/~result-object-contract-pr7-audit.md`
-- `audit/~result-object-contract-pr8-audit.md`
-- `audit/~result-object-contract-pr9-audit.md`
+Detailed implementation history remains in the local audit trail. The tracked
+maintainer references for this completed campaign are this roadmap and
+[`result-object-contract-rfc.md`](result-object-contract-rfc.md).

--- a/maintainers/architecture/tensor-plugin-migration.md
+++ b/maintainers/architecture/tensor-plugin-migration.md
@@ -5,7 +5,7 @@
 Completed architecture note.
 
 This document preserves the durable decisions from the former
-`audit/tensor-plugin-migration.md` note.
+local tensor-plugin migration note.
 
 ## Scope
 

--- a/maintainers/rfcs/INDEX.md
+++ b/maintainers/rfcs/INDEX.md
@@ -84,8 +84,8 @@ For campaign ordering and architecture priorities, see
 
 ## Notes
 
-- Status assignments above follow the documentation consolidation audit in
-  [`audit/~documentation-consolidation-audit-2026-06-21.md`](../../audit/~documentation-consolidation-audit-2026-06-21.md).
+- Status assignments above reflect the current maintainer documentation review
+  and roadmap synchronization work.
 - Several `PROPOSED` RFCs already describe behavior that is partially
   reflected in current code. They remain `PROPOSED` here because the relevant
   contract is not yet fully adopted or reclassified.

--- a/maintainers/rfcs/analysis-fit-result-architecture.md
+++ b/maintainers/rfcs/analysis-fit-result-architecture.md
@@ -2,11 +2,8 @@
 
 **Status:** Draft conceptual RFC
 
-**Audit reference:**
-[`audit/~analysis-fit-result-architecture-audit.md`](../audit/~analysis-fit-result-architecture-audit.md)
-
-**PR9 output semantics reference:**
-[`audit/~pr9-analysis-output-semantics-report.md`](../audit/~pr9-analysis-output-semantics-report.md)
+**Background:** Maintainer analysis and campaign-local audit work informed this
+conceptual RFC.
 
 **Implementation reference:**
 [`maintainers/architecture/result-object-contract-rfc.md`](../architecture/result-object-contract-rfc.md)

--- a/maintainers/rfcs/architecture-roadmap.md
+++ b/maintainers/rfcs/architecture-roadmap.md
@@ -39,7 +39,6 @@ This document should evolve as the project evolves.
 - Reference: `maintainers/rfcs/analysis-fit-result-architecture.md`
 - Implementation reference: `maintainers/architecture/result-object-contract-rfc.md`
 - Campaign summary: `maintainers/architecture/result-object-migration-roadmap.md`
-- Audit reference: `audit/~analysis-fit-result-architecture-audit.md`
 
 ### Units and Dimensional Semantics Audit
 
@@ -54,7 +53,6 @@ This document should evolve as the project evolves.
 - Minor inconsistency: `PLSRegression.coef` is unitless while
   `LinearRegressionAnalysis.coef` computes explicit `Y/X` unit ratios.
 - No immediate redesign recommended.
-- Audit reference: `audit/~units-and-dimensional-semantics-audit.md`
 
 ### History and Provenance Semantics Characterization
 
@@ -591,11 +589,11 @@ Status: Audited; RFC drafted; partial implementation completed.
 
 Motivation:
 
-Several audits revealed multiple result-construction paths throughout the codebase.
+Several maintainer reviews revealed multiple result-construction paths
+throughout the codebase.
 
 Current state:
 
-- Analysis and Fit Result Architecture audit completed (`audit/~analysis-fit-result-architecture-audit.md`).
 - RFC drafted (`maintainers/rfcs/analysis-fit-result-architecture.md`).
 - Result Object contract implemented and documented in
   `maintainers/architecture/result-object-contract-rfc.md`.

--- a/maintainers/rfcs/coord-labels-portable-semantics.md
+++ b/maintainers/rfcs/coord-labels-portable-semantics.md
@@ -14,8 +14,8 @@ model.
 
 - `maintainers/rfcs/nddataset-xarray-mapping-specification.md`
 - `maintainers/rfcs/xarray-backed-netcdf-persistence.md`
-- `audit/~portable-coordset-enrichment-audit.md`
-- `audit/~portable-same-dim-coords-progress.md`
+- the recent portable `CoordSet` enrichment work and same-dimension coordinate
+  progress reviews
 
 ---
 
@@ -34,7 +34,8 @@ A clear portable semantics decision is needed before implementing, because:
 - several readers (OPUS, JCAMP, Omnic, SPC, CSV) populate labels with
   acquisition metadata that users may expect to survive round-trip;
 - the xarray mapping RFC explicitly lists labels as an open question;
-- the enrichment audit recommends deferring labels to a dedicated RFC.
+- earlier portable-persistence review recommended deferring labels to a
+  dedicated RFC.
 
 This RFC resolves that open question by classifying label usages and defining
 which subset is portable.

--- a/maintainers/rfcs/csdm-position-statement.md
+++ b/maintainers/rfcs/csdm-position-statement.md
@@ -8,8 +8,8 @@ SpectroChemPy.
 **Related issue:**
 [#1153](https://github.com/spectrochempy/spectrochempy/issues/1153)
 
-**Supporting audit:**
-`audit/~csdm-interoperability-and-native-persistence-evaluation.md`
+**Supporting context:** This position is informed by the recent maintainer
+evaluation of CSDM interoperability and native-persistence candidates.
 
 ## Decision
 

--- a/maintainers/rfcs/nddataset-xarray-mapping-specification.md
+++ b/maintainers/rfcs/nddataset-xarray-mapping-specification.md
@@ -13,8 +13,8 @@ mechanics.
 
 - `maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md`
 - `maintainers/rfcs/trusted-and-portable-persistence.md`
-- `audit/~portable-xarray-netcdf-format-architecture-audit.md`
-- `audit/~csdm-native-persistence-candidate-audit.md`
+- the recent portable xarray / NetCDF architecture review
+- the recent CSDM native-persistence candidate review
 
 The key words MUST, SHOULD, and MAY express the intended future contract. They
 do not change current behavior until separately implemented.
@@ -505,7 +505,8 @@ However, based on the CSDM audit:
   whole at this stage;
 - it should not replace the xarray-centered mapping model defined here.
 
-See `audit/~csdm-native-persistence-candidate-audit.md`.
+See the related CSDM position statement and the portable-persistence RFCs for
+the tracked maintainer direction.
 
 ## Recommendations
 

--- a/maintainers/rfcs/project-copy-semantics-rfc.md
+++ b/maintainers/rfcs/project-copy-semantics-rfc.md
@@ -8,7 +8,8 @@
 (PRs #1230–#1234). Copy semantics was explicitly deferred there and is the
 subject of this RFC.
 
-**Prerequisite audit:** `audit/~project-copy-semantics-audit.md`
+**Prerequisite analysis:** This RFC follows the completed maintainer review of
+`Project` copy behavior and ownership invariants.
 
 ## Motivation
 
@@ -22,7 +23,7 @@ because:
 3. It was unclear whether `copy()` should be shallow, deep, or something in
    between.
 
-The audit (`audit/~project-copy-semantics-audit.md`) found that:
+The prerequisite review found that:
 
 - The current behavior is **not the result of an explicit design decision**.
   It is a side effect of how Traitlets type validators interact with

--- a/maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md
+++ b/maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md
@@ -15,7 +15,7 @@ through separately approved work.
 - `maintainers/architecture/result-object-migration-roadmap.md`
 - `maintainers/rfcs/analysis-fit-result-architecture.md`
 - `maintainers/rfcs/metadata-contract.md`
-- `audit/~project-and-serialization-architecture-review.md`
+- recent maintainer review of `Project` and serialization boundaries
 
 ## Motivation
 

--- a/maintainers/rfcs/trusted-and-portable-persistence.md
+++ b/maintainers/rfcs/trusted-and-portable-persistence.md
@@ -9,7 +9,7 @@
 **Related documents:**
 
 - `maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md`
-- `audit/~serialization-security-and-trust-boundary-audit.md`
+- recent maintainer security and trust-boundary review work
 
 ---
 

--- a/maintainers/rfcs/xarray-backed-netcdf-persistence.md
+++ b/maintainers/rfcs/xarray-backed-netcdf-persistence.md
@@ -12,8 +12,7 @@ persistence, Zarr-specific policy, implementation, migration, or API work.
 
 - `maintainers/rfcs/nddataset-xarray-mapping-specification.md`
 - `maintainers/rfcs/trusted-and-portable-persistence.md`
-- `audit/~xarray-prototype-implementation-notes.md`
-- `audit/~portable-xarray-netcdf-format-architecture-audit.md`
+- the earlier xarray / NetCDF prototype and architecture reviews
 
 The key words MUST, SHOULD, and MAY express the intended future contract. They
 do not change current behavior until separately implemented.


### PR DESCRIPTION
## Motivation

Recent documentation consolidation clarified that `maintainers/` is the authoritative tracked layer while `audit/` remains local working history. A follow-up pass was still needed to remove remaining maintainer references that depended on local audit files and to formalize the architecture-document lifecycle in `AGENTS.md`.

## Changes

- formalize the architecture documentation lifecycle in `AGENTS.md`
- require promotion review from major audits into tracked maintainer documents before campaign closure
- clarify the distinction between implementation-history authority and current maintained architecture authority
- remove remaining direct maintainer references to local `audit/` files
- replace inaccessible audit pointers with tracked maintainer references or generic local-audit wording
- tighten a few maintainer README and status labels to match the current governance model

## No Functional Changes

Documentation-only PR.

No code changes.
No tests.
No behavioral changes.

## Validation

- documentation review only
- no test run requested for this documentation-only PR
