### PR TITLE
MAINT: add IRIS.result and align the IRIS plugin

### DIFF
--- a/docs/sources/userguide/plugins/iris.rst
+++ b/docs/sources/userguide/plugins/iris.rst
@@ -22,6 +22,13 @@ Use package-level classes from ``scp.iris`` and dataset-bound helpers from
 
     analysis = scp.iris.IRIS()
     kernel = dataset.iris.kernel_matrix(kernel_type="langmuir")
+    analysis.fit(dataset, kernel)
+
+    distribution = analysis.result.f
+    residual_sum_squares = analysis.result.RSS
+
+The existing direct accessors, such as ``analysis.f``, ``analysis.K``,
+``analysis.RSS``, and ``analysis.SM``, remain supported.
 
 New code should prefer the namespaced API. Compatibility aliases may be
 available for older scripts during the transition.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -21,7 +21,8 @@ New Features
 
 - Result objects now provide attribute-style access to named outputs and
   diagnostics, for example `pca.result.scores`, `pca.result.loadings`, and
-  `pca.result.explained_variance`.
+  `pca.result.explained_variance`. The IRIS plugin now follows the same
+  contract through `iris.result`.
 
 - Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
   exchange using `scipy.io.savemat`. This is an exchange format, not

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -17,7 +17,8 @@ New Features
 
 - Result objects now provide attribute-style access to named outputs and
   diagnostics, for example `pca.result.scores`, `pca.result.loadings`, and
-  `pca.result.explained_variance`.
+  `pca.result.explained_variance`. The IRIS plugin now follows the same
+  contract through `iris.result`.
 
 - Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
   exchange using `scipy.io.savemat`. This is an exchange format, not

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -221,7 +221,7 @@ following alignment tasks should be completed:
 - define the minimum scientifically complete `FitResult` payload;
 - align the remaining maintained stateful core candidates (`Baseline`,
   `LSTSQ`, and `NNLS`) or document them as explicit exceptions;
-- complete IRIS plugin alignment;
+- keep the completed IRIS plugin alignment covered by compatibility tests;
 - complete TENSOR/CP plugin alignment;
 - update analysis and official-plugin documentation to teach `.result`;
 - coordinate compatible IRIS and TENSOR releases before the core 0.11 release,
@@ -237,7 +237,8 @@ and dataset persistence are sufficient for 0.11.
 1. Document the selected live, cached, or fit-time snapshot lifecycle semantics
    and publish the public Result type path.
 2. Complete Baseline, LSTSQ, and NNLS alignment.
-3. Complete IRIS and TENSOR/CP plugin alignment and release compatible plugins.
+3. Complete TENSOR/CP plugin alignment and release compatible official plugins;
+   IRIS Result alignment is implemented.
 4. Update user documentation and remove only confirmed deprecated aliases.
 5. Keep Results runtime-only in 0.11, using dataset export and established
    dataset persistence when saved outputs are needed.

--- a/maintainers/rfcs/architecture-roadmap.md
+++ b/maintainers/rfcs/architecture-roadmap.md
@@ -33,8 +33,8 @@ This document should evolve as the project evolves.
   boundary, and the dataset-persistence boundary are clarified.
 - Result alignment remaining: public Result exports, Baseline, LSTSQ, NNLS,
   compatibility review, and documentation alignment.
-- Plugin alignment remaining: IRIS and TENSOR/CP must expose `.result`, be
-  tested against 0.11, and be released with compatible dependency bounds.
+- Plugin alignment: IRIS now exposes `.result`; TENSOR/CP alignment, 0.11
+  compatibility testing, and compatible plugin releases remain.
 - Lifecycle decision: the implementation is currently a live view. Retaining
   it, caching it, or adopting a fit-time snapshot remain open alternatives; no
   direction is currently preferred.

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/__init__.py
@@ -232,7 +232,8 @@ def batch_iris_analysis(
     Returns
     -------
     list[dict]
-        Each dict contains ``label``, ``iris``, ``f``, ``RSS``, ``SM``.
+        Each dict contains ``label``, ``iris``, ``result``, ``f``, ``RSS``,
+        ``SM``.
     """
     from ._core import IRIS as _IRIS  # noqa: PLC0415
     from ._core import IrisKernel as _IrisKernel  # noqa: PLC0415
@@ -254,14 +255,16 @@ def batch_iris_analysis(
         kernel = _IrisKernel(ds, kernel_fn, q=q)
         iris = _IRIS(reg_par=reg_par)
         iris.fit(ds, kernel)
+        result = iris.result
 
         results.append(
             {
                 "label": label,
                 "iris": iris,
-                "f": iris.f,
-                "RSS": iris.RSS,
-                "SM": iris.SM,
+                "result": result,
+                "f": result.f,
+                "RSS": result.RSS,
+                "SM": result.SM,
             }
         )
 
@@ -291,7 +294,8 @@ def compare_kernel_models(
     Returns
     -------
     list[dict]
-        Each dict contains ``kernel``, ``iris``, ``RSS``, ``SM``, ``n_components``.
+        Each dict contains ``kernel``, ``iris``, ``result``, ``RSS``, ``SM``,
+        ``n_components``.
     """
     from ._core import IRIS as _IRIS  # noqa: PLC0415
     from ._core import IrisKernel as _IrisKernel  # noqa: PLC0415
@@ -311,14 +315,16 @@ def compare_kernel_models(
         kernel = _IrisKernel(dataset, kernel_fn, q=q)
         iris = _IRIS(reg_par=reg_par)
         iris.fit(dataset, kernel)
+        result = iris.result
 
         results.append(
             {
                 "kernel": name,
                 "iris": iris,
-                "RSS": iris.RSS,
-                "SM": iris.SM,
-                "n_components": iris.f.shape[0],
+                "result": result,
+                "RSS": result.RSS,
+                "SM": result.SM,
+                "n_components": result.f.shape[0],
             }
         )
 

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
@@ -807,6 +807,49 @@ class IRIS(DecompositionAnalysis):
     def SM(self):
         return self._outfit[2]
 
+    @property
+    def result(self):
+        """
+        Return the IRIS analysis result.
+
+        Returns
+        -------
+        AnalysisResult
+            Result containing the distribution, kernel, and regularization
+            diagnostics.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                "The fit method must be used before accessing the result"
+            )
+
+        from spectrochempy.analysis._base._result import AnalysisResult
+
+        return AnalysisResult(
+            estimator="IRIS",
+            parameters={
+                "qpsolver": self.qpsolver,
+                "reg_par": self.reg_par,
+                "warm_start": self._warm_start,
+                "regularization": self._regularization,
+                "search_reg": self._search_reg,
+            },
+            outputs={
+                "f": self.f,
+                "K": self.K,
+            },
+            diagnostics={
+                "RSS": self.RSS,
+                "SM": self.SM,
+                "lambdas": self.lambdas,
+            },
+        )
+
     def inverse_transform(self):  # override the decomposition method
         r"""
         Transform data back to the original space.

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -16,10 +16,12 @@ from spectrochempy_iris import iris_analysis_report
 from spectrochempy_iris import plot_distribution_grid
 from spectrochempy_iris import plot_kernel_comparison
 
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.api.plugins import PluginCapability
 from spectrochempy.api.plugins import PluginState
 from spectrochempy.api.plugins import check_plugin_compatibility
 from spectrochempy.testing.plugins import PluginTestHarness
+from spectrochempy.utils.exceptions import NotFittedError
 
 # ------------------------------------------------------------------
 # Test data helpers
@@ -48,6 +50,19 @@ def _make_test_dataset(n_spectra: int = 19, n_channels: int = 50) -> object:
         x=scp.Coord(wavenumbers, title="Wavenumber"),
     )
     return ds
+
+
+@pytest.fixture()
+def fitted_iris():
+    """Return a fitted IRIS estimator using a small synthetic dataset."""
+    from spectrochempy_iris import IRIS
+    from spectrochempy_iris import IrisKernel
+
+    ds = _make_test_dataset(n_spectra=8, n_channels=15)
+    kernel = IrisKernel(ds, "langmuir", q=[-6, 1, 6])
+    iris = IRIS()
+    iris.fit(ds, kernel)
+    return iris
 
 
 # ------------------------------------------------------------------
@@ -295,6 +310,56 @@ def test_iris_analysis_report():
     assert report["n_channels"] == ds.data.shape[-1]
 
 
+class TestIRISResult:
+    """IRIS follows the core runtime Result contract."""
+
+    def test_result_is_analysis_result(self, fitted_iris):
+        assert isinstance(fitted_iris.result, AnalysisResult)
+        assert fitted_iris.result.estimator == "IRIS"
+
+    def test_outputs_match_direct_accessors(self, fitted_iris):
+        result = fitted_iris.result
+        np.testing.assert_allclose(result.f.data, fitted_iris.f.data)
+        assert result.K is fitted_iris.K
+
+    def test_diagnostics_match_direct_accessors(self, fitted_iris):
+        result = fitted_iris.result
+        assert result.RSS is fitted_iris.RSS
+        assert result.SM is fitted_iris.SM
+        assert result.lambdas is fitted_iris.lambdas
+
+    def test_attribute_access_and_discovery(self, fitted_iris):
+        result = fitted_iris.result
+        assert set(result.outputs) == {"f", "K"}
+        assert set(result.diagnostics) == {"RSS", "SM", "lambdas"}
+        assert result.f is result.outputs["f"]
+        assert result.RSS is result.diagnostics["RSS"]
+        assert {"f", "K", "RSS", "SM", "lambdas"} <= set(dir(result))
+
+    def test_parameters_describe_solver_and_regularization(self, fitted_iris):
+        parameters = fitted_iris.result.parameters
+        assert parameters == {
+            "qpsolver": "osqp",
+            "reg_par": None,
+            "warm_start": False,
+            "regularization": False,
+            "search_reg": False,
+        }
+
+    def test_result_raises_before_fit(self):
+        from spectrochempy_iris import IRIS
+
+        with pytest.raises(NotFittedError):
+            _ = IRIS().result
+
+    def test_existing_direct_accessors_remain_available(self, fitted_iris):
+        assert fitted_iris.f.shape == (1, 6, 15)
+        assert fitted_iris.K.shape == (8, 6)
+        assert fitted_iris.q.size == 6
+        assert fitted_iris.RSS.shape == (1,)
+        assert fitted_iris.SM.shape == (1,)
+
+
 def test_batch_iris_analysis():
     """batch_iris_analysis runs IRIS on multiple datasets."""
     ds1 = _make_test_dataset(n_spectra=10, n_channels=20)
@@ -311,9 +376,13 @@ def test_batch_iris_analysis():
     assert results[1]["label"] == "high_pressure"
     for r in results:
         assert "iris" in r
+        assert "result" in r
         assert "f" in r
         assert "RSS" in r
         assert "SM" in r
+        assert r["f"] is r["result"].f
+        assert r["RSS"] is r["result"].RSS
+        assert r["SM"] is r["result"].SM
 
 
 def test_batch_iris_list_input():
@@ -340,6 +409,8 @@ def test_compare_kernel_models():
     assert results[1]["kernel"] == "ca"
     for r in results:
         assert "iris" in r
+        assert "result" in r
+        assert isinstance(r["result"], AnalysisResult)
         assert r["iris"]._fitted
 
 


### PR DESCRIPTION
## Summary

- Add `IRIS.result` using the existing `AnalysisResult` contract.
- Preserve all direct IRIS accessors and numerical behavior.
- Add Result forwarding to IRIS batch and kernel-comparison helpers.
- Update the IRIS documentation and Result alignment roadmaps.

## Result mapping

```python
result = iris.result
```

Outputs:

```python
result.f
result.K
```

Diagnostics:

```python
result.RSS
result.SM
result.lambdas
```

Parameters include the solver and regularization configuration.

`q` remains available through `iris.q`. It is not duplicated in Result because it is an input-domain coordinate already carried by `K.x` and `f.y`.

The reconstructed dataset is intentionally omitted to avoid hidden computation; users can continue to call `iris.inverse_transform()` explicitly.

## Backward compatibility

Existing APIs remain unchanged:

```python
iris.f
iris.K
iris.RSS
iris.SM
iris.q
```

Batch helpers preserve their historical keys and add a new `result` key:

```python
output["f"]
output["RSS"]
output["SM"]
output["result"]
```

## Out of scope

- No `IRISResult` subclass.
- No changes to fitting or numerical behavior.
- No caching or snapshot semantics.
- No Result persistence or Project integration.
- No CP/TENSOR migration.
- No IRIS vocabulary normalization.

## Validation

- Full IRIS plugin suite: 43 passed.
- Plugin API tests: 32 passed.
- Focused IRIS Result/helper tests: 9 passed.
- Core Result/PCA tests: 30 passed.
- Ruff check and format check passed.
- `git diff --check` passed.