### PR TITLE
FIX: normalize acquisition_date across core readers: OMNIC, OPUS, JCAMP, and LabSpec

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,11 @@ Bug Fixes
   existing dataset, and restored through the portable xarray/NetCDF import
   paths. (:issue:`1227`)
 
+- OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
+  ``acquisition_date`` when reliable acquisition timestamps are already
+  available from the source data, while preserving the existing
+  coordinate-based time representations.
+
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related
   displays, instead of unexpectedly showing ``pp``.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -47,6 +47,11 @@ Bug Fixes
   existing dataset, and restored through the portable xarray/NetCDF import
   paths. (:issue:`1227`)
 
+- OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
+  ``acquisition_date`` when reliable acquisition timestamps are already
+  available from the source data, while preserving the existing
+  coordinate-based time representations.
+
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related
   displays, instead of unexpectedly showing ``pp``.

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -367,6 +367,9 @@ def _read_jdx(*args, **kwargs):
     else:
         _y = Coord()
     dataset.set_coordset(y=_y, x=_x)
+    valid_dates = [date for date in alldates if date is not None]
+    if valid_dates:
+        dataset.acquisition_date = min(valid_dates)
 
     # Set origin, description and history
     if nspec > 1:

--- a/src/spectrochempy/core/readers/read_labspec.py
+++ b/src/spectrochempy/core/readers/read_labspec.py
@@ -209,6 +209,7 @@ def _read_txt(*args, **kwargs):
     dataset.name = filename.stem
     dataset.filename = filename
     dataset.meta = meta
+    dataset.acquisition_date = date_acq
 
     # date_acq is Acquisition date at start (first moment of acquisition)
     dataset.description = "Spectrum acquisition : " + str(date_acq)

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -780,6 +780,8 @@ def _read_spg(*args, **kwargs):
     )
 
     dataset.set_coordset(y=_y, x=_x)
+    if acquisitiondates:
+        dataset.acquisition_date = min(acquisitiondates)
 
     # Set description, date and history
     # Omnic spg file don't have specific "origin" field stating the oirigin of the data
@@ -977,6 +979,8 @@ def _read_spa(*args, **kwargs):
     dataset.set_coordset(y=_y, x=_x)
     dataset.name = spa_name  # to be consistent with omnic behaviour
     dataset.filename = filename
+    if return_ifg != "background":
+        dataset.acquisition_date = acquisitiondate
 
     # Set origin, description, history, date
     # Omnic spg file don't have specific "origin" field stating the oirigin of the data

--- a/src/spectrochempy/core/readers/read_opus.py
+++ b/src/spectrochempy/core/readers/read_opus.py
@@ -463,6 +463,12 @@ def _read_opus(*args, **kwargs):
 
     # set dataset's Coordset
     dataset.set_coordset(y=yaxis, x=xaxis)
+    try:
+        dt, _ = _get_timestamp_from(d.params)
+    except (AttributeError, TypeError, ValueError):
+        dt = None
+    if dt is not None:
+        dataset.acquisition_date = dt
 
     # Set name, origin, description and history
     dataset.name = filename.stem

--- a/tests/test_core/test_readers/_reader_semantic_helpers.py
+++ b/tests/test_core/test_readers/_reader_semantic_helpers.py
@@ -37,7 +37,8 @@ def assert_dataset_provenance(
     if description_contains is not None:
         assert description_contains in dataset.description
     if acquisition_date_present is True:
-        assert isinstance(dataset.acquisition_date, datetime)
+        assert dataset.acquisition_date is not None
+        assert isinstance(datetime.fromisoformat(dataset.acquisition_date), datetime)
     elif acquisition_date_present is False:
         assert dataset.acquisition_date is None
 

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -5,9 +5,12 @@
 # ======================================================================================
 # ruff: noqa
 
+from datetime import datetime
+
 import numpy as np
 
 from spectrochempy import read_jcamp, read, Coord, NDDataset
+from spectrochempy.utils.datetimeutils import UTC
 
 
 def test_read_jcamp(JDX_2D):
@@ -15,6 +18,7 @@ def test_read_jcamp(JDX_2D):
     Y = read_jcamp({"some2Dspectra.jdx": JDX_2D.encode("utf8")})
     assert str(Y.coordset) == "CoordSet: [x:wavenumbers, y:acquisition timestamp (GMT)]"
     assert Y.shape == (3, 20)
+    assert Y._acquisition_date == datetime(2016, 7, 6, 19, 3, 14, tzinfo=UTC)
 
     f = Y.write_jcamp("2D.jdx", confirm=False)
     Y = read(f)
@@ -23,6 +27,47 @@ def test_read_jcamp(JDX_2D):
     assert Y.name == "IR_2D"
 
     f.unlink()
+
+
+def test_read_jcamp_single_spectrum_sets_acquisition_date():
+    jdx = """##TITLE=single_semantic
+##JCAMP-DX=5.01
+##DATA TYPE=INFRARED SPECTRUM
+##LONGDATE=2016/07/06
+##TIME=19:03:14
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+    4000.0 1.0 0.9 0.8 0.7
+##END
+"""
+    ds = read_jcamp({"single_semantic.jdx": jdx.encode("utf8")})
+    assert ds._acquisition_date == datetime(2016, 7, 6, 19, 3, 14, tzinfo=UTC)
+    assert ds.y.is_empty
+
+
+def test_read_jcamp_without_date_keeps_acquisition_date_empty():
+    jdx = """##TITLE=no_date
+##JCAMP-DX=5.01
+##DATA TYPE=INFRARED SPECTRUM
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 1.0 0.9 0.8 0.7
+##END
+"""
+    ds = read_jcamp({"no_date.jdx": jdx.encode("utf8")})
+    assert ds.acquisition_date is None
 
 
 def test_read_jcamp_transmittance_units():

--- a/tests/test_core/test_readers/test_read_labspec.py
+++ b/tests/test_core/test_readers/test_read_labspec.py
@@ -5,6 +5,7 @@
 # ======================================================================================
 # ruff: noqa
 
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,9 @@ def test_read_labspec_latin1_content():
 
     assert nd.shape == (1, 2)
     assert nd.meta["Comment"] == "20°C"
+    assert nd._acquisition_date == datetime(2024, 1, 1, 0, 0, 0)
+    assert nd.y.title == "Time"
+    assert str(nd.y.units) == "s"
 
     # non labspec txt file
     f = Path("i_am_not_labspec.txt")

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -39,6 +39,9 @@ def test_read_omnic_local_wodger():
         content = fil.read()
     nd2 = scp.read_omnic({filename_wodger: content})
     assert nd1 == nd2
+    assert nd1.acquisition_date is not None
+    assert nd1.y.title == "acquisition timestamp (GMT)"
+    assert str(nd1.y.units) == "s"
 
 
 @pytest.mark.usefixtures("_skip_if_no_testdata")

--- a/tests/test_core/test_readers/test_read_opus.py
+++ b/tests/test_core/test_readers/test_read_opus.py
@@ -122,6 +122,11 @@ class TestOpusMetadata:
         assert acquisition["AQM"].name == "Acquisition Mode"
         assert acquisition["DEL"].value == 0
 
+    def test_single_file_sets_acquisition_date_without_removing_timestamp_axis(self):
+        assert self.dataset.acquisition_date is not None
+        assert self.dataset.y.title == "acquisition timestamp (GMT)"
+        assert str(self.dataset.y.units) == "s"
+
 
 class TestOpusMerging:
     """Test OPUS file merging behavior."""
@@ -196,6 +201,7 @@ class TestOpusAssembledTimeResolved:
         assert dataset.x.title == "wavenumber"
         assert str(dataset.x.units) == "cm^-1"
         assert dataset.units == "absorbance"
+        assert dataset.acquisition_date is not None
 
     def test_sm_series(self):
         """Reading SM type should return sample spectra series."""

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -17,6 +17,7 @@ import spectrochempy as scp
 from spectrochempy.application.preferences import preferences as prefs
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.readers.read_labspec import _read_txt
+from spectrochempy.utils.datetimeutils import UTC
 from tests.test_core.test_readers._reader_semantic_helpers import (
     assert_coordinate_semantics,
 )
@@ -107,6 +108,25 @@ def jcamp_single_with_owner():
 
 
 @pytest.fixture
+def jcamp_single_without_date():
+    content = """##TITLE=single_no_date
+##JCAMP-DX=5.01
+##DATA TYPE=INFRARED SPECTRUM
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 1.0 0.9 0.8 0.7
+##END
+"""
+    return scp.read_jcamp({"single_no_date.jdx": content.encode("utf8")})
+
+
+@pytest.fixture
 def csv_omnic_dataset():
     content = "4000.0,0.5\n4001.0,0.6\n4002.0,0.7\n"
     return scp.read_csv(
@@ -160,7 +180,7 @@ class TestOmnicCharacterization:
             filename_name="wodger.spg",
             origin="",
             description_contains="Omnic title: wodger.spg",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
         assert_history_present(dataset, "Imported from spg file", "Sorted by date")
 
@@ -179,7 +199,7 @@ class TestOmnicCharacterization:
         assert_dataset_provenance(
             dataset,
             origin="",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
         assert_history_present(dataset, "Imported from spa file")
         assert_coordinate_semantics(
@@ -231,7 +251,7 @@ class TestOpusCharacterization:
             filename_name="test.0000",
             origin="opus-AB",
             description_contains="opus files",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
         assert_history_present(dataset, "import from opus files")
 
@@ -254,7 +274,7 @@ class TestOpusCharacterization:
         assert_dataset_provenance(
             dataset,
             origin="opus-AB",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
         assert_history_present(dataset, "import from opus files")
         assert_coordinate_semantics(dataset, "x", title="wavenumber", units="cm⁻¹")
@@ -281,8 +301,9 @@ class TestJcampCharacterization:
             filename_name="semantic_linked.jdx",
             origin="omnic",
             description_contains="Dataset from jdx file: 'IR_2D'",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
+        assert dataset._acquisition_date == datetime(2016, 7, 6, 19, 3, 14, tzinfo=UTC)
         assert_history_present(dataset, "Imported from jdx file", "Sorted by date")
         assert_coordinate_semantics(dataset, "x", title="wavenumbers", units="cm⁻¹")
         y = assert_coordinate_semantics(
@@ -308,11 +329,26 @@ class TestJcampCharacterization:
             filename_name="single_semantic.jdx",
             origin="",
             description_contains="Dataset from jdx file: 'single_semantic'",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
+        assert dataset._acquisition_date == datetime(2016, 7, 6, 19, 3, 14, tzinfo=UTC)
         assert dataset.author != "reader-owner"
         assert dataset.y.is_empty
         assert_history_present(dataset, "Imported from jdx file")
+
+    def test_single_jcamp_without_date_keeps_acquisition_date_empty(
+        self, jcamp_single_without_date
+    ):
+        dataset = jcamp_single_without_date
+
+        assert_dataset_provenance(
+            dataset,
+            filename_name="single_no_date.jdx",
+            origin="",
+            description_contains="Dataset from jdx file: 'single_no_date'",
+            acquisition_date_present=False,
+        )
+        assert dataset.y.is_empty
 
 
 class TestCsvCharacterization:
@@ -384,8 +420,9 @@ class TestLabSpecCharacterization:
             filename_name="latin_labspec.txt",
             origin="",
             description_contains="Spectrum acquisition : 2024-01-01 00:00:00",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
+        assert dataset._acquisition_date == datetime(2024, 1, 1, 0, 0, 0)
         assert_history_present(dataset, "Imported from LabSpec6 text file")
 
         assert_coordinate_semantics(dataset, "x", title="Raman shift", units="cm⁻¹")
@@ -401,7 +438,7 @@ class TestLabSpecCharacterization:
         assert_dataset_provenance(
             dataset,
             origin="",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
         assert_history_present(dataset, "Imported from LabSpec6 text file")
         assert_coordinate_semantics(dataset, "x", title="Raman shift", units="cm⁻¹")


### PR DESCRIPTION
## Summary

Normalizes dataset-level `acquisition_date` for the core readers covered by the
reader-alignment campaign:

- OMNIC
- OPUS
- JCAMP
- LabSpec

The PR promotes already available reader timestamps to
`dataset.acquisition_date` while preserving the existing coordinate-based time
representations.

It also updates semantic characterization coverage so the relevant
acquisition-date expectations now act as alignment tests.

## Out of scope

- `origin` normalization
- `history` normalization
- coordinate redesign
- label redesign
- TopSpin changes
- portable persistence changes
