### PR TITLE
MAINT: add CP.result and align the tensor plugin

### DIFF
--- a/docs/sources/userguide/plugins/tensor.rst
+++ b/docs/sources/userguide/plugins/tensor.rst
@@ -31,9 +31,13 @@ Use
 
     model = scp.tensor.CP(n_components=2)
     model.fit(dataset)
+    factors = model.result.factors
+    weights = model.result.weights
 
 The historical ``scp.CP`` alias is kept as a deprecated compatibility path.
 New code should use ``scp.tensor.CP``.
+Direct accessors such as ``model.A``, ``model.B``, ``model.C``, and
+``model.weights`` remain available.
 
 Extensibility
 =============

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -21,8 +21,8 @@ New Features
 
 - Result objects now provide attribute-style access to named outputs and
   diagnostics, for example `pca.result.scores`, `pca.result.loadings`, and
-  `pca.result.explained_variance`. The IRIS plugin now follows the same
-  contract through `iris.result`.
+  `pca.result.explained_variance`. The IRIS and TENSOR/CP plugins now follow
+  the same contract through `iris.result` and `cp.result`.
 
 - Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
   exchange using `scipy.io.savemat`. This is an exchange format, not

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -17,8 +17,8 @@ New Features
 
 - Result objects now provide attribute-style access to named outputs and
   diagnostics, for example `pca.result.scores`, `pca.result.loadings`, and
-  `pca.result.explained_variance`. The IRIS plugin now follows the same
-  contract through `iris.result`.
+  `pca.result.explained_variance`. The IRIS and TENSOR/CP plugins now follow
+  the same contract through `iris.result` and `cp.result`.
 
 - Added a minimal MATLAB `.mat` writer for simple numeric `NDDataset`
   exchange using `scipy.io.savemat`. This is an exchange format, not

--- a/maintainers/architecture/result-object-migration-roadmap.md
+++ b/maintainers/architecture/result-object-migration-roadmap.md
@@ -222,7 +222,7 @@ following alignment tasks should be completed:
 - align the remaining maintained stateful core candidates (`Baseline`,
   `LSTSQ`, and `NNLS`) or document them as explicit exceptions;
 - keep the completed IRIS plugin alignment covered by compatibility tests;
-- complete TENSOR/CP plugin alignment;
+- keep the completed TENSOR/CP plugin alignment covered by compatibility tests;
 - update analysis and official-plugin documentation to teach `.result`;
 - coordinate compatible IRIS and TENSOR releases before the core 0.11 release,
   because both plugins currently declare an upper core bound below 0.11.
@@ -237,8 +237,8 @@ and dataset persistence are sufficient for 0.11.
 1. Document the selected live, cached, or fit-time snapshot lifecycle semantics
    and publish the public Result type path.
 2. Complete Baseline, LSTSQ, and NNLS alignment.
-3. Complete TENSOR/CP plugin alignment and release compatible official plugins;
-   IRIS Result alignment is implemented.
+3. Keep IRIS and TENSOR/CP plugin alignment covered by compatibility tests and
+   release compatible official plugins.
 4. Update user documentation and remove only confirmed deprecated aliases.
 5. Keep Results runtime-only in 0.11, using dataset export and established
    dataset persistence when saved outputs are needed.

--- a/maintainers/rfcs/architecture-roadmap.md
+++ b/maintainers/rfcs/architecture-roadmap.md
@@ -33,8 +33,8 @@ This document should evolve as the project evolves.
   boundary, and the dataset-persistence boundary are clarified.
 - Result alignment remaining: public Result exports, Baseline, LSTSQ, NNLS,
   compatibility review, and documentation alignment.
-- Plugin alignment: IRIS now exposes `.result`; TENSOR/CP alignment, 0.11
-  compatibility testing, and compatible plugin releases remain.
+- Plugin alignment: IRIS and TENSOR/CP now expose `.result`; 0.11
+  compatibility testing and compatible plugin releases remain.
 - Lifecycle decision: the implementation is currently a live view. Retaining
   it, caching it, or adopting a fit-time snapshot remain open alternatives; no
   direction is currently preferred.

--- a/plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py
+++ b/plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py
@@ -702,6 +702,68 @@ class CP(DecompositionAnalysis):
 
         return X_hat
 
+    @property
+    def result(self):
+        """
+        Return the CP analysis result.
+
+        Returns
+        -------
+        AnalysisResult
+            Result containing the primary CP outputs and fit diagnostics.
+
+        Raises
+        ------
+        NotFittedError
+            If the estimator has not been fitted yet.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                "The fit method must be used before accessing the result"
+            )
+
+        from spectrochempy.analysis._base._result import AnalysisResult  # noqa: PLC0415
+
+        return AnalysisResult(
+            estimator="CP",
+            parameters={
+                "n_components": self.n_components,
+                "n_iter_max": self.n_iter_max,
+                "n_iter_max_inner": self.n_iter_max_inner,
+                "init": self.init,
+                "svd": self.svd,
+                "tol_outer": self.tol_outer,
+                "tol_inner": self.tol_inner,
+                "random_state": self.random_state,
+                "verbose": self.verbose,
+                "return_errors": self.return_errors,
+                "non_negative": self.non_negative,
+                "l1_reg": self.l1_reg,
+                "l2_reg": self.l2_reg,
+                "l2_square_reg": self.l2_square_reg,
+                "unimodality": self.unimodality,
+                "normalize": self.normalize,
+                "simplex": self.simplex,
+                "normalized_sparsity": self.normalized_sparsity,
+                "soft_sparsity": self.soft_sparsity,
+                "smoothness": self.smoothness,
+                "monotonicity": self.monotonicity,
+                "hard_sparsity": self.hard_sparsity,
+                "cvg_criterion": self.cvg_criterion,
+                "fixed_modes": self.fixed_modes,
+            },
+            outputs={
+                "factors": self.loadings,
+                "weights": self.weights,
+            },
+            diagnostics={
+                "errors": self.errors,
+                "SSE": self.SSE,
+                "explained_variance": self.explained_variance,
+                "core_consistency": self.core_consistency,
+            },
+        )
+
     # ----------------------------------------------------------------------------------
     # Public properties
     # ----------------------------------------------------------------------------------

--- a/plugins/spectrochempy-tensor/tests/test_tensor_cp.py
+++ b/plugins/spectrochempy-tensor/tests/test_tensor_cp.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from spectrochempy.analysis._base._analysisbase import NotFittedError
+from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy_tensor import CP
@@ -249,6 +250,103 @@ class TestCP:
         # Need to compare .data since components returns NDDataset
         np.testing.assert_array_equal(cp.components.data, cp.B.data)
 
+    def test_cp_result_is_analysis_result(self):
+        """Test result property returns an AnalysisResult."""
+        ds = _make_synthetic_3d()
+        cp = CP(n_components=2)
+        cp.fit(ds)
+
+        result = cp.result
+
+        assert isinstance(result, AnalysisResult)
+        assert result.estimator == "CP"
+
+    def test_cp_result_outputs_match_properties(self):
+        """Test result outputs use the same public accessors as CP properties."""
+        ds = _make_synthetic_3d()
+        cp = CP(n_components=2)
+        cp.fit(ds)
+
+        result = cp.result
+
+        assert result.factors == cp.loadings
+        assert result.weights is cp.weights
+        assert result.factors[0] is cp.A
+        assert result.factors[1] is cp.B
+        assert result.factors[2] is cp.C
+
+    def test_cp_result_diagnostics_match_properties(self):
+        """Test result diagnostics expose the current CP metrics."""
+        ds = _make_synthetic_3d()
+        cp = CP(n_components=2, return_errors=True)
+        cp.fit(ds)
+
+        result = cp.result
+
+        assert result.errors is cp.errors
+        assert result.SSE == cp.SSE
+        assert result.explained_variance == cp.explained_variance
+        assert result.core_consistency == cp.core_consistency
+
+    def test_cp_result_attribute_access_and_dir(self):
+        """Test attribute-style result access and discovery."""
+        ds = _make_synthetic_3d()
+        cp = CP(n_components=2)
+        cp.fit(ds)
+
+        result = cp.result
+
+        assert result.factors == result.outputs["factors"]
+        assert result.weights is result.outputs["weights"]
+        assert result.SSE == result.diagnostics["SSE"]
+        assert result.explained_variance == result.diagnostics["explained_variance"]
+        names = dir(result)
+        assert "factors" in names
+        assert "weights" in names
+        assert "SSE" in names
+        assert "explained_variance" in names
+
+    def test_cp_result_parameters(self):
+        """Test result parameters expose the main CP configuration."""
+        cp = CP(
+            n_components=2,
+            init="random",
+            svd="randomized_svd",
+            tol_outer=1.0e-6,
+            tol_inner=1.0e-5,
+            cvg_criterion="rec_error",
+            fixed_modes=[0],
+            return_errors=True,
+        )
+        cp.fit(_make_synthetic_3d())
+
+        assert cp.result.parameters == {
+            "n_components": 2,
+            "n_iter_max": 100,
+            "n_iter_max_inner": 10,
+            "init": "random",
+            "svd": "randomized_svd",
+            "tol_outer": 1.0e-6,
+            "tol_inner": 1.0e-5,
+            "random_state": None,
+            "verbose": 0,
+            "return_errors": True,
+            "non_negative": False,
+            "l1_reg": None,
+            "l2_reg": None,
+            "l2_square_reg": None,
+            "unimodality": None,
+            "normalize": None,
+            "simplex": None,
+            "normalized_sparsity": None,
+            "soft_sparsity": None,
+            "smoothness": None,
+            "monotonicity": None,
+            "hard_sparsity": None,
+            "cvg_criterion": "rec_error",
+            "fixed_modes": [0],
+        }
+
     def test_cp_not_fitted_error(self):
         """Test that properties raise NotFittedError when not fitted."""
         cp = CP(n_components=2)
@@ -265,6 +363,8 @@ class TestCP:
             _ = cp.explained_variance
         with pytest.raises(NotFittedError):
             _ = cp.core_consistency
+        with pytest.raises(NotFittedError):
+            _ = cp.result
 
     def test_cp_svd_options(self):
         """Test different svd options."""


### PR DESCRIPTION
## Summary

This PR aligns the official TENSOR plugin with the existing runtime Result contract by adding `CP.result` as an `AnalysisResult`.

The new Result groups the current public CP outputs and diagnostics without changing CP fitting behavior, numerical behavior, reconstruction behavior, or plugin architecture.

Mapping used in this PR:

- `parameters`
  - core CP configuration and public constraint / regularization settings
- `outputs`
  - `factors`
  - `weights`
- `diagnostics`
  - `errors`
  - `SSE`
  - `explained_variance`
  - `core_consistency`

The Result is built from the existing public CP accessors, so direct access and Result access share the same source of truth.

## Out of scope

- no `CPResult` subclass
- no Result persistence
- no Project integration
- no caching or snapshot semantics
- no tensor architecture redesign
- no migration of other tensor algorithms

## Notes

A reconstructed dataset was deliberately not added to `cp.result`; `inverse_transform()` remains the explicit reconstruction path.

`components` remains a public compatibility alias on `CP`, but the canonical Result outputs use tensor-native naming (`factors`, `weights`).


## Follow-up

The remaining Result alignment work is now mainly:
- public Result exports
- Baseline / LSTSQ / NNLS alignment
- compatibility review
- official plugin release coordination for 0.11 compatibility