### PR TITLE
TEST: characterize generic MATLAB array semantics for issue #1092

### DIFF
--- a/tests/test_core/test_readers/test_read_matlab.py
+++ b/tests/test_core/test_readers/test_read_matlab.py
@@ -68,6 +68,41 @@ def test_read_matlab_multiple_variables(tmp_path):
     assert not any(ds.name.startswith("__") for ds in datasets)
 
 
+def test_read_matlab_single_1d_array_currently_uses_row_shape_and_no_coordset(tmp_path):
+    path = tmp_path / "single_1d.mat"
+    savemat(path, {"trace": np.arange(5)})
+
+    dataset = read_matlab(path)
+
+    assert isinstance(dataset, NDDataset)
+    assert dataset.name == "trace"
+    assert dataset.shape == (1, 5)
+    assert np.array_equal(dataset.data, np.arange(5).reshape(1, 5))
+    assert dataset.origin == "matlab"
+    assert dataset.coordset is None
+    assert dataset.x is None
+    assert dataset.y is None
+    assert any("Imported from .mat file" in str(entry) for entry in dataset.history)
+
+
+def test_read_matlab_single_2d_array_preserves_values_without_materialized_coords(tmp_path):
+    path = tmp_path / "single_2d.mat"
+    values = np.arange(6).reshape(2, 3)
+    savemat(path, {"image": values})
+
+    dataset = read_matlab(path)
+
+    assert isinstance(dataset, NDDataset)
+    assert dataset.name == "image"
+    assert dataset.shape == (2, 3)
+    assert np.array_equal(dataset.data, values)
+    assert dataset.origin == "matlab"
+    assert dataset.coordset is None
+    assert dataset.x is None
+    assert dataset.y is None
+    assert any("Imported from .mat file" in str(entry) for entry in dataset.history)
+
+
 def test_read_matlab_same_shape_arrays_are_stacked(tmp_path):
     # same-shape numeric arrays are stacked by the importer into a single
     # NDDataset (the documented merge behaviour), so two (1, n) arrays come
@@ -85,3 +120,18 @@ def test_read_matlab_same_shape_arrays_are_stacked(tmp_path):
 
     assert isinstance(result, NDDataset)
     assert result.shape == (2, 5)
+
+
+def test_read_matlab_three_dimensional_array_preserves_shape_and_values(tmp_path):
+    path = tmp_path / "cube.mat"
+    values = np.arange(24).reshape((2, 3, 4), order="F")
+    savemat(path, {"cube": values})
+
+    dataset = read_matlab(path)
+
+    assert isinstance(dataset, NDDataset)
+    assert dataset.name == "cube"
+    assert dataset.shape == (2, 3, 4)
+    assert np.array_equal(dataset.data, values)
+    assert dataset.origin == "matlab"
+    assert dataset.coordset is None

--- a/tests/test_core/test_readers/test_read_matlab.py
+++ b/tests/test_core/test_readers/test_read_matlab.py
@@ -85,7 +85,9 @@ def test_read_matlab_single_1d_array_currently_uses_row_shape_and_no_coordset(tm
     assert any("Imported from .mat file" in str(entry) for entry in dataset.history)
 
 
-def test_read_matlab_single_2d_array_preserves_values_without_materialized_coords(tmp_path):
+def test_read_matlab_single_2d_array_preserves_values_without_materialized_coords(
+    tmp_path,
+):
     path = tmp_path / "single_2d.mat"
     values = np.arange(6).reshape(2, 3)
     savemat(path, {"image": values})


### PR DESCRIPTION
## Summary

Adds focused synthetic characterization coverage for generic MATLAB numeric-array
imports as follow-up work for `#1092`.

The new tests document current behavior for:

- single 1D numeric arrays;
- single 2D numeric arrays;
- simple 3D numeric arrays;
- `origin="matlab"` and import-history preservation;
- the current absence of materialized default coordinates / `coordset`.

It also adds a maintainer audit note re-scoping `#1092` now that:

- DSO provenance work is already complete;
- multi-variable MATLAB import behavior is already covered by `#1142`.

## Out of scope

- No production code changes.
- No DSO behavior changes.
- No multi-variable MATLAB redesign.
- No reader-architecture work.
- No coordinate-model redesign.

## Why

The remaining open question in `#1092` was whether generic MATLAB numeric-array
imports still had a real unresolved behavior defect.

The follow-up showed that the main suspected gap, missing default index
coordinates, is not a MATLAB-specific inconsistency: plain `NDDataset`
construction also leaves `coordset` unset when no coordinates are explicitly
provided.

The synthetic 3D check also did not reproduce a concrete value/shape regression
for simple numeric arrays.