### PR TITLE
FIX: report ignored files during ZIP import

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -72,6 +72,10 @@ Bug Fixes
   inside a single top-level directory. Existing filtering of ``__MACOSX`` and
   ``.DS_Store`` entries is preserved. (:issue:`1139`)
 
+- ``read_zip()`` now emits a single warning summarizing unsupported files that
+  were ignored during ZIP import, making mixed archives easier to troubleshoot
+  without changing import behavior for supported files. (:issue:`1140`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -65,6 +65,10 @@ Bug Fixes
   inside a single top-level directory. Existing filtering of ``__MACOSX`` and
   ``.DS_Store`` entries is preserved. (:issue:`1139`)
 
+- ``read_zip()`` now emits a single warning summarizing unsupported files that
+  were ignored during ZIP import, making mixed archives easier to troubleshoot
+  without changing import behavior for supported files. (:issue:`1140`)
+
 - OMNIC, OPUS, JCAMP, and LabSpec readers now populate dataset-level
   ``acquisition_date`` when reliable acquisition timestamps are already
   available from the source data, while preserving the existing

--- a/src/spectrochempy/core/readers/read_zip.py
+++ b/src/spectrochempy/core/readers/read_zip.py
@@ -12,6 +12,7 @@ from spectrochempy.core.readers.importer import Importer
 from spectrochempy.core.readers.importer import _importer_method
 from spectrochempy.core.readers.importer import _openfid
 from spectrochempy.core.readers.importer import read
+from spectrochempy.utils._logging import warning_
 
 
 # ======================================================================================
@@ -147,15 +148,14 @@ def _read_zip(*args, **kwargs):
         only = kwargs.pop("only", len(filelist))
 
         datasets = []
+        ignored_files = []
+        supported_extensions = set(
+            list(zip(*(registry.aliases + registry.filetypes), strict=False))[0]
+        )
 
         def extract(children, **kwargs):
             extension = children.name.split(".")[-1]
-            if (
-                extension.lower()
-                not in list(
-                    zip(*(registry.aliases + registry.filetypes), strict=False)
-                )[0]
-            ):
+            if extension.lower() not in supported_extensions:
                 return None
             origin = kwargs.get("origin", "")
             return read(
@@ -175,6 +175,15 @@ def _read_zip(*args, **kwargs):
             if d is not None:
                 datasets.append(d)
                 count += 1
+            else:
+                ignored_files.append(zipinfo.filename)
+
+        if ignored_files:
+            ignored_list = "\n".join(f"- {name}" for name in ignored_files)
+            warning_(
+                f"Some files in {filename} were ignored because no reader is available:\n"
+                f"{ignored_list}"
+            )
 
         if len(datasets) == 1:
             return datasets[0]

--- a/tests/test_core/test_readers/test_read_zip.py
+++ b/tests/test_core/test_readers/test_read_zip.py
@@ -6,6 +6,7 @@
 # ruff: noqa
 
 import io
+import warnings
 import zipfile
 
 import pytest
@@ -177,3 +178,55 @@ def test_read_zip_nested_identical_basenames_keep_current_naming_behavior():
     assert isinstance(datasets, ScpObjectList)
     assert len(datasets) == 2
     assert [ds.name for ds in datasets] == ["sample", "sample"]
+
+
+def test_read_zip_reports_ignored_unsupported_files_in_mixed_archive():
+    content = _make_synthetic_zip(
+        {
+            "sample1.csv": "1,10\n2,20\n",
+            "sample2.csv": "1,11\n2,21\n",
+            "notes.txt": "notes",
+            "calibration.dat": "binary-ish",
+        }
+    )
+
+    with pytest.warns(UserWarning, match="ignored because no reader is available"):
+        datasets = read_zip({"mixed_ignored.zip": content}, merge=False)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert sorted(ds.name for ds in datasets) == ["sample1", "sample2"]
+
+
+def test_read_zip_no_warning_when_all_files_are_supported():
+    content = _make_synthetic_zip(
+        {
+            "sample1.csv": "1,10\n2,20\n",
+            "sample2.csv": "1,11\n2,21\n",
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        datasets = read_zip({"all_supported.zip": content}, merge=False)
+
+    assert isinstance(datasets, ScpObjectList)
+    assert len(datasets) == 2
+    assert [
+        w for w in caught if "ignored because no reader is available" in str(w.message)
+    ] == []
+
+
+def test_read_zip_reports_ignored_files_in_nested_archives():
+    content = _make_synthetic_zip(
+        {
+            "experiment/sample1.csv": "1,10\n2,20\n",
+            "experiment/notes.txt": "notes",
+            "calibration.dat": "binary-ish",
+        }
+    )
+
+    with pytest.warns(UserWarning, match="notes.txt"):
+        datasets = read_zip({"nested_ignored.zip": content}, merge=False)
+
+    assert datasets.name == "sample1"


### PR DESCRIPTION
## Summary

Fixes #1140 by reporting unsupported files that are ignored during ZIP import.

Previously, files inside ZIP archives whose extensions had no registered reader
were silently skipped. This made mixed archives difficult to troubleshoot when
users expected more datasets to be imported.

`read_zip()` now accumulates ignored file names and emits a single summary
warning when at least one unsupported file is encountered, while preserving the
existing import behavior for supported files.

## Out of scope

- no changes to merge behavior
- no changes to dataset naming
- no changes to reader registration or ZIP import architecture
- no unrelated ZIP cleanup

## Tests

Adds synthetic in-memory ZIP coverage for:

- mixed archive with supported and unsupported files
- archive with only supported files (no warning)
- nested archive with ignored files reported regardless of nesting depth

Existing ZIP tests continue to pass.

