### PR TITLE
FIX: preserve count as canonical unit for TopSpin intensity display

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,10 @@ Bug Fixes
   existing dataset, and restored through the portable xarray/NetCDF import
   paths. (:issue:`1227`)
 
+- TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
+  render that canonical unit consistently in dataset summaries and related
+  displays, instead of unexpectedly showing ``pp``.
+
 - ``Coord`` labels are no longer silently dropped when a labeled
   ``Coord`` is copied into a ``CoordSet`` (e.g.
   ``CoordSet(labeled_coord)``). The ``CoordSet`` constructor creates a copy

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -47,6 +47,10 @@ Bug Fixes
   existing dataset, and restored through the portable xarray/NetCDF import
   paths. (:issue:`1227`)
 
+- TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
+  render that canonical unit consistently in dataset summaries and related
+  displays, instead of unexpectedly showing ``pp``.
+
 - ``Coord`` labels are no longer silently dropped when a labeled
   ``Coord`` is copied into a ``CoordSet`` (e.g.
   ``CoordSet(labeled_coord)``). The ``CoordSet`` constructor creates a copy

--- a/plugins/spectrochempy-nmr/tests/test_read_topspin.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_topspin.py
@@ -44,23 +44,23 @@ def _has_readdir_nmr_data():
 @pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
 def test_read_topspin():
     nd = _read_topspin_or_skip(_require_path(nmrdir / "exam2d_HC/3/pdata/1/2rr"))
-    assert str(nd) == "NDDataset: [quaternion] pp (shape: (y:1024, x:1024))"
+    assert str(nd) == "NDDataset: [quaternion] count (shape: (y:1024, x:1024))"
     assert nd.y.size == 1024
     assert nd.x.size == 1024
 
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/fid"))
-    assert str(nd) == "NDDataset: [complex128] pp (size: 12411)"
+    assert str(nd) == "NDDataset: [complex128] count (size: 12411)"
     assert nd.x.size == 12411
 
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/pdata/1/1r"))
-    assert str(nd) == "NDDataset: [complex128] pp (size: 16384)"
+    assert str(nd) == "NDDataset: [complex128] count (size: 16384)"
     assert nd.x.size == 16384
 
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_2d/1/ser"))
-    assert str(nd) == "NDDataset: [quaternion] pp (shape: (y:96, x:474))"
+    assert str(nd) == "NDDataset: [quaternion] count (shape: (y:96, x:474))"
 
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_2d/1/pdata/1/2rr"))
-    assert str(nd) == "NDDataset: [quaternion] pp (shape: (y:1024, x:2048))"
+    assert str(nd) == "NDDataset: [quaternion] count (shape: (y:1024, x:2048))"
 
     nd1 = _read_topspin_or_skip(_require_path(nmrdir / "topspin_2d"), expno=1, procno=1)
     assert nd1 == nd
@@ -70,8 +70,8 @@ def test_read_topspin():
 
     nd = _read_topspin_or_skip(_require_path(nmrdir), glob="topspin*/*/pdata/*/*")
     assert isinstance(nd, list)
-    assert str(nd[0]) == "NDDataset: [complex128] pp (shape: (y:1, x:16384))"
-    assert str(nd[1]) == "NDDataset: [quaternion] pp (shape: (y:1024, x:2048))"
+    assert str(nd[0]) == "NDDataset: [complex128] count (shape: (y:1, x:16384))"
+    assert str(nd[1]) == "NDDataset: [quaternion] count (shape: (y:1024, x:2048))"
 
 
 @pytest.mark.data

--- a/plugins/spectrochempy-nmr/tests/test_topspin_semantic_characterization.py
+++ b/plugins/spectrochempy-nmr/tests/test_topspin_semantic_characterization.py
@@ -72,7 +72,7 @@ def test_topspin_1d_currently_sets_origin_filename_typed_acquisition_date_and_me
     dataset = topspin_dataset_1d
 
     assert_dataset_identity(dataset, title="intensity")
-    assert str(dataset.units) in {"count", "pp"}
+    assert str(dataset.units) == "count"
     assert_dataset_provenance(
         dataset,
         origin="topspin",
@@ -95,7 +95,7 @@ def test_topspin_2d_currently_uses_runtime_coordinates_and_no_import_history(
     dataset = topspin_dataset_2d
 
     assert_dataset_identity(dataset, title="intensity")
-    assert str(dataset.units) in {"count", "pp"}
+    assert str(dataset.units) == "count"
     assert_dataset_provenance(
         dataset,
         origin="topspin",

--- a/src/spectrochempy/core/units/__init__.py
+++ b/src/spectrochempy/core/units/__init__.py
@@ -243,7 +243,7 @@ if globals().get("ur", None) is None:
     ur.define(
         "__wrapped__ = 1",
     )  # <- hack to avoid an error with pytest (doctest activated)
-    ur.define("@alias point = count")
+    ur.define("@alias count = point")
     ur.define("transmittance = 1. / 100. = %")
     ur.define("absolute_transmittance = 1.")
     ur.define("absorbance = 1. = a.u.")

--- a/tests/test_core/test_units/test_units.py
+++ b/tests/test_core/test_units/test_units.py
@@ -32,6 +32,12 @@ def test_units():
     assert x.dimensionless
 
 
+def test_count_is_canonical_and_point_remains_an_alias():
+    assert str(ur.Unit("count")) == "count"
+    assert str(ur.Unit("point")) == "count"
+    assert ur.Unit("count") == ur.Unit("point")
+
+
 def test_repr_html():
     a = Quantity(10, "s/km")
     assert "{}".format(a) == "10 s⋅km⁻¹"


### PR DESCRIPTION
## Summary

Fixes TopSpin/NMR intensity unit rendering so datasets explicitly assigned
`count` no longer display as `pp` in dataset summaries and related displays.

This PR also completes the reader semantic characterization baseline for the
high-value readers covered in Reader Alignment PR1, including OMNIC, OPUS,
JCAMP, LabSpec, CSV, and TopSpin.

## Scope

Includes:
- a narrow unit-registry fix to keep `count` as the canonical rendered unit
  while preserving `point` as an accepted alias
- targeted TopSpin regression updates
- reader semantic characterization helpers and characterization tests
- maintainer audit notes for the reader characterization baseline and the
  TopSpin unit investigation

Out of scope:
- reader normalization changes
- provenance/history alignment work
- coordinate redesign
- label redesign
- broad unit-system changes

## Root cause

The TopSpin reader already set `dataset.units = "count"` correctly.

The unexpected `pp` rendering came from the local SpectroChemPy unit-registry
alias direction, which canonicalized `count` to `point`; the pretty unit
formatter then rendered that canonical unit as `pp`.

The fix is intentionally narrow and applied at the smallest responsible layer.
