### PR TITLE
FIX: traverse nested ZIP directories recursively (#1139)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -67,6 +67,11 @@ Bug Fixes
   semicolon, and tab. The reader remains intentionally limited to simple
   numeric tabular files. (:issue:`1137`)
 
+- ``read_zip()`` now discovers readable files recursively inside nested ZIP
+  directory structures instead of assuming files are only at archive root or
+  inside a single top-level directory. Existing filtering of ``__MACOSX`` and
+  ``.DS_Store`` entries is preserved. (:issue:`1139`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -60,6 +60,11 @@ Bug Fixes
   semicolon, and tab. The reader remains intentionally limited to simple
   numeric tabular files. (:issue:`1137`)
 
+- ``read_zip()`` now discovers readable files recursively inside nested ZIP
+  directory structures instead of assuming files are only at archive root or
+  inside a single top-level directory. Existing filtering of ``__MACOSX`` and
+  ``.DS_Store`` entries is preserved. (:issue:`1139`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/src/spectrochempy/core/readers/read_zip.py
+++ b/src/spectrochempy/core/readers/read_zip.py
@@ -5,6 +5,8 @@
 # ======================================================================================
 __all__ = ["read_zip"]
 
+import zipfile
+
 from spectrochempy.core.readers.filetypes import registry
 from spectrochempy.core.readers.importer import Importer
 from spectrochempy.core.readers.importer import _importer_method
@@ -130,9 +132,6 @@ def read_zip(*paths, **kwargs):
 # ======================================================================================
 @_importer_method
 def _read_zip(*args, **kwargs):
-    # Below we assume that files to read are in a unique directory
-    import zipfile
-
     # read zip file
     _, filename = args
 
@@ -143,23 +142,6 @@ def _read_zip(*args, **kwargs):
         only = kwargs.pop("only", len(filelist))
 
         datasets = []
-
-        files = []
-        dirs = []
-
-        for file in filelist:
-            if "__MACOSX" in file.filename:
-                continue  # bypass non-data files
-            if ".DS_Store" in file.filename:
-                continue
-
-            # make a pathlib object (python > 3.7)
-            file = zipfile.Path(zf, at=file.filename)
-            # seek the parent directory containing the files to read
-            if not file.is_dir():
-                files.append(file)
-            else:
-                dirs.append(file)
 
         def extract(children, **kwargs):
             extension = children.name.split(".")[-1]
@@ -175,29 +157,19 @@ def _read_zip(*args, **kwargs):
                 children.name, content=children.read_bytes(), origin=origin, merge=False
             )
 
-        # We assume that we have only a single dir with not subdir
-        if dirs:
-            # a single directory
-            count = 0
-            for children in dirs[0].iterdir():
-                if count == only:
-                    # limits to only this number of files
-                    break
-                if "__MACOSX" in str(children.name):
-                    continue  # bypass non-data files
-                if ".DS_Store" in str(children.name):
-                    continue
-                # print(count, children)
-                # TODO: why this pose problem in pycharm-debug?????
-                d = extract(children, **kwargs)
-                if d is not None:
-                    datasets.append(d)
-                    count += 1
-        else:
-            for file in files:
-                d = extract(file, **kwargs)
-                if d is not None:
-                    datasets.append(d)
+        count = 0
+        for zipinfo in filelist:
+            if count == only:
+                break
+            if "__MACOSX" in zipinfo.filename or ".DS_Store" in zipinfo.filename:
+                continue
+            file = zipfile.Path(zf, at=zipinfo.filename)
+            if file.is_dir():
+                continue
+            d = extract(file, **kwargs)
+            if d is not None:
+                datasets.append(d)
+                count += 1
 
         if len(datasets) == 1:
             return datasets[0]

--- a/src/spectrochempy/core/readers/read_zip.py
+++ b/src/spectrochempy/core/readers/read_zip.py
@@ -80,6 +80,11 @@ def read_zip(*paths, **kwargs):
         A pattern to filter the files to read.
 
         .. versionadded:: 0.7.2
+    only : `int`, optional
+        Limit ZIP import to the first readable files discovered in the archive.
+        This is mainly useful for sampling large archives or for tests. The
+        limit is applied according to archive discovery order after filtering
+        ignored entries such as ``__MACOSX`` and ``.DS_Store``.
     protocol : `str`, optional
         ``Protocol`` used for reading, for example ``'scp'``, ``'omnic'``,
         ``'opus'``, ``'matlab'``, ``'jcamp'``, ``'csv'``, or ``'excel'``.

--- a/tests/test_core/test_readers/test_read_zip.py
+++ b/tests/test_core/test_readers/test_read_zip.py
@@ -5,24 +5,26 @@
 # ======================================================================================
 # ruff: noqa
 
+import io
+import zipfile
 
 import pytest
 
-from spectrochempy.application.preferences import preferences as prefs
 from spectrochempy import read_zip
+from spectrochempy.application.preferences import preferences as prefs
+from spectrochempy.utils.objects import ScpObjectList
 
 DATADIR = prefs.datadir
 AGIRDATA = DATADIR / "agirdata"
 
-pytestmark = pytest.mark.data
-
 
 @pytest.fixture(autouse=True)
-def _skip_if_no_testdata():
-    if not AGIRDATA.exists():
+def _skip_if_no_testdata(request):
+    if request.node.get_closest_marker("data") and not AGIRDATA.exists():
         pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
 
 
+@pytest.mark.data
 def test_read_zip():
     A = read_zip(
         "agirdata/P350/FTIR/FTIR.zip",
@@ -50,3 +52,128 @@ def test_read_zip():
         merge=True,
     )
     assert C.shape == (20, 2843)
+
+
+def _make_synthetic_zip(mapping):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        for name, content in mapping.items():
+            zf.writestr(name, content)
+    return buffer.getvalue()
+
+
+def test_read_zip_root_files_synthetic_csv_merge_false():
+    content = _make_synthetic_zip(
+        {
+            "sample1.csv": "1,10\n2,20\n3,30\n",
+            "sample2.csv": "1,11\n2,21\n3,31\n",
+        }
+    )
+
+    datasets = read_zip({"root.zip": content}, merge=False)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert sorted(ds.name for ds in datasets) == ["sample1", "sample2"]
+
+
+def test_read_zip_single_top_level_directory_synthetic_csv_merge_false():
+    content = _make_synthetic_zip(
+        {
+            "experiment/sample1.csv": "1,10\n2,20\n3,30\n",
+            "experiment/sample2.csv": "1,11\n2,21\n3,31\n",
+        }
+    )
+
+    datasets = read_zip({"single_dir.zip": content}, merge=False)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert sorted(ds.name for ds in datasets) == ["sample1", "sample2"]
+
+
+def test_read_zip_nested_directories_synthetic_csv_merge_false():
+    content = _make_synthetic_zip(
+        {
+            "experiment1/sample1.csv": "1,10\n2,20\n3,30\n",
+            "experiment1/sample2.csv": "1,11\n2,21\n3,31\n",
+            "experiment2/sub/sample3.csv": "1,12\n2,22\n3,32\n",
+            "experiment2/sub/sample4.csv": "1,13\n2,23\n3,33\n",
+            "__MACOSX/ignored.csv": "1,999\n2,999\n",
+            "experiment2/.DS_Store": "ignored",
+        }
+    )
+
+    datasets = read_zip({"nested.zip": content}, merge=False)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 4
+    assert sorted(ds.name for ds in datasets) == [
+        "sample1",
+        "sample2",
+        "sample3",
+        "sample4",
+    ]
+
+
+def test_read_zip_mixed_root_and_nested_files_are_all_discovered():
+    content = _make_synthetic_zip(
+        {
+            "root.csv": "1,10\n2,20\n",
+            "exp/nested.csv": "1,30\n2,40\n",
+        }
+    )
+
+    datasets = read_zip({"mixed.zip": content}, merge=False)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert sorted(ds.name for ds in datasets) == ["nested", "root"]
+
+
+def test_read_zip_nested_only_preserves_discovery_limiting_semantics():
+    content = _make_synthetic_zip(
+        {
+            "experiment1/sample1.csv": "1,10\n2,20\n3,30\n",
+            "experiment1/sample2.csv": "1,11\n2,21\n3,31\n",
+            "experiment2/sub/sample3.csv": "1,12\n2,22\n3,32\n",
+            "experiment2/sub/sample4.csv": "1,13\n2,23\n3,33\n",
+        }
+    )
+
+    datasets = read_zip({"nested_only.zip": content}, merge=False, only=2)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert sorted(ds.name for ds in datasets) == ["sample1", "sample2"]
+
+
+def test_read_zip_only_uses_archive_discovery_order_for_mixed_archives():
+    content = _make_synthetic_zip(
+        {
+            "root.csv": "1,10\n2,20\n",
+            "exp/nested.csv": "1,30\n2,40\n",
+            "later.csv": "1,50\n2,60\n",
+        }
+    )
+
+    datasets = read_zip({"mixed_only.zip": content}, merge=False, only=2)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert sorted(ds.name for ds in datasets) == ["nested", "root"]
+
+
+def test_read_zip_nested_identical_basenames_keep_current_naming_behavior():
+    content = _make_synthetic_zip(
+        {
+            "experiment1/sample.csv": "1,10\n2,20\n",
+            "experiment2/sample.csv": "1,30\n2,40\n",
+        }
+    )
+
+    datasets = read_zip({"duplicate_names.zip": content}, merge=False)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert [ds.name for ds in datasets] == ["sample", "sample"]


### PR DESCRIPTION
## Summary

Fixes #1139 by teaching `read_zip()` to discover readable files at any
nesting depth inside ZIP archives.

The previous implementation handled:

- files stored directly at archive root; or
- files stored inside a single top-level directory

but did not recurse into deeper directory structures, and when directories were
present it could also ignore root-level files.

This PR keeps the ZIP import path lightweight and local:

- no archive extraction to disk;
- no merge-semantics changes;
- no reader-registry redesign;
- no unrelated ZIP cleanup.

## What changed

`read_zip()` now scans ZIP archive entries directly and processes readable files
regardless of nesting depth.

The implementation preserves:

- existing in-memory ZIP reading;
- existing filtering of `__MACOSX` and `.DS_Store`;
- existing per-file reader dispatch;
- existing merge behavior;
- existing `only=` limiting semantics relative to archive discovery order.

To avoid hidden regressions, the traversal preserves archive entry order rather
than introducing a new recursive sort order. This keeps observable discovery
behavior stable where `only=` matters.

## Tests added

Synthetic ZIP coverage was added for:

- flat archive with files at root;
- archive with a single top-level directory;
- archive with nested subdirectories;
- mixed archive containing both root-level and nested files;
- nested archive with `only=` limiting;
- observable discovery order for mixed archives;
- unchanged duplicate-basename naming behavior;
- continued filtering of `__MACOSX` and `.DS_Store`.

All new tests use in-memory synthetic ZIP payloads and do not depend on
external files.

## Out of scope

- no API changes;
- no merge behavior changes;
- no nested path preservation in dataset names;
- no duplicate-basename naming redesign;
- no broader ZIP architecture work.