### PR TITLE
DOC: promote .result in examples and reduce gallery repr noise

### DIFF
--- a/docs/sources/gettingstarted/quickstart.py
+++ b/docs/sources/gettingstarted/quickstart.py
@@ -253,7 +253,7 @@ blc.n_components = 5
 # Apply correction
 
 # %%
-blc.fit(smoothed)
+_ = blc.fit(smoothed)
 _ = blc.corrected.plot()
 
 # %% [markdown]

--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -71,7 +71,7 @@ d = scp.fromfunction(
 # %%
 prefs = scp.preferences
 prefs.figure.figsize = (7, 3)
-d.plot_scatter(markersize=7, mfc="red", label="Original data")
+_ = d.plot_scatter(markersize=7, mfc="red", label="Original data")
 
 # %% [markdown]
 # We want to fit a line through these data-points of equation
@@ -85,13 +85,13 @@ d.plot_scatter(markersize=7, mfc="red", label="Original data")
 
 # %%
 lst = scp.LSTSQ()
-lst.fit(time, d)
+_ = lst.fit(time, d)
 
 v, d0 = lst.coef, lst.intercept
 print(f"speed : {v:.3f},  distance at time 0 : {d0:.3f}")
 
 dfit = lst.predict()
-dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
+_ = dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
 
 
 # %% [markdown]
@@ -105,14 +105,14 @@ dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
 
 # %%
 lst = scp.LSTSQ()
-lst.fit(d)
+_ = lst.fit(d)
 v, d0 = lst.coef, lst.intercept
 
 # %% [markdown]
 # and the final plot
 
 # %%
-d.plot_scatter(
+_ = d.plot_scatter(
     markersize=7,
     mfc="red",
     mec="black",
@@ -120,7 +120,7 @@ d.plot_scatter(
     title=f"Linear regression, $r^2={lst.score(): .3f} ",
 )
 dfit = lst.predict()
-dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
+_ = dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
 
 
 # %% [markdown]
@@ -147,7 +147,7 @@ d2 = scp.NDDataset.fromfunction(
     title="distance travelled",
 )
 
-d2.plot_scatter(markersize=7, mfc="red")
+_ = d2.plot_scatter(markersize=7, mfc="red")
 
 # %% [markdown]
 # Now we must use the first syntax LSTQ(X, Y) as the variation is not proportional
@@ -156,13 +156,13 @@ d2.plot_scatter(markersize=7, mfc="red")
 # %%
 X = time**2
 lst = scp.LSTSQ()
-lst.fit(X, d2)
+_ = lst.fit(X, d2)
 
 v, d0 = lst.coef, lst.intercept
 print(f"acceleration : {v:.3f},  distance at time 0 : {d0:.3f}")
 
 # %%
-d2.plot_scatter(
+_ = d2.plot_scatter(
     markersize=7,
     mfc="red",
     mec="black",
@@ -171,7 +171,7 @@ d2.plot_scatter(
 )
 dfit = lst.predict()
 
-dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
+_ = dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
 
 # %% [markdown]
 # ## Least square with non-negativity constraint (NNLS)
@@ -186,13 +186,13 @@ dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
 # %%
 X = time**2
 nls = scp.NNLS()
-nls.fit(X, d2)
+_ = nls.fit(X, d2)
 
 v, d0 = lst.coef, lst.intercept
 print(f"acceleration : {v: .3f},  distance at time 0 : {d0: .3f}")
 
 # %%
-d2.plot_scatter(
+_ = d2.plot_scatter(
     markersize=7,
     mfc="red",
     mec="black",
@@ -201,7 +201,7 @@ d2.plot_scatter(
 )
 dfit = lst.predict()
 
-dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
+_ = dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="best")
 
 # %% [markdown]
 # ## NDDataset modelling using non-linear optimisation method
@@ -440,16 +440,25 @@ f1 = scp.Optimize(log_level="INFO")
 f1.script = script
 f1.max_iter = 2000
 # f1.autobase = True
-f1.fit(ndOHcorr)
+_ = f1.fit(ndOHcorr)
+
+# %%
+fitted = f1.result.fitted
+components = f1.result.components
+
+# %% [markdown]
+# `f1.result` groups fitted outputs and diagnostics without removing the
+# existing direct estimator surface. Direct access such as `f1.components`,
+# `f1.predict()`, and plotting helpers remains supported.
 
 # Show the result
 _ = ndOHcorr.plot()
-ax = (f1.components[:]).plot(clear=False)
+ax = (components[:]).plot(clear=False)
 ax.autoscale(enable=True, axis="y")
 
 # plotmerit
-som = f1.inverse_transform()
-f1.plotmerit(offset=0, kind="scatter")
+som = fitted
+_ = f1.plotmerit(offset=0, kind="scatter")
 
 
 # %% [markdown]

--- a/docs/sources/userguide/analysis/mcr_als.py
+++ b/docs/sources/userguide/analysis/mcr_als.py
@@ -159,7 +159,7 @@ mcr = scp.MCRALS(log_level="INFO")
 # so we have a summary of the ALS iterations
 
 # %%
-mcr.fit(X, St0)
+_ = mcr.fit(X, St0)
 
 # %% [markdown]
 # The optimization has converged within few iterations. The figures reported for each
@@ -184,7 +184,7 @@ mcr.fit(X, St0)
 
 # %%
 mcr.tol = 0.01
-mcr.fit(X, St0)
+_ = mcr.fit(X, St0)
 
 # %% [markdown]
 # As could be expected more iterations have been necessary to reach this stricter
@@ -200,7 +200,7 @@ mcr.fit(X, St0)
 
 # %%
 mcr.tol = 0.001
-mcr.fit(X, St0)
+_ = mcr.fit(X, St0)
 
 # %% [markdown]
 # #### More information about the MCRALS estimator
@@ -257,7 +257,16 @@ _ = mcr1.St.plot(clear=False, cmap=None, color="blue")
 
 # %%
 mcr1 = scp.MCRALS()
-mcr1.fit(X, St0)
+_ = mcr1.fit(X, St0)
+
+# %%
+C = mcr1.result.C
+St = mcr1.result.components
+
+# %% [markdown]
+# The grouped `.result` view is convenient when the fitted outputs are consumed
+# together. Historical direct access through `mcr1.C` and `mcr1.St` remains
+# available in this release.
 
 # %% [markdown]
 # As the dimensions of C are such that the rows' direction (C.y) corresponds to the
@@ -267,13 +276,13 @@ mcr1.fit(X, St0)
 # to plot the concentration vs. the elution time.
 
 # %%
-_ = mcr1.C.T.plot()
+_ = C.T.plot()
 
 # %% [markdown]
 # On the other hand, the spectra of the pure species can be plotted directly:
 
 # %%
-_ = mcr1.St.plot()
+_ = St.plot()
 
 # %% [markdown]
 # #### A basic illustration of the rotational ambiguity
@@ -295,10 +304,10 @@ _ = mcr1.St.plot()
 
 # %%
 mcr2 = scp.MCRALS(normSpec="euclid")
-mcr2.fit(X, St0)
+_ = mcr2.fit(X, St0)
 
 mcr3 = scp.MCRALS(normSpec="max")
-mcr3.fit(X, St0)
+_ = mcr3.fit(X, St0)
 
 _ = mcr1.St.plot()
 _ = mcr2.St.plot()
@@ -334,7 +343,7 @@ _ = mcr3.C.T.plot()
 
 # %%
 pca = scp.PCA(n_components=8)
-pca.fit(X)
+_ = pca.fit(X)
 pca.printev()
 _ = pca.screeplot()
 
@@ -363,7 +372,7 @@ _ = scores.T.plot()
 
 # %%
 efa = scp.EFA()
-efa.fit(X)
+_ = efa.fit(X)
 efa.n_components = 4
 C0 = efa.transform()
 _ = C0.T.plot()
@@ -373,7 +382,7 @@ _ = C0.T.plot()
 
 # %%
 mcr4 = scp.MCRALS(max_iter=100, normSpec="euclid")
-mcr4.fit(X, C0)
+_ = mcr4.fit(X, C0)
 
 # %%
 _ = mcr4.C.T.plot()
@@ -402,7 +411,7 @@ _ = X2.plot(method="map")
 
 # %%
 mcr5 = scp.MCRALS(unimodConc=[])
-mcr5.fit(X2, St0)
+_ = mcr5.fit(X2, St0)
 
 # %%
 _ = mcr5.C.T.plot()

--- a/docs/sources/userguide/analysis/pca.py
+++ b/docs/sources/userguide/analysis/pca.py
@@ -101,7 +101,7 @@ surf = X.plot_surface(linewidth=0.0)
 # First, we create a PCA object with default parameters and we compute the components with the fit() method:
 # %%
 pca = scp.PCA()
-pca.fit(X)
+_ = pca.fit(X)
 
 # %% [markdown]
 # The default number of components is given by min(X.shape). As often in spectroscopy
@@ -115,17 +115,17 @@ pca.n_components
 # This can be done by either reseting the number of components of an existing object:
 # %%
 pca.n_components = 8
-pca.fit(X)
+_ = pca.fit(X)
 
 # %% [markdown]
 # Or directly by creating a PCA instance with the desired number of components:
 # %%
 pca = scp.PCA(n_components=8)
-pca.fit(X)
+_ = pca.fit(X)
 
 # %% [markdown]
-# The grouped PCA outputs are available from `pca.result`. Named outputs and
-# diagnostics use direct attribute access in normal user code:
+# The grouped PCA outputs are available from `pca.result`. This is the most
+# convenient grouped API when you want related fitted outputs together:
 # %%
 scores = pca.result.scores
 loadings = pca.result.loadings
@@ -135,7 +135,8 @@ variance = pca.result.explained_variance
 # The mapping form, such as `pca.result.outputs["scores"]`, remains available
 # for introspection and programmatic access. Historical direct estimator
 # accessors such as `pca.scores`, `pca.loadings`, and `pca.transform()` also
-# remain supported.
+# remain supported in this release, so `.result` is promoted without being
+# mandatory.
 
 # %% [markdown]
 # The choice of the optimum number of components to describe a dataset is always a delicate matter. It can be based on:
@@ -177,8 +178,8 @@ _ = pca.loadings.plot()
 # the `plotmerit()` method which plots both $X$, $\hat{X}$ (in orange) and the residuals (in grey):
 # %%
 pca = scp.PCA(n_components=4)
-pca.fit(X)
-pca.plot_merit()
+_ = pca.fit(X)
+_ = pca.plot_merit()
 
 
 # %% [markdown]

--- a/docs/sources/userguide/analysis/pls.py
+++ b/docs/sources/userguide/analysis/pls.py
@@ -115,18 +115,16 @@ pls = scp.PLSRegression(n_components=5)
 _ = pls.fit(X_train, y_train)
 
 # %% [markdown]
-# Grouped fitted outputs are also available from `pls.result`:
-# %%
-x_loadings = pls.result.x_loadings
-_ = pls.result.coef
-
-# %% [markdown]
-# Historical direct estimator attributes such as `pls.x_loadings` and
-# `pls.coef` remain supported, and `score()` stays an estimator method because
-# it depends on the evaluation data. Let's for instance plot the $S_X$ matrix:
+# Grouped fitted outputs are also available from `pls.result`, for example
+# `pls.result.x_loadings` and `pls.result.coef`.
+#
+# In this example we keep using the direct estimator surface, which remains
+# supported in this release. In particular, `score()` stays an estimator method
+# because it depends on the evaluation data. Let's for instance plot the
+# $S_X$ matrix:
 
 # %%
-_ = x_loadings.plot()
+_ = pls.x_loadings.plot()
 
 # %% [markdown]
 # Once fitted, the PLS model can be used to predict the property values of another dataset, for instance:

--- a/docs/sources/userguide/analysis/pls.py
+++ b/docs/sources/userguide/analysis/pls.py
@@ -115,11 +115,18 @@ pls = scp.PLSRegression(n_components=5)
 _ = pls.fit(X_train, y_train)
 
 # %% [markdown]
-# The scores and loading matrices are stored in the `x_scores`,`x_loadings`, `y_scores` and `y_loadings`
-# attributes. Let's for instance, plot the $S_X$ matrix:
+# Grouped fitted outputs are also available from `pls.result`:
+# %%
+x_loadings = pls.result.x_loadings
+_ = pls.result.coef
+
+# %% [markdown]
+# Historical direct estimator attributes such as `pls.x_loadings` and
+# `pls.coef` remain supported, and `score()` stays an estimator method because
+# it depends on the evaluation data. Let's for instance plot the $S_X$ matrix:
 
 # %%
-_ = pls.x_loadings.plot()
+_ = x_loadings.plot()
 
 # %% [markdown]
 # Once fitted, the PLS model can be used to predict the property values of another dataset, for instance:

--- a/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
+++ b/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
@@ -56,8 +56,13 @@ print(f"Loaded dataset: {ds}")
 
 K = ds.iris.kernel_matrix(kernel_type="langmuir", q=[-7, -1, 50])
 iris_analysis = scp.iris.IRIS(reg_par=[-10, 1, 12])
-iris_analysis.fit(ds, K)
+_ = iris_analysis.fit(ds, K)
 
-_ = iris_analysis.f[-7].plot_contour(colorbar=True)
+# %%
+# Grouped fitted outputs are also available from `iris_analysis.result`, while
+# direct access such as `iris_analysis.f` remains supported.
+f = iris_analysis.result.f
+
+_ = f[-7].plot_contour(colorbar=True)
 
 # scp.show()

--- a/plugins/spectrochempy-iris/examples/plot_iris.py
+++ b/plugins/spectrochempy-iris/examples/plot_iris.py
@@ -113,11 +113,18 @@ kernel
 
 # %%
 # Now we fit the model - we can pass either the Kernel object or the kernel NDDataset
-iris1.fit(X_, K)
+_ = iris1.fit(X_, K)
+
+# %%
+# Grouped fitted outputs are also available from `iris1.result`. Historical
+# direct access such as `iris1.f`, `iris1.K`, `iris1.RSS`, and `iris1.SM`
+# remains supported.
+f = iris1.result.f
+_ = iris1.result.K
 
 # %%
 # Plots the results
-_ = iris1.f.plot_contour()
+_ = f.plot_contour()
 
 # %%
 _ = iris1.plotmerit()
@@ -129,7 +136,7 @@ iris2 = IRIS(reg_par=[-10, 1, 12])
 
 # %%
 # We keep the same kernel object as previously - performs the fit.
-iris2.fit(X_, K)
+_ = iris2.fit(X_, K)
 _ = iris2.plotlcurve(title="L curve, manual search")
 # %%
 # Visually, the best regularization parameter is at index ~ -6, corresponding to lambda = 1e-4
@@ -143,7 +150,7 @@ _ = iris2.plotmerit(-6)
 # Now try an automatic search of the regularization parameter around the best value found manually:
 
 iris3 = IRIS(log_level="INFO", reg_par=[-6, -2])
-iris3.fit(X_, K)
+_ = iris3.fit(X_, K)
 _ = iris3.plotlcurve(title="L curve, automated search")
 # %%
 # The data corresponding to the largest curvature of the L-curve

--- a/plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py
+++ b/plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py
@@ -181,8 +181,8 @@ class CP(DecompositionAnalysis):
     >>> X = np.random.rand(6, 8, 10)
     >>> ds = scp.NDDataset(X)
     >>> cp = scp.tensor.CP(n_components=2)
-    >>> cp.fit(ds)
-    >>> A, B, C = cp.loadings
+    >>> _ = cp.fit(ds)
+    >>> A, B, C = cp.result.factors
     >>> Xr = cp.inverse_transform()
     """
 


### PR DESCRIPTION
## Summary

This documentation-only PR improves the user-facing examples after the completed Result Alignment campaign.

It does two narrow things:

- promotes `.result` in selected high-visibility examples as the grouped runtime Result contract;
- reduces unhelpful notebook/gallery `_repr_` output by using `_ = ...` where the returned object is not pedagogically useful.

No runtime code, tests, public API, or behavior are changed.

## What changed

### 1. Result examples

Selected examples now present `.result` as the convenient grouped-output API for fitted estimator-style objects, while explicitly preserving the current release posture:

- direct estimator attributes remain supported;
- `.result` is promoted but not made mandatory;
- estimator methods such as `score()` remain documented as methods when they are evaluation-time operations rather than stored fitted outputs.

This was applied to examples around:

- `PCA`
- `MCRALS`
- `Optimize`
- official `IRIS` examples
- the `CP` example snippet

For `PLSRegression`, `.result` is mentioned in prose, but the executable example still uses the direct estimator surface. This keeps the tutorial aligned with the current release posture and avoids introducing a runtime-facing fix in a documentation-only PR.

### 2. Gallery / notebook repr cleanup

Selected bare calls were changed to `_ = ...` where the returned object display was not useful, especially for:

- `fit()` calls in examples;
- plotting calls where only the figure matters.

This keeps notebook and gallery output cleaner without changing the example logic.

## Files modified

- `docs/sources/gettingstarted/quickstart.py`
- `docs/sources/userguide/analysis/fitting.py`
- `docs/sources/userguide/analysis/mcr_als.py`
- `docs/sources/userguide/analysis/pca.py`
- `docs/sources/userguide/analysis/pls.py`
- `plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py`
- `plugins/spectrochempy-iris/examples/plot_iris.py`
- `plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py`

## Validation

- `git diff --check`
- `conda run -n scpy-core python -m py_compile docs/sources/userguide/analysis/pca.py docs/sources/userguide/analysis/pls.py docs/sources/userguide/analysis/mcr_als.py docs/sources/userguide/analysis/fitting.py docs/sources/gettingstarted/quickstart.py plugins/spectrochempy-iris/examples/plot_iris.py plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py`

## Notes

- This PR does not introduce any deprecation of direct estimator attributes.
- It does not make `.result` mandatory in the current release.