### PR TITLE
ENH: add attribute access to named Result outputs

### DIFF
--- a/docs/sources/userguide/analysis/pca.py
+++ b/docs/sources/userguide/analysis/pca.py
@@ -124,6 +124,20 @@ pca = scp.PCA(n_components=8)
 pca.fit(X)
 
 # %% [markdown]
+# The grouped PCA outputs are available from `pca.result`. Named outputs and
+# diagnostics use direct attribute access in normal user code:
+# %%
+scores = pca.result.scores
+loadings = pca.result.loadings
+variance = pca.result.explained_variance
+
+# %% [markdown]
+# The mapping form, such as `pca.result.outputs["scores"]`, remains available
+# for introspection and programmatic access. Historical direct estimator
+# accessors such as `pca.scores`, `pca.loadings`, and `pca.transform()` also
+# remain supported.
+
+# %% [markdown]
 # The choice of the optimum number of components to describe a dataset is always a delicate matter. It can be based on:
 # - examination of the explained variance
 # - examination of the scores and loadings

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,10 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Result objects now provide attribute-style access to named outputs and
+  diagnostics, for example `pca.result.scores`, `pca.result.loadings`, and
+  `pca.result.explained_variance`.
+
 - Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
   exchange using `scipy.io.savemat`. This is an exchange format, not
   native SpectroChemPy persistence.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,10 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- Result objects now provide attribute-style access to named outputs and
+  diagnostics, for example `pca.result.scores`, `pca.result.loadings`, and
+  `pca.result.explained_variance`.
+
 - Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
   exchange using `scipy.io.savemat`. This is an exchange format, not
   native SpectroChemPy persistence.

--- a/src/spectrochempy/analysis/_base/_result.py
+++ b/src/spectrochempy/analysis/_base/_result.py
@@ -47,6 +47,38 @@ class ResultBase:
         """Named diagnostic values produced by the operation."""
         return self._diagnostics
 
+    def __getattr__(self, name):
+        """
+        Return a named output or diagnostic using attribute-style access.
+
+        Normal attributes and methods are resolved before this fallback.
+        Named outputs take precedence over diagnostics when both mappings use
+        the same key. Parameters remain available through :attr:`parameters`.
+        """
+        outputs = self.__dict__.get("_outputs", {})
+        if name in outputs:
+            return outputs[name]
+
+        diagnostics = self.__dict__.get("_diagnostics", {})
+        if name in diagnostics:
+            return diagnostics[name]
+
+        raise AttributeError(
+            f"{type(self).__name__!s} object has no attribute {name!r}"
+        )
+
+    def __dir__(self):
+        """Include named outputs and diagnostics in attribute discovery."""
+        names = set(super().__dir__())
+        for mapping_name in ("_outputs", "_diagnostics"):
+            mapping = self.__dict__.get(mapping_name, {})
+            names.update(
+                name
+                for name in mapping
+                if isinstance(name, str) and name.isidentifier()
+            )
+        return sorted(names)
+
     # ----------------------------------------------------------------------------------
     # Representation
     # ----------------------------------------------------------------------------------

--- a/tests/test_analysis/test_decomposition/test_pca_result.py
+++ b/tests/test_analysis/test_decomposition/test_pca_result.py
@@ -68,6 +68,78 @@ class TestResultBase:
         assert "b" in result.outputs
         assert "d" in result.diagnostics
 
+    def test_output_attribute_access(self):
+        scores = np.ones((2, 3))
+        concentrations = object()
+        spectra = object()
+        result = ResultBase(
+            estimator="Test",
+            outputs={"scores": scores, "C": concentrations, "St": spectra},
+        )
+        assert result.scores is result.outputs["scores"]
+        assert result.C is result.outputs["C"]
+        assert result.St is result.outputs["St"]
+
+    def test_diagnostic_attribute_access(self):
+        variance = np.array([2.0, 1.0])
+        result = ResultBase(
+            estimator="Test",
+            diagnostics={"explained_variance": variance},
+        )
+        assert result.explained_variance is result.diagnostics["explained_variance"]
+
+    def test_missing_attribute_raises_attribute_error(self):
+        result = ResultBase(estimator="Test")
+        with pytest.raises(
+            AttributeError,
+            match="ResultBase object has no attribute 'missing'",
+        ):
+            _ = result.missing
+
+    def test_existing_attributes_are_not_shadowed(self):
+        result = ResultBase(
+            estimator="Test",
+            parameters={"alpha": 1},
+            outputs={
+                "outputs": "shadowed outputs",
+                "diagnostics": "shadowed diagnostics",
+                "parameters": "shadowed parameters",
+                "estimator": "shadowed estimator",
+            },
+        )
+        assert result.outputs["outputs"] == "shadowed outputs"
+        assert result.diagnostics == {}
+        assert result.parameters == {"alpha": 1}
+        assert result.estimator == "Test"
+
+    def test_output_wins_over_diagnostic(self):
+        output = object()
+        diagnostic = object()
+        result = ResultBase(
+            estimator="Test",
+            outputs={"shared": output},
+            diagnostics={"shared": diagnostic},
+        )
+        assert result.shared is output
+
+    def test_parameters_are_not_exposed_as_attributes(self):
+        result = ResultBase(estimator="Test", parameters={"alpha": 1})
+        with pytest.raises(AttributeError):
+            _ = result.alpha
+
+    def test_dir_includes_outputs_and_diagnostics_but_not_parameters(self):
+        result = ResultBase(
+            estimator="Test",
+            parameters={"alpha": 1},
+            outputs={"scores": object(), "not-valid": object()},
+            diagnostics={"explained_variance": object()},
+        )
+        names = dir(result)
+        assert "scores" in names
+        assert "explained_variance" in names
+        assert "alpha" not in names
+        assert "not-valid" not in names
+
     def test_repr(self):
         result = ResultBase(
             estimator="Test",
@@ -104,6 +176,11 @@ class TestFitResult:
         result = FitResult(estimator="Optimize")
         assert isinstance(result, FitResult)
         assert isinstance(result, ResultBase)
+
+    def test_inherits_attribute_access(self):
+        fitted = object()
+        result = FitResult(estimator="Optimize", outputs={"fitted": fitted})
+        assert result.fitted is fitted
 
 
 # ======================================================================================
@@ -164,6 +241,17 @@ class TestPCAResult:
             result.diagnostics["explained_variance_ratio"].data,
             pca.explained_variance_ratio.data,
         )
+
+    def test_result_attribute_access(self, low_rank_dataset):
+        pca = PCA(n_components=2).fit(low_rank_dataset)
+        result = pca.result
+        assert result.scores is result.outputs["scores"]
+        assert result.loadings is result.outputs["loadings"]
+        assert (
+            result.explained_variance
+            is result.diagnostics["explained_variance"]
+        )
+        assert {"scores", "loadings", "explained_variance"} <= set(dir(result))
 
     def test_repr_contains_expected_fields(self, low_rank_dataset):
         pca = PCA()

--- a/tests/test_analysis/test_decomposition/test_pca_result.py
+++ b/tests/test_analysis/test_decomposition/test_pca_result.py
@@ -247,10 +247,7 @@ class TestPCAResult:
         result = pca.result
         assert result.scores is result.outputs["scores"]
         assert result.loadings is result.outputs["loadings"]
-        assert (
-            result.explained_variance
-            is result.diagnostics["explained_variance"]
-        )
+        assert result.explained_variance is result.diagnostics["explained_variance"]
         assert {"scores", "loadings", "explained_variance"} <= set(dir(result))
 
     def test_repr_contains_expected_fields(self, low_rank_dataset):


### PR DESCRIPTION
## Summary

- Add attribute-style access to named Result outputs and diagnostics.
- Add IPython/Jupyter autocompletion through `__dir__()`.
- Document the preferred user-facing syntax:

```python
pca.result.scores
pca.result.loadings
pca.result.explained_variance
```

The mapping form remains available for introspection:

```python
pca.result.outputs["scores"]
```

## Out of scope

- No estimator behavior changes.
- No changes to direct estimator accessors.
- No Result persistence or Project integration.
- No caching or snapshot-semantics decision.
- No plugin or estimator migration.
