### PR TITLE
FIX: preserve simple CSV metadata in SpectroChemPy round-trips (#1136)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,12 @@ Bug Fixes
   existing dataset, and restored through the portable xarray/NetCDF import
   paths. (:issue:`1227`)
 
+- ``read_csv()`` now restores the simple metadata header already emitted by
+  ``write_csv()`` for SpectroChemPy-generated 1D CSV files, preserving dataset
+  ``title``/``units`` and x-coordinate ``title``/``units`` in basic
+  write→read round-trips. Generic external CSV files keep the existing
+  fallback behavior. (:issue:`1136`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -47,6 +47,12 @@ Bug Fixes
   existing dataset, and restored through the portable xarray/NetCDF import
   paths. (:issue:`1227`)
 
+- ``read_csv()`` now restores the simple metadata header already emitted by
+  ``write_csv()`` for SpectroChemPy-generated 1D CSV files, preserving dataset
+  ``title``/``units`` and x-coordinate ``title``/``units`` in basic
+  write→read round-trips. Generic external CSV files keep the existing
+  fallback behavior. (:issue:`1136`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -22,6 +22,60 @@ from spectrochempy.core.readers.importer import Importer
 from spectrochempy.core.readers.importer import _importer_method
 from spectrochempy.core.readers.importer import _openfid
 
+
+def _parse_spectrochempy_csv_header(row):
+    """
+    Parse the simple metadata header emitted by ``write_csv()``.
+
+    The current writer emits either:
+
+    * ``[dataset_title / dataset_units]`` for data-only 1D exports; or
+    * ``[coord_title / coord_units, dataset_title / dataset_units]`` for 1D
+      exports with coordinates.
+
+    Metadata reconstruction is intentionally conservative: cells must contain
+    the explicit ``" / "`` separator used by the writer. Any parse failure
+    falls back to ``None`` metadata so generic external CSV files keep the
+    current semantics.
+    """
+
+    def _split_title_and_unit(cell):
+        if not isinstance(cell, str) or " / " not in cell:
+            return None, None
+        title, unit = cell.rsplit(" / ", 1)
+        title = title.strip()
+        unit = unit.strip()
+        if not title or not unit:
+            return None, None
+        return title, unit
+
+    if not row:
+        return {}
+
+    if len(row) == 1:
+        dataset_title, dataset_units = _split_title_and_unit(row[0])
+        if dataset_title is None:
+            return {}
+        return {
+            "dataset_title": dataset_title,
+            "dataset_units": dataset_units,
+        }
+
+    if len(row) == 2:
+        coord_title, coord_units = _split_title_and_unit(row[0])
+        dataset_title, dataset_units = _split_title_and_unit(row[1])
+        if coord_title is None or dataset_title is None:
+            return {}
+        return {
+            "coord_title": coord_title,
+            "coord_units": coord_units,
+            "dataset_title": dataset_title,
+            "dataset_units": dataset_units,
+        }
+
+    return {}
+
+
 try:
     locale.setlocale(locale.LC_ALL, "en_US")  # to avoid problems with date format
 except Exception:  # pragma: no cover
@@ -169,6 +223,7 @@ def _read_csv(*args, **kwargs):
         delimiter = ";"
 
     d = list(csv.reader(txt.splitlines(), delimiter=delimiter))
+    header_metadata = {}
 
     # Skip header row if present (non-numeric first row from write_csv)
     def _is_numeric_row(row):
@@ -181,6 +236,7 @@ def _read_csv(*args, **kwargs):
         return True
 
     if d and not _is_numeric_row(d[0]):
+        header_metadata = _parse_spectrochempy_csv_header(d[0])
         d = d[1:]
 
     d = np.array(d, dtype=float).T
@@ -244,6 +300,15 @@ def _read_csv(*args, **kwargs):
     dataset.units = kwargs.get("units", None)
     dataset.description = kwargs.get("description", '"name" ' + "read from .csv file")
     dataset.history = "Read from .csv file"
+
+    if kwargs.get("title", None) is None and "dataset_title" in header_metadata:
+        dataset.title = header_metadata["dataset_title"]
+    if kwargs.get("units", None) is None and "dataset_units" in header_metadata:
+        dataset.units = header_metadata["dataset_units"]
+    if "coord_title" in header_metadata:
+        dataset.x.title = header_metadata["coord_title"]
+    if "coord_units" in header_metadata:
+        dataset.x.units = header_metadata["coord_units"]
 
     # here we can check some particular format
     origin = kwargs.get("origin", "")

--- a/tests/test_core/test_readers/test_read_csv_roundtrip.py
+++ b/tests/test_core/test_readers/test_read_csv_roundtrip.py
@@ -70,3 +70,41 @@ def test_read_csv_roundtrip_with_units(tmp_path):
     assert loaded.squeeze().shape == ds.shape
     assert np.allclose(loaded.data.squeeze(), ds.data)
     assert np.allclose(loaded.x.data, ds.x.data)
+
+
+def test_read_csv_roundtrip_preserves_simple_scp_metadata_header(tmp_path):
+    coord = scp.Coord(np.linspace(100, 500, 5), title="wavelength", units="nm")
+    ds = scp.NDDataset(
+        np.array([0.1, 0.2, 0.3, 0.4, 0.5]),
+        coordset=[coord],
+        title="absorbance",
+        units="absorbance",
+    )
+    filepath = tmp_path / "test_metadata_roundtrip.csv"
+    ds.write_csv(filepath)
+
+    loaded = scp.read_csv(filepath)
+
+    assert loaded.title == "absorbance"
+    assert loaded.units == ds.units
+    assert loaded.x.title == "wavelength"
+    assert loaded.x.units == ds.x.units
+    assert np.allclose(loaded.x.data, ds.x.data)
+    assert np.allclose(loaded.data.squeeze(), ds.data)
+
+
+def test_read_csv_external_header_without_scp_metadata_keeps_current_semantics(
+    tmp_path,
+):
+    filepath = tmp_path / "external.csv"
+    filepath.write_text("x,y\n1,10\n2,20\n3,30\n")
+
+    loaded = scp.read_csv(filepath)
+
+    assert loaded.name == "external"
+    assert loaded.title == "<untitled>"
+    assert loaded.units is None
+    assert loaded.x.title == "<untitled>"
+    assert loaded.x.units is None
+    assert np.allclose(loaded.x.data, np.array([1.0, 2.0, 3.0]))
+    assert np.allclose(loaded.data.squeeze(), np.array([10.0, 20.0, 30.0]))

--- a/tests/test_core/test_readers/test_read_soc.py
+++ b/tests/test_core/test_readers/test_read_soc.py
@@ -16,7 +16,7 @@ from spectrochempy.utils.objects import ScpObjectList
 pytestmark = pytest.mark.network
 
 
-def test_read_soc_merge_behavior():
+def test_read_soc_merge_behavior(tmp_path):
     """Test that read_soc respects merge parameter.
 
     This test downloads sample files and verifies:
@@ -36,9 +36,10 @@ def test_read_soc_merge_behavior():
         try:
             response = requests.get(baseurl + fname, timeout=10)
             if response.status_code == 200:
-                with open(fname, "wb") as f:
+                local_path = tmp_path / Path(fname).name
+                with local_path.open("wb") as f:
                     f.write(response.content)
-                downloaded_files[Path(fname).suffix.upper()] = fname
+                downloaded_files[Path(fname).suffix.upper()] = local_path
         except requests.exceptions.RequestException:
             # Network error, skip this file
             continue
@@ -94,13 +95,13 @@ def test_read_soc_merge_behavior():
         # Cleanup downloaded files
         for fname in downloaded_files.values():
             if int(platform.python_version_tuple()[1]) > 7:
-                Path(fname).unlink(missing_ok=True)
+                fname.unlink(missing_ok=True)
             else:
-                if Path(fname).exists():
-                    Path(fname).unlink()
+                if fname.exists():
+                    fname.unlink()
 
 
-def test_read_SOC():
+def test_read_SOC(tmp_path):
     """upload and read surface oftics exemple"""
 
     # the following does not work
@@ -122,25 +123,26 @@ def test_read_SOC():
             continue
 
         downloaded_any = True
-        with open(fname, "wb") as f:
+        local_path = tmp_path / Path(fname).name
+        with local_path.open("wb") as f:
             f.write(response.content)
 
         try:
-            ds = scp.read_soc(fname)
+            ds = scp.read_soc(local_path)
             assert str(ds) == "NDDataset: [float64] unitless (shape: (y:1, x:599))"
             assert ds.title == "reflectance"
             if i == 0:
-                ds_ = scp.read_ddr(fname)
+                ds_ = scp.read_ddr(local_path)
             elif i == 1:
-                ds_ = scp.read_hdr(fname)
+                ds_ = scp.read_hdr(local_path)
             else:
-                ds_ = scp.read_sdr(fname)
+                ds_ = scp.read_sdr(local_path)
             assert ds_.name == ds.name
         finally:
             if int(platform.python_version_tuple()[1]) > 7:
-                Path(fname).unlink(missing_ok=True)
+                local_path.unlink(missing_ok=True)
             else:
-                Path(fname).unlink()
+                local_path.unlink()
 
     if not downloaded_any:
         pytest.skip("Could not download SOC test data from GitHub")


### PR DESCRIPTION
## Summary

Fixes `#1136` by restoring the simple metadata header already emitted by
`write_csv()` when SpectroChemPy reads its own 1D CSV files back.

This preserves:

- dataset `title`
- dataset `units`
- x-coordinate `title`
- x-coordinate `units`

when the header clearly matches the existing SpectroChemPy convention
`title / unit`.

## Out of scope

- no CSV reader tolerance work (`#1137`)
- no comments or blank-line handling
- no multi-column or multi-Y import
- no 2D CSV export (`#1138`)
- no provenance or label reconstruction
