### PR TITLE
ENH: tolerate simple external CSV headers, comments, and tabs (#1137)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -60,6 +60,13 @@ Bug Fixes
   write→read round-trips. Generic external CSV files keep the existing
   fallback behavior. (:issue:`1136`)
 
+- ``read_csv()`` now tolerates a narrow set of common external scientific CSV
+  patterns: leading ``#``/``;`` comment lines, blank lines before the tabular
+  section, simple non-numeric first-row headers such as ``x,y`` or
+  ``time,intensity``, and basic delimiter auto-detection across comma,
+  semicolon, and tab. The reader remains intentionally limited to simple
+  numeric tabular files. (:issue:`1137`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -53,6 +53,13 @@ Bug Fixes
   write→read round-trips. Generic external CSV files keep the existing
   fallback behavior. (:issue:`1136`)
 
+- ``read_csv()`` now tolerates a narrow set of common external scientific CSV
+  patterns: leading ``#``/``;`` comment lines, blank lines before the tabular
+  section, simple non-numeric first-row headers such as ``x,y`` or
+  ``time,intensity``, and basic delimiter auto-detection across comma,
+  semicolon, and tab. The reader remains intentionally limited to simple
+  numeric tabular files. (:issue:`1137`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -76,6 +76,51 @@ def _parse_spectrochempy_csv_header(row):
     return {}
 
 
+def _iter_meaningful_csv_lines(text):
+    """
+    Yield non-empty, non-comment CSV lines.
+
+    Only the narrow comment prefixes requested for simple external CSV support
+    are recognized here: ``#`` and ``;``.
+    """
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#") or stripped.startswith(";"):
+            continue
+        yield line
+
+
+def _detect_csv_delimiter(lines, fallback):
+    """
+    Detect a simple delimiter among comma, semicolon, and tab.
+
+    The heuristic intentionally stays conservative and only looks for a stable
+    repeated separator in the first few meaningful lines.
+    """
+
+    candidates = [",", ";", "\t"]
+    sample = list(lines[:5])
+    best = fallback
+    best_score = 0
+
+    for candidate in candidates:
+        counts = [line.count(candidate) for line in sample]
+        positive = [count for count in counts if count > 0]
+        if not positive:
+            continue
+        if len(set(positive)) != 1:
+            continue
+        score = positive[0]
+        if score > best_score:
+            best = candidate
+            best_score = score
+
+    return best
+
+
 try:
     locale.setlocale(locale.LC_ALL, "en_US")  # to avoid problems with date format
 except Exception:  # pragma: no cover
@@ -215,14 +260,14 @@ def _read_csv(*args, **kwargs):
     txt = fid.read()
     fid.close()
 
-    # We assume this csv file contains only numbers # TODO: write a more general reader
-    if ";" in txt:
-        # look like the delimiter is ;
-        # if comma is also present, it could be that french writer was used.
-        txt = txt.replace(",", ".")
-        delimiter = ";"
+    lines = list(_iter_meaningful_csv_lines(txt))
+    delimiter = _detect_csv_delimiter(lines, delimiter)
 
-    d = list(csv.reader(txt.splitlines(), delimiter=delimiter))
+    # Semicolon-delimited scientific exports often also use decimal commas.
+    if delimiter == ";":
+        lines = [line.replace(",", ".") for line in lines]
+
+    d = list(csv.reader(lines, delimiter=delimiter))
     header_metadata = {}
 
     # Skip header row if present (non-numeric first row from write_csv)

--- a/tests/test_core/test_readers/test_read_csv.py
+++ b/tests/test_core/test_readers/test_read_csv.py
@@ -60,3 +60,41 @@ def test_read_csv():
         {"test_omnic.csv": omnic_csv_content.encode("utf-8")}, origin="opus"
     )
     assert not D
+
+
+def test_read_csv_skips_leading_comments_and_blank_lines():
+    content = (
+        "# collected by external script\n"
+        "; exported manually\n"
+        "\n"
+        "time,intensity\n"
+        "1,10\n"
+        "2,20\n"
+        "3,30\n"
+    )
+
+    dataset = scp.read_csv({"commented.csv": content.encode("utf-8")})
+
+    assert dataset.shape == (1, 3)
+    assert list(dataset.x.data) == [1.0, 2.0, 3.0]
+    assert list(dataset.data.squeeze()) == [10.0, 20.0, 30.0]
+
+
+def test_read_csv_accepts_simple_external_header():
+    content = "wavenumber,absorbance\n4000,0.1\n3990,0.2\n3980,0.3\n"
+
+    dataset = scp.read_csv({"header.csv": content.encode("utf-8")})
+
+    assert dataset.shape == (1, 3)
+    assert list(dataset.x.data) == [4000.0, 3990.0, 3980.0]
+    assert list(dataset.data.squeeze()) == [0.1, 0.2, 0.3]
+
+
+def test_read_csv_autodetects_tab_delimiter_for_simple_numeric_table():
+    content = "x\tintensity\n1\t10\n2\t20\n3\t30\n"
+
+    dataset = scp.read_csv({"tabbed.csv": content.encode("utf-8")})
+
+    assert dataset.shape == (1, 3)
+    assert list(dataset.x.data) == [1.0, 2.0, 3.0]
+    assert list(dataset.data.squeeze()) == [10.0, 20.0, 30.0]


### PR DESCRIPTION
Close #1137

## Summary

Improves `read_csv()` for a narrow set of common external scientific CSV files.

The reader now tolerates:

- leading comment lines starting with `#` or `;`
- blank lines before the tabular section
- a simple non-numeric first-row header such as `x,y` or `time,intensity`
- conservative delimiter detection across comma, semicolon, and tab

Existing SpectroChemPy CSV behavior is preserved, including the PR1 metadata
round-trip logic for SpectroChemPy-generated 1D CSV files.

## Out of scope

- no 2D CSV export (`#1138`)
- no multiple-Y import
- no spreadsheet parsing
- no provenance or label reconstruction
- no persistence redesign
