### PR TITLE
FIX: align MATLAB/DSO reader provenance

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -62,7 +62,8 @@ Bug Fixes
   ``origin="labspec"``, and JCAMP imports now preserve deterministic source
   origin information when provided.
 
-- Reader provenance alignment for second-wave formats (WiRE, Quadera, SOC).
+- Reader provenance alignment for second-wave formats (WiRE, Quadera, SOC,
+  MATLAB/DSO).
   WiRE: populates ``dataset.author`` from the file username field,
   ``dataset.acquisition_date`` from the first ORGN timestamp, and uses a clean
   history message without redundant inline timestamps.
@@ -71,6 +72,11 @@ Bug Fixes
   SOC: sets ``dataset.origin = "soc"`` (replaces inherited ``"omnic"``) and
   appends an SOC-specific import-history entry instead of mutating the last
   OMNIC history entry, preserving all inherited provenance.
+  MATLAB/DSO: sets ``dataset.origin = "matlab"`` for generic MAT imports and
+  ``"dso"`` for DSO struct imports; fixes DSO vendor-history preservation
+  (17 entries were collapsed by incorrect numpy indexing — now all are
+  correctly extracted); replaces ad-hoc ``dataset.date`` with
+  ``dataset.acquisition_date`` for serialization compatibility.
 
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -55,7 +55,8 @@ Bug Fixes
   ``origin="labspec"``, and JCAMP imports now preserve deterministic source
   origin information when provided.
 
-- Reader provenance alignment for second-wave formats (WiRE, Quadera, SOC).
+- Reader provenance alignment for second-wave formats (WiRE, Quadera, SOC,
+  MATLAB/DSO).
   WiRE: populates ``dataset.author`` from the file username field,
   ``dataset.acquisition_date`` from the first ORGN timestamp, and uses a clean
   history message without redundant inline timestamps.
@@ -64,6 +65,11 @@ Bug Fixes
   SOC: sets ``dataset.origin = "soc"`` (replaces inherited ``"omnic"``) and
   appends an SOC-specific import-history entry instead of mutating the last
   OMNIC history entry, preserving all inherited provenance.
+  MATLAB/DSO: sets ``dataset.origin = "matlab"`` for generic MAT imports and
+  ``"dso"`` for DSO struct imports; fixes DSO vendor-history preservation
+  (17 entries were collapsed by incorrect numpy indexing — now all are
+  correctly extracted); replaces ad-hoc ``dataset.date`` with
+  ``dataset.acquisition_date`` for serialization compatibility.
 
 - TopSpin/NMR datasets whose reader assigns intensity units as ``count`` now
   render that canonical unit consistently in dataset summaries and related

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -184,6 +184,7 @@ def _read_mat(*args, **kwargs):
             dataset.data = data
             dataset.name = name
             dataset.filename = filename
+            dataset.origin = "matlab"
             dataset.history = "Imported from .mat file"
             # TODO: reshape from fortran/Matlab order to C opder
             # for 3D or higher datasets ?
@@ -291,8 +292,9 @@ def _read_dso(dataset, name, data):
     dataset.data = dat
     dataset.set_coordset(*list(coords))
     dataset.author = author
+    dataset.origin = "dso"
     dataset.name = name
-    dataset.date = date
+    dataset.acquisition_date = date
 
     # TODO: reshape from fortran/Matlab order to C order
     #  for 3D or higher datasets ?
@@ -300,8 +302,8 @@ def _read_dso(dataset, name, data):
     for i in data["description"][0][0]:
         dataset.description += i
 
-    for i in data["history"][0][0][0][0]:
-        dataset.history = i
+    for entry in data["history"][0, 0].ravel():
+        dataset.history = entry.item()
 
     dataset.history = "Imported by spectrochempy."
     return dataset

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import requests
+from scipy.io import savemat
 
 import spectrochempy as scp
 from spectrochempy.application.preferences import preferences as prefs
@@ -764,3 +765,86 @@ class TestSocCharacterization:
 
     def test_sdr_variant_history_message(self, soc_sdr_dataset):
         assert_history_present(soc_sdr_dataset, "Imported from SOC SDR file")
+
+
+MATLABDATA = prefs.datadir / "matlabdata"
+
+
+@pytest.fixture
+def matlabdata():
+    if not MATLABDATA.exists():
+        pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
+    return MATLABDATA
+
+
+class TestMatlabCharacterization:
+    """Characterize current MATLAB/DSO semantic placement."""
+
+    CURRENT_HISTORY = "Imported from .mat file"
+
+    @pytest.fixture
+    def matlab_generic_dataset(self, tmp_path):
+        path = tmp_path / "generic.mat"
+        savemat(path, {"data": np.linspace(0.0, 1.0, 5).reshape(1, 5)})
+        result = scp.read_matlab(path)
+        if isinstance(result, list):
+            return result[0]
+        return result
+
+    def test_generic_mat_identity_and_provenance(self, matlab_generic_dataset):
+        dataset = matlab_generic_dataset
+
+        assert_dataset_identity(dataset, name="data")
+        assert_dataset_provenance(
+            dataset,
+            filename_name="generic.mat",
+            origin="matlab",
+            acquisition_date_present=False,
+        )
+        assert_history_present(dataset, self.CURRENT_HISTORY)
+        assert dataset.shape == (1, 5)
+
+    @pytest.mark.data
+    def test_dso_provenance_and_date(self, matlabdata):
+        dataset = scp.read_matlab(matlabdata / "dso.mat")
+
+        assert_dataset_identity(
+            dataset,
+            name="Group sust_base line withoutEQU.SPG",
+        )
+        assert_dataset_provenance(
+            dataset,
+            origin="dso",
+            acquisition_date_present=True,
+        )
+        assert dataset.author == "traverta@DESKTOP-98Q6FCE"
+        assert not hasattr(dataset, "date")
+        assert_history_present(
+            dataset,
+            "Created by traverta@DESKTOP-98Q6FCE",
+            "Imported by spectrochempy",
+        )
+
+    @pytest.mark.data
+    def test_dso_coordinates_and_labels(self, matlabdata):
+        dataset = scp.read_matlab(matlabdata / "dso.mat")
+
+        assert_coordinate_semantics(dataset, "x", size=426)
+        assert_coordinate_semantics(dataset, "y", size=20)
+
+        # Only y-coordinate has labels (spectrum identifiers); x-coordinate labels are None
+        y_labels = assert_label_structure(dataset.y)
+        assert y_labels.shape[0] == 20
+        assert all(isinstance(lbl, str) for lbl in y_labels)
+
+    @pytest.mark.data
+    def test_dso_history_preserves_vendor_entries(self, matlabdata):
+        dataset = scp.read_matlab(matlabdata / "dso.mat")
+
+        assert_history_present(
+            dataset,
+            "Created by traverta@DESKTOP-98Q6FCE",
+            "spgreadr",
+            "Delsamps",
+            "Imported by spectrochempy",
+        )


### PR DESCRIPTION
Changes to read_matlab.py
src/spectrochempy/core/readers/read_matlab.py (3 changes):
1. Origin: dataset.origin = "matlab" for generic MAT (line 187), dataset.origin = "dso" for DSO (line 295)
2. History fix: Replaced broken indexing data["history"][0][0][0][0] with data["history"][0, 0].ravel() — correctly iterates all 17 DSO vendor entries instead of collapsing them into garbled output
3. Acquisition date: Replaced ad-hoc dataset.date (never serialized) with dataset.acquisition_date (tracked property, persisted)
Characterization tests
tests/test_core/test_readers/test_reader_semantic_characterization.py — added TestMatlabCharacterization with 4 tests:
- test_generic_mat_identity_and_provenance — origin, filename, history, shape
- test_dso_provenance_and_date — origin, author, acquisition_date, no date attr
- test_dso_coordinates_and_labels — x/y sizes, y-labels present
- test_dso_history_preserves_vendor_entries — all 17 DSO entries + import event