### PR TITLE
ENH: preserve history in portable xarray and NetCDF round-trips

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -23,7 +23,7 @@ New Features
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
   ``name``/``title``, dataset-level
-  ``description``/``author``/``origin``/``created``/``modified``/``acquisition_date``,
+  ``description``/``author``/``origin``/``created``/``modified``/``acquisition_date``/``history``,
   auxiliary same-dimension ``CoordSet`` coordinates (multiple numeric
   coordinates sharing a dimension), and portable string labels on coordinates
   (1D string-only, ``None`` preserved via metadata marker). Auxiliary
@@ -34,7 +34,8 @@ New Features
   ``scpy_coord_role="label"`` and restored on import. Non-exportable labels
   (mixed types, datetime, multi-row) trigger an explicit
   :class:`~spectrochempy.utils._logging.warning_` instead of silent
-  omission. (:issue:`1227`)
+  omission. Portable history is persisted as a stable human-readable textual
+  event trail through the same xarray-backed NetCDF path. (:issue:`1227`)
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -19,7 +19,7 @@ New Features
   numerical data, default coordinates, units, explicit masks,
   JSON-compatible metadata, complex data (split real/imag convention),
   ``name``/``title``, dataset-level
-  ``description``/``author``/``origin``/``created``/``modified``/``acquisition_date``,
+  ``description``/``author``/``origin``/``created``/``modified``/``acquisition_date``/``history``,
   auxiliary same-dimension ``CoordSet`` coordinates (multiple numeric
   coordinates sharing a dimension), and portable string labels on coordinates
   (1D string-only, ``None`` preserved via metadata marker). Auxiliary
@@ -30,7 +30,8 @@ New Features
   ``scpy_coord_role="label"`` and restored on import. Non-exportable labels
   (mixed types, datetime, multi-row) trigger an explicit
   :class:`~spectrochempy.utils._logging.warning_` instead of silent
-  omission. (:issue:`1227`)
+  omission. Portable history is persisted as a stable human-readable textual
+  event trail through the same xarray-backed NetCDF path. (:issue:`1227`)
 
 Bug Fixes
 ~~~~~~~~~

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -139,11 +139,51 @@ def _restore_portable_datetime(value):
     return datetime.fromisoformat(value)
 
 
+def _serialize_portable_history(history) -> list[str] | None:
+    """Return a portable textual history payload or ``None`` for empty history."""
+    if not history:
+        return None
+    if not isinstance(history, list):
+        raise TypeError(
+            f"Portable history must be exported as a list, got {type(history).__name__}"
+        )
+    for entry in history:
+        if not isinstance(entry, str):
+            raise TypeError(
+                "Portable history entries must be strings, "
+                f"got {type(entry).__name__}"
+            )
+    return list(history)
+
+
+def _restore_portable_history(value):
+    """Return internal history tuples restored from portable textual content."""
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise TypeError(
+            f"Portable history attr must be a list, got {type(value).__name__}"
+        )
+
+    restored = []
+    for entry in value:
+        if not isinstance(entry, str):
+            raise TypeError(
+                "Portable history entries must be strings, "
+                f"got {type(entry).__name__}"
+            )
+        date_text, separator, message = entry.partition("> ")
+        if separator != "> " or not message:
+            raise ValueError("Portable history entry must use '<timestamp> <text>'")
+        restored.append((datetime.fromisoformat(date_text), message))
+    return restored
+
+
 def _prepare_xarray_dataset_for_netcdf(dataset):
     """Convert a canonical xarray Dataset into a NetCDF-safe representation."""
     xds = dataset.copy(deep=True)
 
-    for attr_name in ("scpy_meta", "scpy_skipped_meta_keys"):
+    for attr_name in ("scpy_meta", "scpy_skipped_meta_keys", "scpy_history"):
         if attr_name in xds.attrs:
             xds.attrs[attr_name] = json.dumps(xds.attrs[attr_name], sort_keys=True)
 
@@ -191,7 +231,7 @@ def _restore_xarray_dataset_from_netcdf(dataset):
     """Restore the canonical xarray Dataset representation from NetCDF content."""
     xds = dataset.copy(deep=True)
 
-    for attr_name in ("scpy_meta", "scpy_skipped_meta_keys"):
+    for attr_name in ("scpy_meta", "scpy_skipped_meta_keys", "scpy_history"):
         if attr_name in xds.attrs and isinstance(xds.attrs[attr_name], str):
             xds.attrs[attr_name] = json.loads(xds.attrs[attr_name])
 
@@ -1644,6 +1684,9 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             serialized = _serialize_portable_datetime(value)
             if serialized is not None:
                 dataset_attrs[dataset_attr] = serialized
+        serialized_history = _serialize_portable_history(self.history)
+        if serialized_history is not None:
+            dataset_attrs["scpy_history"] = serialized_history
         if meta:
             dataset_attrs["scpy_meta"] = json.loads(json.dumps(meta))
         if skipped_meta_keys:
@@ -1830,6 +1873,12 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             kwargs["mask"] = np.asarray(dataset[mask_name].data, dtype=bool)
 
         result = cls(np.asarray(data_var.data), **kwargs)
+
+        if "scpy_history" in dataset.attrs:
+            with suppress(TypeError, ValueError):
+                result._history = _restore_portable_history(
+                    dataset.attrs["scpy_history"]
+                )
 
         for dataset_attr, internal_attr in (
             ("scpy_created", "_created"),

--- a/tests/test_core/test_dataset/test_netcdf_mapping.py
+++ b/tests/test_core/test_dataset/test_netcdf_mapping.py
@@ -5,6 +5,7 @@
 # ======================================================================================
 
 import importlib.util
+import json
 from datetime import UTC
 from datetime import datetime
 
@@ -26,6 +27,13 @@ def _portable_attr_datetime(value):
     if value is None:
         return None
     return value.isoformat(sep=" ", timespec="seconds")
+
+
+def _make_history_entries():
+    return [
+        (datetime(2024, 1, 1, 8, 0, 0, tzinfo=UTC), "Imported from instrument"),
+        (datetime(2024, 1, 1, 8, 30, 0, tzinfo=UTC), "Baseline corrected"),
+    ]
 
 
 def _make_dataset(data=None, *, complex_data=False, acquisition_date=None):
@@ -79,6 +87,8 @@ def test_netcdf_roundtrip_preserves_coordinates_identity_provenance_and_metadata
     tmp_path,
 ):
     ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
     filename = tmp_path / "dataset.nc"
 
     ds.to_netcdf(filename)
@@ -99,6 +109,47 @@ def test_netcdf_roundtrip_preserves_coordinates_identity_provenance_and_metadata
     assert rebuilt.created == ds.created
     assert rebuilt.modified == ds.modified
     assert rebuilt.acquisition_date == ds.acquisition_date
+    assert rebuilt.history == ds.history
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_empty_history_without_emitting_attr(tmp_path):
+    ds = _make_dataset()
+    filename = tmp_path / "dataset_empty_history.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    with xr.open_dataset(filename, engine="scipy") as opened:
+        assert "scpy_history" not in opened.attrs
+
+    assert rebuilt.history == []
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_single_history_entry(tmp_path):
+    ds = _make_dataset()
+    ds._history = _make_history_entries()[:1]
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+    filename = tmp_path / "dataset_single_history.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    assert rebuilt.history == ds.history
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_netcdf_roundtrip_preserves_multi_entry_history(tmp_path):
+    ds = _make_dataset()
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+    filename = tmp_path / "dataset_multi_history.nc"
+
+    ds.to_netcdf(filename)
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    assert rebuilt.history == ds.history
 
 
 @pytest.mark.skipif(xr is None, reason="xarray is not installed")
@@ -124,6 +175,8 @@ def test_netcdf_complex_roundtrip_uses_split_real_imag_convention(tmp_path):
 @pytest.mark.skipif(xr is None, reason="xarray is not installed")
 def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
     ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
     filename = tmp_path / "dataset.nc"
 
     ds.to_netcdf(filename)
@@ -139,6 +192,7 @@ def test_netcdf_file_is_readable_by_xarray_open_dataset(tmp_path):
         assert opened.attrs["scpy_acquisition_date"] == _portable_attr_datetime(
             ds._acquisition_date
         )
+        assert opened.attrs["scpy_history"] == json.dumps(ds.history, sort_keys=True)
         assert opened["spectra"].dims == ("y", "x")
         assert opened["spectra__mask"].dims == ("y", "x")
 
@@ -173,6 +227,22 @@ def test_from_netcdf_missing_timestamp_attrs_keeps_existing_fallback_behavior(tm
     assert rebuilt.created != ds.created
     assert rebuilt.modified != ds.modified
     assert rebuilt.acquisition_date is None
+
+
+@pytest.mark.skipif(xr is None, reason="xarray is not installed")
+def test_from_netcdf_missing_history_attr_keeps_existing_fallback_behavior(tmp_path):
+    ds = _make_dataset()
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+    filename = tmp_path / "dataset_without_history_attr.nc"
+
+    xds = ds.to_xarray()
+    xds.attrs.pop("scpy_history")
+    ndmodule._prepare_xarray_dataset_for_netcdf(xds).to_netcdf(filename, engine="scipy")
+
+    rebuilt = NDDataset.from_netcdf(filename)
+
+    assert rebuilt.history == []
 
 
 def _make_same_dim_netcdf_dataset():

--- a/tests/test_core/test_dataset/test_portable_persistence_characterization.py
+++ b/tests/test_core/test_dataset/test_portable_persistence_characterization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from datetime import UTC
 from datetime import datetime
 from pathlib import Path
@@ -110,10 +111,10 @@ def test_to_xarray_currently_exports_aligned_identity_and_selected_provenance():
         "vendor_metadata": {"firmware": "1.2.3", "serial": "abc"},
     }
     assert "scpy_filename" not in xds.attrs
-    assert "scpy_history" not in xds.attrs
+    assert xds.attrs["scpy_history"] == ds.history
 
 
-def test_from_xarray_currently_preserves_aligned_provenance_and_still_loses_other_fields():
+def test_from_xarray_currently_preserves_aligned_provenance_and_only_still_loses_filename():
     ds = _make_portable_metadata_dataset()
 
     rebuilt = NDDataset.from_xarray(ds.to_xarray())
@@ -130,7 +131,7 @@ def test_from_xarray_currently_preserves_aligned_provenance_and_still_loses_othe
     assert rebuilt.modified == ds.modified
     assert rebuilt.acquisition_date == ds.acquisition_date
     assert rebuilt.filename == Path("portable_demo.scp")
-    assert rebuilt.history == []
+    assert rebuilt.history == ds.history
     assert rebuilt.meta["nested"] == ds.meta["nested"]
     assert rebuilt.meta["reader_metadata"] == ds.meta["reader_metadata"]
     assert rebuilt.meta["vendor_metadata"] == ds.meta["vendor_metadata"]
@@ -199,7 +200,7 @@ def test_from_xarray_currently_preserves_nullable_text_labels():
     assert list(rebuilt.coord("x").labels) == ["A", None, "C"]
 
 
-def test_to_netcdf_and_from_netcdf_currently_preserve_aligned_provenance_and_still_lose_other_fields(
+def test_to_netcdf_and_from_netcdf_currently_preserve_aligned_provenance_and_only_still_lose_filename(
     tmp_path,
 ):
     ds = _make_portable_metadata_dataset()
@@ -220,13 +221,13 @@ def test_to_netcdf_and_from_netcdf_currently_preserve_aligned_provenance_and_sti
     assert rebuilt.modified == ds.modified
     assert rebuilt.acquisition_date == ds.acquisition_date
     assert rebuilt.filename == Path("portable_demo.scp")
-    assert rebuilt.history == []
+    assert rebuilt.history == ds.history
     assert rebuilt.meta["nested"] == ds.meta["nested"]
     assert rebuilt.meta["reader_metadata"] == ds.meta["reader_metadata"]
     assert rebuilt.meta["vendor_metadata"] == ds.meta["vendor_metadata"]
 
 
-def test_netcdf_currently_omits_only_remaining_unaligned_provenance_attrs(tmp_path):
+def test_netcdf_currently_omits_only_remaining_unaligned_filename_attr(tmp_path):
     ds = _make_portable_metadata_dataset()
     filename = tmp_path / "portable_demo.nc"
 
@@ -243,8 +244,8 @@ def test_netcdf_currently_omits_only_remaining_unaligned_provenance_attrs(tmp_pa
         assert opened.attrs["scpy_acquisition_date"] == _portable_attr_datetime(
             ds._acquisition_date
         )
+        assert opened.attrs["scpy_history"] == json.dumps(ds.history, sort_keys=True)
         assert "scpy_filename" not in opened.attrs
-        assert "scpy_history" not in opened.attrs
 
 
 def test_from_netcdf_currently_transforms_same_dim_auxiliary_coordinate_names(tmp_path):

--- a/tests/test_core/test_dataset/test_xarray_mapping.py
+++ b/tests/test_core/test_dataset/test_xarray_mapping.py
@@ -29,6 +29,13 @@ def _portable_attr_datetime(value):
     return value.isoformat(sep=" ", timespec="seconds")
 
 
+def _make_history_entries():
+    return [
+        (datetime(2024, 1, 1, 8, 0, 0, tzinfo=UTC), "Imported from instrument"),
+        (datetime(2024, 1, 1, 8, 30, 0, tzinfo=UTC), "Baseline corrected"),
+    ]
+
+
 def _make_dataset(
     data=None,
     *,
@@ -87,6 +94,16 @@ def test_to_xarray_returns_dataset():
     assert xds.attrs["scpy_modified"] == _portable_attr_datetime(ds._modified)
 
 
+def test_to_xarray_exports_history_as_portable_text_list():
+    ds = _make_dataset()
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+
+    xds = ds.to_xarray()
+
+    assert xds.attrs["scpy_history"] == ds.history
+
+
 def test_xarray_roundtrip_preserves_numerical_data_dims_and_coordinates():
     ds = _make_dataset()
 
@@ -101,6 +118,8 @@ def test_xarray_roundtrip_preserves_numerical_data_dims_and_coordinates():
 
 def test_xarray_roundtrip_preserves_units_identity_and_selected_provenance():
     ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
 
     xds = ds.to_xarray()
     rebuilt = NDDataset.from_xarray(xds)
@@ -115,8 +134,39 @@ def test_xarray_roundtrip_preserves_units_identity_and_selected_provenance():
     assert rebuilt.created == ds.created
     assert rebuilt.modified == ds.modified
     assert rebuilt.acquisition_date == ds.acquisition_date
+    assert rebuilt.history == ds.history
     assert str(rebuilt.coord("x").units) == str(ds.coord("x").units)
     assert rebuilt.coord("x").title == ds.coord("x").title
+
+
+def test_xarray_roundtrip_preserves_empty_history_without_emitting_attr():
+    ds = _make_dataset()
+
+    xds = ds.to_xarray()
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert "scpy_history" not in xds.attrs
+    assert rebuilt.history == []
+
+
+def test_xarray_roundtrip_preserves_single_history_entry():
+    ds = _make_dataset()
+    ds._history = _make_history_entries()[:1]
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+
+    rebuilt = NDDataset.from_xarray(ds.to_xarray())
+
+    assert rebuilt.history == ds.history
+
+
+def test_xarray_roundtrip_preserves_multi_entry_history():
+    ds = _make_dataset()
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+
+    rebuilt = NDDataset.from_xarray(ds.to_xarray())
+
+    assert rebuilt.history == ds.history
 
 
 def test_xarray_roundtrip_preserves_naive_acquisition_date():
@@ -131,14 +181,17 @@ def test_xarray_roundtrip_preserves_naive_acquisition_date():
 
 def test_from_xarray_restores_modified_after_acquisition_date_side_effect():
     ds = _make_dataset(acquisition_date=datetime(2024, 1, 3, 9, 10, 11, tzinfo=UTC))
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
 
     xds = ds.to_xarray()
     rebuilt = NDDataset.from_xarray(xds)
 
-    # Restoring acquisition_date can touch _modified through trait observation,
-    # so the portable importer must restore modified last.
+    # Restoring acquisition_date and history can touch _modified through trait
+    # observation, so the portable importer must restore modified last.
     assert rebuilt.modified == ds.modified
     assert rebuilt.acquisition_date == ds.acquisition_date
+    assert rebuilt.history == ds.history
 
 
 def test_from_xarray_missing_timestamp_attrs_keeps_existing_fallback_behavior():
@@ -153,6 +206,18 @@ def test_from_xarray_missing_timestamp_attrs_keeps_existing_fallback_behavior():
     assert rebuilt.created != ds.created
     assert rebuilt.modified != ds.modified
     assert rebuilt.acquisition_date is None
+
+
+def test_from_xarray_missing_history_attr_keeps_existing_fallback_behavior():
+    ds = _make_dataset()
+    ds._history = _make_history_entries()
+    ds._modified = datetime(2024, 1, 2, 6, 7, 8, tzinfo=UTC)
+
+    xds = ds.to_xarray()
+    xds.attrs.pop("scpy_history")
+    rebuilt = NDDataset.from_xarray(xds)
+
+    assert rebuilt.history == []
 
 
 def test_xarray_roundtrip_preserves_json_compatible_metadata():


### PR DESCRIPTION
## Summary

This PR aligns portable metadata persistence for `history` with the Portable Metadata Subset Contract.

Portable `NDDataset` round-trips through both:

- `to_xarray()` / `from_xarray()`
- `to_netcdf()` / `from_netcdf()`

now preserve meaningful history content using a stable, human-readable textual representation.

## What changed

- added portable `history` export on the canonical xarray carrier via `scpy_history`
- restored `history` on import from the same portable attr
- reused the existing xarray-backed NetCDF path rather than introducing a NetCDF-only metadata mapping
- kept empty or missing history attrs backward-compatible with current fallback behavior
- updated characterization coverage and converted relevant history cases into contract tests

## Serialization approach

`history` is persisted as portable text rather than Python objects.

- xarray carrier: list of strings in `scpy_history`
- NetCDF storage: JSON-encoded form of the same list through the existing structured-attr path

This keeps the representation:

- human-readable
- stable
- backend-independent
- safe for portable persistence

## Backward compatibility

This PR does not change public APIs.

Behavior remains compatible with:

- older portable files without `scpy_history`
- generic xarray datasets
- datasets with empty history
- datasets where history metadata is absent

If no portable history attr is present, import keeps the existing fallback behavior.

## Tests

Updated and added targeted tests for:

- xarray history preservation
- NetCDF history preservation
- empty history
- single-entry history
- multi-entry history
- missing-history-attr fallback
- characterization baseline updates
- regression validation against existing history semantic tests

