### PR TITLE
TEST: factor semantic baseline fixtures and assertions

### DIFF
--- a/tests/test_core/test_dataset/_semantic_dataset_helpers.py
+++ b/tests/test_core/test_dataset/_semantic_dataset_helpers.py
@@ -1,0 +1,107 @@
+"""Shared helpers for semantic baseline dataset construction and assertions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.nddataset import NDDataset
+from spectrochempy.utils.constants import MASKED
+
+
+def make_semantic_2d_dataset(
+    *,
+    data=None,
+    title,
+    name,
+    units=None,
+    author="test_author",
+    description="test description",
+    origin="test_origin",
+    meta_project="test_project",
+    meta_instrument=None,
+    meta_processing=None,
+    history="original entry",
+    filename=None,
+    x_labels=None,
+    y_values=None,
+    x_values=None,
+):
+    """Build a semantic-rich 2D dataset used across characterization suites."""
+    y = Coord(
+        np.linspace(0.0, 60.0, 5) if y_values is None else y_values,
+        title="time",
+        units="s",
+    )
+    x = Coord(
+        np.linspace(4000.0, 1000.0, 7) if x_values is None else x_values,
+        title="wavenumber",
+        units="cm^-1",
+        labels=x_labels,
+    )
+    if data is None:
+        data = np.arange(35.0, dtype="float64").reshape(5, 7)
+
+    dataset = NDDataset(data, coordset=[y, x], units=units, title=title, name=name)
+    dataset.author = author
+    dataset.description = description
+    dataset.origin = origin
+    dataset.meta.project = meta_project
+    if meta_instrument is not None:
+        dataset.meta.instrument = meta_instrument
+    if meta_processing is not None:
+        dataset.meta.processing = list(meta_processing)
+    if filename is not None:
+        dataset.filename = Path(filename)
+    dataset.history = history
+    return dataset
+
+
+def mask_dataset_points(dataset, *indices):
+    """Mask selected dataset elements using the current dataset masking policy."""
+    for index in indices:
+        dataset[index] = MASKED
+    return dataset
+
+
+def assert_basic_metadata_preserved(
+    result,
+    source,
+    *,
+    check_name=True,
+    check_title=True,
+    check_filename=False,
+    meta_keys=("project",),
+):
+    """Assert the standard semantic metadata contract shared by many baselines."""
+    if check_name:
+        assert result.name == source.name
+    if check_title:
+        assert result.title == source.title
+    assert result.author == source.author
+    assert result.description == source.description
+    assert result.origin == source.origin
+    for key in meta_keys:
+        assert getattr(result.meta, key) == getattr(source.meta, key)
+    if check_filename:
+        assert result.filename == source.filename
+
+
+def assert_coordset_matches(
+    result,
+    source,
+    *,
+    dims=("y", "x"),
+    check_titles=False,
+    check_units=False,
+):
+    """Assert that selected coordinates were preserved from source to result."""
+    assert result.coordset is not None
+    for dim in dims:
+        np.testing.assert_allclose(result[dim].data, source[dim].data)
+        if check_titles:
+            assert result[dim].title == source[dim].title
+        if check_units:
+            assert str(result[dim].units) == str(source[dim].units)

--- a/tests/test_core/test_dataset/test_combination_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_combination_semantics_baseline.py
@@ -24,6 +24,9 @@ from spectrochempy.processing.transformation.concatenate import concatenate
 from spectrochempy.processing.transformation.concatenate import stack
 from spectrochempy.utils.exceptions import DimensionsCompatibilityError
 from spectrochempy.utils.exceptions import UnitsCompatibilityError
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    make_semantic_2d_dataset,
+)
 
 # ======================================================================================
 # FIXTURES
@@ -39,20 +42,15 @@ def dataset_x():
     - CoordSet with titles, units
     - full metadata
     """
-    y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
-    x = Coord(np.linspace(4000.0, 1000.0, 7), title="wavenumber", units="cm^-1")
-    ds = NDDataset(
-        np.arange(35.0, dtype="float64").reshape(5, 7),
-        coordset=[y, x],
+    return make_semantic_2d_dataset(
         title="dataset_x",
         name="dataset_x_name",
+        author="author_x",
+        description="description_x",
+        origin="origin_x",
+        meta_project="project_x",
+        history=["original_x"],
     )
-    ds.author = "author_x"
-    ds.description = "description_x"
-    ds.origin = "origin_x"
-    ds.meta.project = "project_x"
-    ds.history = ["original_x"]
-    return ds
 
 
 @pytest.fixture
@@ -63,20 +61,16 @@ def dataset_y():
     Same shape as dataset_x along non-concatenated dimensions.
     Different metadata values for propagation characterization.
     """
-    y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
-    x = Coord(np.linspace(4000.0, 1000.0, 7), title="wavenumber", units="cm^-1")
-    ds = NDDataset(
-        np.full((5, 7), 99.0, dtype="float64"),
-        coordset=[y, x],
+    return make_semantic_2d_dataset(
+        data=np.full((5, 7), 99.0, dtype="float64"),
         title="dataset_y",
         name="dataset_y_name",
+        author="author_y",
+        description="description_y",
+        origin="origin_y",
+        meta_project="project_y",
+        history=["original_y"],
     )
-    ds.author = "author_y"
-    ds.description = "description_y"
-    ds.origin = "origin_y"
-    ds.meta.project = "project_y"
-    ds.history = ["original_y"]
-    return ds
 
 
 @pytest.fixture

--- a/tests/test_core/test_dataset/test_indexing_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_indexing_semantics_baseline.py
@@ -17,6 +17,12 @@ import pytest
 
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    assert_basic_metadata_preserved,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    make_semantic_2d_dataset,
+)
 
 # ======================================================================================
 # FIXTURES
@@ -32,25 +38,13 @@ def ds():
     - CoordSet with titles, units, labels
     - Full metadata
     """
-    y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
-    x = Coord(
-        np.linspace(4000.0, 1000.0, 7),
-        title="wavenumber",
-        units="cm^-1",
-        labels=["a", "b", "c", "d", "e", "f", "g"],
-    )
-    ds = NDDataset(
-        np.arange(35.0, dtype="float64").reshape(5, 7),
-        coordset=[y, x],
+    return make_semantic_2d_dataset(
         title="ds_title",
         name="ds_name",
+        x_labels=["a", "b", "c", "d", "e", "f", "g"],
+        description="test description",
+        history=["original entry"],
     )
-    ds.author = "test_author"
-    ds.description = "test description"
-    ds.origin = "test_origin"
-    ds.meta.project = "test_project"
-    ds.history = ["original entry"]
-    return ds
 
 
 @pytest.fixture
@@ -404,19 +398,19 @@ class TestMetadata:
 
     def test_author_preserved(self, ds):
         r = ds[0]
-        assert r.author == "test_author"
+        assert_basic_metadata_preserved(r, ds, check_name=False, check_title=False)
 
     def test_description_preserved(self, ds):
         r = ds[0]
-        assert r.description == "test description"
+        assert_basic_metadata_preserved(r, ds, check_name=False, check_title=False)
 
     def test_origin_preserved(self, ds):
         r = ds[0]
-        assert r.origin == "test_origin"
+        assert_basic_metadata_preserved(r, ds, check_name=False, check_title=False)
 
     def test_meta_project_preserved(self, ds):
         r = ds[0]
-        assert r.meta.project == "test_project"
+        assert_basic_metadata_preserved(r, ds, check_name=False, check_title=False)
 
     def test_meta_deep_copied(self, ds):
         r = ds[0]

--- a/tests/test_core/test_dataset/test_math_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_math_semantics_baseline.py
@@ -28,8 +28,17 @@ from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.units import Unit
-from spectrochempy.utils.constants import MASKED
 from spectrochempy.utils.testing import assert_array_equal
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    assert_basic_metadata_preserved,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    assert_coordset_matches,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    make_semantic_2d_dataset,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import mask_dataset_points
 
 # ======================================================================================
 # FIXTURES
@@ -55,58 +64,34 @@ def rich_dataset():
         mask             -- some invalid values
         history          -- initial provenance marker
     """
-    # Coordinates: y = time, x = wavenumber
-    y = Coord(
-        np.linspace(0.0, 60.0, 5),
-        title="time",
-        units="s",
-    )
-    x = Coord(
-        np.linspace(4000.0, 1000.0, 7),
-        title="wavenumber",
-        units="cm^-1",
-    )
-    data = np.arange(35.0, dtype="float64").reshape(5, 7)
-
-    ds = NDDataset(
-        data,
-        coordset=[y, x],
+    ds = make_semantic_2d_dataset(
         units="absorbance",
         title="reference spectrum",
+        name="rich_dataset",
+        description="Synthetic dataset for semantic characterization",
+        meta_project="semantic_characterization",
+        meta_instrument="test_instrument",
+        history="Initial creation for semantic baseline",
     )
-    ds.name = "rich_dataset"
-    ds.author = "test_author"
-    ds.description = "Synthetic dataset for semantic characterization"
-    ds.origin = "test_origin"
-    ds.meta.project = "semantic_characterization"
-    ds.meta.instrument = "test_instrument"
-    ds.history = "Initial creation for semantic baseline"
 
     # Mask a few values.
     # NOTE: setting MASKED on a 2D NDDataset masks the entire row AND column
     # intersecting at the given index.  This differs from numpy's per-element
     # masked array behavior and is the current spectroscopy-oriented policy.
-    ds[0, 0] = MASKED
-    ds[2, 3] = MASKED
-    ds[4, 6] = MASKED
-
-    return ds
+    return mask_dataset_points(ds, (0, 0), (2, 3), (4, 6))
 
 
 @pytest.fixture
 def unmasked_dataset():
     """Minimal dataset without mask for numerical correctness checks."""
-    y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
-    x = Coord(np.linspace(4000.0, 1000.0, 7), title="wavenumber", units="cm^-1")
-    data = np.arange(35.0, dtype="float64").reshape(5, 7)
-    ds = NDDataset(data, coordset=[y, x], units="absorbance", title="unmasked")
-    ds.name = "unmasked_dataset"
-    ds.author = "test_author"
-    ds.description = "Unmasked dataset for numerical checks"
-    ds.origin = "test_origin"
-    ds.meta.project = "numeric_checks"
-    ds.history = "Unmasked dataset creation"
-    return ds
+    return make_semantic_2d_dataset(
+        title="unmasked",
+        name="unmasked_dataset",
+        units="absorbance",
+        description="Unmasked dataset for numerical checks",
+        meta_project="numeric_checks",
+        history="Unmasked dataset creation",
+    )
 
 
 @pytest.fixture
@@ -116,32 +101,17 @@ def compatible_dataset():
 
     Same shape, same coordinate values -- compatible for arithmetic.
     """
-    y = Coord(
-        np.linspace(0.0, 60.0, 5),
-        title="time",
-        units="s",
-    )
-    x = Coord(
-        np.linspace(4000.0, 1000.0, 7),
-        title="wavenumber",
-        units="cm^-1",
-    )
-    data = np.ones((5, 7), dtype="float64") * 10.0
-
-    ds = NDDataset(
-        data,
-        coordset=[y, x],
+    return make_semantic_2d_dataset(
+        data=np.ones((5, 7), dtype="float64") * 10.0,
         units="absorbance",
         title="compatible spectrum",
+        name="compatible_dataset",
+        author="compat_author",
+        description="Compatible dataset for binary arithmetic",
+        origin="compat_origin",
+        meta_project="compat_project",
+        history="Compatible dataset creation",
     )
-    ds.name = "compatible_dataset"
-    ds.author = "compat_author"
-    ds.description = "Compatible dataset for binary arithmetic"
-    ds.origin = "compat_origin"
-    ds.meta.project = "compat_project"
-    ds.history = "Compatible dataset creation"
-
-    return ds
 
 
 # ======================================================================================
@@ -244,28 +214,16 @@ class TestDatasetScalarArithmetic:
     # ---- CoordSet ----
 
     def test_add_coordset(self, rich_dataset):
-        result = rich_dataset + 2.0
-        assert result.coordset is not None
-        np.testing.assert_allclose(result.y.data, rich_dataset.y.data)
-        np.testing.assert_allclose(result.x.data, rich_dataset.x.data)
+        assert_coordset_matches(rich_dataset + 2.0, rich_dataset)
 
     def test_sub_coordset(self, rich_dataset):
-        result = rich_dataset - 2.0
-        assert result.coordset is not None
-        np.testing.assert_allclose(result.y.data, rich_dataset.y.data)
-        np.testing.assert_allclose(result.x.data, rich_dataset.x.data)
+        assert_coordset_matches(rich_dataset - 2.0, rich_dataset)
 
     def test_mul_coordset(self, rich_dataset):
-        result = rich_dataset * 2.0
-        assert result.coordset is not None
-        np.testing.assert_allclose(result.y.data, rich_dataset.y.data)
-        np.testing.assert_allclose(result.x.data, rich_dataset.x.data)
+        assert_coordset_matches(rich_dataset * 2.0, rich_dataset)
 
     def test_truediv_coordset(self, rich_dataset):
-        result = rich_dataset / 2.0
-        assert result.coordset is not None
-        np.testing.assert_allclose(result.y.data, rich_dataset.y.data)
-        np.testing.assert_allclose(result.x.data, rich_dataset.x.data)
+        assert_coordset_matches(rich_dataset / 2.0, rich_dataset)
 
     # ---- dims ----
 
@@ -354,24 +312,39 @@ class TestDatasetScalarArithmetic:
 
     @pytest.mark.parametrize("op", ["add", "sub", "mul", "truediv"])
     def test_author_preserved(self, rich_dataset, op):
-        result = getattr(rich_dataset, f"__{op}__")(2.0)
-        assert result.author == "test_author"
+        assert_basic_metadata_preserved(
+            getattr(rich_dataset, f"__{op}__")(2.0),
+            rich_dataset,
+            check_filename=False,
+            meta_keys=("project", "instrument"),
+        )
 
     @pytest.mark.parametrize("op", ["add", "sub", "mul", "truediv"])
     def test_description_preserved(self, rich_dataset, op):
-        result = getattr(rich_dataset, f"__{op}__")(2.0)
-        assert result.description == ("Synthetic dataset for semantic characterization")
+        assert_basic_metadata_preserved(
+            getattr(rich_dataset, f"__{op}__")(2.0),
+            rich_dataset,
+            check_filename=False,
+            meta_keys=("project", "instrument"),
+        )
 
     @pytest.mark.parametrize("op", ["add", "sub", "mul", "truediv"])
     def test_origin_preserved(self, rich_dataset, op):
-        result = getattr(rich_dataset, f"__{op}__")(2.0)
-        assert result.origin == "test_origin"
+        assert_basic_metadata_preserved(
+            getattr(rich_dataset, f"__{op}__")(2.0),
+            rich_dataset,
+            check_filename=False,
+            meta_keys=("project", "instrument"),
+        )
 
     @pytest.mark.parametrize("op", ["add", "sub", "mul", "truediv"])
     def test_meta_preserved(self, rich_dataset, op):
-        result = getattr(rich_dataset, f"__{op}__")(2.0)
-        assert result.meta.project == "semantic_characterization"
-        assert result.meta.instrument == "test_instrument"
+        assert_basic_metadata_preserved(
+            getattr(rich_dataset, f"__{op}__")(2.0),
+            rich_dataset,
+            check_filename=False,
+            meta_keys=("project", "instrument"),
+        )
 
     # ---- numerical correctness (unmasked dataset) ----
 
@@ -424,15 +397,12 @@ class TestDatasetDatasetArithmetic:
         assert (rich_dataset - compatible_dataset).units == Unit("absorbance")
 
     def test_add_coordset_preserved(self, rich_dataset, compatible_dataset):
-        result = rich_dataset + compatible_dataset
-        assert result.coordset is not None
-        np.testing.assert_allclose(result.y.data, rich_dataset.y.data)
-        np.testing.assert_allclose(result.x.data, rich_dataset.x.data)
+        assert_coordset_matches(rich_dataset + compatible_dataset, rich_dataset)
 
     def test_sub_coordset_preserved(self, rich_dataset, compatible_dataset):
-        result = rich_dataset - compatible_dataset
-        assert result.coordset is not None
-        np.testing.assert_allclose(result.y.data, rich_dataset.y.data)
+        assert_coordset_matches(
+            rich_dataset - compatible_dataset, rich_dataset, dims=("y",)
+        )
 
     def test_add_dims(self, rich_dataset, compatible_dataset):
         assert (rich_dataset + compatible_dataset).dims == ["y", "x"]

--- a/tests/test_core/test_dataset/test_metadata_characterization.py
+++ b/tests/test_core/test_dataset/test_metadata_characterization.py
@@ -11,39 +11,47 @@ import numpy as np
 import pytest
 
 import spectrochempy as scp
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    assert_basic_metadata_preserved,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    assert_coordset_matches,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    make_semantic_2d_dataset,
+)
 
 
 @pytest.fixture
 def metadata_dataset():
-    y = scp.Coord(np.arange(4.0), title="sample", units="s")
-    x = scp.Coord(np.linspace(0.0, 4.0, 9), title="wavelength", units="cm^-1")
-    xx, yy = np.meshgrid(x.data, y.data)
-    dataset = scp.NDDataset(
-        xx**2 + 2.0 * yy,
-        coordset=[y, x],
+    x_values = np.linspace(0.0, 4.0, 9)
+    y_values = np.arange(4.0)
+    xx, yy = np.meshgrid(x_values, y_values)
+    return make_semantic_2d_dataset(
+        data=xx**2 + 2.0 * yy,
         units="absorbance",
         title="test_title",
+        name="sample_001",
+        author="test_author",
+        description="test_description",
+        origin="test_origin",
+        meta_project="metadata_contract",
+        meta_instrument="test_instrument",
+        meta_processing=["source"],
+        filename=Path("test_filename.spc"),
+        history="initial history marker",
+        x_values=x_values,
+        y_values=y_values,
     )
-
-    dataset.name = "sample_001"
-    dataset.meta.project = "metadata_contract"
-    dataset.meta.instrument = "test_instrument"
-    dataset.meta.processing = ["source"]
-    dataset.author = "test_author"
-    dataset.description = "test_description"
-    dataset.origin = "test_origin"
-    dataset.filename = Path("test_filename.spc")
-    dataset.history = "initial history marker"
-
-    return dataset
 
 
 @pytest.fixture
 def metadata_peak_dataset():
-    x = scp.Coord(np.linspace(0.0, 4.0, 9), title="wavelength", units="cm^-1")
     dataset = scp.NDDataset(
         np.array([0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 1.0, 0.0]),
-        coordset=[x],
+        coordset=[
+            scp.Coord(np.linspace(0.0, 4.0, 9), title="wavelength", units="cm^-1")
+        ],
         units="absorbance",
         title="test_title",
     )
@@ -63,19 +71,15 @@ def metadata_peak_dataset():
 def test_copy_based_add_preserves_metadata(metadata_dataset):
     result = metadata_dataset + 1
 
-    assert result.name == metadata_dataset.name
-    assert result.title == metadata_dataset.title
-    assert result.meta.project == metadata_dataset.meta.project
-    assert result.meta.instrument == metadata_dataset.meta.instrument
-    assert result.author == metadata_dataset.author
-    assert result.description == metadata_dataset.description
-    assert result.origin == metadata_dataset.origin
-    assert result.filename == metadata_dataset.filename
+    assert_basic_metadata_preserved(
+        result,
+        metadata_dataset,
+        check_filename=True,
+        meta_keys=("project", "instrument"),
+    )
     assert result.units == metadata_dataset.units
     assert result.dims == ["y", "x"]
-    assert result.coordset is not None
-    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
-    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert_coordset_matches(result, metadata_dataset)
     assert len(result.history) == 2
     assert "Initial history marker" in result.history[0]
     assert "Binary operation add" in result.history[1]
@@ -84,19 +88,15 @@ def test_copy_based_add_preserves_metadata(metadata_dataset):
 def test_copy_based_multiply_preserves_metadata(metadata_dataset):
     result = metadata_dataset * 2
 
-    assert result.name == metadata_dataset.name
-    assert result.title == metadata_dataset.title
-    assert result.meta.project == metadata_dataset.meta.project
-    assert result.meta.instrument == metadata_dataset.meta.instrument
-    assert result.author == metadata_dataset.author
-    assert result.description == metadata_dataset.description
-    assert result.origin == metadata_dataset.origin
-    assert result.filename == metadata_dataset.filename
+    assert_basic_metadata_preserved(
+        result,
+        metadata_dataset,
+        check_filename=True,
+        meta_keys=("project", "instrument"),
+    )
     assert result.units == metadata_dataset.units
     assert result.dims == ["y", "x"]
-    assert result.coordset is not None
-    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
-    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert_coordset_matches(result, metadata_dataset)
     assert len(result.history) == 2
     assert "Initial history marker" in result.history[0]
     assert "Binary operation mul" in result.history[1]
@@ -105,19 +105,15 @@ def test_copy_based_multiply_preserves_metadata(metadata_dataset):
 def test_copy_based_abs_preserves_metadata(metadata_dataset):
     result = abs(metadata_dataset)
 
-    assert result.name == metadata_dataset.name
-    assert result.title == metadata_dataset.title
-    assert result.meta.project == metadata_dataset.meta.project
-    assert result.meta.instrument == metadata_dataset.meta.instrument
-    assert result.author == metadata_dataset.author
-    assert result.description == metadata_dataset.description
-    assert result.origin == metadata_dataset.origin
-    assert result.filename == metadata_dataset.filename
+    assert_basic_metadata_preserved(
+        result,
+        metadata_dataset,
+        check_filename=True,
+        meta_keys=("project", "instrument"),
+    )
     assert result.units == metadata_dataset.units
     assert result.dims == ["y", "x"]
-    assert result.coordset is not None
-    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
-    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert_coordset_matches(result, metadata_dataset)
     assert len(result.history) == 2
     assert "Initial history marker" in result.history[0]
     assert "Unary operation abs" in result.history[1]
@@ -145,18 +141,15 @@ def test_mean_along_dimension_preserves_metadata_and_drops_reduced_coord(
 ):
     result = metadata_dataset.mean(dim="x")
 
-    assert result.name == metadata_dataset.name
-    assert result.title == metadata_dataset.title
-    assert result.meta.project == metadata_dataset.meta.project
-    assert result.meta.instrument == metadata_dataset.meta.instrument
-    assert result.author == metadata_dataset.author
-    assert result.description == metadata_dataset.description
-    assert result.origin == metadata_dataset.origin
-    assert result.filename == metadata_dataset.filename
+    assert_basic_metadata_preserved(
+        result,
+        metadata_dataset,
+        check_filename=True,
+        meta_keys=("project", "instrument"),
+    )
     assert result.units == metadata_dataset.units
     assert result.dims == ["y"]
-    assert result.coordset is not None
-    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    assert_coordset_matches(result, metadata_dataset, dims=("y",))
     assert "Initial history marker" in result.history[0]
 
 
@@ -175,15 +168,17 @@ def test_wrapper_based_filter_preserves_scientific_context_metadata(
     assert result.meta.processing is not metadata_dataset.meta.processing
     result.meta.processing.append("result")
     assert metadata_dataset.meta.processing == ["source"]
-    assert result.author == metadata_dataset.author
-    assert result.description == metadata_dataset.description
-    assert result.origin == metadata_dataset.origin
-    assert result.filename == metadata_dataset.filename
+    assert_basic_metadata_preserved(
+        result,
+        metadata_dataset,
+        check_name=False,
+        check_title=False,
+        check_filename=True,
+        meta_keys=("project", "instrument"),
+    )
     assert result.units == metadata_dataset.units
     assert result.dims == ["y", "x"]
-    assert result.coordset is not None
-    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
-    np.testing.assert_allclose(result.x.data, metadata_dataset.x.data)
+    assert_coordset_matches(result, metadata_dataset)
     assert len(result.history) == 1
     assert "Created using method Filter.transform" in result.history[0]
 
@@ -216,18 +211,15 @@ def test_interpolate_preserves_metadata_and_replaces_interpolated_coord(
 
     result = metadata_dataset.interpolate(dim="x", coord=new_x)
 
-    assert result.name == metadata_dataset.name
-    assert result.title == metadata_dataset.title
-    assert result.meta.project == metadata_dataset.meta.project
-    assert result.meta.instrument == metadata_dataset.meta.instrument
-    assert result.author == metadata_dataset.author
-    assert result.description == metadata_dataset.description
-    assert result.origin == metadata_dataset.origin
-    assert result.filename == metadata_dataset.filename
+    assert_basic_metadata_preserved(
+        result,
+        metadata_dataset,
+        check_filename=True,
+        meta_keys=("project", "instrument"),
+    )
     assert result.units == metadata_dataset.units
     assert result.dims == ["y", "x"]
-    assert result.coordset is not None
-    np.testing.assert_allclose(result.y.data, metadata_dataset.y.data)
+    assert_coordset_matches(result, metadata_dataset, dims=("y",))
     np.testing.assert_allclose(result.x.data, new_x)
     assert len(result.history) == 2
     assert "Initial history marker" in result.history[0]

--- a/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
@@ -23,6 +23,12 @@ import pytest
 
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    assert_basic_metadata_preserved,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    make_semantic_2d_dataset,
+)
 
 # ======================================================================================
 # FIXTURES
@@ -38,16 +44,12 @@ def reduction_dataset():
     - CoordSet with titles, units
     - title, name, metadata, history
     """
-    y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
-    x = Coord(np.linspace(4000.0, 1000.0, 7), title="wavenumber", units="cm^-1")
-    data = np.arange(35.0, dtype="float64").reshape(5, 7)
-    ds = NDDataset(data, coordset=[y, x], title="reduction_dataset", name="red_name")
-    ds.author = "test_author"
-    ds.description = "test description"
-    ds.origin = "test_origin"
-    ds.meta.project = "test_project"
-    ds.history = ["original entry"]
-    return ds
+    return make_semantic_2d_dataset(
+        title="reduction_dataset",
+        name="red_name",
+        description="test description",
+        history=["original entry"],
+    )
 
 
 @pytest.fixture
@@ -127,10 +129,7 @@ class TestSumCharacterization:
 
     def test_sum_preserves_metadata(self, reduction_dataset):
         s = reduction_dataset.sum(dim="x")
-        assert s.author == "test_author"
-        assert s.description == "test description"
-        assert s.origin == "test_origin"
-        assert s.meta.project == "test_project"
+        assert_basic_metadata_preserved(s, reduction_dataset)
 
     def test_sum_appends_history(self, reduction_dataset):
         s = reduction_dataset.sum(dim="x")

--- a/tests/test_core/test_dataset/test_shape_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_shape_semantics_baseline.py
@@ -20,6 +20,12 @@ import pytest
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    assert_basic_metadata_preserved,
+)
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    make_semantic_2d_dataset,
+)
 
 # ======================================================================================
 # FIXTURES
@@ -35,16 +41,12 @@ def shape_dataset():
     - CoordSet with titles, units
     - title, name, metadata, history
     """
-    y = Coord(np.linspace(0.0, 60.0, 5), title="time", units="s")
-    x = Coord(np.linspace(4000.0, 1000.0, 7), title="wavenumber", units="cm^-1")
-    data = np.arange(35.0, dtype="float64").reshape(5, 7)
-    ds = NDDataset(data, coordset=[y, x], title="shape_dataset", name="shape_name")
-    ds.author = "test_author"
-    ds.description = "test description"
-    ds.origin = "test_origin"
-    ds.meta.project = "test_project"
-    ds.history = ["original entry"]
-    return ds
+    return make_semantic_2d_dataset(
+        title="shape_dataset",
+        name="shape_name",
+        description="test description",
+        history=["original entry"],
+    )
 
 
 @pytest.fixture
@@ -152,10 +154,7 @@ class TestTransposeCharacterization:
 
     def test_transpose_preserves_metadata(self, shape_dataset):
         t = shape_dataset.transpose()
-        assert t.author == "test_author"
-        assert t.description == "test description"
-        assert t.origin == "test_origin"
-        assert t.meta.project == "test_project"
+        assert_basic_metadata_preserved(t, shape_dataset)
 
     def test_transpose_appends_history(self, shape_dataset):
         t = shape_dataset.transpose()
@@ -228,8 +227,7 @@ class TestSwapdimsCharacterization:
 
     def test_swapdims_preserves_metadata(self, shape_dataset):
         s = shape_dataset.swapdims("y", "x")
-        assert s.author == "test_author"
-        assert s.meta.project == "test_project"
+        assert_basic_metadata_preserved(s, shape_dataset)
 
     def test_swapdims_appends_history(self, shape_dataset):
         s = shape_dataset.swapdims("y", "x")
@@ -382,8 +380,7 @@ class TestReshapeCharacterization:
 
     def test_reshape_preserves_metadata(self, shape_dataset):
         r = shape_dataset.reshape((35,))
-        assert r.author == "test_author"
-        assert r.meta.project == "test_project"
+        assert_basic_metadata_preserved(r, shape_dataset)
 
     def test_reshape_appends_history(self, shape_dataset):
         r = shape_dataset.reshape((7, 5), dims=("x", "y"))


### PR DESCRIPTION
## Summary

This PR implements Stage 1 of the test-suite rationalization work.

It extracts shared semantic dataset construction and repeated preservation assertions used by several dataset baseline/characterization suites.

## Adds

- `_semantic_dataset_helpers.py`
- shared semantic-rich dataset factory
- shared metadata-preservation helper
- shared coordset-preservation helper
- shared masked-point setup helper

## Scope

No tests are deleted.
No test cases are merged.
No semantic assertions are intentionally removed.
No product behavior is changed.
