### PR TITLE
FIX: align SOC wrapper provenance semantics

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -62,14 +62,15 @@ Bug Fixes
   ``origin="labspec"``, and JCAMP imports now preserve deterministic source
   origin information when provided.
 
-- The WiRE reader now populates ``dataset.author`` from the file's username
-  field, ``dataset.acquisition_date`` from the first ORGN time-stamp, and
-   records a clean ``Imported from {filename.name}`` history entry without a
-   redundant inline timestamp (the setter auto-prepends one).
-
-- The Quadera reader now sets ``dataset.origin = "quadera"`` and populates
-  ``dataset.acquisition_date`` from the first acquisition timestamp. Channel
-  labels and y-coordinate timestamps are preserved unchanged.
+- Reader provenance alignment for second-wave formats (WiRE, Quadera, SOC).
+  WiRE: populates ``dataset.author`` from the file username field,
+  ``dataset.acquisition_date`` from the first ORGN timestamp, and uses a clean
+  history message without redundant inline timestamps.
+  Quadera: sets ``dataset.origin = "quadera"`` and populates
+  ``dataset.acquisition_date`` from the first acquisition timestamp.
+  SOC: sets ``dataset.origin = "soc"`` (replaces inherited ``"omnic"``) and
+  appends an SOC-specific import-history entry instead of mutating the last
+  OMNIC history entry, preserving all inherited provenance.
 
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -55,14 +55,15 @@ Bug Fixes
   ``origin="labspec"``, and JCAMP imports now preserve deterministic source
   origin information when provided.
 
-- The WiRE reader now populates ``dataset.author`` from the file's username
-  field, ``dataset.acquisition_date`` from the first ORGN time-stamp, and
-   records a clean ``Imported from {filename.name}`` history entry without a
-   redundant inline timestamp (the setter auto-prepends one).
-
-- The Quadera reader now sets ``dataset.origin = "quadera"`` and populates
-  ``dataset.acquisition_date`` from the first acquisition timestamp. Channel
-  labels and y-coordinate timestamps are preserved unchanged.
+- Reader provenance alignment for second-wave formats (WiRE, Quadera, SOC).
+  WiRE: populates ``dataset.author`` from the file username field,
+  ``dataset.acquisition_date`` from the first ORGN timestamp, and uses a clean
+  history message without redundant inline timestamps.
+  Quadera: sets ``dataset.origin = "quadera"`` and populates
+  ``dataset.acquisition_date`` from the first acquisition timestamp.
+  SOC: sets ``dataset.origin = "soc"`` (replaces inherited ``"omnic"``) and
+  appends an SOC-specific import-history entry instead of mutating the last
+  OMNIC history entry, preserving all inherited provenance.
 
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related

--- a/src/spectrochempy/core/readers/read_soc.py
+++ b/src/spectrochempy/core/readers/read_soc.py
@@ -410,19 +410,22 @@ def read_sdr(*paths, **kwargs):
 @_importer_method
 def _read_ddr(*args, **kwargs):
     ds = _read_spa(*args, **kwargs)
-    ds.history[-1] = "Imported from ddr file(s)"
+    ds.origin = "soc"
+    ds.history = "Imported from SOC DDR file"
     return ds
 
 
 @_importer_method
 def _read_hdr(*args, **kwargs):
     ds = _read_spa(*args, **kwargs)
-    ds.history[-1] = "Imported from hdr file(s)"
+    ds.origin = "soc"
+    ds.history = "Imported from SOC HDR file"
     return ds
 
 
 @_importer_method
 def _read_sdr(*args, **kwargs):
     ds = _read_spa(*args, **kwargs)
-    ds.history[-1] = "Imported from sdr file(s)"
+    ds.origin = "soc"
+    ds.history = "Imported from SOC SDR file"
     return ds

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import requests
 
 import spectrochempy as scp
 from spectrochempy.application.preferences import preferences as prefs
@@ -40,6 +41,7 @@ RAMANDIR = DATADIR / "ramandata" / "labspec"
 WIREDIR = DATADIR / "ramandata" / "wire"
 QUADERADIR = DATADIR / "msdata"
 WODGER = Path(__file__).parent / "ressources" / "omnic" / "wodger.spg"
+SOC_BASEURL = "https://github.com/chet-j-ski/SOC100_example_data/raw/main/"
 
 pytestmark = pytest.mark.data
 
@@ -216,6 +218,54 @@ def quadera_real_dataset():
     if not path.exists():
         pytest.skip("Quadera characterization data not available")
     return scp.read_quadera(path)
+
+
+@pytest.fixture
+def soc_ddr_dataset():
+    url = SOC_BASEURL + "Fused%20Silica0004.DDR"
+    fname = Path("Fused%20Silica0004.DDR")
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.RequestException:
+        pytest.skip("SOC DDR test data not available")
+    fname.write_bytes(response.content)
+    try:
+        return scp.read_ddr(fname)
+    finally:
+        fname.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def soc_hdr_dataset():
+    url = SOC_BASEURL + "Fused%20Silica0004.HDR"
+    fname = Path("Fused%20Silica0004.HDR")
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.RequestException:
+        pytest.skip("SOC HDR test data not available")
+    fname.write_bytes(response.content)
+    try:
+        return scp.read_hdr(fname)
+    finally:
+        fname.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def soc_sdr_dataset():
+    url = SOC_BASEURL + "Fused%20Silica0004.SDR"
+    fname = Path("Fused%20Silica0004.SDR")
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.RequestException:
+        pytest.skip("SOC SDR test data not available")
+    fname.write_bytes(response.content)
+    try:
+        return scp.read_sdr(fname)
+    finally:
+        fname.unlink(missing_ok=True)
 
 
 @pytest.fixture
@@ -631,3 +681,86 @@ class TestQuaderaCharacterization:
         assert_history_present(dataset, self.CURRENT_DESCRIPTION)
         assert_coordinate_semantics(dataset, "y")
         assert_coordinate_semantics(dataset, "x")
+
+
+@pytest.mark.network
+class TestSocCharacterization:
+    """Characterize SOC semantic placement and verify provenance alignment."""
+
+    def test_ddr_origin_history_and_inherited_provenance(self, soc_ddr_dataset):
+        dataset = soc_ddr_dataset
+
+        assert_dataset_identity(
+            dataset,
+            title="reflectance",
+        )
+        assert_dataset_provenance(
+            dataset,
+            origin="soc",
+            acquisition_date_present=True,
+        )
+        assert_history_present(
+            dataset,
+            "Imported from spa file",
+            "Imported from SOC DDR file",
+        )
+
+        assert_coordinate_semantics(dataset, "x", title="wavenumbers", units="cm⁻¹")
+        y = assert_coordinate_semantics(
+            dataset, "y", title="acquisition timestamp (GMT)", units="s"
+        )
+        assert y.labels is not None
+
+        assert_meta_keys_present(
+            dataset,
+            "collection_length",
+            "optical_velocity",
+            "laser_frequency",
+        )
+
+    def test_ddr_history_contains_omnic_and_soc(self, soc_ddr_dataset):
+        dataset = soc_ddr_dataset
+        assert_history_present(
+            dataset, "Imported from spa file", "Imported from SOC DDR file"
+        )
+
+    def test_all_variants_set_soc_origin(
+        self, soc_ddr_dataset, soc_hdr_dataset, soc_sdr_dataset
+    ):
+        assert soc_ddr_dataset.origin == "soc"
+        assert soc_hdr_dataset.origin == "soc"
+        assert soc_sdr_dataset.origin == "soc"
+
+    def test_all_variants_preserve_acquisition_date(
+        self, soc_ddr_dataset, soc_hdr_dataset, soc_sdr_dataset
+    ):
+        assert soc_ddr_dataset.acquisition_date is not None
+        assert soc_hdr_dataset.acquisition_date is not None
+        assert soc_sdr_dataset.acquisition_date is not None
+
+    def test_all_variants_preserve_inherited_coordinates(
+        self, soc_ddr_dataset, soc_hdr_dataset, soc_sdr_dataset
+    ):
+        for ds in [soc_ddr_dataset, soc_hdr_dataset, soc_sdr_dataset]:
+            assert_coordinate_semantics(ds, "x", title="wavenumbers", units="cm⁻¹")
+            y = assert_coordinate_semantics(
+                ds, "y", title="acquisition timestamp (GMT)", units="s"
+            )
+            assert y.labels is not None
+
+    def test_all_variants_preserve_inherited_meta(
+        self, soc_ddr_dataset, soc_hdr_dataset, soc_sdr_dataset
+    ):
+        for ds in [soc_ddr_dataset, soc_hdr_dataset, soc_sdr_dataset]:
+            assert_meta_keys_present(
+                ds, "collection_length", "optical_velocity", "laser_frequency"
+            )
+
+    def test_ddr_variant_history_message(self, soc_ddr_dataset):
+        assert_history_present(soc_ddr_dataset, "Imported from SOC DDR file")
+
+    def test_hdr_variant_history_message(self, soc_hdr_dataset):
+        assert_history_present(soc_hdr_dataset, "Imported from SOC HDR file")
+
+    def test_sdr_variant_history_message(self, soc_sdr_dataset):
+        assert_history_present(soc_sdr_dataset, "Imported from SOC SDR file")


### PR DESCRIPTION
What was fixed
1. Origin normalization: SOC datasets now expose origin = "soc" instead of inheriting "omnic" from the OMNIC SPA reader.
2. History preservation: Changed from ds.history[-1] = "Imported from ddr file(s)" (which was a no-op — the getter returns a temporary list) to ds.history = "Imported from SOC DDR file" (append via setter). OMNIC provenance is preserved; SOC provenance is added.
