### PR TITLE
FIX: normalize origin across OMNIC, JCAMP, and LabSpec reader

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -57,7 +57,10 @@ Bug Fixes
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing
-  coordinate-based time representations.
+  coordinate-based time representations. OMNIC imports now expose a stable
+  ``origin="omnic"`` across SPA/SPG/SRS variants, LabSpec imports now use
+  ``origin="labspec"``, and JCAMP imports now preserve deterministic source
+  origin information when provided.
 
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -50,7 +50,10 @@ Bug Fixes
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing
-  coordinate-based time representations.
+  coordinate-based time representations. OMNIC imports now expose a stable
+  ``origin="omnic"`` across SPA/SPG/SRS variants, LabSpec imports now use
+  ``origin="labspec"``, and JCAMP imports now preserve deterministic source
+  origin information when provided.
 
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -372,14 +372,11 @@ def _read_jdx(*args, **kwargs):
         dataset.acquisition_date = min(valid_dates)
 
     # Set origin, description and history
-    if nspec > 1:
-        origins = set(allorigins)
-        if len(origins) == 0:
-            pass
-        elif len(origins) == 1:
-            dataset.origin = allorigins[0]
-        else:
-            dataset.origin = [(origin + "; ") for origin in set(allorigins)][0][:-2]
+    origins = sorted({origin for origin in allorigins if origin})
+    if len(origins) == 1:
+        dataset.origin = origins[0]
+    elif len(origins) > 1:
+        dataset.origin = "; ".join(origins)
 
     dataset.description = f"Dataset from jdx file: '{jdx_title}'"
 

--- a/src/spectrochempy/core/readers/read_labspec.py
+++ b/src/spectrochempy/core/readers/read_labspec.py
@@ -208,6 +208,7 @@ def _read_txt(*args, **kwargs):
     dataset.units = None
     dataset.name = filename.stem
     dataset.filename = filename
+    dataset.origin = "labspec"
     dataset.meta = meta
     dataset.acquisition_date = date_acq
 

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -782,6 +782,7 @@ def _read_spg(*args, **kwargs):
     dataset.set_coordset(y=_y, x=_x)
     if acquisitiondates:
         dataset.acquisition_date = min(acquisitiondates)
+    dataset.origin = "omnic"
 
     # Set description, date and history
     # Omnic spg file don't have specific "origin" field stating the oirigin of the data
@@ -981,6 +982,7 @@ def _read_spa(*args, **kwargs):
     dataset.filename = filename
     if return_ifg != "background":
         dataset.acquisition_date = acquisitiondate
+    dataset.origin = "omnic"
 
     # Set origin, description, history, date
     # Omnic spg file don't have specific "origin" field stating the oirigin of the data

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -47,8 +47,67 @@ def test_read_jcamp_single_spectrum_sets_acquisition_date():
 ##END
 """
     ds = read_jcamp({"single_semantic.jdx": jdx.encode("utf8")})
+    assert ds.origin == ""
     assert ds._acquisition_date == datetime(2016, 7, 6, 19, 3, 14, tzinfo=UTC)
     assert ds.y.is_empty
+
+
+def test_read_jcamp_single_spectrum_preserves_origin():
+    jdx = """##TITLE=single_origin
+##JCAMP-DX=5.01
+##DATA TYPE=INFRARED SPECTRUM
+##ORIGIN=omnic
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 1.0 0.9 0.8 0.7
+##END
+"""
+    ds = read_jcamp({"single_origin.jdx": jdx.encode("utf8")})
+    assert ds.origin == "omnic"
+
+
+def test_read_jcamp_linked_multi_origin_is_deterministic():
+    jdx = """##TITLE=linked_origin
+##JCAMP-DX=5.01
+##DATA TYPE=LINK
+##BLOCKS=2
+##TITLE=spec_1
+##ORIGIN=omnic
+##LONGDATE=2016/07/06
+##TIME=19:03:14
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 1.0 0.9 0.8 0.7
+##END=
+##TITLE=spec_2
+##ORIGIN=labspec
+##LONGDATE=2016/07/06
+##TIME=19:04:14
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 0.7 0.6 0.5 0.4
+##END=
+"""
+    ds = read_jcamp({"linked_origin.jdx": jdx.encode("utf8")})
+    assert ds.origin == "labspec; omnic"
 
 
 def test_read_jcamp_without_date_keeps_acquisition_date_empty():

--- a/tests/test_core/test_readers/test_read_labspec.py
+++ b/tests/test_core/test_readers/test_read_labspec.py
@@ -60,6 +60,7 @@ def test_read_labspec_latin1_content():
 
     assert nd.shape == (1, 2)
     assert nd.meta["Comment"] == "20°C"
+    assert nd.origin == "labspec"
     assert nd._acquisition_date == datetime(2024, 1, 1, 0, 0, 0)
     assert nd.y.title == "Time"
     assert str(nd.y.units) == "s"

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -39,6 +39,7 @@ def test_read_omnic_local_wodger():
         content = fil.read()
     nd2 = scp.read_omnic({filename_wodger: content})
     assert nd1 == nd2
+    assert nd1.origin == "omnic"
     assert nd1.acquisition_date is not None
     assert nd1.y.title == "acquisition timestamp (GMT)"
     assert str(nd1.y.units) == "s"
@@ -69,6 +70,7 @@ def test_read_omnic():
 
     nd = scp.read_spa(IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA")
     assert str(nd) == "NDDataset: [float64] a.u. (shape: (y:1, x:5549))"
+    assert nd.origin == "omnic"
 
     nd2 = scp.read_omnic(IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA")
     assert nd2 == nd

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -127,6 +127,44 @@ def jcamp_single_without_date():
 
 
 @pytest.fixture
+def jcamp_linked_multi_origin_dataset():
+    content = """##TITLE=IR_multi_origin
+##JCAMP-DX=5.01
+##DATA TYPE=LINK
+##BLOCKS=2
+##TITLE=spec_1
+##ORIGIN=omnic
+##LONGDATE=2016/07/06
+##TIME=19:03:14
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 1.0 0.9 0.8 0.7
+##END=
+##TITLE=spec_2
+##ORIGIN=labspec
+##LONGDATE=2016/07/06
+##TIME=19:04:14
+##XUNITS=1/CM
+##YUNITS=ABSORBANCE
+##FIRSTX=4000.0
+##LASTX=3997.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 0.7 0.6 0.5 0.4
+##END=
+"""
+    return scp.read_jcamp({"linked_multi_origin.jdx": content.encode("utf8")})
+
+
+@pytest.fixture
 def csv_omnic_dataset():
     content = "4000.0,0.5\n4001.0,0.6\n4002.0,0.7\n"
     return scp.read_csv(
@@ -178,7 +216,7 @@ class TestOmnicCharacterization:
         assert_dataset_provenance(
             dataset,
             filename_name="wodger.spg",
-            origin="",
+            origin="omnic",
             description_contains="Omnic title: wodger.spg",
             acquisition_date_present=True,
         )
@@ -193,12 +231,12 @@ class TestOmnicCharacterization:
         assert isinstance(labels[1, 0], datetime)
         assert x.labels is None
 
-    def test_spa_currently_uses_empty_origin_and_label_rows(self, omnic_spa_dataset):
+    def test_spa_uses_omnic_origin_and_label_rows(self, omnic_spa_dataset):
         dataset = omnic_spa_dataset
 
         assert_dataset_provenance(
             dataset,
-            origin="",
+            origin="omnic",
             acquisition_date_present=True,
         )
         assert_history_present(dataset, "Imported from spa file")
@@ -313,7 +351,7 @@ class TestJcampCharacterization:
         assert isinstance(labels[0, 0], datetime)
         assert isinstance(labels[0, 1], str)
 
-    def test_single_jcamp_currently_ignores_owner_and_does_not_set_origin(
+    def test_single_jcamp_preserves_origin_and_keeps_owner_unmapped(
         self, jcamp_single_with_owner
     ):
         dataset = jcamp_single_with_owner
@@ -327,7 +365,7 @@ class TestJcampCharacterization:
         assert_dataset_provenance(
             dataset,
             filename_name="single_semantic.jdx",
-            origin="",
+            origin="omnic",
             description_contains="Dataset from jdx file: 'single_semantic'",
             acquisition_date_present=True,
         )
@@ -335,6 +373,20 @@ class TestJcampCharacterization:
         assert dataset.author != "reader-owner"
         assert dataset.y.is_empty
         assert_history_present(dataset, "Imported from jdx file")
+
+    def test_linked_jcamp_multi_origin_uses_deterministic_join(
+        self, jcamp_linked_multi_origin_dataset
+    ):
+        dataset = jcamp_linked_multi_origin_dataset
+
+        assert_dataset_provenance(
+            dataset,
+            filename_name="linked_multi_origin.jdx",
+            origin="labspec; omnic",
+            description_contains="Dataset from jdx file: 'IR_multi_origin'",
+            acquisition_date_present=True,
+        )
+        assert_history_present(dataset, "Imported from jdx file", "Sorted by date")
 
     def test_single_jcamp_without_date_keeps_acquisition_date_empty(
         self, jcamp_single_without_date
@@ -404,7 +456,7 @@ class TestCsvCharacterization:
 class TestLabSpecCharacterization:
     """Characterize current LabSpec semantic placement."""
 
-    def test_synthetic_labspec_currently_uses_description_for_start_date_and_meta(
+    def test_synthetic_labspec_uses_labspec_origin_description_and_meta(
         self, labspec_synthetic_dataset
     ):
         dataset = labspec_synthetic_dataset
@@ -418,7 +470,7 @@ class TestLabSpecCharacterization:
         assert_dataset_provenance(
             dataset,
             filename_name="latin_labspec.txt",
-            origin="",
+            origin="labspec",
             description_contains="Spectrum acquisition : 2024-01-01 00:00:00",
             acquisition_date_present=True,
         )
@@ -430,14 +482,14 @@ class TestLabSpecCharacterization:
         assert y.labels is None
         assert_meta_keys_present(dataset, "Comment", "Acquired", "Accumulations")
 
-    def test_real_labspec_series_currently_uses_datetime_label_rows(
+    def test_real_labspec_series_uses_labspec_origin_and_datetime_label_rows(
         self, labspec_real_dataset
     ):
         dataset = labspec_real_dataset
 
         assert_dataset_provenance(
             dataset,
-            origin="",
+            origin="labspec",
             acquisition_date_present=True,
         )
         assert_history_present(dataset, "Imported from LabSpec6 text file")


### PR DESCRIPTION
## Summary

Normalizes dataset-level `origin` for the high-value readers covered by this
reader-alignment step:

- OMNIC SPA / SPG / SRS
- JCAMP
- LabSpec

The PR sets stable origin values where reader identity is already unambiguous
and keeps the implementation intentionally narrow.

For JCAMP, single-spectrum imports now preserve `##ORIGIN` when present, and
linked imports use a deterministic sorted `"; "`-joined representation when
multiple distinct origins are encountered.

## Out of scope

- acquisition-date changes
- history normalization
- coordinate changes
- label changes
- vendor `Meta` changes
- OPUS origin redesign
- TopSpin origin changes
