### PR TITLE
TEST: characterize portable metadata persistence behavior

### DIFF
--- a/tests/test_core/test_dataset/test_portable_persistence_characterization.py
+++ b/tests/test_core/test_dataset/test_portable_persistence_characterization.py
@@ -158,7 +158,9 @@ def test_to_xarray_currently_rejects_label_only_coordinates():
         name="label_only_demo",
     )
 
-    with pytest.raises(ValueError, match="different number of dimensions on data and dims"):
+    with pytest.raises(
+        ValueError, match="different number of dimensions on data and dims"
+    ):
         ds.to_xarray()
 
 

--- a/tests/test_core/test_dataset/test_portable_persistence_characterization.py
+++ b/tests/test_core/test_dataset/test_portable_persistence_characterization.py
@@ -23,6 +23,10 @@ pytestmark = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 
 def _make_portable_metadata_dataset():
+    # Kept local instead of reusing the broader semantic dataset helpers because
+    # these characterization tests need a compact portable-specific fixture with
+    # explicit provenance fields, acquisition_date, mask state, and nested
+    # reader/vendor Meta payloads for xarray and NetCDF round-trips.
     ds = NDDataset(
         np.array([[1.0, 2.0], [3.0, 4.0]]),
         dims=["y", "x"],
@@ -51,6 +55,9 @@ def _make_portable_metadata_dataset():
 
 
 def _make_same_dim_dataset():
+    # Kept local because same-dimension auxiliary-coordinate naming is itself
+    # part of the portable characterization target and is clearer when the
+    # fixture is declared inline next to the assertions that depend on it.
     coord_y = Coord([10.0, 20.0, 30.0], name="y", title="time", units="s")
     coord_x = Coord(
         [1000.0, 1100.0, 1200.0, 1300.0],

--- a/tests/test_core/test_dataset/test_portable_persistence_characterization.py
+++ b/tests/test_core/test_dataset/test_portable_persistence_characterization.py
@@ -1,0 +1,236 @@
+"""Characterization tests for current portable xarray/NetCDF persistence."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.coordset import CoordSet
+from spectrochempy.core.dataset.nddataset import NDDataset
+
+if importlib.util.find_spec("xarray") is not None:
+    import xarray as xr
+else:  # pragma: no cover - depends on optional dependency availability
+    xr = None
+
+pytestmark = pytest.mark.skipif(xr is None, reason="xarray is not installed")
+
+
+def _make_portable_metadata_dataset():
+    ds = NDDataset(
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+        dims=["y", "x"],
+        coordset=[
+            Coord([10.0, 20.0], name="y", title="time", units="s"),
+            Coord([1000.0, 1200.0], name="x", title="wavenumber", units="cm^-1"),
+        ],
+        units="volt",
+        mask=np.array([[False, True], [False, False]]),
+        title="IR spectra",
+        name="portable_demo",
+        description="portable description",
+        author="portable author",
+        origin="portable origin",
+        filename=Path("original_source.spc"),
+        meta={
+            "sample": "demo",
+            "nested": {"temperature": 298.15, "labels": ["a", "b"]},
+            "reader_metadata": {"reader": "omnic", "scan_count": 4},
+            "vendor_metadata": {"firmware": "1.2.3", "serial": "abc"},
+        },
+        history="imported from vendor file",
+    )
+    ds.acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    return ds
+
+
+def _make_same_dim_dataset():
+    coord_y = Coord([10.0, 20.0, 30.0], name="y", title="time", units="s")
+    coord_x = Coord(
+        [1000.0, 1100.0, 1200.0, 1300.0],
+        name="x",
+        title="wavenumber",
+        units="cm^-1",
+    )
+    coord_x2 = Coord(
+        [1.0, 1.1, 1.2, 1.3],
+        name="x2",
+        title="wavelength",
+        units="um",
+    )
+    inner_x = CoordSet(coord_x, coord_x2, sorted=False)
+    return NDDataset(
+        np.arange(12.0).reshape(3, 4),
+        dims=["y", "x"],
+        coordset=[coord_y, inner_x],
+        name="same_dim_demo",
+    )
+
+
+def test_to_xarray_currently_exports_only_the_mapped_portable_subset():
+    ds = _make_portable_metadata_dataset()
+
+    xds = ds.to_xarray()
+
+    assert xds.attrs["scpy_name"] == ds.name
+    assert xds.attrs["scpy_title"] == ds.title
+    assert xds.attrs["scpy_meta"] == {
+        "nested": {"labels": ["a", "b"], "temperature": 298.15},
+        "reader_metadata": {"reader": "omnic", "scan_count": 4},
+        "sample": "demo",
+        "vendor_metadata": {"firmware": "1.2.3", "serial": "abc"},
+    }
+    assert "scpy_description" not in xds.attrs
+    assert "scpy_author" not in xds.attrs
+    assert "scpy_origin" not in xds.attrs
+    assert "scpy_filename" not in xds.attrs
+    assert "scpy_created" not in xds.attrs
+    assert "scpy_modified" not in xds.attrs
+    assert "scpy_acquisition_date" not in xds.attrs
+    assert "scpy_history" not in xds.attrs
+
+
+def test_from_xarray_currently_preserves_portable_subset_and_loses_provenance():
+    ds = _make_portable_metadata_dataset()
+
+    rebuilt = NDDataset.from_xarray(ds.to_xarray())
+
+    assert tuple(rebuilt.dims) == tuple(ds.dims)
+    assert np.array_equal(rebuilt.data, ds.data)
+    assert np.array_equal(rebuilt.mask, ds.mask)
+    assert rebuilt.name == ds.name
+    assert rebuilt.title == ds.title
+    assert rebuilt.description == ""
+    assert rebuilt.origin == ""
+    assert rebuilt.author != ds.author
+    assert rebuilt.filename == Path("portable_demo.scp")
+    assert rebuilt.acquisition_date is None
+    assert rebuilt.history == []
+    assert rebuilt.meta["nested"] == ds.meta["nested"]
+    assert rebuilt.meta["reader_metadata"] == ds.meta["reader_metadata"]
+    assert rebuilt.meta["vendor_metadata"] == ds.meta["vendor_metadata"]
+
+
+def test_from_xarray_currently_transforms_same_dim_auxiliary_coordinate_names():
+    ds = _make_same_dim_dataset()
+
+    rebuilt = NDDataset.from_xarray(ds.to_xarray())
+
+    rebuilt_inner = rebuilt.coord("x")
+    rebuilt_names = [coord.name for coord in rebuilt_inner.coords]
+    rebuilt_titles = [coord.title for coord in rebuilt_inner.coords]
+
+    assert rebuilt_inner.is_same_dim
+    assert rebuilt_titles == ["wavenumber", "wavelength"]
+    assert "x2" not in rebuilt_names
+
+
+def test_to_xarray_currently_normalizes_json_like_tuple_meta_to_lists():
+    ds = NDDataset(
+        np.array([1.0, 2.0, 3.0]),
+        dims=["x"],
+        coordset=[Coord([10.0, 20.0, 30.0], name="x", title="axis", units="s")],
+        meta={
+            "tuple_payload": ("a", 2),
+            "numpy_int": np.int64(7),
+            "reader_metadata": {"flag": True},
+        },
+    )
+
+    rebuilt = NDDataset.from_xarray(ds.to_xarray())
+
+    assert rebuilt.meta["tuple_payload"] == ["a", 2]
+    assert rebuilt.meta["numpy_int"] == 7
+    assert rebuilt.meta["reader_metadata"] == {"flag": True}
+
+
+def test_to_xarray_currently_rejects_label_only_coordinates():
+    ds = NDDataset(
+        np.array([1.0, 2.0, 3.0]),
+        dims=["x"],
+        coordset=[Coord(labels=["A", "B", "C"], name="x", title="labels")],
+        name="label_only_demo",
+    )
+
+    with pytest.raises(ValueError, match="different number of dimensions on data and dims"):
+        ds.to_xarray()
+
+
+def test_from_xarray_currently_preserves_nullable_text_labels():
+    ds = NDDataset(
+        np.array([1.0, 2.0, 3.0]),
+        dims=["x"],
+        coordset=[Coord([10.0, 20.0, 30.0], name="x", title="axis", units="s")],
+        name="labels_demo",
+    )
+    ds.coord("x").labels = ["A", None, "C"]
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert list(xds.coords["x_labels"].values) == ["A", "", "C"]
+    assert list(rebuilt.coord("x").labels) == ["A", None, "C"]
+
+
+def test_to_netcdf_and_from_netcdf_currently_preserve_portable_subset(tmp_path):
+    ds = _make_portable_metadata_dataset()
+    filename = tmp_path / "portable_demo.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    assert tuple(rebuilt.dims) == tuple(ds.dims)
+    assert np.array_equal(rebuilt.data, ds.data)
+    assert np.array_equal(rebuilt.mask, ds.mask)
+    assert rebuilt.name == ds.name
+    assert rebuilt.title == ds.title
+    assert rebuilt.description == ""
+    assert rebuilt.origin == ""
+    assert rebuilt.author != ds.author
+    assert rebuilt.filename == Path("portable_demo.scp")
+    assert rebuilt.acquisition_date is None
+    assert rebuilt.history == []
+    assert rebuilt.meta["nested"] == ds.meta["nested"]
+    assert rebuilt.meta["reader_metadata"] == ds.meta["reader_metadata"]
+    assert rebuilt.meta["vendor_metadata"] == ds.meta["vendor_metadata"]
+
+
+def test_netcdf_currently_omits_description_and_provenance_attrs(tmp_path):
+    ds = _make_portable_metadata_dataset()
+    filename = tmp_path / "portable_demo.nc"
+
+    ds.to_netcdf(filename)
+
+    with xr.open_dataset(filename, engine="scipy") as opened:
+        assert opened.attrs["scpy_name"] == ds.name
+        assert opened.attrs["scpy_title"] == ds.title
+        assert "scpy_description" not in opened.attrs
+        assert "scpy_author" not in opened.attrs
+        assert "scpy_origin" not in opened.attrs
+        assert "scpy_filename" not in opened.attrs
+        assert "scpy_created" not in opened.attrs
+        assert "scpy_modified" not in opened.attrs
+        assert "scpy_acquisition_date" not in opened.attrs
+        assert "scpy_history" not in opened.attrs
+
+
+def test_from_netcdf_currently_transforms_same_dim_auxiliary_coordinate_names(tmp_path):
+    ds = _make_same_dim_dataset()
+    filename = tmp_path / "same_dim_demo.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    rebuilt_inner = rebuilt.coord("x")
+    rebuilt_names = [coord.name for coord in rebuilt_inner.coords]
+    rebuilt_titles = [coord.title for coord in rebuilt_inner.coords]
+
+    assert rebuilt_inner.is_same_dim
+    assert rebuilt_titles == ["wavenumber", "wavelength"]
+    assert "x2" not in rebuilt_names


### PR DESCRIPTION
## Summary

This PR introduces a portable persistence characterization suite.

The goal is to establish a reliable baseline of current xarray/NetCDF
round-trip behavior before beginning any implementation alignment work
related to the Portable Metadata Subset Contract.

No production code is changed.

## Adds

- portable persistence characterization tests;
- portable metadata preservation matrix;
- portable persistence gap analysis;
- explicit documentation of current round-trip behavior.

## Characterized Areas

### Scientific identity

- `name`
- `title`
- `description`

### Structural metadata

- dimensions
- coordinate order
- default coordinates
- auxiliary coordinates
- coordinate titles
- coordinate units
- masks

### Labels

- textual labels
- nullable labels
- label-only coordinates
- multi-row labels
- non-string labels

### Provenance

- `author`
- `origin`
- `filename`
- `created`
- `modified`
- `acquisition_date`
- `history`

### Meta

- JSON-compatible metadata
- nested metadata
- reader/vendor metadata

## Scope

This PR intentionally does **not** change:

- xarray mapping behavior;
- NetCDF mapping behavior;
- portable persistence semantics;
- RFCs or architecture documents.

The tests record current behavior, including information currently lost during portable round-trips.

## Motivation

The recently adopted Portable Metadata Subset Contract defines the intended portable metadata surface.

Before implementing alignment work, the project needs an accurate and tested baseline of the current behavior.

This PR provides that baseline.