### PR TITLE
ENH: standardize unsupported reader error messages

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,10 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Standardized unsupported reader errors so invalid protocols, unrecognized
+  file types, and unsupported CSV origins report the affected filename,
+  requested or detected value, and supported alternatives. (#1143)
+
 - Clarified specialized writer docstrings so format-specific APIs such as
   `write_csv()`, `write_jcamp()`, and `write_matlab()` no longer advertise the
   generic multi-protocol export options documented on `write()`.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,10 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Standardized unsupported reader errors so invalid protocols, unrecognized
+  file types, and unsupported CSV origins report the affected filename,
+  requested or detected value, and supported alternatives. (#1143)
+
 - Clarified specialized writer docstrings so format-specific APIs such as
   `write_csv()`, `write_jcamp()`, and `write_matlab()` no longer advertise the
   generic multi-protocol export options documented on `write()`.

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -28,6 +28,7 @@ from spectrochempy.utils._logging import info_
 from spectrochempy.utils._logging import warning_
 from spectrochempy.utils.exceptions import ProtocolError
 from spectrochempy.utils.exceptions import SpectroChemPyError
+from spectrochempy.utils.exceptions import WrongFileFormatError
 from spectrochempy.utils.file import check_filename_to_open
 from spectrochempy.utils.file import get_directory_name
 from spectrochempy.utils.file import get_filenames
@@ -103,7 +104,23 @@ class Importer(HasTraits):
                 not in list(zip(*registry.filetypes, strict=False))[0]
                 + list(zip(*registry.aliases, strict=False))[0]
             ):
-                raise TypeError(f"Filetype `{key}` is unknown in spectrochempy")
+                filename = self.files[key][0]
+                requested_protocol = kwargs.get("protocol")
+                if requested_protocol == "ALL":
+                    requested_protocol = None
+                requested = (
+                    f" with protocol='{requested_protocol}'"
+                    if requested_protocol is not None
+                    else ""
+                )
+                available = ", ".join(
+                    f"'{item}'" for item in sorted(set(self.protocols.values()))
+                )
+                raise WrongFileFormatError(
+                    f"Cannot read '{filename}'{requested}: detected file type "
+                    f"'{key}' is unsupported.\n"
+                    f"Supported protocols are: {available}."
+                )
             else:
                 # here files are read / or remotely from the disk using filenames
                 self._switch_protocol(key, self.files, **kwargs)
@@ -171,8 +188,14 @@ class Importer(HasTraits):
         if protocol is not None and protocol != "ALL":
             if not isinstance(protocol, list):
                 protocol = [protocol]
-            if key and key[1:] not in protocol and self.alias[key[1:]] not in protocol:
-                return
+            detected_protocol = self.alias.get(key[1:], key[1:])
+            if key and key[1:] not in protocol and detected_protocol not in protocol:
+                raise ProtocolError(
+                    protocol[0] if len(protocol) == 1 else protocol,
+                    list(self.protocols.values()),
+                    filename=files[key][0],
+                    detected_protocol=detected_protocol,
+                )
 
         datasets = []
         files[key] = sorted(files[key])  # sort the files according their names
@@ -436,9 +459,13 @@ def read(*paths, **kwargs):
         try:
             kwargs["filetypes"] = [importer.filetypes[protocol]]
         except KeyError as e:
+            filename = paths[0] if paths else None
+            if isinstance(filename, dict) and filename:
+                filename = next(iter(filename))
             raise ProtocolError(
                 protocol,
                 list(importer.protocols.values()),
+                filename=filename,
             ) from e
 
     return importer(*paths, **kwargs)

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -21,6 +21,7 @@ from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.readers.importer import Importer
 from spectrochempy.core.readers.importer import _importer_method
 from spectrochempy.core.readers.importer import _openfid
+from spectrochempy.utils.exceptions import UnsupportedOriginError
 
 
 def _parse_spectrochempy_csv_header(row):
@@ -357,17 +358,18 @@ def _read_csv(*args, **kwargs):
 
     # here we can check some particular format
     origin = kwargs.get("origin", "")
-    if "omnic" in origin:
+    if origin == "omnic":
         # this will be treated as csv export from omnic (IR data)
         dataset = _add_omnic_info(dataset, **kwargs)
-    elif "tga" in origin:
+    elif origin == "tga":
         # this will be treated as csv export from tga analysis
         dataset = _add_tga_info(dataset, **kwargs)
     elif origin:
-        raise NotImplementedError(
-            f"Sorry, but reading a csv file with '{origin}' origin is not implemented. "
-            "Please, remove or set the keyword 'origin'\n "
-            "(Up to now implemented csv files are: `omnic` , `tga` )",
+        raise UnsupportedOriginError(
+            filename=filename,
+            protocol="csv",
+            origin=origin,
+            supported_origins=("omnic", "tga"),
         )
 
     # reset modification date to cretion date

--- a/src/spectrochempy/utils/exceptions.py
+++ b/src/spectrochempy/utils/exceptions.py
@@ -248,7 +248,7 @@ class InvalidCoordSetSizeError(SpectroChemPyError):
 
 class ProtocolError(SpectroChemPyError):
     """
-    Exception raised when a wrong protocol is secified to the spectrochempy importer.
+    Exception raised when an unsupported protocol is specified to the importer.
 
     Parameters
     ----------
@@ -256,18 +256,55 @@ class ProtocolError(SpectroChemPyError):
         The protocol string that was at the origin of the exception.
     available_protocols : list of str
         The available (implemented) protocols.
+    filename : str or path-like, optional
+        The file that could not be read.
+    detected_protocol : str, optional
+        The protocol inferred from the filename when it conflicts with ``protocol``.
     """
 
-    def __init__(self, protocol, available_protocols):
-        self.message = (
-            f"IO - The `{protocol}` protocol is unknown or not yet implemented.\n"
-            f"It is expected to be one of {tuple(available_protocols)}"
+    def __init__(
+        self,
+        protocol,
+        available_protocols,
+        filename=None,
+        detected_protocol=None,
+    ):
+        supported = ", ".join(f"'{item}'" for item in sorted(set(available_protocols)))
+        location = (
+            f"Cannot read '{filename}'" if filename is not None else "Cannot read"
         )
+
+        if detected_protocol is not None:
+            self.message = (
+                f"{location} with protocol='{protocol}'.\n"
+                f"The filename indicates protocol='{detected_protocol}'.\n"
+                f"Choose protocol='{detected_protocol}' or omit the protocol argument."
+            )
+        else:
+            self.message = (
+                f"{location} with protocol='{protocol}'.\n"
+                "The requested protocol is unknown or not implemented.\n"
+                f"Supported protocols are: {supported}."
+            )
 
         super().__init__(self.message)
 
 
-class WrongFileFormatError(SpectroChemPyError):
+class UnsupportedOriginError(SpectroChemPyError, NotImplementedError):
+    """Exception raised when a reader does not support a requested origin."""
+
+    def __init__(self, filename, protocol, origin, supported_origins):
+        supported = ", ".join(f"'{item}'" for item in supported_origins)
+        protocol_name = protocol.upper()
+        message = (
+            f"Cannot read {protocol_name} file '{filename}' with origin='{origin}'.\n"
+            f"Supported {protocol_name} origins are: {supported}.\n"
+            "Remove the origin argument or choose a supported origin."
+        )
+        super().__init__(message)
+
+
+class WrongFileFormatError(SpectroChemPyError, TypeError):
     """Exception raised when the file format is incorrect or not supported."""
 
 

--- a/tests/test_core/test_readers/test_importer.py
+++ b/tests/test_core/test_readers/test_importer.py
@@ -6,6 +6,7 @@
 
 import os
 import pathlib
+import re
 
 import pytest
 
@@ -192,7 +193,7 @@ class TestBasicImporter:
         with pytest.raises(
             spectrochempy.utils.exceptions.WrongFileFormatError,
             match=(
-                rf"Cannot read '{filename}'"
+                rf"Cannot read '{re.escape(str(filename))}'"
                 r": detected file type '\.unsupported' is unsupported\.\n"
                 r"Supported protocols are:"
             ),
@@ -208,7 +209,8 @@ class TestBasicImporter:
         with pytest.raises(
             spectrochempy.utils.exceptions.ProtocolError,
             match=(
-                rf"Cannot read '{filename}' with protocol='omnic'\.\n"
+                rf"Cannot read '{re.escape(str(filename))}' "
+                r"with protocol='omnic'\.\n"
                 r"The filename indicates protocol='csv'\.\n"
                 r"Choose protocol='csv' or omit the protocol argument\."
             ),

--- a/tests/test_core/test_readers/test_importer.py
+++ b/tests/test_core/test_readers/test_importer.py
@@ -173,8 +173,47 @@ class TestBasicImporter:
     def test_invalid_protocol(self, fs):
         """Test behavior with invalid protocol."""
         self.setup_method()
-        with pytest.raises(spectrochempy.utils.exceptions.ProtocolError):
+        with pytest.raises(
+            spectrochempy.utils.exceptions.ProtocolError,
+            match=(
+                r"Cannot read '.+test\.opus\.fk' with protocol='wrongfake'\.\n"
+                r"The requested protocol is unknown or not implemented\."
+            ),
+        ):
             read(self.test_file, protocol="wrongfake", local_only=True)
+
+    def test_unsupported_filetype_reports_filename_and_supported_protocols(
+        self, tmp_path
+    ):
+        """An unregistered extension should produce an actionable error."""
+        filename = tmp_path / "sample.unsupported"
+        filename.write_text("not a supported format")
+
+        with pytest.raises(
+            spectrochempy.utils.exceptions.WrongFileFormatError,
+            match=(
+                rf"Cannot read '{filename}'"
+                r": detected file type '\.unsupported' is unsupported\.\n"
+                r"Supported protocols are:"
+            ),
+        ) as exc_info:
+            read(filename, local_only=True)
+        assert isinstance(exc_info.value, TypeError)
+
+    def test_protocol_mismatch_reports_requested_and_detected_protocols(self, tmp_path):
+        """A protocol conflicting with the extension should be explicit."""
+        filename = tmp_path / "sample.csv"
+        filename.write_text("x,y\n1,2\n")
+
+        with pytest.raises(
+            spectrochempy.utils.exceptions.ProtocolError,
+            match=(
+                rf"Cannot read '{filename}' with protocol='omnic'\.\n"
+                r"The filename indicates protocol='csv'\.\n"
+                r"Choose protocol='csv' or omit the protocol argument\."
+            ),
+        ):
+            read(filename, protocol="omnic", local_only=True)
 
     def test_single_file_read(self, fs, monkeypatch):
         """Test reading a single file."""

--- a/tests/test_core/test_readers/test_read_csv.py
+++ b/tests/test_core/test_readers/test_read_csv.py
@@ -9,6 +9,7 @@ import pytest
 
 import spectrochempy as scp
 from spectrochempy.application.preferences import preferences as prefs
+from spectrochempy.utils.exceptions import UnsupportedOriginError
 
 
 def test_read_csv():
@@ -55,11 +56,26 @@ def test_read_csv():
     C = scp.read_csv({"somename.csv": omnic_csv_content.encode("utf-8")})
     assert C.shape == (1, 5)
 
-    # wrong origin parameters - should return None
-    D = scp.read_csv(
-        {"test_omnic.csv": omnic_csv_content.encode("utf-8")}, origin="opus"
-    )
-    assert not D
+    # An unsupported origin should produce an actionable reader error.
+    with pytest.raises(
+        UnsupportedOriginError,
+        match=(
+            r"Cannot read CSV file 'test_omnic\.csv' with origin='opus'\.\n"
+            r"Supported CSV origins are: 'omnic', 'tga'\.\n"
+            r"Remove the origin argument or choose a supported origin\."
+        ),
+    ) as exc_info:
+        scp.read_csv(
+            {"test_omnic.csv": omnic_csv_content.encode("utf-8")},
+            origin="opus",
+        )
+    assert isinstance(exc_info.value, NotImplementedError)
+
+    with pytest.raises(UnsupportedOriginError, match="origin='vendor_omnic'"):
+        scp.read_csv(
+            {"test_omnic.csv": omnic_csv_content.encode("utf-8")},
+            origin="vendor_omnic",
+        )
 
 
 def test_read_csv_skips_leading_comments_and_blank_lines():


### PR DESCRIPTION
Standardize actionable errors for unsupported protocols, file types, and CSV origins.

Successful reader behavior and protocol inference remain unchanged.

Closes #1143