### PR TITLE
ENH: extend portable xarray/NetCDF metadata round-trips

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -22,10 +22,11 @@ New Features
 - Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
-  ``name``/``title``, auxiliary same-dimension ``CoordSet`` coordinates
-  (multiple numeric coordinates sharing a dimension), and portable string
-  labels on coordinates (1D string-only, ``None`` preserved via metadata
-  marker). Auxiliary coordinates are exported as non-dimension coordinates with
+  ``name``/``title``, dataset-level ``description``/``author``/``origin``,
+  auxiliary same-dimension ``CoordSet`` coordinates (multiple numeric
+  coordinates sharing a dimension), and portable string labels on coordinates
+  (1D string-only, ``None`` preserved via metadata marker). Auxiliary
+  coordinates are exported as non-dimension coordinates with
   ``scpy_coord_role`` and ``scpy_owner_dim`` markers and restored on import
   with the dimension coordinate as default. Portable string labels are
   exported as non-dimension coordinate variables with

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,10 +18,11 @@ New Features
 - Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
-  ``name``/``title``, auxiliary same-dimension ``CoordSet`` coordinates
-  (multiple numeric coordinates sharing a dimension), and portable string
-  labels on coordinates (1D string-only, ``None`` preserved via metadata
-  marker). Auxiliary coordinates are exported as non-dimension coordinates with
+  ``name``/``title``, dataset-level ``description``/``author``/``origin``,
+  auxiliary same-dimension ``CoordSet`` coordinates (multiple numeric
+  coordinates sharing a dimension), and portable string labels on coordinates
+  (1D string-only, ``None`` preserved via metadata marker). Auxiliary
+  coordinates are exported as non-dimension coordinates with
   ``scpy_coord_role`` and ``scpy_owner_dim`` markers and restored on import
   with the dimension coordinate as default. Portable string labels are
   exported as non-dimension coordinate variables with

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -1612,6 +1612,9 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             "scpy_primary_variable": primary_name,
             "scpy_name": self.name,
             "scpy_title": self.title,
+            "scpy_description": self.description,
+            "scpy_author": self.author,
+            "scpy_origin": self.origin,
         }
         if meta:
             dataset_attrs["scpy_meta"] = json.loads(json.dumps(meta))
@@ -1694,7 +1697,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
 
         This prototype covers numerical data, default coordinates, auxiliary
         same-dimension coordinates, units, masks, JSON-compatible metadata,
-        title, name, and portable string labels.
+        title, name, description, author, origin, and portable string labels.
 
         Auxiliary coordinates are detected by ``scpy_coord_role`` and
         ``scpy_owner_dim`` attributes and reassembled into a same-dimension
@@ -1781,6 +1784,13 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             "title": dataset.attrs.get("scpy_title"),
             "meta": dataset.attrs.get("scpy_meta"),
         }
+        for dataset_attr, kwarg_name in (
+            ("scpy_description", "description"),
+            ("scpy_author", "author"),
+            ("scpy_origin", "origin"),
+        ):
+            if dataset_attr in dataset.attrs:
+                kwargs[kwarg_name] = dataset.attrs[dataset_attr]
 
         units = data_var.attrs.get("units")
         if units is not None:

--- a/tests/test_core/test_dataset/test_netcdf_mapping.py
+++ b/tests/test_core/test_dataset/test_netcdf_mapping.py
@@ -38,6 +38,9 @@ def _make_dataset(data=None, *, complex_data=False):
         mask=np.array([[False, True], [False, False]]),
         title="IR spectra",
         name="spectra",
+        description="portable description",
+        author="portable author",
+        origin="portable origin",
         meta={
             "sample": "demo",
             "nested": {"temperature": 298.15, "labels": ["a", "b"]},
@@ -59,7 +62,9 @@ def test_netcdf_roundtrip_preserves_simple_float_dataset(tmp_path):
 
 
 @pytest.mark.skipif(xr is None, reason="xarray is not installed")
-def test_netcdf_roundtrip_preserves_coordinates_units_mask_and_metadata(tmp_path):
+def test_netcdf_roundtrip_preserves_coordinates_identity_provenance_and_metadata(
+    tmp_path,
+):
     ds = _make_dataset()
     filename = tmp_path / "dataset.nc"
 
@@ -75,6 +80,9 @@ def test_netcdf_roundtrip_preserves_coordinates_units_mask_and_metadata(tmp_path
     assert rebuilt.meta["nested"]["temperature"] == 298.15
     assert rebuilt.name == ds.name
     assert rebuilt.title == ds.title
+    assert rebuilt.description == ds.description
+    assert rebuilt.author == ds.author
+    assert rebuilt.origin == ds.origin
 
 
 @pytest.mark.skipif(xr is None, reason="xarray is not installed")
@@ -107,6 +115,9 @@ def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
     with xr.open_dataset(filename, engine="scipy") as opened:
         assert opened.attrs["scpy_primary_variable"] == "spectra"
         assert opened.attrs["scpy_mask_variable"] == "spectra__mask"
+        assert opened.attrs["scpy_description"] == ds.description
+        assert opened.attrs["scpy_author"] == ds.author
+        assert opened.attrs["scpy_origin"] == ds.origin
         assert opened["spectra"].dims == ("y", "x")
         assert opened["spectra__mask"].dims == ("y", "x")
 

--- a/tests/test_core/test_dataset/test_portable_persistence_characterization.py
+++ b/tests/test_core/test_dataset/test_portable_persistence_characterization.py
@@ -80,22 +80,22 @@ def _make_same_dim_dataset():
     )
 
 
-def test_to_xarray_currently_exports_only_the_mapped_portable_subset():
+def test_to_xarray_currently_exports_aligned_identity_and_selected_provenance():
     ds = _make_portable_metadata_dataset()
 
     xds = ds.to_xarray()
 
     assert xds.attrs["scpy_name"] == ds.name
     assert xds.attrs["scpy_title"] == ds.title
+    assert xds.attrs["scpy_description"] == ds.description
+    assert xds.attrs["scpy_author"] == ds.author
+    assert xds.attrs["scpy_origin"] == ds.origin
     assert xds.attrs["scpy_meta"] == {
         "nested": {"labels": ["a", "b"], "temperature": 298.15},
         "reader_metadata": {"reader": "omnic", "scan_count": 4},
         "sample": "demo",
         "vendor_metadata": {"firmware": "1.2.3", "serial": "abc"},
     }
-    assert "scpy_description" not in xds.attrs
-    assert "scpy_author" not in xds.attrs
-    assert "scpy_origin" not in xds.attrs
     assert "scpy_filename" not in xds.attrs
     assert "scpy_created" not in xds.attrs
     assert "scpy_modified" not in xds.attrs
@@ -103,7 +103,7 @@ def test_to_xarray_currently_exports_only_the_mapped_portable_subset():
     assert "scpy_history" not in xds.attrs
 
 
-def test_from_xarray_currently_preserves_portable_subset_and_loses_provenance():
+def test_from_xarray_currently_preserves_aligned_provenance_and_still_loses_other_fields():
     ds = _make_portable_metadata_dataset()
 
     rebuilt = NDDataset.from_xarray(ds.to_xarray())
@@ -113,9 +113,9 @@ def test_from_xarray_currently_preserves_portable_subset_and_loses_provenance():
     assert np.array_equal(rebuilt.mask, ds.mask)
     assert rebuilt.name == ds.name
     assert rebuilt.title == ds.title
-    assert rebuilt.description == ""
-    assert rebuilt.origin == ""
-    assert rebuilt.author != ds.author
+    assert rebuilt.description == ds.description
+    assert rebuilt.origin == ds.origin
+    assert rebuilt.author == ds.author
     assert rebuilt.filename == Path("portable_demo.scp")
     assert rebuilt.acquisition_date is None
     assert rebuilt.history == []
@@ -187,7 +187,9 @@ def test_from_xarray_currently_preserves_nullable_text_labels():
     assert list(rebuilt.coord("x").labels) == ["A", None, "C"]
 
 
-def test_to_netcdf_and_from_netcdf_currently_preserve_portable_subset(tmp_path):
+def test_to_netcdf_and_from_netcdf_currently_preserve_aligned_provenance_and_still_lose_other_fields(
+    tmp_path,
+):
     ds = _make_portable_metadata_dataset()
     filename = tmp_path / "portable_demo.nc"
 
@@ -199,9 +201,9 @@ def test_to_netcdf_and_from_netcdf_currently_preserve_portable_subset(tmp_path):
     assert np.array_equal(rebuilt.mask, ds.mask)
     assert rebuilt.name == ds.name
     assert rebuilt.title == ds.title
-    assert rebuilt.description == ""
-    assert rebuilt.origin == ""
-    assert rebuilt.author != ds.author
+    assert rebuilt.description == ds.description
+    assert rebuilt.origin == ds.origin
+    assert rebuilt.author == ds.author
     assert rebuilt.filename == Path("portable_demo.scp")
     assert rebuilt.acquisition_date is None
     assert rebuilt.history == []
@@ -210,7 +212,7 @@ def test_to_netcdf_and_from_netcdf_currently_preserve_portable_subset(tmp_path):
     assert rebuilt.meta["vendor_metadata"] == ds.meta["vendor_metadata"]
 
 
-def test_netcdf_currently_omits_description_and_provenance_attrs(tmp_path):
+def test_netcdf_currently_omits_only_remaining_unaligned_provenance_attrs(tmp_path):
     ds = _make_portable_metadata_dataset()
     filename = tmp_path / "portable_demo.nc"
 
@@ -219,9 +221,9 @@ def test_netcdf_currently_omits_description_and_provenance_attrs(tmp_path):
     with xr.open_dataset(filename, engine="scipy") as opened:
         assert opened.attrs["scpy_name"] == ds.name
         assert opened.attrs["scpy_title"] == ds.title
-        assert "scpy_description" not in opened.attrs
-        assert "scpy_author" not in opened.attrs
-        assert "scpy_origin" not in opened.attrs
+        assert opened.attrs["scpy_description"] == ds.description
+        assert opened.attrs["scpy_author"] == ds.author
+        assert opened.attrs["scpy_origin"] == ds.origin
         assert "scpy_filename" not in opened.attrs
         assert "scpy_created" not in opened.attrs
         assert "scpy_modified" not in opened.attrs

--- a/tests/test_core/test_dataset/test_xarray_mapping.py
+++ b/tests/test_core/test_dataset/test_xarray_mapping.py
@@ -47,6 +47,9 @@ def _make_dataset(data=None, *, complex_data=False, unsupported_meta=False):
         mask=np.array([[False, True], [False, False]]),
         title="IR spectra",
         name="spectra",
+        description="portable description",
+        author="portable author",
+        origin="portable origin",
         meta=meta,
     )
 
@@ -58,6 +61,9 @@ def test_to_xarray_returns_dataset():
 
     assert isinstance(xds, xr.Dataset)
     assert xds.attrs["scpy_primary_variable"] == "spectra"
+    assert xds.attrs["scpy_description"] == ds.description
+    assert xds.attrs["scpy_author"] == ds.author
+    assert xds.attrs["scpy_origin"] == ds.origin
 
 
 def test_xarray_roundtrip_preserves_numerical_data_dims_and_coordinates():
@@ -72,7 +78,7 @@ def test_xarray_roundtrip_preserves_numerical_data_dims_and_coordinates():
     assert np.array_equal(rebuilt.coord("y").data, ds.coord("y").data)
 
 
-def test_xarray_roundtrip_preserves_units_mask_title_and_name():
+def test_xarray_roundtrip_preserves_units_identity_and_selected_provenance():
     ds = _make_dataset()
 
     xds = ds.to_xarray()
@@ -82,6 +88,9 @@ def test_xarray_roundtrip_preserves_units_mask_title_and_name():
     assert np.array_equal(rebuilt.mask, ds.mask)
     assert rebuilt.title == ds.title
     assert rebuilt.name == ds.name
+    assert rebuilt.description == ds.description
+    assert rebuilt.author == ds.author
+    assert rebuilt.origin == ds.origin
     assert str(rebuilt.coord("x").units) == str(ds.coord("x").units)
     assert rebuilt.coord("x").title == ds.coord("x").title
 


### PR DESCRIPTION
## Summary of changes
Extend portable NDDataset ↔ xarray / NetCDF persistence to preserve dataset-level description, author, and origin in addition to the already supported portable subset. Update the xarray and NetCDF mapping tests to make these fields contract coverage, refresh the portable characterization tests to reflect the new baseline, and add maintainer audit notes for the characterization baseline and PR1 alignment work.

## Intentionally out of scope
This PR does not address filename, created, modified, acquisition_date, history, label semantics, label-only coordinates, or auxiliary coordinate naming stability. No public APIs were changed.

## Related context
Follows the portable persistence characterization campaign and aligns PR1 scope with the Portable Metadata Subset Contract for description, author, and origin.