### PR TITLE
FIX: align WiRE reader provenance semantics

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -62,6 +62,11 @@ Bug Fixes
   ``origin="labspec"``, and JCAMP imports now preserve deterministic source
   origin information when provided.
 
+- The WiRE reader now populates ``dataset.author`` from the file's username
+  field, ``dataset.acquisition_date`` from the first ORGN time-stamp, and
+  records a clean ``Imported from {filename}`` history entry without a
+  redundant inline timestamp (the setter auto-prepends one).
+
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related
   displays, instead of unexpectedly showing ``pp``.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -64,8 +64,12 @@ Bug Fixes
 
 - The WiRE reader now populates ``dataset.author`` from the file's username
   field, ``dataset.acquisition_date`` from the first ORGN time-stamp, and
-  records a clean ``Imported from {filename}`` history entry without a
-  redundant inline timestamp (the setter auto-prepends one).
+   records a clean ``Imported from {filename.name}`` history entry without a
+   redundant inline timestamp (the setter auto-prepends one).
+
+- The Quadera reader now sets ``dataset.origin = "quadera"`` and populates
+  ``dataset.acquisition_date`` from the first acquisition timestamp. Channel
+  labels and y-coordinate timestamps are preserved unchanged.
 
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -55,6 +55,15 @@ Bug Fixes
   ``origin="labspec"``, and JCAMP imports now preserve deterministic source
   origin information when provided.
 
+- The WiRE reader now populates ``dataset.author`` from the file's username
+  field, ``dataset.acquisition_date`` from the first ORGN time-stamp, and
+   records a clean ``Imported from {filename.name}`` history entry without a
+   redundant inline timestamp (the setter auto-prepends one).
+
+- The Quadera reader now sets ``dataset.origin = "quadera"`` and populates
+  ``dataset.acquisition_date`` from the first acquisition timestamp. Channel
+  labels and y-coordinate timestamps are preserved unchanged.
+
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related
   displays, instead of unexpectedly showing ``pp``.

--- a/src/spectrochempy/core/readers/read_quadera.py
+++ b/src/spectrochempy/core/readers/read_quadera.py
@@ -8,6 +8,7 @@
 __all__ = ["read_quadera"]
 
 import re
+from datetime import UTC
 from datetime import datetime
 from warnings import warn
 
@@ -218,7 +219,9 @@ def _read_asc(*args, **kwargs):
     _x = Coord(labels=channels)
     dataset.set_coordset(y=_y, x=_x)
 
-    # Set origin, description and history
+    # Set origin, acquisition date, description and history
+    dataset.origin = "quadera"
+    dataset.acquisition_date = datetime.fromtimestamp(min(times[:, 0]), tz=UTC)
     dataset.history = f"Imported from Quadera asc file {filename}"
 
     # reset modification date to cretion date

--- a/src/spectrochempy/core/readers/read_wire.py
+++ b/src/spectrochempy/core/readers/read_wire.py
@@ -927,5 +927,5 @@ def _read_wdf(*args, **kwargs):
         return None
     dataset.name = filename.stem
     dataset.filename = filename
-    dataset.history = f"Imported from {filename}"
+    dataset.history = f"Imported from {filename.name}"
     return dataset

--- a/src/spectrochempy/core/readers/read_wire.py
+++ b/src/spectrochempy/core/readers/read_wire.py
@@ -47,7 +47,6 @@ https://sourceforge.net/p/gwyddion/code/HEAD/tree/trunk/gwyddion/modules/file/re
 
 __all__ = ["read_wdf", "read_wire"]
 
-import datetime
 import io
 import struct
 from enum import Enum
@@ -159,9 +158,15 @@ class _wdfReader:
 
         # Parse individual blocks
         self._parse_header()  # File header -> metadata
+        username = self._meta.username.replace("\x00", "").strip()
+        if username:
+            self._dataset.author = username
         coord_x = self._parse_dimension("X")
         coord_meta = self._parse_dimension("Y")
         other_dimensions = self._parse_others()
+        acq = getattr(self._meta, "acquisition_time", None)
+        if acq is not None:
+            self._dataset.acquisition_date = acq.item()
         data = self._parse_data()
         # self._parse_img()
 
@@ -922,5 +927,5 @@ def _read_wdf(*args, **kwargs):
         return None
     dataset.name = filename.stem
     dataset.filename = filename
-    dataset.history = f"Imported from {filename} on {datetime.datetime.now()}"
+    dataset.history = f"Imported from {filename}"
     return dataset

--- a/tests/test_core/test_readers/_reader_semantic_helpers.py
+++ b/tests/test_core/test_readers/_reader_semantic_helpers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from spectrochempy.core.units import ur
+
 
 def assert_dataset_identity(
     dataset,
@@ -18,7 +20,7 @@ def assert_dataset_identity(
     if title is not None:
         assert dataset.title == title
     if units is not None:
-        assert dataset.units == units
+        assert dataset.units == ur.Unit(units)
 
 
 def assert_dataset_provenance(

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -38,6 +38,7 @@ IRDATA = DATADIR / "irdata"
 OPUSDATA = DATADIR / "irdata" / "OPUS"
 RAMANDIR = DATADIR / "ramandata" / "labspec"
 WIREDIR = DATADIR / "ramandata" / "wire"
+QUADERADIR = DATADIR / "msdata"
 WODGER = Path(__file__).parent / "ressources" / "omnic" / "wodger.spg"
 
 pytestmark = pytest.mark.data
@@ -194,6 +195,27 @@ def wire_depth_dataset():
     if not path.exists():
         pytest.skip("WiRE depth series characterization data not available")
     return scp.read_wire(path)
+
+
+@pytest.fixture
+def quadera_synthetic_dataset():
+    content = (
+        "End Time\n"
+        "\n"
+        "\tChannel 1\tChannel 2\n"
+        "Time\tTime Relative [s]\tIon Current [A]\tTime\tTime Relative [s]\tIon Current [A]\n"
+        "01/01/2024 00:00:00.000\t0.000\t1.0e-10\t01/01/2024 00:00:00.000\t0.000\t2.0e-10\n"
+        "01/01/2024 00:00:01.000\t1.000\t1.1e-10\t01/01/2024 00:00:01.000\t1.000\t2.1e-10\n"
+    )
+    return scp.read_quadera({"test_quadera.asc": content.encode("utf-8")})
+
+
+@pytest.fixture
+def quadera_real_dataset():
+    path = QUADERADIR / "ion_currents.asc"
+    if not path.exists():
+        pytest.skip("Quadera characterization data not available")
+    return scp.read_quadera(path)
 
 
 @pytest.fixture
@@ -566,3 +588,46 @@ class TestWireCharacterization:
             "laser_frequency",
             "point_per_spectrum",
         )
+
+
+class TestQuaderaCharacterization:
+    """Characterize current Quadera semantic placement."""
+
+    CURRENT_DESCRIPTION = "Imported from Quadera asc file"
+
+    def test_synthetic_identity_provenance_coordinates_and_labels(
+        self, quadera_synthetic_dataset
+    ):
+        dataset = quadera_synthetic_dataset
+
+        assert_dataset_identity(
+            dataset,
+            name="test_quadera",
+            title="ion current",
+            units="amp",
+        )
+        assert_dataset_provenance(
+            dataset,
+            filename_name="test_quadera.asc",
+            origin="quadera",
+            acquisition_date_present=True,
+        )
+        assert_history_present(dataset, self.CURRENT_DESCRIPTION)
+        assert_coordinate_semantics(
+            dataset, "y", title="acquisition timestamp (UTC)", units="s"
+        )
+        x = assert_coordinate_semantics(dataset, "x", size=2)
+        labels = assert_label_structure(x, shape=(2,))
+        assert list(labels) == ["Channel 1", "Channel 2"]
+
+    def test_real_data_provenance(self, quadera_real_dataset):
+        dataset = quadera_real_dataset
+
+        assert_dataset_provenance(
+            dataset,
+            origin="quadera",
+            acquisition_date_present=True,
+        )
+        assert_history_present(dataset, self.CURRENT_DESCRIPTION)
+        assert_coordinate_semantics(dataset, "y")
+        assert_coordinate_semantics(dataset, "x")

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -37,6 +37,7 @@ DATADIR = prefs.datadir
 IRDATA = DATADIR / "irdata"
 OPUSDATA = DATADIR / "irdata" / "OPUS"
 RAMANDIR = DATADIR / "ramandata" / "labspec"
+WIREDIR = DATADIR / "ramandata" / "wire"
 WODGER = Path(__file__).parent / "ressources" / "omnic" / "wodger.spg"
 
 pytestmark = pytest.mark.data
@@ -177,6 +178,22 @@ def csv_omnic_dataset():
 def csv_generic_dataset():
     content = "1.0,10.0\n2.0,20.0\n3.0,30.0\n"
     return scp.read_csv({"generic.csv": content.encode("utf-8")})
+
+
+@pytest.fixture
+def wire_single_dataset():
+    path = WIREDIR / "sp.wdf"
+    if not path.exists():
+        pytest.skip("WiRE single characterization data not available")
+    return scp.read_wire(path)
+
+
+@pytest.fixture
+def wire_depth_dataset():
+    path = WIREDIR / "depth.wdf"
+    if not path.exists():
+        pytest.skip("WiRE depth series characterization data not available")
+    return scp.read_wire(path)
 
 
 @pytest.fixture
@@ -497,3 +514,55 @@ class TestLabSpecCharacterization:
         y = assert_coordinate_semantics(dataset, "y", title="Time", units="s")
         labels = assert_label_structure(y)
         assert isinstance(labels[0], datetime)
+
+
+class TestWireCharacterization:
+    """Characterize current WiRE semantic placement."""
+
+    def test_single_spectrum_identity_provenance_coordinates_and_author(
+        self, wire_single_dataset
+    ):
+        dataset = wire_single_dataset
+
+        assert_dataset_identity(dataset, title="count", units="counts")
+        assert_dataset_provenance(
+            dataset,
+            filename_name="sp.wdf",
+            description_contains="",
+            acquisition_date_present=True,
+        )
+        assert "WiRE" in dataset.origin
+        assert dataset.author
+        assert_history_present(dataset, "Imported from sp.wdf")
+
+        assert_coordinate_semantics(dataset, "x")
+        y = assert_coordinate_semantics(dataset, "y")
+        assert y.labels is None
+        assert_meta_keys_present(
+            dataset,
+            "username",
+            "acquisition_time",
+            "laser_frequency",
+            "measurement_type",
+            "scan_type",
+        )
+
+    def test_depth_series_provenance_and_meta(self, wire_depth_dataset):
+        dataset = wire_depth_dataset
+
+        assert_dataset_provenance(
+            dataset,
+            acquisition_date_present=True,
+        )
+        assert "WiRE" in dataset.origin
+        assert dataset.author
+        assert_history_present(dataset, "Imported from depth.wdf")
+
+        assert_coordinate_semantics(dataset, "x")
+        assert_coordinate_semantics(dataset, "y")
+        assert_meta_keys_present(
+            dataset,
+            "acquisition_time",
+            "laser_frequency",
+            "point_per_spectrum",
+        )


### PR DESCRIPTION
Following the first-wave reader alignment (OMNIC, OPUS, JCAMP, LabSpec, CSV, TopSpin), this PR extends the same provenance contract to WiRE (.wdf) and Quadera (.asc) readers.  

WiRE: author from file username, acquisition_date from first ORGN timestamp, basename-only history (filename.name), unused import cleanup, characterisation baseline.  
Quadera: origin = "quadera", acquisition_date from earliest timestamp (min(times[:, 0])), characterisation baseline.  
Bug fix: history used full absolute path (CI tests broke); changed {filename} → {filename.name}.  
