### PR TITLE
TEST: extend shared Result helpers to remaining *result.py files

### DIFF
--- a/tests/test_analysis/test_crossdecomposition/test_pls_result.py
+++ b/tests/test_analysis/test_crossdecomposition/test_pls_result.py
@@ -13,6 +13,9 @@ from numpy.testing import assert_allclose
 from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.analysis.crossdecomposition.pls import PLSRegression
 from spectrochempy.utils.exceptions import NotFittedError
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -50,11 +53,7 @@ class TestPLSRegressionResult:
     """Tests for PLSRegression.result returning AnalysisResult."""
 
     def test_result_is_analysis_result(self, pls_fitted):
-        result = pls_fitted.result
-        assert isinstance(result, AnalysisResult)
-
-    def test_estimator_name(self, pls_fitted):
-        assert pls_fitted.result.estimator == "PLSRegression"
+        assert_result_basics(pls_fitted, AnalysisResult, "PLSRegression")
 
     def test_outputs_contain_keys(self, pls_fitted):
         outputs = pls_fitted.result.outputs
@@ -148,13 +147,8 @@ class TestPLSRegressionResult:
         assert "parameters:" in text
         assert "n_components" in text
 
-    def test_result_is_not_cached(self, pls_fitted):
-        assert pls_fitted.result is not pls_fitted.result
-
     def test_raises_before_fit(self):
-        pls = PLSRegression(n_components=3)
-        with pytest.raises(NotFittedError):
-            _ = pls.result
+        assert_result_raises_before_fit(PLSRegression(n_components=3), NotFittedError)
 
     def test_fit_still_returns_self(self, pls_fitted):
         rng = np.random.default_rng(42)
@@ -163,8 +157,7 @@ class TestPLSRegressionResult:
         import spectrochempy as scp
 
         pls = PLSRegression(n_components=3)
-        ret = pls.fit(scp.NDDataset(X), scp.NDDataset(Y))
-        assert ret is pls
+        assert_fit_returns_self(pls, scp.NDDataset(X), scp.NDDataset(Y))
 
     def test_existing_properties_unchanged(self, pls_fitted):
         pls = pls_fitted

--- a/tests/test_analysis/test_decomposition/test_fast_ica_result.py
+++ b/tests/test_analysis/test_decomposition/test_fast_ica_result.py
@@ -15,6 +15,9 @@ from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.decomposition.fast_ica import FastICA
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
@@ -24,14 +27,8 @@ class TestFastICAResult:
     def test_result_is_analysis_result(self, fastica_dataset):
         ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
         ica.fit(fastica_dataset)
-        result = ica.result
-        assert isinstance(result, AnalysisResult)
+        result = assert_result_basics(ica, AnalysisResult, "FastICA")
         assert isinstance(result, ResultBase)
-
-    def test_estimator_name(self, fastica_dataset):
-        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
-        ica.fit(fastica_dataset)
-        assert ica.result.estimator == "FastICA"
 
     def test_outputs_contain_keys(self, fastica_dataset):
         ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
@@ -85,14 +82,6 @@ class TestFastICAResult:
         assert "components" in text
         assert "mixing" in text
         assert "n_iter" in text
-
-    def test_result_is_not_cached(self, fastica_dataset):
-        ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
-        ica.fit(fastica_dataset)
-        assert ica.result is not ica.result, (
-            "AnalysisResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
 
     def test_parameters_contain_expected_keys(self, fastica_dataset):
         ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
@@ -153,14 +142,11 @@ class TestFastICAResult:
         assert "whiten" in text
 
     def test_raises_before_fit(self):
-        ica = FastICA()
-        with pytest.raises(NotFittedError):
-            _ = ica.result
+        assert_result_raises_before_fit(FastICA(), NotFittedError)
 
     def test_fit_still_returns_self(self, fastica_dataset):
         ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")
-        ret = ica.fit(fastica_dataset)
-        assert ret is ica
+        assert_fit_returns_self(ica, fastica_dataset)
 
     def test_existing_properties_unchanged(self, fastica_dataset):
         ica = FastICA(n_components=4, random_state=123, whiten="unit-variance")

--- a/tests/test_analysis/test_decomposition/test_mcrals_result.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_result.py
@@ -15,6 +15,9 @@ from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.decomposition.mcrals import MCRALS
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
@@ -45,12 +48,8 @@ def fitted_mcrals(mcrals_dataset):
 # ======================================================================================
 class TestMCRALSResult:
     def test_result_is_analysis_result(self, fitted_mcrals):
-        result = fitted_mcrals.result
-        assert isinstance(result, AnalysisResult)
+        result = assert_result_basics(fitted_mcrals, AnalysisResult, "MCRALS")
         assert isinstance(result, ResultBase)
-
-    def test_estimator_name(self, fitted_mcrals):
-        assert fitted_mcrals.result.estimator == "MCRALS"
 
     def test_outputs_contain_keys(self, fitted_mcrals):
         result = fitted_mcrals.result
@@ -90,12 +89,6 @@ class TestMCRALSResult:
         assert "components" in text
         assert "n_iter" in text
         assert "converged" in text
-
-    def test_result_is_not_cached(self, fitted_mcrals):
-        assert fitted_mcrals.result is not fitted_mcrals.result, (
-            "AnalysisResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
 
     def test_parameters_contain_expected_keys(self, fitted_mcrals):
         params = fitted_mcrals.result.parameters
@@ -187,15 +180,12 @@ class TestMCRALSResult:
         assert "max_iter" in text
 
     def test_raises_before_fit(self):
-        mcr = MCRALS()
-        with pytest.raises(NotFittedError):
-            _ = mcr.result
+        assert_result_raises_before_fit(MCRALS(), NotFittedError)
 
     def test_fit_still_returns_self(self, mcrals_dataset):
         X, C0 = mcrals_dataset
         mcr = MCRALS()
-        ret = mcr.fit(X, C0)
-        assert ret is mcr
+        assert_fit_returns_self(mcr, X, C0)
 
     def test_existing_properties_unchanged(self, fitted_mcrals):
         assert fitted_mcrals.components.shape == (2, 6)

--- a/tests/test_analysis/test_decomposition/test_nmf_result.py
+++ b/tests/test_analysis/test_decomposition/test_nmf_result.py
@@ -15,6 +15,9 @@ from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.decomposition.nmf import NMF
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
@@ -42,12 +45,8 @@ def fitted_nmf(nmf_dataset):
 # ======================================================================================
 class TestNMFResult:
     def test_result_is_analysis_result(self, fitted_nmf):
-        result = fitted_nmf.result
-        assert isinstance(result, AnalysisResult)
+        result = assert_result_basics(fitted_nmf, AnalysisResult, "NMF")
         assert isinstance(result, ResultBase)
-
-    def test_estimator_name(self, fitted_nmf):
-        assert fitted_nmf.result.estimator == "NMF"
 
     def test_outputs_contain_keys(self, fitted_nmf):
         result = fitted_nmf.result
@@ -86,12 +85,6 @@ class TestNMFResult:
         assert "W" in text
         assert "reconstruction_error" in text
         assert "n_iter" in text
-
-    def test_result_is_not_cached(self, fitted_nmf):
-        assert fitted_nmf.result is not fitted_nmf.result, (
-            "AnalysisResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
 
     def test_parameters_contain_expected_keys(self, fitted_nmf):
         params = fitted_nmf.result.parameters
@@ -141,16 +134,13 @@ class TestNMFResult:
         assert "solver" in text
 
     def test_raises_before_fit(self):
-        nmf = NMF()
-        with pytest.raises(NotFittedError):
-            _ = nmf.result
+        assert_result_raises_before_fit(NMF(), NotFittedError)
 
     def test_fit_still_returns_self(self, nmf_dataset):
         nmf = NMF(
             n_components=3, init="random", max_iter=500, random_state=42, tol=1e-8
         )
-        ret = nmf.fit(nmf_dataset)
-        assert ret is nmf
+        assert_fit_returns_self(nmf, nmf_dataset)
 
     def test_existing_properties_unchanged(self, fitted_nmf):
         assert fitted_nmf.components.shape == (3, 6)

--- a/tests/test_analysis/test_decomposition/test_simplisma_result.py
+++ b/tests/test_analysis/test_decomposition/test_simplisma_result.py
@@ -15,6 +15,9 @@ from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.decomposition.simplisma import SIMPLISMA
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
@@ -24,14 +27,8 @@ class TestSIMPLISMAResult:
     def test_result_is_analysis_result(self, simplisma_dataset):
         sma = SIMPLISMA(n_components=2, log_level="WARNING")
         sma.fit(simplisma_dataset)
-        result = sma.result
-        assert isinstance(result, AnalysisResult)
+        result = assert_result_basics(sma, AnalysisResult, "SIMPLISMA")
         assert isinstance(result, ResultBase)
-
-    def test_estimator_name(self, simplisma_dataset):
-        sma = SIMPLISMA(n_components=2, log_level="WARNING")
-        sma.fit(simplisma_dataset)
-        assert sma.result.estimator == "SIMPLISMA"
 
     def test_outputs_contain_keys(self, simplisma_dataset):
         sma = SIMPLISMA(n_components=2, log_level="WARNING")
@@ -92,14 +89,6 @@ class TestSIMPLISMAResult:
         assert "residual_std" in text
         assert "n_components_selected" in text
 
-    def test_result_is_not_cached(self, simplisma_dataset):
-        sma = SIMPLISMA(n_components=2, log_level="WARNING")
-        sma.fit(simplisma_dataset)
-        assert sma.result is not sma.result, (
-            "AnalysisResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
-
     def test_parameters_contain_expected_keys(self, simplisma_dataset):
         sma = SIMPLISMA(n_components=2, log_level="WARNING")
         sma.fit(simplisma_dataset)
@@ -134,14 +123,11 @@ class TestSIMPLISMAResult:
         assert "noise" in text
 
     def test_raises_before_fit(self):
-        sma = SIMPLISMA()
-        with pytest.raises(NotFittedError):
-            _ = sma.result
+        assert_result_raises_before_fit(SIMPLISMA(), NotFittedError)
 
     def test_fit_still_returns_self(self, simplisma_dataset):
         sma = SIMPLISMA(n_components=2, log_level="WARNING")
-        ret = sma.fit(simplisma_dataset)
-        assert ret is sma
+        assert_fit_returns_self(sma, simplisma_dataset)
 
     def test_existing_properties_unchanged(self, simplisma_dataset):
         sma = SIMPLISMA(n_components=2, log_level="WARNING")

--- a/tests/test_analysis/test_decomposition/test_svd_result.py
+++ b/tests/test_analysis/test_decomposition/test_svd_result.py
@@ -16,6 +16,9 @@ from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.decomposition.svd import SVD
+from tests.test_analysis.result_test_helpers import assert_fit_returns_self
+from tests.test_analysis.result_test_helpers import assert_result_basics
+from tests.test_analysis.result_test_helpers import assert_result_raises_before_fit
 
 
 # ======================================================================================
@@ -43,26 +46,8 @@ class TestSVDResult:
     def test_result_is_analysis_result(self, low_rank_dataset):
         svd = SVD()
         svd.fit(low_rank_dataset)
-        result = svd.result
-        assert isinstance(result, AnalysisResult)
-
-    def test_result_is_instance_of_base(self, low_rank_dataset):
-        svd = SVD()
-        svd.fit(low_rank_dataset)
-        assert isinstance(svd.result, ResultBase)
-
-    def test_estimator_name(self, low_rank_dataset):
-        svd = SVD()
-        svd.fit(low_rank_dataset)
-        assert svd.result.estimator == "SVD"
-
-    def test_result_is_not_cached(self, low_rank_dataset):
-        svd = SVD()
-        svd.fit(low_rank_dataset)
-        assert svd.result is not svd.result, (
-            "AnalysisResult is recreated on every access; "
-            "change this assertion if caching is added later"
-        )
+        result = assert_result_basics(svd, AnalysisResult, "SVD")
+        assert isinstance(result, ResultBase)
 
     # ----------------------------------------------------------------------------------
     # Outputs
@@ -169,26 +154,17 @@ class TestSVDResult:
         assert "explained_variance" in text
         assert "full_matrices" in text
 
-    def test_repr_does_not_crash(self, low_rank_dataset):
-        svd = SVD()
-        svd.fit(low_rank_dataset)
-        _ = repr(svd.result)
-
     # ----------------------------------------------------------------------------------
     # Pre-fit guard
     # ----------------------------------------------------------------------------------
     def test_raises_before_fit(self):
-        svd = SVD()
-        with pytest.raises(NotFittedError):
-            _ = svd.result
+        assert_result_raises_before_fit(SVD(), NotFittedError)
 
     # ----------------------------------------------------------------------------------
     # Existing behaviour preserved
     # ----------------------------------------------------------------------------------
     def test_fit_still_returns_self(self, low_rank_dataset):
-        svd = SVD()
-        ret = svd.fit(low_rank_dataset)
-        assert ret is svd
+        assert_fit_returns_self(SVD(), low_rank_dataset)
 
     def test_existing_properties_unchanged(self, low_rank_dataset):
         svd = SVD()


### PR DESCRIPTION
## Summary
Replaced duplicated generic Result contract checks (type, estimator name, not-cached, repr smoke) with shared assert_result_basics, assert_result_raises_before_fit, and assert_fit_returns_self helpers across the remaining 6 *_result.py files. 8 redundant test methods removed. All estimator-specific assertions preserved. 88/88 tests pass.
## Out of scope
- Runtime code, Result implementation
- Scientific test files (test_*.py without _result)
- Semantic baselines
- _outfit