### PR TITLE
DOC: clarify reader semantic normalization in the adding-a-reader guide

### DIFF
--- a/docs/sources/credits/credits.rst
+++ b/docs/sources/credits/credits.rst
@@ -15,12 +15,19 @@ The main contributors are:
 
 Other contributions have been made by:
 
+
 * Guillaume Clet (ORCID: `0000-0001-5999-5880 <https://orcid.org/0000-0001-5999-5880>`_)
+
 * Abdelhafid Ait Blal (ORCID: `0000-0002-1825-0097 <https://orcid.org/0000-0002-1825-0097>`_)
+
 * William Guerin
+
 * Matthias Mailänder
+
 * Sebastian Rejman (ORCID: `0000-0001-7976-6372 <https://orcid.org/0000-0001-7976-6372>`_)
+
 * Vincent Gao
+
 
 We thank all the users who have reported bugs, suggested improvements,
 and contributed to improve the documentation.

--- a/docs/sources/devguide/codespec_adding_reader.rst
+++ b/docs/sources/devguide/codespec_adding_reader.rst
@@ -103,30 +103,88 @@ Step 4: Data Format Guidelines
 When implementing the reader:
 
 1. Always return 2D datasets, even for 1D spectra
-2. Use timestamps for time axes when available
-3. Include relevant metadata and units
-4. Add proper description
+2. Set coordinates, metadata, and provenance on the semantic destination
+3. Include relevant units and descriptions
+4. Keep parser-only temporary state out of the returned dataset
+
+Reader semantic normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the existing dataset fields for shared meanings instead of inventing
+reader-specific conventions:
+
+* signal identity:
+  ``dataset.name``, ``dataset.title``, ``dataset.units``,
+  ``dataset.description``
+* source provenance:
+  ``dataset.filename``, ``dataset.origin``, ``dataset.author``
+* acquisition/session time:
+  ``dataset.acquisition_date``
+* pointwise time or support geometry:
+  ``Coord`` values
+* pointwise identifiers or categories:
+  ``Coord.labels``
+* import and processing events:
+  ``dataset.history``
+* vendor-specific technical payloads:
+  ``dataset.meta``
+* parser-only temporary state:
+  do not persist it on the returned dataset
+
+Dual-time rule:
+
+* ``acquisition_date`` = dataset or session provenance
+* time coordinates = observation geometry
+* both may coexist in the same imported dataset
+
+Examples:
+
+* a single acquisition start time belongs in ``dataset.acquisition_date``
+* a timestamp or elapsed-time axis for each spectrum belongs in a ``Coord``
+* sample IDs, acquisition names, or categorical row identifiers belong in
+  ``Coord.labels``
+* vendor parameter blocks belong in ``dataset.meta``
 
 Example of proper axis setup:
 
 .. code-block:: python
 
-    # Set up coordinates
-    x_data = get_wavelengths(file)  # Your implementation
-    x_coord = scp.Coord(x_data, title="wavelength", units="nm")
+    from spectrochempy.core.dataset.coord import Coord
+    from spectrochempy.core.dataset.nddataset import NDDataset
 
-    y_data = get_timestamps(file)  # Your implementation
-    y_coord = scp.Coord(y_data, title="Time", units="s",
-                        labels=acquisition_dates)
+    x_coord = Coord(wavenumbers, title="wavenumber", units="cm^-1")
+    y_coord = Coord(
+        elapsed_seconds,
+        title="elapsed time",
+        units="s",
+        labels=sample_ids,
+    )
 
-    # Create dataset
-    data = get_spectra(file)  # Your implementation
-    dataset = NDDataset(data,
-                       coords=[y_coord, x_coord],
-                       title="Absorption",
-                       units="absorbance")
-    dataset.description = "Dataset from .spc file\n"
-    dataset.history.append(f"Imported from {filename}")
+    dataset = NDDataset(data)
+    dataset.set_coordset(y=y_coord, x=x_coord)
+    dataset.name = filename.stem
+    dataset.title = "absorbance"
+    dataset.units = "absorbance"
+    dataset.description = "Dataset imported from vendor_x"
+
+    dataset.filename = filename
+    dataset.origin = "vendor_x"
+    dataset.acquisition_date = acquisition_start
+    dataset.history = f"Imported from vendor_x file {filename}"
+
+    dataset.meta.instrument_model = instrument_model
+    dataset.meta.processing_mode = processing_mode
+
+In this example:
+
+* ``elapsed_seconds`` stays on the ``y`` coordinate because it locates each
+  observation
+* ``sample_ids`` stays in ``Coord.labels`` because it identifies points along
+  the imported axis
+* ``acquisition_start`` becomes ``dataset.acquisition_date`` because it is
+  session provenance
+* vendor parameters remain in ``dataset.meta`` instead of being promoted to new
+  typed dataset fields
 
 Step 5: Documentation
 ---------------------
@@ -137,3 +195,28 @@ Step 5: Documentation
 4. Update `whatsnew/changelog.rst`
 
 For complete implementation examples, see existing readers in ``spectrochempy/core/readers/``.
+
+Step 6: Semantic Reader Tests
+-----------------------------
+
+In addition to basic shape or import tests, add focused semantic tests for the
+reader you introduce.
+
+Recommended coverage:
+
+* identity:
+  ``name``, ``title``, ``units``, ``description``
+* provenance:
+  ``filename``, ``origin``, ``author``, ``acquisition_date`` when available
+* coordinate semantics:
+  coordinate values, titles, units, and time-axis meaning
+* labels:
+  which axis carries labels and what they identify
+* retained ``Meta``:
+  important vendor-specific technical payloads
+* history:
+  import events and vendor processing history when preserved
+
+These tests should check semantic placement, not only raw values. A good reader
+test should make it obvious why a field lives on the dataset, on a coordinate,
+in labels, or in ``Meta``.


### PR DESCRIPTION
## Summary

Updates the developer guide page for adding readers so new contributors follow
the maintained semantic destinations for imported information.

The page now includes a concise practical section covering:

- signal identity fields
- provenance fields
- `acquisition_date`
- coordinate-based support/time
- `Coord.labels`
- `history`
- vendor payloads in `Meta`
- parser-only temporary state that should not persist

It also adds the dual-time rule, a compact example reader snippet, and
recommended semantic reader-test coverage.

## Out of scope

- reader implementation changes
- architecture note rewrites
- RFC changes
- broad documentation restructuring
