### PR TITLE
ENH: implement minimal MATLAB writer and clarify writer docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ to build reproducible spectroscopy workflows in Python.
   * SVD, PCA, MCR-ALS, EFA, PLS, fitting, and related result objects
 * **I/O and Interoperability**:
   * Import from major spectroscopy and scientific data formats
-  * Export to lightweight interchange formats such as CSV and JCAMP-DX
+  * Export to lightweight interchange formats such as CSV, JCAMP-DX, and
+    minimal MATLAB `.mat` exchange files
   * Portable `NDDataset ↔ xarray.Dataset ↔ NetCDF` round-trips for the
     maintained portable subset
   * Safe native `.scp` / `.pscp` persistence by default, with explicit legacy

--- a/docs/sources/gettingstarted/quickstart.py
+++ b/docs/sources/gettingstarted/quickstart.py
@@ -107,6 +107,12 @@ print(f"y-axis unit: {ds.y.units}")  # Show time units
 # [Import tutorial](../userguide/importexport/import.ipynb) section.
 #
 # The `read` function returns an `NDDataset` object.
+#
+# SpectroChemPy can also write lightweight exchange files such as CSV,
+# JCAMP-DX, and minimal MATLAB `.mat` files for simple numeric datasets.
+# For structured SpectroChemPy storage and portable round-trips, prefer the
+# native `.scp` format or the `NDDataset ↔ xarray ↔ NetCDF` path described in
+# the import/export guide.
 
 # %% [markdown]
 # ## Exploring the Data

--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -131,6 +131,12 @@ X
 # only; full `CoordSet` fidelity and `Project` round-trips are not guaranteed
 # by the current portable subset.
 #
+# MATLAB export is available as a minimal exchange writer through
+# ``write_matlab()`` / ``write_mat()`` for simple numeric `NDDataset` objects.
+# It is not SpectroChemPy native persistence and does not aim at full
+# round-trip fidelity. For structured SpectroChemPy storage, prefer native safe
+# persistence or the portable xarray / NetCDF path.
+#
 # Other reader functions return either a single `NDDataset` or multiple `NDDataset`
 # objects, depending on the file type and content.
 #

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,9 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
+  exchange using `scipy.io.savemat`. This is an exchange format, not
+  native SpectroChemPy persistence.
 
 .. section
 
@@ -26,6 +29,9 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Clarified specialized writer docstrings so format-specific APIs such as
+  `write_csv()`, `write_jcamp()`, and `write_matlab()` no longer advertise the
+  generic multi-protocol export options documented on `write()`.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,3 +11,17 @@ What's New in Revision 0.10.2.dev
 
 These are the changes in SpectroChemPy-0.10.2.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+New Features
+~~~~~~~~~~~~
+
+- Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
+  exchange using `scipy.io.savemat`. This is an exchange format, not
+  native SpectroChemPy persistence.
+
+Bug Fixes
+~~~~~~~~~
+
+- Clarified specialized writer docstrings so format-specific APIs such as
+  `write_csv()`, `write_jcamp()`, and `write_matlab()` no longer advertise the
+  generic multi-protocol export options documented on `write()`.

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -3,7 +3,7 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-"""Plugin module to extend NDDataset with a JCAMP-DX export method."""
+"""Plugin module to extend NDDataset with a CSV export method."""
 
 # import os as os
 import csv
@@ -29,9 +29,6 @@ def write_csv(*args, **kwargs):
     ----------
     filename: str or pathlib object, optional
         If not provided, a dialog is opened to select a file for writing.
-    protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
-        Protocol used for writing. If not provided, the correct protocol
-        is inferred (whnever it is possible) from the file name extension.
     directory : str, optional
         Where to write the specified `filename` . If not specified, write in the current directory.
     description: str, optional
@@ -39,6 +36,9 @@ def write_csv(*args, **kwargs):
     delimiter : str, optional
         Set the column delimiter in CSV file.
         By default it is ',' or the one set in SpectroChemPy `Preferences` .
+    **kwargs
+        Additional keyword arguments accepted by the generic writer API.
+        This specialized writer always exports CSV files.
 
     Returns
     -------

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -28,13 +28,13 @@ def write_jcamp(*args, **kwargs):
     ----------
     filename: str or pathlib object, optional
         If not provided, a dialog is opened to select a file for writing.
-    protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
-        Protocol used for writing. If not provided, the correct protocol
-        is inferred (whnever it is possible) from the file name extension.
     directory : str, optional
         Where to write the specified `filename` . If not specified, write in the current directory.
     description: str, optional
         A Custom description.
+    **kwargs
+        Additional keyword arguments accepted by the generic writer API.
+        This specialized writer always exports JCAMP-DX files.
 
     Returns
     -------

--- a/src/spectrochempy/core/writers/write_matlab.py
+++ b/src/spectrochempy/core/writers/write_matlab.py
@@ -3,7 +3,10 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-"""Plugin module to extend NDDataset with a JCAMP-DX export method."""
+"""Plugin module to extend NDDataset with a minimal MATLAB export method."""
+
+import numpy as np
+from scipy.io import savemat
 
 from spectrochempy.core.writers.exporter import Exporter
 from spectrochempy.core.writers.exporter import exportermethod
@@ -14,12 +17,19 @@ __dataset_methods__ = __all__
 
 def write_matlab(*args, **kwargs):
     r"""
-    Write a dataset in CSV format.
+    Write a dataset to a MATLAB `.mat` exchange file.
+
+    This writer targets simple MATLAB / Octave interoperability through
+    `scipy.io.savemat`. It is not SpectroChemPy native persistence and does
+    not claim full round-trip fidelity.
 
     Parameters
     ----------
-    *args
+    filename : str or pathlib object, optional
+        If not provided, a dialog is opened to select a file for writing.
     **kwargs
+        Additional keyword arguments accepted by the generic writer API.
+        This specialized writer always exports MATLAB `.mat` files.
 
     Returns
     -------
@@ -44,4 +54,60 @@ write_mat.__doc__ = "This method is an alias of `write_matlab` ."
 
 @exportermethod
 def _write_matlab(*args, **kwargs):
-    raise NotImplementedError
+    dataset, filename = args
+
+    values = _matlab_export_data(dataset)
+    payload = {
+        "data": values,
+        "dims": np.asarray([str(dim) for dim in dataset.dims], dtype=object),
+        "coords": {},
+        "coord_units": {},
+        "coord_titles": {},
+        "name": str(dataset.name or ""),
+        "title": str(dataset.title or ""),
+    }
+
+    if dataset.units is not None:
+        payload["units"] = _matlab_stringify_units(dataset.units)
+    if dataset.description:
+        payload["description"] = str(dataset.description)
+
+    for dim in dataset.dims:
+        coord = dataset.coord(dim)
+        if coord is None or coord.is_empty:
+            continue
+        payload["coords"][str(dim)] = np.asarray(coord.data)
+        if coord.units is not None:
+            payload["coord_units"][str(dim)] = _matlab_stringify_units(coord.units)
+        if coord.title and coord.title != "<untitled>":
+            payload["coord_titles"][str(dim)] = str(coord.title)
+
+    savemat(filename, payload, do_compression=False)
+    return filename
+
+
+def _matlab_export_data(dataset):
+    """Return a MATLAB-compatible numeric array for minimal exchange export."""
+    if dataset.ndim not in (1, 2):
+        raise NotImplementedError(
+            "MATLAB export is only implemented for 1D and 2D NDDataset objects."
+        )
+
+    values = np.asarray(dataset.data)
+    if values.dtype.kind == "c":
+        raise TypeError("MATLAB export does not support complex NDDataset data.")
+    if values.dtype.kind not in "biuf":
+        raise TypeError(
+            "MATLAB export only supports numeric boolean/integer/float "
+            "NDDataset data."
+        )
+
+    if dataset.is_masked:
+        values = np.asarray(np.ma.filled(dataset.masked_data, np.nan), dtype=float)
+
+    return values
+
+
+def _matlab_stringify_units(units):
+    """Return a simple ASCII unit string for MATLAB exchange payloads."""
+    return f"{units:~D}"

--- a/tests/test_core/test_writers/test_write_matlab.py
+++ b/tests/test_core/test_writers/test_write_matlab.py
@@ -1,0 +1,115 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+import numpy as np
+import pytest
+from scipy.io import loadmat
+
+import spectrochempy as scp
+
+
+def test_write_matlab_1d_with_coordinate_and_metadata(tmp_path):
+    coord = scp.Coord(
+        np.linspace(4000.0, 1000.0, 5),
+        title="wavenumber",
+        units="cm^-1",
+    )
+    dataset = scp.NDDataset(
+        np.linspace(0.1, 0.5, 5),
+        coordset=[coord],
+        name="spectrum",
+        title="absorbance",
+        units="mV",
+        description="Simple exchange test",
+    )
+
+    path = tmp_path / "spectrum.mat"
+    returned = dataset.write_matlab(path, confirm=False)
+
+    assert returned == path
+    exported = loadmat(path, simplify_cells=True)
+
+    assert np.allclose(exported["data"], np.linspace(0.1, 0.5, 5))
+    assert list(np.ravel(exported["dims"])) == ["x"]
+    assert np.allclose(exported["coords"]["x"], np.linspace(4000.0, 1000.0, 5))
+    assert exported["coord_units"]["x"] == "cm^-1"
+    assert exported["coord_titles"]["x"] == "wavenumber"
+    assert exported["name"] == "spectrum"
+    assert exported["title"] == "absorbance"
+    assert exported["units"] == "mV"
+    assert exported["description"] == "Simple exchange test"
+
+
+def test_write_matlab_2d_with_two_coordinates(tmp_path):
+    x = scp.Coord(np.linspace(4000.0, 1000.0, 4), title="wavenumber", units="cm^-1")
+    y = scp.Coord(np.array([0.0, 10.0, 20.0]), title="time", units="s")
+    values = np.arange(12, dtype=float).reshape(3, 4)
+    dataset = scp.NDDataset(values, coordset=[y, x], name="image", title="intensity")
+
+    path = tmp_path / "image.mat"
+    dataset.write_matlab(path, confirm=False)
+
+    exported = loadmat(path, simplify_cells=True)
+
+    assert exported["data"].shape == (3, 4)
+    assert np.array_equal(exported["data"], values)
+    assert list(np.ravel(exported["dims"])) == ["y", "x"]
+    assert np.array_equal(exported["coords"]["x"], x.data)
+    assert np.array_equal(exported["coords"]["y"], y.data)
+    assert exported["coord_units"]["x"] == "cm^-1"
+    assert exported["coord_units"]["y"] == "s"
+    assert exported["coord_titles"]["x"] == "wavenumber"
+    assert exported["coord_titles"]["y"] == "time"
+
+
+def test_write_matlab_alias_uses_mat_suffix(tmp_path):
+    dataset = scp.NDDataset(np.arange(5.0), name="trace")
+
+    path = dataset.write_mat(tmp_path / "trace", confirm=False)
+
+    assert path.name == "trace.mat"
+    assert path.exists()
+
+
+def test_write_matlab_generic_dispatch_uses_mat_protocol(tmp_path):
+    dataset = scp.NDDataset(np.arange(6.0).reshape(2, 3), name="grid")
+
+    path = dataset.write(tmp_path / "grid.mat", confirm=False)
+
+    assert path.name == "grid.mat"
+    exported = loadmat(path, simplify_cells=True)
+    assert np.array_equal(exported["data"], np.arange(6.0).reshape(2, 3))
+
+
+def test_write_matlab_rejects_unsupported_object():
+    with pytest.raises(
+        TypeError, match="the API write method needs a NDDataset object"
+    ):
+        scp.write_matlab(object(), "invalid.mat")
+
+
+def test_write_matlab_rejects_complex_data(tmp_path):
+    dataset = scp.NDDataset(np.array([1 + 1j, 2 + 0j]), name="complex")
+
+    with pytest.raises(TypeError, match="does not support complex"):
+        dataset.write_matlab(tmp_path / "complex.mat", confirm=False)
+
+
+def test_write_matlab_rejects_higher_dimensional_data(tmp_path):
+    dataset = scp.NDDataset(np.arange(24.0).reshape(2, 3, 4), name="cube")
+
+    with pytest.raises(NotImplementedError, match="only implemented for 1D and 2D"):
+        dataset.write_matlab(tmp_path / "cube.mat", confirm=False)
+
+
+def test_write_matlab_does_not_modify_source_dataset(tmp_path):
+    dataset = scp.NDDataset(np.arange(5.0), name="trace")
+    original_filename = dataset.filename
+
+    dataset.write_matlab(tmp_path / "trace.mat", confirm=False)
+
+    assert dataset.filename == original_filename


### PR DESCRIPTION
## Summary

Adds a real minimal MATLAB `.mat` writer for simple numeric `NDDataset`
exchange using `scipy.io.savemat`.

It also fixes misleading specialized writer docstrings so fixed-format APIs
such as `write_csv()`, `write_jcamp()`, and `write_matlab()` no longer
advertise the generic multi-protocol behavior documented on `write()`.

## Scope

A focused MATLAB export implementation plus a small writer-documentation
consistency fix.

## Included

- implements `write_matlab()` / `write_mat()` for simple numeric
  `NDDataset` objects
- supports 1D and 2D numeric datasets only
- exports simple coordinates and basic textual metadata
- keeps generic `.write(..., ".mat")` dispatch working
- rejects unsupported shapes and unsupported data types with clear errors
- ensures MATLAB export does not mutate the source dataset
- adds targeted synthetic writer tests using `scipy.io.loadmat`
- adds a concise user-guide note
- updates the changelog
- clarifies specialized writer docstrings for CSV, JCAMP, and MATLAB writers

## Not Included

- MATLAB read support
- native persistence claims
- Project / Result Object serialization
- rich metadata or provenance export
- MATLAB v7.3 / HDF5 support
- any writer API redesign

## Rationale

MATLAB writing was exposed but not actually implemented. This PR provides a
small exchange writer for common MATLAB / Octave interoperability without
claiming full SpectroChemPy round-trip fidelity.

The docstring fix keeps the specialized writer APIs aligned with their actual
behavior and avoids confusion between fixed-format writers and the generic
`write()` dispatcher.
