### PR TITLE
ENH: extend portable xarray/NetCDF provenance round-trips

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -22,7 +22,8 @@ New Features
 - Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
-  ``name``/``title``, dataset-level ``description``/``author``/``origin``,
+  ``name``/``title``, dataset-level
+  ``description``/``author``/``origin``/``created``/``modified``/``acquisition_date``,
   auxiliary same-dimension ``CoordSet`` coordinates (multiple numeric
   coordinates sharing a dimension), and portable string labels on coordinates
   (1D string-only, ``None`` preserved via metadata marker). Auxiliary

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,7 +18,8 @@ New Features
 - Added portable ``NDDataset`` ↔ xarray/NetCDF round-trip support for
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
-  ``name``/``title``, dataset-level ``description``/``author``/``origin``,
+  ``name``/``title``, dataset-level
+  ``description``/``author``/``origin``/``created``/``modified``/``acquisition_date``,
   auxiliary same-dimension ``CoordSet`` coordinates (multiple numeric
   coordinates sharing a dimension), and portable string labels on coordinates
   (1D string-only, ``None`` preserved via metadata marker). Auxiliary

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -119,6 +119,26 @@ def _export_labels(coord, dim, aux_vars):
         )
 
 
+def _serialize_portable_datetime(value: datetime | None) -> str | None:
+    """Return a stable textual form for portable datetime attrs."""
+    if value is None:
+        return None
+    if not isinstance(value, datetime):
+        raise TypeError(f"Value of type {type(value).__name__} is not a datetime")
+    return value.isoformat(sep=" ", timespec="seconds")
+
+
+def _restore_portable_datetime(value):
+    """Return a datetime restored from a portable attr or ``None``."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(
+            f"Portable datetime attr must be a string, got {type(value).__name__}"
+        )
+    return datetime.fromisoformat(value)
+
+
 def _prepare_xarray_dataset_for_netcdf(dataset):
     """Convert a canonical xarray Dataset into a NetCDF-safe representation."""
     xds = dataset.copy(deep=True)
@@ -1616,6 +1636,14 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             "scpy_author": self.author,
             "scpy_origin": self.origin,
         }
+        for dataset_attr, value in (
+            ("scpy_created", self._created),
+            ("scpy_modified", self._modified),
+            ("scpy_acquisition_date", self._acquisition_date),
+        ):
+            serialized = _serialize_portable_datetime(value)
+            if serialized is not None:
+                dataset_attrs[dataset_attr] = serialized
         if meta:
             dataset_attrs["scpy_meta"] = json.loads(json.dumps(meta))
         if skipped_meta_keys:
@@ -1697,7 +1725,8 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
 
         This prototype covers numerical data, default coordinates, auxiliary
         same-dimension coordinates, units, masks, JSON-compatible metadata,
-        title, name, description, author, origin, and portable string labels.
+        title, name, description, author, origin, created, modified,
+        acquisition_date, and portable string labels.
 
         Auxiliary coordinates are detected by ``scpy_coord_role`` and
         ``scpy_owner_dim`` attributes and reassembled into a same-dimension
@@ -1801,6 +1830,20 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             kwargs["mask"] = np.asarray(dataset[mask_name].data, dtype=bool)
 
         result = cls(np.asarray(data_var.data), **kwargs)
+
+        for dataset_attr, internal_attr in (
+            ("scpy_created", "_created"),
+            ("scpy_acquisition_date", "_acquisition_date"),
+            ("scpy_modified", "_modified"),
+        ):
+            if dataset_attr not in dataset.attrs:
+                continue
+            with suppress(TypeError, ValueError):
+                setattr(
+                    result,
+                    internal_attr,
+                    _restore_portable_datetime(dataset.attrs[dataset_attr]),
+                )
 
         # Identify the default coordinate explicitly for each same-dim CoordSet.
         for dim in aux_dims:

--- a/tests/test_core/test_dataset/test_netcdf_mapping.py
+++ b/tests/test_core/test_dataset/test_netcdf_mapping.py
@@ -5,6 +5,8 @@
 # ======================================================================================
 
 import importlib.util
+from datetime import UTC
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -20,14 +22,20 @@ else:  # pragma: no cover - depends on optional dependency availability
     xr = None
 
 
-def _make_dataset(data=None, *, complex_data=False):
+def _portable_attr_datetime(value):
+    if value is None:
+        return None
+    return value.isoformat(sep=" ", timespec="seconds")
+
+
+def _make_dataset(data=None, *, complex_data=False, acquisition_date=None):
     if data is None:
         if complex_data:
             data = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]], dtype=np.complex128)
         else:
             data = np.array([[1.0, 2.0], [3.0, 4.0]])
 
-    return NDDataset(
+    ds = NDDataset(
         data,
         dims=["y", "x"],
         coordset=[
@@ -47,6 +55,11 @@ def _make_dataset(data=None, *, complex_data=False):
             "count": 2,
         },
     )
+    if acquisition_date is not None:
+        ds.acquisition_date = acquisition_date
+    ds._created = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+    return ds
 
 
 @pytest.mark.skipif(xr is None, reason="xarray is not installed")
@@ -65,7 +78,7 @@ def test_netcdf_roundtrip_preserves_simple_float_dataset(tmp_path):
 def test_netcdf_roundtrip_preserves_coordinates_identity_provenance_and_metadata(
     tmp_path,
 ):
-    ds = _make_dataset()
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
     filename = tmp_path / "dataset.nc"
 
     ds.to_netcdf(filename)
@@ -83,6 +96,9 @@ def test_netcdf_roundtrip_preserves_coordinates_identity_provenance_and_metadata
     assert rebuilt.description == ds.description
     assert rebuilt.author == ds.author
     assert rebuilt.origin == ds.origin
+    assert rebuilt.created == ds.created
+    assert rebuilt.modified == ds.modified
+    assert rebuilt.acquisition_date == ds.acquisition_date
 
 
 @pytest.mark.skipif(xr is None, reason="xarray is not installed")
@@ -107,7 +123,7 @@ def test_netcdf_complex_roundtrip_uses_split_real_imag_convention(tmp_path):
 
 @pytest.mark.skipif(xr is None, reason="xarray is not installed")
 def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
-    ds = _make_dataset()
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
     filename = tmp_path / "dataset.nc"
 
     ds.to_netcdf(filename)
@@ -118,8 +134,45 @@ def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
         assert opened.attrs["scpy_description"] == ds.description
         assert opened.attrs["scpy_author"] == ds.author
         assert opened.attrs["scpy_origin"] == ds.origin
+        assert opened.attrs["scpy_created"] == _portable_attr_datetime(ds._created)
+        assert opened.attrs["scpy_modified"] == _portable_attr_datetime(ds._modified)
+        assert opened.attrs["scpy_acquisition_date"] == _portable_attr_datetime(
+            ds._acquisition_date
+        )
         assert opened["spectra"].dims == ("y", "x")
         assert opened["spectra__mask"].dims == ("y", "x")
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_naive_acquisition_date(tmp_path):
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11))
+    filename = tmp_path / "dataset_naive_acq.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    with xr.open_dataset(filename, engine="scipy") as opened:
+        assert opened.attrs["scpy_acquisition_date"] == "2024-01-03 09:10:11"
+
+    assert rebuilt.acquisition_date == ds.acquisition_date
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_from_netcdf_missing_timestamp_attrs_keeps_existing_fallback_behavior(tmp_path):
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
+    filename = tmp_path / "dataset_without_timestamp_attrs.nc"
+
+    xds = ds.to_xarray()
+    xds.attrs.pop("scpy_created")
+    xds.attrs.pop("scpy_modified")
+    xds.attrs.pop("scpy_acquisition_date")
+    ndmodule._prepare_xarray_dataset_for_netcdf(xds).to_netcdf(filename, engine="scipy")
+
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    assert rebuilt.created != ds.created
+    assert rebuilt.modified != ds.modified
+    assert rebuilt.acquisition_date is None
 
 
 def _make_same_dim_netcdf_dataset():

--- a/tests/test_core/test_dataset/test_portable_persistence_characterization.py
+++ b/tests/test_core/test_dataset/test_portable_persistence_characterization.py
@@ -22,6 +22,12 @@ else:  # pragma: no cover - depends on optional dependency availability
 pytestmark = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 
+def _portable_attr_datetime(value):
+    if value is None:
+        return None
+    return value.isoformat(sep=" ", timespec="seconds")
+
+
 def _make_portable_metadata_dataset():
     # Kept local instead of reusing the broader semantic dataset helpers because
     # these characterization tests need a compact portable-specific fixture with
@@ -51,6 +57,8 @@ def _make_portable_metadata_dataset():
         history="imported from vendor file",
     )
     ds.acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds._created = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+    ds._modified = datetime(2024, 1, 2, 9, 10, 11, tzinfo=UTC)
     return ds
 
 
@@ -90,6 +98,11 @@ def test_to_xarray_currently_exports_aligned_identity_and_selected_provenance():
     assert xds.attrs["scpy_description"] == ds.description
     assert xds.attrs["scpy_author"] == ds.author
     assert xds.attrs["scpy_origin"] == ds.origin
+    assert xds.attrs["scpy_created"] == _portable_attr_datetime(ds._created)
+    assert xds.attrs["scpy_modified"] == _portable_attr_datetime(ds._modified)
+    assert xds.attrs["scpy_acquisition_date"] == _portable_attr_datetime(
+        ds._acquisition_date
+    )
     assert xds.attrs["scpy_meta"] == {
         "nested": {"labels": ["a", "b"], "temperature": 298.15},
         "reader_metadata": {"reader": "omnic", "scan_count": 4},
@@ -97,9 +110,6 @@ def test_to_xarray_currently_exports_aligned_identity_and_selected_provenance():
         "vendor_metadata": {"firmware": "1.2.3", "serial": "abc"},
     }
     assert "scpy_filename" not in xds.attrs
-    assert "scpy_created" not in xds.attrs
-    assert "scpy_modified" not in xds.attrs
-    assert "scpy_acquisition_date" not in xds.attrs
     assert "scpy_history" not in xds.attrs
 
 
@@ -116,8 +126,10 @@ def test_from_xarray_currently_preserves_aligned_provenance_and_still_loses_othe
     assert rebuilt.description == ds.description
     assert rebuilt.origin == ds.origin
     assert rebuilt.author == ds.author
+    assert rebuilt.created == ds.created
+    assert rebuilt.modified == ds.modified
+    assert rebuilt.acquisition_date == ds.acquisition_date
     assert rebuilt.filename == Path("portable_demo.scp")
-    assert rebuilt.acquisition_date is None
     assert rebuilt.history == []
     assert rebuilt.meta["nested"] == ds.meta["nested"]
     assert rebuilt.meta["reader_metadata"] == ds.meta["reader_metadata"]
@@ -204,8 +216,10 @@ def test_to_netcdf_and_from_netcdf_currently_preserve_aligned_provenance_and_sti
     assert rebuilt.description == ds.description
     assert rebuilt.origin == ds.origin
     assert rebuilt.author == ds.author
+    assert rebuilt.created == ds.created
+    assert rebuilt.modified == ds.modified
+    assert rebuilt.acquisition_date == ds.acquisition_date
     assert rebuilt.filename == Path("portable_demo.scp")
-    assert rebuilt.acquisition_date is None
     assert rebuilt.history == []
     assert rebuilt.meta["nested"] == ds.meta["nested"]
     assert rebuilt.meta["reader_metadata"] == ds.meta["reader_metadata"]
@@ -224,10 +238,12 @@ def test_netcdf_currently_omits_only_remaining_unaligned_provenance_attrs(tmp_pa
         assert opened.attrs["scpy_description"] == ds.description
         assert opened.attrs["scpy_author"] == ds.author
         assert opened.attrs["scpy_origin"] == ds.origin
+        assert opened.attrs["scpy_created"] == _portable_attr_datetime(ds._created)
+        assert opened.attrs["scpy_modified"] == _portable_attr_datetime(ds._modified)
+        assert opened.attrs["scpy_acquisition_date"] == _portable_attr_datetime(
+            ds._acquisition_date
+        )
         assert "scpy_filename" not in opened.attrs
-        assert "scpy_created" not in opened.attrs
-        assert "scpy_modified" not in opened.attrs
-        assert "scpy_acquisition_date" not in opened.attrs
         assert "scpy_history" not in opened.attrs
 
 

--- a/tests/test_core/test_dataset/test_xarray_mapping.py
+++ b/tests/test_core/test_dataset/test_xarray_mapping.py
@@ -5,6 +5,8 @@
 # ======================================================================================
 
 import importlib.util
+from datetime import UTC
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -21,7 +23,19 @@ else:  # pragma: no cover - depends on optional dependency availability
 pytestmark = pytest.mark.skipif(xr is None, reason="xarray is not installed")
 
 
-def _make_dataset(data=None, *, complex_data=False, unsupported_meta=False):
+def _portable_attr_datetime(value):
+    if value is None:
+        return None
+    return value.isoformat(sep=" ", timespec="seconds")
+
+
+def _make_dataset(
+    data=None,
+    *,
+    complex_data=False,
+    unsupported_meta=False,
+    acquisition_date=None,
+):
     if data is None:
         if complex_data:
             data = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]], dtype=np.complex128)
@@ -36,7 +50,7 @@ def _make_dataset(data=None, *, complex_data=False, unsupported_meta=False):
     if unsupported_meta:
         meta["unsupported"] = object()
 
-    return NDDataset(
+    ds = NDDataset(
         data,
         dims=["y", "x"],
         coordset=[
@@ -52,6 +66,11 @@ def _make_dataset(data=None, *, complex_data=False, unsupported_meta=False):
         origin="portable origin",
         meta=meta,
     )
+    if acquisition_date is not None:
+        ds.acquisition_date = acquisition_date
+    ds._created = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+    return ds
 
 
 def test_to_xarray_returns_dataset():
@@ -64,6 +83,8 @@ def test_to_xarray_returns_dataset():
     assert xds.attrs["scpy_description"] == ds.description
     assert xds.attrs["scpy_author"] == ds.author
     assert xds.attrs["scpy_origin"] == ds.origin
+    assert xds.attrs["scpy_created"] == _portable_attr_datetime(ds._created)
+    assert xds.attrs["scpy_modified"] == _portable_attr_datetime(ds._modified)
 
 
 def test_xarray_roundtrip_preserves_numerical_data_dims_and_coordinates():
@@ -79,7 +100,7 @@ def test_xarray_roundtrip_preserves_numerical_data_dims_and_coordinates():
 
 
 def test_xarray_roundtrip_preserves_units_identity_and_selected_provenance():
-    ds = _make_dataset()
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
 
     xds = ds.to_xarray()
     rebuilt = NDDataset.from_xarray(xds)
@@ -91,8 +112,47 @@ def test_xarray_roundtrip_preserves_units_identity_and_selected_provenance():
     assert rebuilt.description == ds.description
     assert rebuilt.author == ds.author
     assert rebuilt.origin == ds.origin
+    assert rebuilt.created == ds.created
+    assert rebuilt.modified == ds.modified
+    assert rebuilt.acquisition_date == ds.acquisition_date
     assert str(rebuilt.coord("x").units) == str(ds.coord("x").units)
     assert rebuilt.coord("x").title == ds.coord("x").title
+
+
+def test_xarray_roundtrip_preserves_naive_acquisition_date():
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11))
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert xds.attrs["scpy_acquisition_date"] == "2024-01-03 09:10:11"
+    assert rebuilt.acquisition_date == ds.acquisition_date
+
+
+def test_from_xarray_restores_modified_after_acquisition_date_side_effect():
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    # Restoring acquisition_date can touch _modified through trait observation,
+    # so the portable importer must restore modified last.
+    assert rebuilt.modified == ds.modified
+    assert rebuilt.acquisition_date == ds.acquisition_date
+
+
+def test_from_xarray_missing_timestamp_attrs_keeps_existing_fallback_behavior():
+    ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
+
+    xds = ds.to_xarray()
+    xds.attrs.pop("scpy_created")
+    xds.attrs.pop("scpy_modified")
+    xds.attrs.pop("scpy_acquisition_date")
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert rebuilt.created != ds.created
+    assert rebuilt.modified != ds.modified
+    assert rebuilt.acquisition_date is None
 
 
 def test_xarray_roundtrip_preserves_json_compatible_metadata():


### PR DESCRIPTION
## Summary of changes
Extend portable NDDataset ↔ xarray / NetCDF persistence to preserve timestamp-like provenance fields created, modified, and acquisition_date using stable textual attrs on the existing xarray-backed portable carrier. Update the xarray and NetCDF mapping tests to make these fields contract coverage, add fallback coverage for missing attrs and naive acquisition_date, and refresh the portable characterization baseline to reflect the new preserved status of these timestamps.

## Intentionally out of scope
This PR does not address filename, history, label semantics, label-only coordinates, auxiliary coordinate naming stability, richer CoordSet topology, or result-object persistence. No public APIs were changed.

## Related context
Continues the portable metadata alignment work after PR1, which aligned description, author, and origin, and narrows this step to timestamp provenance only through the existing xarray-backed NetCDF path.