### PR TITLE
MAINT: remove unsupported public Excel writer

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -208,11 +208,9 @@ Export a NDDataset
     NDDataset.save_as
     write
     write_csv
-    write_excel
     write_jcamp
     write_mat
     write_matlab
-    write_xls
     to_array
     to_netcdf
     to_xarray

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -212,6 +212,11 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
 
+- Removed the unsupported public Excel writer entry points
+  ``write_excel()`` and ``write_xls()``. ``.xls`` export attempts now fail
+  through the standard unsupported-format path instead of exposing a public
+  API that was never implemented. (:issue:`1260`)
+
 - ``NDDataset.to_xarray()`` now returns a canonical ``xarray.Dataset`` instead
   of a bare ``xarray.DataArray``, aligning the API with the new portable
   mapping RFC and the future NetCDF/Zarr-oriented interchange model.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -195,6 +195,11 @@ Bug Fixes
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
+- Removed the unsupported public Excel writer entry points
+  ``write_excel()`` and ``write_xls()``. ``.xls`` export attempts now fail
+  through the standard unsupported-format path instead of exposing a public
+  API that was never implemented. (:issue:`1260`)
+
 - ``NDDataset.to_xarray()`` now returns a canonical ``xarray.Dataset`` instead
   of a bare ``xarray.DataArray``, aligning the API with the new portable
   mapping RFC and the future NetCDF/Zarr-oriented interchange model.

--- a/src/spectrochempy/core/readers/filetypes.py
+++ b/src/spectrochempy/core/readers/filetypes.py
@@ -49,7 +49,6 @@ class FileTypeRegistry:
             ("dso", "Data Set Object files (*.dso)"),
             ("jcamp", "JCAMP-DX files (*.jdx *dx)"),
             ("csv", "CSV files (*.csv)"),
-            ("excel", "Microsoft Excel files (*.xls)"),
         ]
 
     def register_filetype(

--- a/src/spectrochempy/core/writers/exporter.py
+++ b/src/spectrochempy/core/writers/exporter.py
@@ -37,13 +37,26 @@ class Exporter(HasTraits):
             if "filetypes" not in kwargs:
                 kwargs["filetypes"] = list(self.filetypes.values())
                 if args and args[0] is not None:  # filename
-                    protocol = self.protocols[pathclean(args[0]).suffix]
-                    kwargs["filetypes"] = [self.filetypes[protocol]]
+                    suffix = pathclean(args[0]).suffix
+                    if suffix in self.protocols:
+                        protocol = self.protocols[suffix]
+                        kwargs["filetypes"] = [self.filetypes[protocol]]
             filename = check_filename_to_save(self.object, *args, **kwargs)
             if filename is None:
                 return None
             if kwargs.get("suffix", ""):
                 filename = filename.with_suffix(kwargs.get("suffix", ""))
+            if filename.suffix not in self.protocols:
+                supported = ", ".join(
+                    sorted(
+                        suffix if suffix.startswith(".") else f".{suffix}"
+                        for suffix in self.protocols
+                    )
+                )
+                raise ValueError(
+                    f"Unsupported export format `{filename.suffix}`. "
+                    f"Supported suffixes are: {supported}."
+                )
             protocol = self.protocols[filename.suffix]
             write_ = getattr(self, f"_write_{protocol}")
             write_(self.object, filename, **kwargs)
@@ -101,7 +114,7 @@ def write(dataset, filename=None, **kwargs):
 
     Other Parameters
     ----------------
-    protocol : {'scp', 'matlab', 'jcamp', 'csv', 'excel'}, optional
+    protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
         Protocol used for writing. If not provided, the correct protocol
         is inferred (whnever it is possible) from the file name extension.
     directory : str, optional

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -29,7 +29,7 @@ def write_csv(*args, **kwargs):
     ----------
     filename: str or pathlib object, optional
         If not provided, a dialog is opened to select a file for writing.
-    protocol : {'scp', 'matlab', 'jcamp', 'csv', 'excel'}, optional
+    protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
         Protocol used for writing. If not provided, the correct protocol
         is inferred (whnever it is possible) from the file name extension.
     directory : str, optional

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -28,7 +28,7 @@ def write_jcamp(*args, **kwargs):
     ----------
     filename: str or pathlib object, optional
         If not provided, a dialog is opened to select a file for writing.
-    protocol : {'scp', 'matlab', 'jcamp', 'csv', 'excel'}, optional
+    protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
         Protocol used for writing. If not provided, the correct protocol
         is inferred (whnever it is possible) from the file name extension.
     directory : str, optional

--- a/src/spectrochempy/lazyimport/api_methods.py
+++ b/src/spectrochempy/lazyimport/api_methods.py
@@ -183,8 +183,6 @@ _LAZY_IMPORTS = {
     "DimensionalityError": "spectrochempy.core.units",
     "write": "spectrochempy.core.writers.exporter",
     "write_csv": "spectrochempy.core.writers.write_csv",
-    "write_excel": "spectrochempy.core.writers.write_excel",
-    "write_xls": "spectrochempy.core.writers.write_excel",
     "write_jcamp": "spectrochempy.core.writers.write_jcamp",
     "write_matlab": "spectrochempy.core.writers.write_matlab",
     "write_mat": "spectrochempy.core.writers.write_matlab",

--- a/src/spectrochempy/lazyimport/dataset_methods.py
+++ b/src/spectrochempy/lazyimport/dataset_methods.py
@@ -63,8 +63,6 @@ _LAZY_DATASETS_IMPORTS = {
     "plot_waterfall": "spectrochempy.plotting.plot3d",
     "write": "spectrochempy.core.writers.exporter",
     "write_csv": "spectrochempy.core.writers.write_csv",
-    "write_excel": "spectrochempy.core.writers.write_excel",
-    "write_xls": "spectrochempy.core.writers.write_excel",
     "write_jcamp": "spectrochempy.core.writers.write_jcamp",
     "write_matlab": "spectrochempy.core.writers.write_matlab",
     "write_mat": "spectrochempy.core.writers.write_matlab",

--- a/tests/test_core/test_writers/test_exporter.py
+++ b/tests/test_core/test_writers/test_exporter.py
@@ -52,4 +52,20 @@ def test_write(mock_cwd, ndataset_1d):
     filename.unlink()
 
 
+def test_excel_writer_entry_points_are_not_public(ndataset_1d):
+    nd = ndataset_1d.copy()
+
+    assert not hasattr(scp, "write_excel")
+    assert not hasattr(scp, "write_xls")
+    assert not hasattr(nd, "write_excel")
+    assert not hasattr(nd, "write_xls")
+
+
+def test_write_xls_uses_unsupported_format_path(ndataset_1d):
+    nd = ndataset_1d.copy()
+
+    with pytest.raises(ValueError, match=r"Unsupported export format `\.xls`"):
+        nd.write("unsupported.xls", overwrite=True)
+
+
 # EOF


### PR DESCRIPTION
## Summary

Removes the non-implemented public Excel writer entry points from the supported
SpectroChemPy API.

The public `write_excel()` / `write_xls()` exposure was misleading because
Excel export was never implemented. `.xls` export attempts now fail through the
standard unsupported-format path with a clear error message.

## Scope

This PR is intentionally narrow:

- remove public Excel writer exposure;
- stop advertising `.xls` as a supported export format;
- add focused regression coverage;
- update the API reference and changelog.

No Excel read support.
No Excel write implementation.
No CSV behavior changes.

Closes #1260