### PR TITLE
DOC: clean remaining gallery repr noise in examples

### DIFF
--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
@@ -43,11 +43,11 @@ new2, curve2 = dataset1D.copy().em(
 
 # %%
 # Plotting
-dataset1D.plot(zlim=(-2, 2), color="k")
-curve1.plot(color="r")
-new1.plot(color="r", clear=False, label=" em = 20 hz")
-curve2.plot(color="b", clear=False)
-new2.plot(dcolor="b", clear=False, label=" em = 30 HZ, shifted = ")
+_ = dataset1D.plot(zlim=(-2, 2), color="k")
+_ = curve1.plot(color="r")
+_ = new1.plot(color="r", clear=False, label=" em = 20 hz")
+_ = curve2.plot(color="b", clear=False)
+_ = new2.plot(dcolor="b", clear=False, label=" em = 30 HZ, shifted = ")
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
@@ -58,20 +58,20 @@ new5, curve5 = dataset1D.sinm(ssb=8, retapod=True, inplace=False)
 
 # %%
 # Plotting
-dataset1D.plot(zlim=(-2, 2), color="k")
-curve1.plot(color="r", clear=False)
+_ = dataset1D.plot(zlim=(-2, 2), color="k")
+_ = curve1.plot(color="r", clear=False)
 new1.plot(
     data_only=True, color="r", clear=False, label=" sinm with ssb= 2 (cosine window)"
 )
-curve2.plot(color="b", clear=False)
+_ = curve2.plot(color="b", clear=False)
 new2.plot(
     data_only=True, color="b", clear=False, label=" sinm with ssb= 1 (sine window)"
 )
-curve3.plot(color="m", clear=False)
-new3.plot(data_only=True, color="m", clear=False, label=" qsin with ssb= 2")
-curve4.plot(color="g", clear=False)
-new4.plot(data_only=True, color="g", clear=False, label=" qsin with ssb= 1")
-curve5.plot(color="c", ls="--", clear=False)
+_ = curve3.plot(color="m", clear=False)
+_ = new3.plot(data_only=True, color="m", clear=False, label=" qsin with ssb= 2")
+_ = curve4.plot(color="g", clear=False)
+_ = new4.plot(data_only=True, color="g", clear=False, label=" qsin with ssb= 1")
+_ = curve5.plot(color="c", ls="--", clear=False)
 new5.plot(
     data_only=True,
     color="c",

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
@@ -189,7 +189,7 @@ fitter.script = """
 	$ tis:  800, 1, 10000
 """
 
-fitter.fit(s)
+_ = fitter.fit(s)
 
 spred = fitter.predict()
 
@@ -213,7 +213,7 @@ fitter.script = """
 	$ tis:  800, 1, 10000
 """
 
-fitter.fit(s)
+_ = fitter.fit(s)
 
 spred = fitter.predict()
 
@@ -237,7 +237,7 @@ fitter.script = """
 	$ tis:  800, 1, 10000
 """
 
-fitter.fit(s)
+_ = fitter.fit(s)
 
 spred = fitter.predict()
 

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -39,36 +39,36 @@ dataset
 
 # %%
 # Plot the dataset
-dataset.plot_map()
+_ = dataset.plot_map()
 # %%
 # Extract slices along x
 s = dataset[-27.6, :]
-s.plot()
+_ = s.plot()
 # %%
 # Baseline correction of this slice
 # Note that only the real part is corrected
 sa = s.snip(snip_width=100)
-sa.plot()
+_ = sa.plot()
 # %%
 # apply this correction to the whole dataset
 sb = dataset.snip(snip_width=100)
-sb.plot_map()
+_ = sb.plot_map()
 # %%
 # Select a region of interest
 sc = sb[
     -40.0:-15.0, 55.0:20.0
 ]  # note the use of float to make selection using coordinates (not point indexes)
-sc.plot_map()
+_ = sc.plot_map()
 # %%
 # Extract slices along x
 s1 = sc[-27.6, :]
-s1.plot()
+_ = s1.plot()
 # %%
 s2 = sc[-25.7, :]
-s2.plot()
+_ = s2.plot()
 # %%
 # plot two slices on the same figure
-s1.plot()
+_ = s1.plot()
 s2.plot(
     clear=False,
     color="red",
@@ -91,8 +91,8 @@ s4 = s4.squeeze()
 
 # %%
 # plot the two slices on the same figure
-s3.plot(color="violet", ls="-", lw="2")
-s4.plot(clear=False, color="green", ls="-", lw="2")
+_ = s3.plot(color="violet", ls="-", lw="2")
+_ = s4.plot(clear=False, color="green", ls="-", lw="2")
 # %%
 # Peak picking
 # ------------
@@ -214,17 +214,17 @@ f1.max_iter = 5000
 
 # %%
 # Fit the slice s4p
-f1.fit(s4p)
+_ = f1.fit(s4p)
 
 # %%
 # Show the result
-s4p.plot()
+_ = s4p.plot()
 ax = (f1.components[:]).plot(clear=False)
 ax.autoscale(enable=True, axis="y")
 
 # Plotmerit
 som = f1.inverse_transform()
-f1.plotmerit(offset=2)
+_ = f1.plotmerit(offset=2)
 
 # %%
 # This ends the example ! The following line can be removed or commented

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
@@ -42,11 +42,11 @@ dataset
 ds = dataset.em(lb=15 * U.Hz)
 ds = ds.fft()
 ds = ds.pk(phc0=-10 * U.deg, phc1=0 * U.deg)
-ds.plot(xlim=(-60, -140))
+_ = ds.plot(xlim=(-60, -140))
 # %%
 # Integrate a region
 dsint = ds[:, -90.0:-115.0].simpson()
-dsint.plot(marker="^", ls=":")
+_ = dsint.plot(marker="^", ls=":")
 dsint.real
 
 # %%
@@ -83,14 +83,14 @@ shape: T1_model
 
 # %%
 # Performs the fit
-fitter.fit(dsint)
+_ = fitter.fit(dsint)
 
 # %%
 som = fitter.predict()
 som
 
 # %%
-fitter.plotmerit(dsint, som, method="scatter", title="T1 relaxation fitting")
+_ = fitter.plotmerit(dsint, som, method="scatter", title="T1 relaxation fitting")
 
 # %%
 # This ends the example ! The following line can be removed or commented

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -36,15 +36,15 @@ dataset[:, 5997.0:5993.0] = scp.MASKED
 # %%
 # difference spectra
 # dataset -= dataset[-1]
-dataset.plot_stack(title="NH4_Y activation dataset")
+_ = dataset.plot_stack(title="NH4_Y activation dataset")
 # %%
 #  Evolving Factor Analysis
 efa1 = scp.EFA()
-efa1.fit(dataset)
+_ = efa1.fit(dataset)
 # %%
 # Forward evolution of the 5 first components
 f = efa1.f_ev[:, :5]
-f.T.plot(yscale="log", legend=f.k.labels)
+_ = f.T.plot(yscale="log", legend=f.k.labels)
 # %%
 # Note the use of coordinate 'k' (component axis) in the expression above.
 # Remember taht to find the actul names of the coordinates, the `dims`
@@ -63,7 +63,7 @@ efa1.cutoff = efa1.f_ev[:, 3].max()
 
 # get concentration
 C1 = efa1.transform()
-C1.T.plot(title="EFA determined concentrations", legend=C1.k.labels)
+_ = C1.T.plot(title="EFA determined concentrations", legend=C1.k.labels)
 # %%
 # Fit transform : Get the concentration in too commands
 # The number of desired components can be passed to the EFA model,
@@ -77,7 +77,7 @@ assert C1 == C2
 # Get components
 #
 St = efa2.get_components()
-St.plot(title="components", legend=St.k.labels)
+_ = St.plot(title="components", legend=St.k.labels)
 # %%
 # Compare with PCA
 pca = scp.PCA(n_components=3)

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -58,14 +58,14 @@ _ = dataset.plot(title="calculated dataset")
 # 4) evolving factor analysis (EFA)
 # *********************************
 efa = scp.EFA()
-efa.fit(dataset)
+_ = efa.fit(dataset)
 
 # %%
 # Plots of the log(EV) for the forward and backward analysis
 #
-efa.f_ev.T.plot(yscale="log", legend=efa.f_ev.k.labels)
+_ = efa.f_ev.T.plot(yscale="log", legend=efa.f_ev.k.labels)
 # %%
-efa.b_ev.T.plot(yscale="log", legend=efa.b_ev.k.labels)
+_ = efa.b_ev.T.plot(yscale="log", legend=efa.b_ev.k.labels)
 # %%
 # Looking at these EFA curves, it is quite obvious that only two components
 # are really significant, and this corresponds to the data that we have in

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
@@ -34,7 +34,7 @@ X.set_coordset(
 X.y.title = "elution time"
 X.y.units = "min"
 X.x.title = "wavelength"
-X.plot()
+_ = X.plot()
 # %%
 # Create and fit a FastICA object
 # -------------------------------
@@ -43,7 +43,7 @@ X.plot()
 # obtain verbose output during fit, and we set the number of component to use at 4.
 
 ica = scp.FastICA(n_components=4, log_level="INFO")
-ica.fit(X)
+_ = ica.fit(X)
 # %%
 # Get the mixing system and source spectral profiles
 # --------------------------------------------------

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
@@ -58,7 +58,7 @@ guess = datasets[3]
 
 # %%
 # Plot of X and of the guess:
-X.plot()
+_ = X.plot()
 _ = guess.plot()
 # %%
 # Create a MCR-ALS object
@@ -76,7 +76,7 @@ mcr = scp.MCRALS(log_level="INFO")
 #
 # Then we execute the optimization process using the `fit` method with
 # the ``X`` and ``guess`` dataset as input arguments.
-mcr.fit(X, guess)
+_ = mcr.fit(X, guess)
 # %%
 # Plotting the results
 # --------------------

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -48,7 +48,7 @@ _ = D.plot()
 # A first estimate of the concentrations can be obtained by EFA:
 print("compute EFA...")
 efa = scp.EFA()
-efa.fit(D[:, 300.0:500.0])
+_ = efa.fit(D[:, 300.0:500.0])
 efa.n_components = 3
 C0 = efa.transform()
 C0 = C0 / C0.max(dim="y") * 5.0
@@ -57,7 +57,7 @@ _ = C0.T.plot()
 # We can get a better estimate of the concentration (C) and pure spectra profiles (St)
 # by soft MCR-ALS:
 mcr_1 = scp.MCRALS(log_level="INFO")
-mcr_1.fit(D, C0)
+_ = mcr_1.fit(D, C0)
 _ = mcr_1.C.T.plot()
 _ = mcr_1.St.plot()
 # %%
@@ -85,7 +85,7 @@ mcr_2.getConc = kin.fit_to_concentrations
 mcr_2.argsGetConc = ([0, 1, 2], [0, 1, 2], param_to_optimize)
 mcr_2.kwargsGetConc = {"ivp_solver_kwargs": {"return_NDDataset": False}}
 
-mcr_2.fit(X, Ckin)
+_ = mcr_2.fit(X, Ckin)
 
 # %%
 # Now, let's compare the concentration profile of MCR-ALS

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
@@ -50,7 +50,7 @@ model = scp.NMF(n_components=4, log_level="INFO")
 # %%
 # Fit the model
 # -------------
-model.fit(dataset)
+_ = model.fit(dataset)
 # Get the results
 # ---------------
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -29,7 +29,7 @@ dataset = scp.load_iris()
 pca = scp.PCA(n_components="mle")
 # %%
 # Fit dataset with the PCA model
-pca.fit(dataset)
+_ = pca.fit(dataset)
 # %%
 # The number of components found is 3:
 pca.n_components
@@ -41,7 +41,7 @@ pca.cumulative_explained_variance[-1].value
 # are needed (a number between 0 and 1 for n_components is required to do this).
 # we found 4 components in this case
 pca = scp.PCA(n_components=0.999)
-pca.fit(dataset)
+_ = pca.fit(dataset)
 pca.n_components
 # %%
 # the 4 components found are in the `components` attribute of pca. These components are

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
@@ -20,12 +20,12 @@ import spectrochempy as scp
 # Load a dataset
 dataset = scp.read_omnic("irdata/nh4y-activation.spg")[::5]
 print(dataset)
-dataset.plot()
+_ = dataset.plot()
 # %%
 # Create a PCA object and fit the dataset so that the explained variance is greater or
 # equal to 99.9%
 pca = scp.PCA(n_components=0.999)
-pca.fit(dataset)
+_ = pca.fit(dataset)
 
 # %%
 # The number of fitted components is given by the n_components attribute
@@ -54,7 +54,7 @@ prefs.lines.markersize = 10
 _ = pca.plot_score()
 # %%
 # Score Plot for 3 PC's in 3D
-pca.plot_score(components=(1, 2, 3))
+_ = pca.plot_score(components=(1, 2, 3))
 # %%
 # Displays 4 loadings
 pca.loadings[:4].plot(legend=True)
@@ -67,7 +67,7 @@ _ = dataset.plot()
 # %%
 # Apply the PCA model
 pca = scp.PCA(n_components=0.999)
-pca.fit(dataset)
+_ = pca.fit(dataset)
 pca.n_components
 
 # %%

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
@@ -40,7 +40,7 @@ ds.x.units = "nm"
 # Fit the SIMPLISMA model
 print("Fit SIMPLISMA on {}\n".format(ds.name))
 simpl = scp.SIMPLISMA(n_components=20, tol=0.2, noise=3, log_level="INFO")
-simpl.fit(ds)
+_ = simpl.fit(ds)
 
 # %%
 # Plot concentration

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -60,7 +60,7 @@ if ds_list is not None:
     # %%
     # Then we create a PLSRegression object and fit the train datasets:
     pls = scp.PLSRegression(n_components=5)
-    pls.fit(X_train, y_train)
+    _ = pls.fit(X_train, y_train)
     # %%
     # Finally we generate a parity plot comparing the predicted and actual values, for
     # both train set and test set.

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -84,7 +84,7 @@ f1.script = script
 # reset dry and continue to show starting model
 f1.dry = True
 f1.autobase = True
-f1.fit(ndOH)
+_ = f1.fit(ndOH)
 
 # get some information
 scp.info_(f"numbers of components: {f1.n_components}")
@@ -95,7 +95,7 @@ ax.autoscale(enable=True, axis="y")
 # %%
 # Now perform a fit with maximum 1000 iterations
 f1.max_iter = 1000
-f1.fit(ndOH)
+_ = f1.fit(ndOH)
 # %%
 # Show the result
 _ = ndOH.plot()
@@ -105,7 +105,7 @@ ax.autoscale(enable=True, axis="y")
 # %%
 # plotmerit
 som = f1.inverse_transform()
-f1.plotmerit(ndOH, som, method="scatter", markevery=5, markersize=2, lw=2)
+_ = f1.plotmerit(ndOH, som, method="scatter", markevery=5, markersize=2, lw=2)
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
@@ -33,7 +33,7 @@ distance = [-1, 0.2, 0.9, 2.1]
 # We would like v and d0 such as
 #    distance = v.time + d0
 lstsq = scp.LSTSQ()
-lstsq.fit(time, distance)
+_ = lstsq.fit(time, distance)
 v = lstsq.coef
 d0 = lstsq.intercept
 rsquare = lstsq.score()
@@ -64,7 +64,7 @@ distance = scp.NDDataset([-1, 0.2, 0.9, 2.1], title="distance", units="kilometer
 # %%
 # we fit it using the new defined time and distance NDDatasets
 lstsq = scp.LSTSQ()
-lstsq.fit(time, distance)
+_ = lstsq.fit(time, distance)
 
 # The results are the same as previously (but with units information)
 v = lstsq.coef
@@ -95,7 +95,7 @@ distance = scp.NDDataset(
 # but here we just need to pass the distance dataset as argument.
 # The time information being the x coordinates.
 lstsq = scp.LSTSQ()
-lstsq.fit(distance)
+_ = lstsq.fit(distance)
 
 # The results are the same as previously.
 v = lstsq.coef

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
@@ -38,7 +38,7 @@ blc.ranges = (
     [1550.0, 1570.0],
     [1250.0, 1300.0],
 )
-blc.fit(band)
+_ = blc.fit(band)
 
 corrected = blc.corrected
 _ = corrected.plot()

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -33,7 +33,7 @@ ndp = nd[:, 1291.0:5999.0]
 
 # %%
 # Plot the dataset
-ndp.plot()
+_ = ndp.plot()
 # %%
 # Remove a basic linear baseline using `basc`:
 ndp = ndp.basc()
@@ -42,7 +42,7 @@ ndp = ndp.basc()
 # Make it positive
 offset = ndp.min()
 ndp -= offset
-ndp.plot()
+_ = ndp.plot()
 # %%
 # Define the Baseline object for a multivariate baseline correction model.
 # The `n_components` parameter is the number of components to use for the
@@ -71,7 +71,7 @@ blc.ranges = [
 
 # %%
 # We can now fit the baseline correction model to the data:
-blc.fit(ndp)
+_ = blc.fit(ndp)
 # %%
 # The baseline is now stored in the `baseline` attribute of the processor:
 # (note that the baseline is a NDDataset too).
@@ -82,7 +82,7 @@ corrected = blc.corrected
 
 # %%
 # Plot the result of the correction
-corrected.plot()
+_ = corrected.plot()
 # %%
 # We can have a more detailed representation using plot
 ax = blc.plot(nb_traces=2, offset=50)
@@ -92,13 +92,13 @@ blc.show_regions(ax)
 # We can also plot the baseline and the corrected dataset together:
 # for some individual spectra to, for example, check the quality of the
 # correction:
-corrected[0].plot()
-baseline[0].plot(clear=False, color="red", ls="-")
-ndp[0].plot(clear=False, color="green", ls="--")
+_ = corrected[0].plot()
+_ = baseline[0].plot(clear=False, color="red", ls="-")
+_ = ndp[0].plot(clear=False, color="green", ls="--")
 # %%
-corrected[10].plot()
-baseline[10].plot(clear=False, color="red", ls="-")
-ndp[10].plot(clear=False, color="green", ls="--")
+_ = corrected[10].plot()
+_ = baseline[10].plot(clear=False, color="red", ls="-")
+_ = ndp[10].plot(clear=False, color="green", ls="--")
 # %%
 # The baseline correction looks ok in some part of the spectra
 # but not in others where the variation seems a little to rigid.
@@ -114,20 +114,20 @@ blc.order = 5  # use a 5th degree polynomial
 
 # %%
 # and fit again the baseline correction model to the data:
-blc.fit(ndp)
+_ = blc.fit(ndp)
 
 baseline = blc.baseline
 corrected = blc.corrected
 
-corrected[0].plot()
-baseline[0].plot(clear=False, color="red", ls="-")
-ndp[0].plot(clear=False, color="green", ls="--")
+_ = corrected[0].plot()
+_ = baseline[0].plot(clear=False, color="red", ls="-")
+_ = ndp[0].plot(clear=False, color="green", ls="--")
 # %%
-corrected[10].plot()
-baseline[10].plot(clear=False, color="red", ls="-")
-ndp[10].plot(clear=False, color="green", ls="--")
+_ = corrected[10].plot()
+_ = baseline[10].plot(clear=False, color="red", ls="-")
+_ = ndp[10].plot(clear=False, color="green", ls="--")
 # %%
-corrected.plot()
+_ = corrected.plot()
 # %%
 # This looks better and smoother. But not perfect.
 
@@ -145,41 +145,41 @@ blc.multivariate = False  # use a sequential approach
 blc.model = "asls"
 blc.mu = 10**9
 blc.asymmetry = 0.002
-blc.fit(ndp)
+_ = blc.fit(ndp)
 # %%
 baseline = blc.baseline
 corrected = blc.corrected
 
 # %%
-corrected[0].plot()
-baseline[0].plot(clear=False, color="red", ls="-")
-ndp[0].plot(clear=False, color="green", ls="--")
+_ = corrected[0].plot()
+_ = baseline[0].plot(clear=False, color="red", ls="-")
+_ = ndp[0].plot(clear=False, color="green", ls="--")
 # %%
 corrected[-1].plot()
 baseline[-1].plot(clear=False, color="red", ls="-")
 ndp[-1].plot(clear=False, color="green", ls="--")
 # %%
-corrected.plot()
+_ = corrected.plot()
 # %%
 # Finally, we will use the snip model
 blc.multivariate = False  # use a sequential approach
 blc.model = "snip"
 blc.snip_width = 200
-blc.fit(ndp)
+_ = blc.fit(ndp)
 # %%
 baseline = blc.baseline
 corrected = blc.corrected
 
 # %%
-corrected[0].plot()
-baseline[0].plot(clear=False, color="red", ls="-")
-ndp[0].plot(clear=False, color="green", ls="--")
+_ = corrected[0].plot()
+_ = baseline[0].plot(clear=False, color="red", ls="-")
+_ = ndp[0].plot(clear=False, color="green", ls="--")
 # %%
 corrected[-1].plot()
 baseline[-1].plot(clear=False, color="red", ls="-")
 ndp[-1].plot(clear=False, color="green", ls="--")
 # %%
-corrected.plot()
+_ = corrected.plot()
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/examples/processing/denoising/plot_denoising.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_denoising.py
@@ -33,25 +33,25 @@ nd = dataset[:, 60.0:]
 # %%
 # Basic plot
 
-nd.plot(title="original data")
+_ = nd.plot(title="original data")
 # %%
 # Detrend the data (for a easier comparison)
 
 nd1 = nd.detrend(title="detrended data")
-nd1.plot()
+_ = nd1.plot()
 # %%
 # Denoise the data using the `denoise` method with the default parameters
 # i.e., ratio=99.8
 nd2 = nd1.denoise()
-nd2.plot(title="denoised data")
+_ = nd2.plot(title="denoised data")
 # %%
 # Denoise the data using a different ratio
 nd3 = nd1.denoise(ratio=95)
-nd3.plot(title="denoised data")
+_ = nd3.plot(title="denoised data")
 # sphinx_gallery_thumbnail_number = 5
 
 nd4 = nd1.denoise(ratio=90)
-nd4.plot(title="denoised data")
+_ = nd4.plot(title="denoised data")
 
 # %%
 # This example shows that denoising can be used effectively on such spectra to increase the signal-to-noise ratio.

--- a/src/spectrochempy/examples/processing/denoising/plot_despike.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_despike.py
@@ -35,7 +35,7 @@ X1 = X.snip()
 
 prefs = scp.preferences
 prefs.figure.figsize = (8, 4)
-X1.plot()
+_ = X1.plot()
 # %%
 # Now let's use the `~spectrochempy.despike` method.
 # Only two parameters needs to be tuned: the `size` of the filter
@@ -45,14 +45,14 @@ X1.plot()
 # of the difference between the original and the smoothed data.
 
 X2 = scp.despike(X1, size=11, delta=5)
-X1.plot()
-X2.plot(clear=False, ls="-", c="r")
+_ = X1.plot()
+_ = X2.plot(clear=False, ls="-", c="r")
 # %%
 # Another method, 'whitaker', is also available (see the documentation for details):
 # %%
 X3 = scp.despike(X1, size=11, delta=5, method="whitaker")
-X1.plot()
-X3.plot(clear=False, ls="-", c="r")
+_ = X1.plot()
+_ = X3.plot(clear=False, ls="-", c="r")
 # %%
 # Getting the desired results require the tuning of size and delta parameters.
 # And sometimes may need to repeat the procedure on a previously filtered spectra.
@@ -61,8 +61,8 @@ X3.plot(clear=False, ls="-", c="r")
 # So careful inspection of the results is crucial.
 
 X4 = scp.despike(X1, size=21, delta=2)
-X1.plot()
-X4.plot(clear=False, ls="-", c="r")
+_ = X1.plot()
+_ = X4.plot(clear=False, ls="-", c="r")
 
 
 # %%

--- a/src/spectrochempy/examples/processing/filtering/plot_filter.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_filter.py
@@ -22,7 +22,7 @@ import spectrochempy as scp
 X = scp.read("ramandata/labspec/SMC1-Initial_RT.txt")
 prefs = scp.preferences
 prefs.figure.figsize = (8, 4)
-X.plot()
+_ = X.plot()
 # %%
 # here `Filter` processor is used to apply a Savitzky-Golay filter to the
 # spectrum.
@@ -33,7 +33,7 @@ filter = scp.Filter(
 
 # plot the result
 Xm = filter(X)
-X.plot(color="b", label="original")
+_ = X.plot(color="b", label="original")
 ax = Xm.plot(clear=False, color="r", ls="-", lw=1.5, label="SG filter")
 diff = X - Xm
 s = round(diff.std(dim=-1).values, 2)
@@ -49,7 +49,7 @@ filter = scp.Filter(method="whittaker", order=2, lamb=1.5)
 Xm = filter(X)
 # plot the result
 Xm = filter(X)
-X.plot(color="b", label="original")
+_ = X.plot(color="b", label="original")
 ax = Xm.plot(clear=False, color="r", ls="-", lw=1.5, label="WE filter")
 diff = X - Xm
 s = round(diff.std(dim=-1).values, 2)

--- a/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
@@ -48,7 +48,7 @@ for size, smoothed_region in smoothed.items():
 # shape preservation.
 
 sg = scp.Filter(method="savgol", size=7, order=2)(region)
-scp.plot_compare(region, sg, title="Savitzky-Golay smoothing (size=7, order=2)")
+_ = scp.plot_compare(region, sg, title="Savitzky-Golay smoothing (size=7, order=2)")
 
 # %%
 # This ends the example. Uncomment the next line to display the figures when

--- a/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
+++ b/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
@@ -27,11 +27,11 @@ A = scp.read_labspec("SMC1-Initial_RT.txt", directory=ramandir)
 
 # %%
 # Plot the spectrum
-A.plot()
+_ = A.plot()
 # %%
 # Crop the spectrum to a useful region
 B = A[60.0:]
-B.plot()
+_ = B.plot()
 # %%
 # Baseline correction
 # -------------------
@@ -60,7 +60,7 @@ blc.order = "linear"
 
 # %%
 # Now we can fit the model to the data
-blc.fit(B)
+_ = blc.fit(B)
 # %%
 # The baseline is now stored in the `baseline` attribute of the processor
 corr = blc.transform()
@@ -86,7 +86,7 @@ plot_result(B, corr, baseline)
 # %%
 # Let's try with a polynomial detrend of order 2
 blc.order = 2  # quadratic detrending
-blc.fit(B)
+_ = blc.fit(B)
 corr = blc.transform()
 baseline = blc.baseline
 plot_result(B, corr, baseline)
@@ -113,7 +113,7 @@ blc.asymmetry = 0.01
 
 # %%
 # Now we can fit the model to the data
-blc.fit(Bd)
+_ = blc.fit(Bd)
 corr = blc.transform()
 baseline = blc.baseline
 plot_result(Bd, corr, baseline)
@@ -125,7 +125,7 @@ plot_result(Bd, corr, baseline)
 blc.model = "snip"
 blc.snip_width = 55  # estimated FWHM of the peaks (expressed in point. TODO: alternatively use true coordinates)
 Bs = A[55.0:]
-blc.fit(Bs)
+_ = blc.fit(Bs)
 corr = blc.transform()
 baseline = blc.baseline
 plot_result(Bs, corr, baseline)
@@ -137,7 +137,7 @@ plot_result(Bs, corr, baseline)
 
 C = scp.read_labspec("Activation.txt", directory=ramandir)
 # C = C[20:]  # discard the first 20 spectra
-C.plot()
+_ = C.plot()
 # %%
 # Now we apply the AsLS method on the series of spectra
 #
@@ -150,14 +150,14 @@ blc.model = "asls"
 blc.log_level = (
     "WARNING"  # supress output of asls (to long for the moment:  TODO optimize this)
 )
-blc.fit(C[::10])
+_ = blc.fit(C[::10])
 corr = blc.transform()
 baseline = blc.baseline
-corr.plot()
+_ = corr.plot()
 # %%
 # or the `snip` method (which is much faster)
 blc.model = "snip"
-blc.fit(C)
+_ = blc.fit(C)
 corr = blc.transform()
 baseline = blc.baseline
 corr[::10].plot()


### PR DESCRIPTION
## Summary

This PR continues the example/gallery cleanup pass to reduce unhelpful notebook and Sphinx-gallery `_repr_` output in remaining examples.

It applies the existing `_ = ...` pattern to bare `fit()` and plotting calls where the returned object is not reused and the visual output is the actual teaching goal.

This includes the missed `plot_efa.py` case and a broader follow-up pass across remaining core and NMR plugin gallery examples.

## What changed

- cleaned remaining bare `fit()` calls in example scripts;
- cleaned remaining bare plotting calls such as:
  - `plot()`
  - `plot_*()`
  - `plot_stack()`
  - `plotmerit()`
  - `scp.plot_compare(...)`
- updated the local audit note:
  - `audit/~result-examples-and-gallery-repr-pass.md`

## Scope intentionally excluded

This PR does not:

- change runtime code;
- change tests;
- change estimator behavior;
- change Result behavior;
- change documentation semantics;
- remove intentionally useful rich displays such as:
  - dataset summaries
  - coordinate displays
  - coordset displays
  - scalar/value displays that are part of the explanation

## Rationale

The goal is to make gallery and notebook rendering cleaner without changing what examples teach.

We keep useful pedagogical displays, but suppress repr noise from returned estimator/axes-like objects when those objects are not the point of the example.



