### PR TITLE
TEST: consolidate shared Result test helpers and fixtures

### DIFF
--- a/tests/test_analysis/result_test_helpers.py
+++ b/tests/test_analysis/result_test_helpers.py
@@ -1,0 +1,40 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+"""Small shared helpers for Result-related tests.
+
+These helpers intentionally stay lightweight. They cover only the repeated
+runtime Result contract checks that are common across many estimator test
+files.
+"""
+
+
+def assert_result_basics(fitted, expected_type, estimator_name):
+    """Assert the generic runtime Result contract for a fitted estimator."""
+    result = fitted.result
+    assert isinstance(result, expected_type)
+    assert result.estimator == estimator_name
+    assert fitted.result is not fitted.result, (
+        f"{expected_type.__name__} is recreated on every access; "
+        "change this assertion if caching is added later"
+    )
+    text = repr(result)
+    assert estimator_name in text
+    return result
+
+
+def assert_result_raises_before_fit(estimator, exc_type):
+    """Assert that `.result` is unavailable before fitting."""
+    import pytest
+
+    with pytest.raises(exc_type):
+        _ = estimator.result
+
+
+def assert_fit_returns_self(estimator, *fit_args):
+    """Assert that fit() preserves the estimator-returning convention."""
+    ret = estimator.fit(*fit_args)
+    assert ret is estimator

--- a/tests/test_analysis/result_test_helpers.py
+++ b/tests/test_analysis/result_test_helpers.py
@@ -4,7 +4,8 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 
-"""Small shared helpers for Result-related tests.
+"""
+Small shared helpers for Result-related tests.
 
 These helpers intentionally stay lightweight. They cover only the repeated
 runtime Result contract checks that are common across many estimator test

--- a/tests/test_analysis/test_base/test_result_base.py
+++ b/tests/test_analysis/test_base/test_result_base.py
@@ -1,0 +1,149 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Tests for the shared Result object infrastructure.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis._base._result import FitResult
+from spectrochempy.analysis._base._result import ResultBase
+
+
+class TestResultBase:
+    def test_minimal_creation(self):
+        result = ResultBase(estimator="TestEstimator")
+        assert result.estimator == "TestEstimator"
+        assert result.outputs == {}
+        assert result.diagnostics == {}
+        assert result.parameters == {}
+
+    def test_with_outputs_and_diagnostics(self):
+        result = ResultBase(
+            estimator="Test",
+            outputs={"a": np.ones(3), "b": np.ones((2, 3))},
+            diagnostics={"d": np.array([1.0, 2.0])},
+        )
+        assert "a" in result.outputs
+        assert "b" in result.outputs
+        assert "d" in result.diagnostics
+
+    def test_output_attribute_access(self):
+        scores = np.ones((2, 3))
+        concentrations = object()
+        spectra = object()
+        result = ResultBase(
+            estimator="Test",
+            outputs={"scores": scores, "C": concentrations, "St": spectra},
+        )
+        assert result.scores is result.outputs["scores"]
+        assert result.C is result.outputs["C"]
+        assert result.St is result.outputs["St"]
+
+    def test_diagnostic_attribute_access(self):
+        variance = np.array([2.0, 1.0])
+        result = ResultBase(
+            estimator="Test",
+            diagnostics={"explained_variance": variance},
+        )
+        assert result.explained_variance is result.diagnostics["explained_variance"]
+
+    def test_missing_attribute_raises_attribute_error(self):
+        result = ResultBase(estimator="Test")
+        with pytest.raises(
+            AttributeError,
+            match="ResultBase object has no attribute 'missing'",
+        ):
+            _ = result.missing
+
+    def test_existing_attributes_are_not_shadowed(self):
+        result = ResultBase(
+            estimator="Test",
+            parameters={"alpha": 1},
+            outputs={
+                "outputs": "shadowed outputs",
+                "diagnostics": "shadowed diagnostics",
+                "parameters": "shadowed parameters",
+                "estimator": "shadowed estimator",
+            },
+        )
+        assert result.outputs["outputs"] == "shadowed outputs"
+        assert result.diagnostics == {}
+        assert result.parameters == {"alpha": 1}
+        assert result.estimator == "Test"
+
+    def test_output_wins_over_diagnostic(self):
+        output = object()
+        diagnostic = object()
+        result = ResultBase(
+            estimator="Test",
+            outputs={"shared": output},
+            diagnostics={"shared": diagnostic},
+        )
+        assert result.shared is output
+
+    def test_parameters_are_not_exposed_as_attributes(self):
+        result = ResultBase(estimator="Test", parameters={"alpha": 1})
+        with pytest.raises(AttributeError):
+            _ = result.alpha
+
+    def test_dir_includes_outputs_and_diagnostics_but_not_parameters(self):
+        result = ResultBase(
+            estimator="Test",
+            parameters={"alpha": 1},
+            outputs={"scores": object(), "not-valid": object()},
+            diagnostics={"explained_variance": object()},
+        )
+        names = dir(result)
+        assert "scores" in names
+        assert "explained_variance" in names
+        assert "alpha" not in names
+        assert "not-valid" not in names
+
+    def test_repr(self):
+        result = ResultBase(
+            estimator="Test",
+            outputs={"x": np.ones((3, 4))},
+            diagnostics={"y": np.ones(2)},
+        )
+        text = repr(result)
+        assert "ResultBase" in text
+        assert "Test" in text
+        assert "x" in text
+        assert "(3, 4)" in text
+        assert "y" in text
+
+
+class TestAnalysisResult:
+    def test_creation(self):
+        result = AnalysisResult(estimator="PCA")
+        assert isinstance(result, AnalysisResult)
+        assert isinstance(result, ResultBase)
+
+    def test_repr(self):
+        result = AnalysisResult(
+            estimator="PCA",
+            outputs={"scores": np.ones((6, 5))},
+            diagnostics={"explained_variance": np.ones(5)},
+        )
+        text = repr(result)
+        assert "AnalysisResult" in text
+        assert "PCA" in text
+
+
+class TestFitResult:
+    def test_creation(self):
+        result = FitResult(estimator="Optimize")
+        assert isinstance(result, FitResult)
+        assert isinstance(result, ResultBase)
+
+    def test_inherits_attribute_access(self):
+        fitted = object()
+        result = FitResult(estimator="Optimize", outputs={"fitted": fitted})
+        assert result.fitted is fitted

--- a/tests/test_analysis/test_curvefitting/conftest.py
+++ b/tests/test_analysis/test_curvefitting/conftest.py
@@ -1,0 +1,66 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis.curvefitting._models import asymmetricvoigtmodel
+
+
+@pytest.fixture()
+def optimize_script():
+    return """
+
+    #-----------------------------------------------------------
+    # syntax for parameters definition :
+    # name : value, low_bound,  high_bound
+    #  * for fixed parameters
+    #  $ for variable parameters
+    #  > for reference to a parameter in the COMMON block
+    #    (> is forbidden in the COMMON block)
+    # common block parameters should not have a _ in their names
+    #-----------------------------------------------------------
+    #
+    COMMON:
+    # common parameters ex.
+    # $ gwidth: 1.0, 0.0, none
+    $ gratio: 0.1, 0.0, 1.0
+
+    MODEL: LINE_1
+    shape: asymmetricvoigtmodel
+        * ampl:  1.0, 0.0, none
+        $ pos:   3620, 3400.0, 3700.0
+        $ ratio: 0.0147, 0.0, 1.0
+        $ asym: 0.1, 0, 1
+        $ width: 200, 0, 1000
+
+    MODEL: LINE_2
+    shape: asymmetricvoigtmodel
+        $ ampl:  0.2, 0.0, none
+        $ pos:   3520, 3400.0, 3700.0
+        > ratio: gratio
+        $ asym: 0.1, 0, 1
+        $ width: 200, 0, 1000
+    """
+
+
+@pytest.fixture()
+def synthetic_two_peak_dataset():
+    x = scp.Coord(np.linspace(3700.0, 3400.0, 301), title="wavenumber", units="cm^-1")
+    model = asymmetricvoigtmodel()
+    y = (
+        model.f(x.data, ampl=1.0, pos=3620.0, width=200.0, ratio=0.0147, asym=0.1)
+        + model.f(x.data, ampl=0.2, pos=3520.0, width=200.0, ratio=0.1, asym=0.1)
+        + 0.0002 * x.data
+        - 0.5
+    )
+    return scp.NDDataset(
+        y,
+        coordset=[x],
+        units="absorbance",
+        title="synthetic optimize spectrum",
+    )

--- a/tests/test_analysis/test_curvefitting/test_optimize.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize.py
@@ -5,74 +5,16 @@
 # ======================================================================================
 # ruff: noqa
 
-import numpy as np
-import pytest
 from numpy.testing import assert_allclose
 
 import spectrochempy as scp
-from spectrochempy.analysis.curvefitting._models import asymmetricvoigtmodel
 
 
-@pytest.fixture()
-def script():
-    return """
-
-    #-----------------------------------------------------------
-    # syntax for parameters definition :
-    # name : value, low_bound,  high_bound
-    #  * for fixed parameters
-    #  $ for variable parameters
-    #  > for reference to a parameter in the COMMON block
-    #    (> is forbidden in the COMMON block)
-    # common block parameters should not have a _ in their names
-    #-----------------------------------------------------------
-    #
-    COMMON:
-    # common parameters ex.
-    # $ gwidth: 1.0, 0.0, none
-    $ gratio: 0.1, 0.0, 1.0
-
-    MODEL: LINE_1
-    shape: asymmetricvoigtmodel
-        * ampl:  1.0, 0.0, none
-        $ pos:   3620, 3400.0, 3700.0
-        $ ratio: 0.0147, 0.0, 1.0
-        $ asym: 0.1, 0, 1
-        $ width: 200, 0, 1000
-
-    MODEL: LINE_2
-    shape: asymmetricvoigtmodel
-        $ ampl:  0.2, 0.0, none
-        $ pos:   3520, 3400.0, 3700.0
-        > ratio: gratio
-        $ asym: 0.1, 0, 1
-        $ width: 200, 0, 1000
-    """
-
-
-@pytest.fixture()
-def synthetic_two_peak_dataset():
-    x = scp.Coord(np.linspace(3700.0, 3400.0, 301), title="wavenumber", units="cm^-1")
-    model = asymmetricvoigtmodel()
-    y = (
-        model.f(x.data, ampl=1.0, pos=3620.0, width=200.0, ratio=0.0147, asym=0.1)
-        + model.f(x.data, ampl=0.2, pos=3520.0, width=200.0, ratio=0.1, asym=0.1)
-        + 0.0002 * x.data
-        - 0.5
-    )
-    return scp.NDDataset(
-        y,
-        coordset=[x],
-        units="absorbance",
-        title="synthetic optimize spectrum",
-    )
-
-
-def test_fit_single_dataset(synthetic_two_peak_dataset, script):
+def test_fit_single_dataset(synthetic_two_peak_dataset, optimize_script):
     dataset = synthetic_two_peak_dataset
 
     f1 = scp.Optimize()
-    f1.script = script
+    f1.script = optimize_script
     f1.autobase = True
     f1.max_iter = 10
     result = f1.fit(dataset)

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -9,71 +9,14 @@ Tests for the Optimize FitResult prototype.
 """
 
 import numpy as np
-import pytest
 
 import spectrochempy as scp
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis._base._result import ResultBase
-from spectrochempy.analysis.curvefitting._models import asymmetricvoigtmodel
-
-
-# ======================================================================================
-# Fixtures (same as test_optimize.py)
-# ======================================================================================
-@pytest.fixture()
-def script():
-    return """
-
-    #-----------------------------------------------------------
-    # syntax for parameters definition :
-    # name : value, low_bound,  high_bound
-    #  * for fixed parameters
-    #  $ for variable parameters
-    #  > for reference to a parameter in the COMMON block
-    #    (> is forbidden in the COMMON block)
-    # common block parameters should not have a _ in their names
-    #-----------------------------------------------------------
-    #
-    COMMON:
-    # common parameters ex.
-    # $ gwidth: 1.0, 0.0, none
-    $ gratio: 0.1, 0.0, 1.0
-
-    MODEL: LINE_1
-    shape: asymmetricvoigtmodel
-        * ampl:  1.0, 0.0, none
-        $ pos:   3620, 3400.0, 3700.0
-        $ ratio: 0.0147, 0.0, 1.0
-        $ asym: 0.1, 0, 1
-        $ width: 200, 0, 1000
-
-    MODEL: LINE_2
-    shape: asymmetricvoigtmodel
-        $ ampl:  0.2, 0.0, none
-        $ pos:   3520, 3400.0, 3700.0
-        > ratio: gratio
-        $ asym: 0.1, 0, 1
-        $ width: 200, 0, 1000
-    """
-
-
-@pytest.fixture()
-def synthetic_two_peak_dataset():
-    x = scp.Coord(np.linspace(3700.0, 3400.0, 301), title="wavenumber", units="cm^-1")
-    model = asymmetricvoigtmodel()
-    y = (
-        model.f(x.data, ampl=1.0, pos=3620.0, width=200.0, ratio=0.0147, asym=0.1)
-        + model.f(x.data, ampl=0.2, pos=3520.0, width=200.0, ratio=0.1, asym=0.1)
-        + 0.0002 * x.data
-        - 0.5
-    )
-    return scp.NDDataset(
-        y,
-        coordset=[x],
-        units="absorbance",
-        title="synthetic optimize spectrum",
-    )
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
@@ -83,48 +26,30 @@ class TestOptimizeResult:
     # ----------------------------------------------------------------------------------
     # Identity and type
     # ----------------------------------------------------------------------------------
-    def test_result_is_fit_result(self, synthetic_two_peak_dataset, script):
+    def test_result_is_fit_result(self, synthetic_two_peak_dataset, optimize_script):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
-        result = opt.result
-        assert isinstance(result, FitResult)
+        assert_result_basics(opt, FitResult, "Optimize")
 
-    def test_result_is_instance_of_base(self, synthetic_two_peak_dataset, script):
+    def test_result_is_instance_of_base(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
         assert isinstance(opt.result, ResultBase)
 
-    def test_estimator_name(self, synthetic_two_peak_dataset, script):
-        opt = scp.Optimize()
-        opt.script = script
-        opt.autobase = True
-        opt.max_iter = 10
-        opt.fit(synthetic_two_peak_dataset)
-        assert opt.result.estimator == "Optimize"
-
-    def test_result_is_not_cached(self, synthetic_two_peak_dataset, script):
-        opt = scp.Optimize()
-        opt.script = script
-        opt.autobase = True
-        opt.max_iter = 10
-        opt.fit(synthetic_two_peak_dataset)
-        assert opt.result is not opt.result, (
-            "FitResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
-
     # ----------------------------------------------------------------------------------
     # Outputs
     # ----------------------------------------------------------------------------------
-    def test_outputs_contain_keys(self, synthetic_two_peak_dataset, script):
+    def test_outputs_contain_keys(self, synthetic_two_peak_dataset, optimize_script):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -132,9 +57,11 @@ class TestOptimizeResult:
         for name in ("fitted", "components"):
             assert name in result.outputs, f"{name} missing from result.outputs"
 
-    def test_output_values_match_properties(self, synthetic_two_peak_dataset, script):
+    def test_output_values_match_properties(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -148,9 +75,9 @@ class TestOptimizeResult:
             opt.components.data,
         )
 
-    def test_output_fitted_shape(self, synthetic_two_peak_dataset, script):
+    def test_output_fitted_shape(self, synthetic_two_peak_dataset, optimize_script):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -162,9 +89,11 @@ class TestOptimizeResult:
     # ----------------------------------------------------------------------------------
     # Parameters
     # ----------------------------------------------------------------------------------
-    def test_parameters_contain_expected_keys(self, synthetic_two_peak_dataset, script):
+    def test_parameters_contain_expected_keys(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -178,9 +107,11 @@ class TestOptimizeResult:
         ):
             assert name in params, f"{name} missing from result.parameters"
 
-    def test_parameters_values_default(self, synthetic_two_peak_dataset, script):
+    def test_parameters_values_default(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -191,10 +122,10 @@ class TestOptimizeResult:
         assert params["amplitude_mode"] == "height"
 
     def test_parameters_match_estimator_config(
-        self, synthetic_two_peak_dataset, script
+        self, synthetic_two_peak_dataset, optimize_script
     ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 20
         opt.method = "simplex"
@@ -208,9 +139,11 @@ class TestOptimizeResult:
     # ----------------------------------------------------------------------------------
     # Diagnostics
     # ----------------------------------------------------------------------------------
-    def test_diagnostics_contain_keys(self, synthetic_two_peak_dataset, script):
+    def test_diagnostics_contain_keys(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -218,9 +151,9 @@ class TestOptimizeResult:
         for name in ("cost", "niter", "ncalls"):
             assert name in diag, f"{name} missing from result.diagnostics"
 
-    def test_diagnostics_are_scalars(self, synthetic_two_peak_dataset, script):
+    def test_diagnostics_are_scalars(self, synthetic_two_peak_dataset, optimize_script):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -229,9 +162,11 @@ class TestOptimizeResult:
         assert isinstance(diag["niter"], int)
         assert isinstance(diag["ncalls"], int)
 
-    def test_diagnostics_meaningful_values(self, synthetic_two_peak_dataset, script):
+    def test_diagnostics_meaningful_values(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -245,9 +180,11 @@ class TestOptimizeResult:
     # ----------------------------------------------------------------------------------
     # Representation
     # ----------------------------------------------------------------------------------
-    def test_repr_contains_expected_fields(self, synthetic_two_peak_dataset, script):
+    def test_repr_contains_expected_fields(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -258,9 +195,9 @@ class TestOptimizeResult:
         assert "components" in text
         assert "cost" in text
 
-    def test_repr_does_not_crash(self, synthetic_two_peak_dataset, script):
+    def test_repr_does_not_crash(self, synthetic_two_peak_dataset, optimize_script):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)
@@ -269,26 +206,26 @@ class TestOptimizeResult:
     # ----------------------------------------------------------------------------------
     # Pre-fit guard
     # ----------------------------------------------------------------------------------
-    def test_raises_before_fit(self, script):
+    def test_raises_before_fit(self, optimize_script):
         opt = scp.Optimize()
-        opt.script = script
-        with pytest.raises(NotFittedError):
-            _ = opt.result
+        opt.script = optimize_script
+        assert_result_raises_before_fit(opt, NotFittedError)
 
     # ----------------------------------------------------------------------------------
     # Existing behaviour preserved
     # ----------------------------------------------------------------------------------
-    def test_fit_still_returns_self(self, synthetic_two_peak_dataset, script):
+    def test_fit_still_returns_self(self, synthetic_two_peak_dataset, optimize_script):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
-        ret = opt.fit(synthetic_two_peak_dataset)
-        assert ret is opt
+        assert_fit_returns_self(opt, synthetic_two_peak_dataset)
 
-    def test_existing_properties_unchanged(self, synthetic_two_peak_dataset, script):
+    def test_existing_properties_unchanged(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
         opt = scp.Optimize()
-        opt.script = script
+        opt.script = optimize_script
         opt.autobase = True
         opt.max_iter = 10
         opt.fit(synthetic_two_peak_dataset)

--- a/tests/test_analysis/test_decomposition/conftest.py
+++ b/tests/test_analysis/test_decomposition/conftest.py
@@ -12,6 +12,66 @@ import spectrochempy as scp
 
 
 @pytest.fixture()
+def low_rank_pca_dataset():
+    u1 = np.array([1.0, 1.0, 1.0, -1.0, -1.0, -1.0]) / np.sqrt(6.0)
+    u2 = np.array([1.0, -1.0, 0.0, 1.0, -1.0, 0.0]) / 2.0
+    u3 = np.array([1.0, 1.0, -2.0, 1.0, 1.0, -2.0]) / np.sqrt(12.0)
+    data = np.column_stack(
+        [
+            6.0 * u1,
+            3.0 * u2,
+            u3,
+            np.zeros(6),
+            np.zeros(6),
+        ]
+    )
+    return scp.NDDataset(
+        data,
+        coordset=[
+            scp.Coord.arange(6, title="sample"),
+            scp.Coord.arange(5, title="feature"),
+        ],
+        units="absorbance",
+        title="synthetic PCA matrix",
+    )
+
+
+@pytest.fixture()
+def expected_variance_ratio():
+    return 100.0 * np.array([36.0, 9.0, 1.0, 0.0, 0.0]) / 46.0
+
+
+@pytest.fixture()
+def efa_dataset():
+    time = np.linspace(0.0, 1.0, 48)
+    features = np.linspace(400.0, 700.0, 12)
+
+    concentrations = np.column_stack(
+        [
+            np.exp(-0.5 * ((time - 0.35) / 0.12) ** 2),
+            0.8 * np.exp(-0.5 * ((time - 0.68) / 0.14) ** 2),
+        ]
+    )
+    spectra = np.vstack(
+        [
+            1.0 + 0.3 * np.cos(np.linspace(0.0, np.pi, features.size)),
+            0.7 + 0.4 * np.sin(np.linspace(0.0, np.pi, features.size)),
+        ]
+    )
+    data = concentrations @ spectra
+
+    return scp.NDDataset(
+        data=data,
+        coordset=[
+            scp.Coord(time, units="minutes", title="time"),
+            scp.Coord(features, units="nm", title="wavelength"),
+        ],
+        title="synthetic EFA mixture",
+        units="absorbance",
+    )
+
+
+@pytest.fixture()
 def simplisma_dataset():
     n_observations = 20
     n_variables = 100

--- a/tests/test_analysis/test_decomposition/test_efa.py
+++ b/tests/test_analysis/test_decomposition/test_efa.py
@@ -16,36 +16,6 @@ from spectrochempy.utils import testing
 from spectrochempy.utils.constants import MASKED
 
 
-@pytest.fixture()
-def efa_dataset():
-    time = np.linspace(0.0, 1.0, 48)
-    features = np.linspace(400.0, 700.0, 12)
-
-    concentrations = np.column_stack(
-        [
-            np.exp(-0.5 * ((time - 0.35) / 0.12) ** 2),
-            0.8 * np.exp(-0.5 * ((time - 0.68) / 0.14) ** 2),
-        ]
-    )
-    spectra = np.vstack(
-        [
-            1.0 + 0.3 * np.cos(np.linspace(0.0, np.pi, features.size)),
-            0.7 + 0.4 * np.sin(np.linspace(0.0, np.pi, features.size)),
-        ]
-    )
-    data = concentrations @ spectra
-
-    return scp.NDDataset(
-        data=data,
-        coordset=[
-            scp.Coord(time, units="minutes", title="time"),
-            scp.Coord(features, units="nm", title="wavelength"),
-        ],
-        title="synthetic EFA mixture",
-        units="absorbance",
-    )
-
-
 # test docstring
 # but this is not intended to work with the debugger - use run instead of debug!
 @pytest.mark.skipif(

--- a/tests/test_analysis/test_decomposition/test_efa_result.py
+++ b/tests/test_analysis/test_decomposition/test_efa_result.py
@@ -15,45 +15,9 @@ from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.decomposition.efa import EFA
-
-
-# ======================================================================================
-# Fixtures
-# ======================================================================================
-@pytest.fixture()
-def efa_dataset():
-    """Small synthetic dataset for EFA testing."""
-    n_observations = 48
-    n_variables = 12
-
-    time = np.linspace(0.0, 1.0, n_observations)
-    features = np.linspace(400.0, 700.0, n_variables)
-
-    concentrations = np.column_stack(
-        [
-            np.exp(-0.5 * ((time - 0.35) / 0.12) ** 2),
-            0.8 * np.exp(-0.5 * ((time - 0.68) / 0.14) ** 2),
-        ]
-    )
-    spectra = np.vstack(
-        [
-            1.0 + 0.3 * np.cos(np.linspace(0.0, np.pi, n_variables)),
-            0.7 + 0.4 * np.sin(np.linspace(0.0, np.pi, n_variables)),
-        ]
-    )
-    data = concentrations @ spectra
-
-    import spectrochempy as scp
-
-    return scp.NDDataset(
-        data=data,
-        coordset=[
-            scp.Coord(time, units="minutes", title="time"),
-            scp.Coord(features, units="nm", title="wavelength"),
-        ],
-        title="synthetic EFA mixture",
-        units="absorbance",
-    )
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
@@ -63,14 +27,8 @@ class TestEFAResult:
     def test_result_is_analysis_result(self, efa_dataset):
         efa = EFA()
         efa.fit(efa_dataset)
-        result = efa.result
-        assert isinstance(result, AnalysisResult)
+        result = assert_result_basics(efa, AnalysisResult, "EFA")
         assert isinstance(result, ResultBase)
-
-    def test_estimator_name(self, efa_dataset):
-        efa = EFA()
-        efa.fit(efa_dataset)
-        assert efa.result.estimator == "EFA"
 
     def test_outputs_contain_keys(self, efa_dataset):
         efa = EFA()
@@ -111,14 +69,6 @@ class TestEFAResult:
         assert "b_ev" in text
         assert "components" in text
 
-    def test_result_is_not_cached(self, efa_dataset):
-        efa = EFA()
-        efa.fit(efa_dataset)
-        assert efa.result is not efa.result, (
-            "AnalysisResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
-
     def test_parameters_contain_expected_keys(self, efa_dataset):
         efa = EFA()
         efa.fit(efa_dataset)
@@ -150,13 +100,11 @@ class TestEFAResult:
 
     def test_raises_before_fit(self):
         efa = EFA()
-        with pytest.raises(NotFittedError):
-            _ = efa.result
+        assert_result_raises_before_fit(efa, NotFittedError)
 
     def test_fit_still_returns_self(self, efa_dataset):
         efa = EFA()
-        ret = efa.fit(efa_dataset)
-        assert ret is efa
+        assert_fit_returns_self(efa, efa_dataset)
 
     def test_existing_properties_unchanged(self, efa_dataset):
         efa = EFA()

--- a/tests/test_analysis/test_decomposition/test_pca.py
+++ b/tests/test_analysis/test_decomposition/test_pca.py
@@ -33,36 +33,6 @@ def test_PCA_docstrings():
     )
 
 
-@pytest.fixture()
-def low_rank_pca_dataset():
-    u1 = np.array([1.0, 1.0, 1.0, -1.0, -1.0, -1.0]) / np.sqrt(6.0)
-    u2 = np.array([1.0, -1.0, 0.0, 1.0, -1.0, 0.0]) / 2.0
-    u3 = np.array([1.0, 1.0, -2.0, 1.0, 1.0, -2.0]) / np.sqrt(12.0)
-    data = np.column_stack(
-        [
-            6.0 * u1,
-            3.0 * u2,
-            u3,
-            np.zeros(6),
-            np.zeros(6),
-        ]
-    )
-    return scp.NDDataset(
-        data,
-        coordset=[
-            scp.Coord.arange(6, title="sample"),
-            scp.Coord.arange(5, title="feature"),
-        ],
-        units="absorbance",
-        title="synthetic PCA matrix",
-    )
-
-
-@pytest.fixture()
-def expected_variance_ratio():
-    return 100.0 * np.array([36.0, 9.0, 1.0, 0.0, 0.0]) / 46.0
-
-
 def test_pca_prefit_n_components():
     pca = PCA(n_components=5)
     assert pca.n_components == 5

--- a/tests/test_analysis/test_decomposition/test_pca_result.py
+++ b/tests/test_analysis/test_decomposition/test_pca_result.py
@@ -11,210 +11,40 @@ Tests for the PCA result object contract prototype.
 import numpy as np
 import pytest
 
-import spectrochempy as scp
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
-from spectrochempy.analysis._base._result import FitResult
-from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.decomposition.pca import PCA
-
-
-# ======================================================================================
-# Fixtures
-# ======================================================================================
-@pytest.fixture()
-def low_rank_dataset():
-    u1 = np.array([1.0, 1.0, 1.0, -1.0, -1.0, -1.0]) / np.sqrt(6.0)
-    u2 = np.array([1.0, -1.0, 0.0, 1.0, -1.0, 0.0]) / 2.0
-    u3 = np.array([1.0, 1.0, -2.0, 1.0, 1.0, -2.0]) / np.sqrt(12.0)
-    data = np.column_stack(
-        [
-            6.0 * u1,
-            3.0 * u2,
-            u3,
-            np.zeros(6),
-            np.zeros(6),
-        ]
-    )
-    return scp.NDDataset(
-        data,
-        coordset=[
-            scp.Coord.arange(6, title="sample"),
-            scp.Coord.arange(5, title="feature"),
-        ],
-        units="absorbance",
-        title="synthetic PCA matrix",
-    )
-
-
-# ======================================================================================
-# ResultBase and AnalysisResult creation tests
-# ======================================================================================
-class TestResultBase:
-    def test_minimal_creation(self):
-        result = ResultBase(estimator="TestEstimator")
-        assert result.estimator == "TestEstimator"
-        assert result.outputs == {}
-        assert result.diagnostics == {}
-        assert result.parameters == {}
-
-    def test_with_outputs_and_diagnostics(self):
-        result = ResultBase(
-            estimator="Test",
-            outputs={"a": np.ones(3), "b": np.ones((2, 3))},
-            diagnostics={"d": np.array([1.0, 2.0])},
-        )
-        assert "a" in result.outputs
-        assert "b" in result.outputs
-        assert "d" in result.diagnostics
-
-    def test_output_attribute_access(self):
-        scores = np.ones((2, 3))
-        concentrations = object()
-        spectra = object()
-        result = ResultBase(
-            estimator="Test",
-            outputs={"scores": scores, "C": concentrations, "St": spectra},
-        )
-        assert result.scores is result.outputs["scores"]
-        assert result.C is result.outputs["C"]
-        assert result.St is result.outputs["St"]
-
-    def test_diagnostic_attribute_access(self):
-        variance = np.array([2.0, 1.0])
-        result = ResultBase(
-            estimator="Test",
-            diagnostics={"explained_variance": variance},
-        )
-        assert result.explained_variance is result.diagnostics["explained_variance"]
-
-    def test_missing_attribute_raises_attribute_error(self):
-        result = ResultBase(estimator="Test")
-        with pytest.raises(
-            AttributeError,
-            match="ResultBase object has no attribute 'missing'",
-        ):
-            _ = result.missing
-
-    def test_existing_attributes_are_not_shadowed(self):
-        result = ResultBase(
-            estimator="Test",
-            parameters={"alpha": 1},
-            outputs={
-                "outputs": "shadowed outputs",
-                "diagnostics": "shadowed diagnostics",
-                "parameters": "shadowed parameters",
-                "estimator": "shadowed estimator",
-            },
-        )
-        assert result.outputs["outputs"] == "shadowed outputs"
-        assert result.diagnostics == {}
-        assert result.parameters == {"alpha": 1}
-        assert result.estimator == "Test"
-
-    def test_output_wins_over_diagnostic(self):
-        output = object()
-        diagnostic = object()
-        result = ResultBase(
-            estimator="Test",
-            outputs={"shared": output},
-            diagnostics={"shared": diagnostic},
-        )
-        assert result.shared is output
-
-    def test_parameters_are_not_exposed_as_attributes(self):
-        result = ResultBase(estimator="Test", parameters={"alpha": 1})
-        with pytest.raises(AttributeError):
-            _ = result.alpha
-
-    def test_dir_includes_outputs_and_diagnostics_but_not_parameters(self):
-        result = ResultBase(
-            estimator="Test",
-            parameters={"alpha": 1},
-            outputs={"scores": object(), "not-valid": object()},
-            diagnostics={"explained_variance": object()},
-        )
-        names = dir(result)
-        assert "scores" in names
-        assert "explained_variance" in names
-        assert "alpha" not in names
-        assert "not-valid" not in names
-
-    def test_repr(self):
-        result = ResultBase(
-            estimator="Test",
-            outputs={"x": np.ones((3, 4))},
-            diagnostics={"y": np.ones(2)},
-        )
-        text = repr(result)
-        assert "ResultBase" in text
-        assert "Test" in text
-        assert "x" in text
-        assert "(3, 4)" in text
-        assert "y" in text
-
-
-class TestAnalysisResult:
-    def test_creation(self):
-        result = AnalysisResult(estimator="PCA")
-        assert isinstance(result, AnalysisResult)
-        assert isinstance(result, ResultBase)
-
-    def test_repr(self):
-        result = AnalysisResult(
-            estimator="PCA",
-            outputs={"scores": np.ones((6, 5))},
-            diagnostics={"explained_variance": np.ones(5)},
-        )
-        text = repr(result)
-        assert "AnalysisResult" in text
-        assert "PCA" in text
-
-
-class TestFitResult:
-    def test_creation(self):
-        result = FitResult(estimator="Optimize")
-        assert isinstance(result, FitResult)
-        assert isinstance(result, ResultBase)
-
-    def test_inherits_attribute_access(self):
-        fitted = object()
-        result = FitResult(estimator="Optimize", outputs={"fitted": fitted})
-        assert result.fitted is fitted
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
 # PCA result integration tests
 # ======================================================================================
 class TestPCAResult:
-    def test_result_is_analysis_result(self, low_rank_dataset):
+    def test_result_is_analysis_result(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
-        result = pca.result
-        assert isinstance(result, AnalysisResult)
+        pca.fit(low_rank_pca_dataset)
+        assert_result_basics(pca, AnalysisResult, "PCA")
 
-    def test_estimator_name(self, low_rank_dataset):
+    def test_outputs_contain_keys(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
-        assert pca.result.estimator == "PCA"
-
-    def test_outputs_contain_keys(self, low_rank_dataset):
-        pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         result = pca.result
         for name in ("scores", "loadings", "components"):
             assert name in result.outputs, f"{name} missing from result.outputs"
 
-    def test_diagnostics_contain_keys(self, low_rank_dataset):
+    def test_diagnostics_contain_keys(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         result = pca.result
         for name in ("explained_variance", "explained_variance_ratio"):
             assert name in result.diagnostics, f"{name} missing from result.diagnostics"
 
-    def test_outputs_match_properties(self, low_rank_dataset):
+    def test_outputs_match_properties(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         result = pca.result
         np.testing.assert_array_equal(
             result.outputs["scores"].data,
@@ -229,9 +59,9 @@ class TestPCAResult:
             pca.components.data,
         )
 
-    def test_diagnostics_match_properties(self, low_rank_dataset):
+    def test_diagnostics_match_properties(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         result = pca.result
         np.testing.assert_array_equal(
             result.diagnostics["explained_variance"].data,
@@ -242,17 +72,17 @@ class TestPCAResult:
             pca.explained_variance_ratio.data,
         )
 
-    def test_result_attribute_access(self, low_rank_dataset):
-        pca = PCA(n_components=2).fit(low_rank_dataset)
+    def test_result_attribute_access(self, low_rank_pca_dataset):
+        pca = PCA(n_components=2).fit(low_rank_pca_dataset)
         result = pca.result
         assert result.scores is result.outputs["scores"]
         assert result.loadings is result.outputs["loadings"]
         assert result.explained_variance is result.diagnostics["explained_variance"]
         assert {"scores", "loadings", "explained_variance"} <= set(dir(result))
 
-    def test_repr_contains_expected_fields(self, low_rank_dataset):
+    def test_repr_contains_expected_fields(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         result = pca.result
         text = repr(result)
         assert "AnalysisResult" in text
@@ -262,24 +92,16 @@ class TestPCAResult:
         assert "components" in text
         assert "explained_variance" in text
 
-    def test_result_is_not_cached(self, low_rank_dataset):
+    def test_parameters_contain_expected_keys(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
-        assert pca.result is not pca.result, (
-            "AnalysisResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
-
-    def test_parameters_contain_expected_keys(self, low_rank_dataset):
-        pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         params = pca.result.parameters
         for name in ("n_components", "standardized", "scaled", "whiten", "svd_solver"):
             assert name in params, f"{name} missing from result.parameters"
 
-    def test_parameters_values(self, low_rank_dataset):
+    def test_parameters_values(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         params = pca.result.parameters
         assert params["n_components"] == 5
         assert params["standardized"] is False
@@ -287,17 +109,17 @@ class TestPCAResult:
         assert params["whiten"] is False
         assert params["svd_solver"] == "auto"
 
-    def test_parameters_match_estimator_config(self, low_rank_dataset):
+    def test_parameters_match_estimator_config(self, low_rank_pca_dataset):
         pca = PCA(n_components=3, whiten=True, svd_solver="full")
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         params = pca.result.parameters
         assert params["n_components"] == 3
         assert params["whiten"] is True
         assert params["svd_solver"] == "full"
 
-    def test_repr_contains_parameters(self, low_rank_dataset):
+    def test_repr_contains_parameters(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         text = repr(pca.result)
         assert "parameters:" in text
         assert "n_components" in text
@@ -305,17 +127,15 @@ class TestPCAResult:
 
     def test_raises_before_fit(self):
         pca = PCA()
-        with pytest.raises(NotFittedError):
-            _ = pca.result
+        assert_result_raises_before_fit(pca, NotFittedError)
 
-    def test_fit_still_returns_self(self, low_rank_dataset):
+    def test_fit_still_returns_self(self, low_rank_pca_dataset):
         pca = PCA()
-        ret = pca.fit(low_rank_dataset)
-        assert ret is pca
+        assert_fit_returns_self(pca, low_rank_pca_dataset)
 
-    def test_existing_properties_unchanged(self, low_rank_dataset):
+    def test_existing_properties_unchanged(self, low_rank_pca_dataset):
         pca = PCA()
-        pca.fit(low_rank_dataset)
+        pca.fit(low_rank_pca_dataset)
         assert pca.loadings.shape == (5, 5)
         assert pca.scores.shape == (6, 5)
         assert pca.components.shape == (5, 5)


### PR DESCRIPTION
## Summary

This PR performs the first low-risk cleanup identified in the analysis test audit.

The goal is to reduce structural duplication in Result-related tests while preserving all scientific and behavioral coverage.

No runtime code is modified.

No estimator behavior is changed.

## Changes

### Shared Result test helpers

Introduced a small shared helper module:

```text
tests/test_analysis/result_test_helpers.py
```

to centralize a few repeated Result contract checks:

* basic Result validation;
* pre-fit guards;
* `fit()` returning `self`.

The intent is to improve consistency without introducing a large testing framework.

### Result infrastructure tests

Moved generic:

* `ResultBase`
* `AnalysisResult`
* `FitResult`

tests from:

```text
tests/test_analysis/test_decomposition/test_pca_result.py
```

to:

```text
tests/test_analysis/test_base/test_result_base.py
```

This better reflects ownership and keeps PCA-specific tests focused on PCA behavior.

### Fixture consolidation

Consolidated duplicated fixtures used by both scientific and Result test suites:

* PCA fixtures moved to decomposition `conftest.py`;
* EFA fixtures moved to decomposition `conftest.py`;
* Optimize fixtures moved to curvefitting `conftest.py`.

No scientific assertions were changed.

## Out of Scope

This PR intentionally does not:

* modify estimator implementations;
* modify Result implementations;
* modify scientific parity tests;
* modify semantic characterization baselines;
* modify `_outfit` behavior;
* reorganize plugin tests.


## Follow-up Work

Possible future cleanup (not part of this PR):

* extend shared Result helper usage to remaining Result suites;
* review duplicated compatibility checks;
* review isolated implementation-coupled assertions such as `_outfit` checks.
