### PR TITLE
FIX: add TopSpin import-history event and fix JCAMP sort dimension

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -149,6 +149,15 @@ Bug Fixes
   variable instead of a literal string; and invalid ``return_ifg`` values
   now produce a clear warning. (:issue:`1144`) (PR by @gaoflow)
 
+- The TopSpin NMR reader now records an explicit ``Imported from TopSpin
+  dataset`` history event on successful import, aligning with other
+  high-value readers that already emit import-history entries.
+
+- JCAMP ``sortbydate`` now reorders spectra by acquisition timestamp
+  (``dim="y"``) instead of sorting wavenumbers (``dim="x"``), matching the
+  intended ``"Sorted by date"`` history message and the OMNIC SPG reference
+  pattern.
+
 .. section
 
 Dependency Updates

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -142,6 +142,15 @@ Bug Fixes
   variable instead of a literal string; and invalid ``return_ifg`` values
   now produce a clear warning. (:issue:`1144`) (PR by @gaoflow)
 
+- The TopSpin NMR reader now records an explicit ``Imported from TopSpin
+  dataset`` history event on successful import, aligning with other
+  high-value readers that already emit import-history entries.
+
+- JCAMP ``sortbydate`` now reorders spectra by acquisition timestamp
+  (``dim="y"``) instead of sorting wavenumbers (``dim="x"``), matching the
+  intended ``"Sorted by date"`` history message and the OMNIC SPG reference
+  pattern.
+
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
@@ -1341,6 +1341,8 @@ def _read_topspin(*args, **kwargs):
     if dataset.meta.date is not None:
         dataset.acquisition_date = datetime.fromtimestamp(dataset.meta.date[-1])
 
+    dataset.history = "Imported from TopSpin dataset"
+
     return dataset
 
     # list_meta.append(meta)  # list_coords.append(coords)  # list_data.append(data)

--- a/plugins/spectrochempy-nmr/tests/test_topspin_semantic_characterization.py
+++ b/plugins/spectrochempy-nmr/tests/test_topspin_semantic_characterization.py
@@ -20,6 +20,7 @@ from tests.test_core.test_readers._reader_semantic_helpers import (
 from tests.test_core.test_readers._reader_semantic_helpers import (
     assert_dataset_provenance,
 )
+from tests.test_core.test_readers._reader_semantic_helpers import assert_history_present
 from tests.test_core.test_readers._reader_semantic_helpers import (
     assert_meta_keys_present,
 )
@@ -80,7 +81,7 @@ def test_topspin_1d_currently_sets_origin_filename_typed_acquisition_date_and_me
     )
     _assert_topspin_time_provenance(dataset)
     assert "expno:1" in dataset.name
-    assert dataset.history in (None, [])
+    assert_history_present(dataset, "Imported from TopSpin dataset")
 
     x = assert_coordinate_semantics(dataset, "x")
     assert x.meta["acquisition_frequency"] is not None
@@ -89,7 +90,7 @@ def test_topspin_1d_currently_sets_origin_filename_typed_acquisition_date_and_me
 
 
 @pytest.mark.data
-def test_topspin_2d_currently_uses_runtime_coordinates_and_no_import_history(
+def test_topspin_2d_currently_sets_import_history(
     topspin_dataset_2d,
 ):
     dataset = topspin_dataset_2d
@@ -102,7 +103,7 @@ def test_topspin_2d_currently_uses_runtime_coordinates_and_no_import_history(
         filename_name="topspin_2d",
     )
     _assert_topspin_time_provenance(dataset)
-    assert dataset.history in (None, [])
+    assert_history_present(dataset, "Imported from TopSpin dataset")
     assert_coordinate_semantics(dataset, "x")
     y = assert_coordinate_semantics(dataset, "y")
     assert y.title in {"time", "Time", "F1 acquisition time", None}

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -383,7 +383,7 @@ def _read_jdx(*args, **kwargs):
     dataset.history = "Imported from jdx file"
 
     if sortbydate and nspec > 1:
-        dataset.sort(dim="x", inplace=True)
+        dataset.sort(dim="y", inplace=True)
         dataset.history = "Sorted by date"
     # Todo: make sure that the lowest index correspond to the largest wavenumber
     #  for compatibility with dataset created by read_omnic:


### PR DESCRIPTION
## Summary

Narrow reader-alignment PR that adds the missing TopSpin import-history
event, corrects the JCAMP sortbydate dimension, and strengthens semantic
history coverage.

## Changes

### TopSpin import history

The TopSpin reader set `origin`, `filename`, `acquisition_date`, and `Meta`
but emitted no explicit import-history entry. Now records:

    Imported from TopSpin dataset

### JCAMP sort dimension

`sortbydate` used `dim="x"` (sorting wavenumbers per spectrum) while claiming
"Sorted by date". Fixed to `dim="y"` (reordering spectra by acquisition
timestamp), matching the OMNIC SPG reference pattern.

### Tests

Updated TopSpin semantic characterization tests to assert import history
present. All existing reader history assertions remain unchanged.

## Out of scope

- SPG vendor-history extraction
- SRS history enrichment
- Wrapper-reader policy
- Merge-sort policy
- OPUS vendor-history extraction
- Reader-wide wording normalization