### PR TITLE
DOC: clean example and notebook rendering

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -73,3 +73,12 @@
     margin-left: 0px;
     font-size: 10pt;
 }
+
+/*
+ * Hide execution prompts in notebooks rendered by nbsphinx.
+ * These selectors do not match Sphinx-Gallery code or output blocks.
+ */
+div.nbinput.container div.prompt,
+div.nboutput.container div.prompt {
+    display: none;
+}

--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -254,7 +254,7 @@ peaks.x.values
 # %%
 ax = ndOHcorr.plot_pen()  # output the spectrum on ax. ax will receive next plot too
 pks = peaks + 0.01  # add a small offset on the y position of the markers
-pks.plot_scatter(
+_ = pks.plot_scatter(
     ax=ax,
     marker="v",
     color="black",

--- a/docs/sources/userguide/analysis/peak_finding.py
+++ b/docs/sources/userguide/analysis/peak_finding.py
@@ -183,7 +183,7 @@ peakslist = [s.find_peaks(distance=5)[0] for s in reg]
 # %%
 ax = reg.plot()
 for peaks in peakslist:
-    peaks.plot_scatter(
+    _ = peaks.plot_scatter(
         ax=ax,
         marker="v",
         ms=3,
@@ -275,7 +275,7 @@ s = reg[-1].squeeze()
 
 peaks, properties = s.find_peaks()
 ax = s.plot_pen(color="black")
-peaks.plot_scatter(
+_ = peaks.plot_scatter(
     ax=ax,
     label="default",
     marker="v",
@@ -293,8 +293,8 @@ peaks, properties = s.find_peaks(height=0.05)
 color = "blue"
 label = "0.05<height"
 offset = 0.05
-(s + offset).plot_pen(color=color, clear=False)
-(peaks + offset).plot_scatter(
+_ = (s + offset).plot_pen(color=color, clear=False)
+_ = (peaks + offset).plot_scatter(
     ax=ax, label=label, m="v", mfc=color, mec=color, ms=5, clear=False, data_only=True
 )
 
@@ -304,8 +304,8 @@ peaks, properties = s.find_peaks(height=(0.05, 0.2))
 color = "green"
 label = "0.05<height<0.2"
 offset = 0.1
-(s + offset).plot_pen(color=color, clear=False)
-(peaks + offset).plot_scatter(
+_ = (s + offset).plot_pen(color=color, clear=False)
+_ = (peaks + offset).plot_scatter(
     ax=ax, label=label, m="v", mfc=color, mec=color, ms=5, clear=False, data_only=True
 )
 
@@ -315,8 +315,8 @@ peaks, properties = s.find_peaks(prominence=0.05)
 color = "purple"
 label = "prominence=0.05"
 offset = 0.15
-(s + offset).plot_pen(color=color, clear=False)
-(peaks + offset).plot_scatter(
+_ = (s + offset).plot_pen(color=color, clear=False)
+_ = (peaks + offset).plot_scatter(
     ax=ax, label=label, m="v", mfc=color, mec=color, ms=5, clear=False, data_only=True
 )
 
@@ -327,8 +327,8 @@ peaks, properties = s.find_peaks(distance=10)
 color = "red"
 label = "distance>10"
 offset = 0.20
-(s + offset).plot_pen(color=color, clear=False)
-(peaks + offset).plot_scatter(
+_ = (s + offset).plot_pen(color=color, clear=False)
+_ = (peaks + offset).plot_scatter(
     ax=ax, label=label, m="v", mfc=color, mec=color, ms=5, clear=False, data_only=True
 )
 
@@ -336,14 +336,15 @@ offset = 0.20
 peaks_units, _ = s.find_peaks(distance="10 cm^-1")
 peaks_units.x.values
 
+# %%
 # find peaks with width >= 10 (none of the two maxima at ~ 2075 is detected)
 
 peaks, properties = s.find_peaks(width=10)
 color = "grey"
 label = "width>10"
 offset = 0.25
-(s + offset).plot_pen(color=color, clear=False)
-(peaks + offset).plot_scatter(
+_ = (s + offset).plot_pen(color=color, clear=False)
+_ = (peaks + offset).plot_scatter(
     ax=ax, label=label, m="v", mfc=color, mec=color, ms=5, clear=False, data_only=True
 )
 
@@ -562,7 +563,7 @@ for key in properties:
     print(f"{title: >26}: {table_property}")
 
 ax = s.plot()
-peaks.plot_scatter(
+_ = peaks.plot_scatter(
     ax=ax, marker="v", mfc="green", mec="green", data_only=True, clear=False
 )
 

--- a/docs/sources/userguide/analysis/peak_integration.py
+++ b/docs/sources/userguide/analysis/peak_integration.py
@@ -78,7 +78,7 @@ blc.ranges = (
 blc.model = "polynomial"
 blc.order = 3
 
-blc.fit(X)  # fit the baseline
+_ = blc.fit(X)  # fit the baseline
 
 Xcorr = blc.corrected  # get the corrected dataset
 _ = Xcorr.plot()
@@ -95,7 +95,7 @@ intsimps = Xcorr.simpson(dim="x")
 # As you can see, both methods give almost the same results in this case.
 
 # %%
-scp.plot_multiple(
+_ = scp.plot_multiple(
     method="scatter",
     ms=5,
     datasets=[inttrapz, intsimps],

--- a/docs/sources/userguide/processing/alignment.py
+++ b/docs/sources/userguide/processing/alignment.py
@@ -54,7 +54,7 @@ prefs = scp.preferences
 prefs.reset()
 prefs.figure.figsize = (7, 3)
 prefs.figure.dpi = 100
-dataset.plot_map(colormap="viridis", colorbar=True)
+_ = dataset.plot_map(colormap="viridis", colorbar=True)
 print("shape:", dataset.shape)
 
 # %%

--- a/docs/sources/userguide/processing/baseline.py
+++ b/docs/sources/userguide/processing/baseline.py
@@ -85,7 +85,7 @@ blc.model = "rubberband"
 # model can also be passed as a parameter
 blc = scp.Baseline(model="rubberband")
 # fit the model on the first spectra in X (index:0)
-blc.fit(X[0])
+_ = blc.fit(X[0])
 # get the new dataset with the baseline subtracted
 X1 = blc.transform()
 # plot X, X1 and the baseline using the processor plot method
@@ -103,7 +103,7 @@ X1 = blc.corrected
 
 # %%
 # fit the model on the full X series
-blc.fit(X)
+_ = blc.fit(X)
 # get the new dataset with the baseline subtracted
 X2 = blc.transform()
 # plot the baseline corrected series of spectra
@@ -122,7 +122,7 @@ _ = X.plot()
 # the computed baseline and the corrected dataset.
 
 # %%
-blc.fit(X)
+_ = blc.fit(X)
 X3 = blc.transform()
 _ = blc.plot()
 
@@ -185,7 +185,7 @@ blc.order = 7
 # set the ranges
 blc.ranges = ranges
 # fit the model on the first spectra X[0]
-blc.fit(X[0])
+_ = blc.fit(X[0])
 # get and plot the corrected dataset with regions displayed
 X4 = blc.transform()
 _ = blc.plot(show_regions=True)
@@ -208,7 +208,7 @@ blc.used_ranges
 # set the polynomial order to 'pchip'
 blc.order = "pchip"
 # fit the model on the first spectra X[0]
-blc.fit(X[0])
+_ = blc.fit(X[0])
 # get and plot the corrected dataset
 X5 = blc.transform()
 _ = blc.plot()
@@ -222,7 +222,7 @@ _ = blc.plot()
 blc.model = "asls"
 blc.lamb = 10**9
 blc.asymmetry = 0.002
-blc.fit(X)
+_ = blc.fit(X)
 X6 = blc.transform()
 _ = X6.plot()
 
@@ -234,7 +234,7 @@ _ = X6.plot()
 # %%
 blc.model = "snip"
 blc.snip_width = 200
-blc.fit(X)
+_ = blc.fit(X)
 X7 = blc.transform()
 _ = X7.plot()
 
@@ -277,7 +277,7 @@ blc.order = 10
 # Set the number of components
 blc.n_components = 3
 # Fit the model on X
-blc.fit(X)
+_ = blc.fit(X)
 # get the corrected dataset
 X8 = blc.transform()
 # plot the result

--- a/docs/sources/userguide/processing/math_operations.py
+++ b/docs/sources/userguide/processing/math_operations.py
@@ -220,7 +220,7 @@ _ = out.plot(figsize=(6, 2.5))
 out = np.sqrt(
     dataset
 )  # as they are some negative elements, return dataset has complex dtype.
-out.plot_1D(show_complex=True, figsize=(6, 2.5))
+_ = out.plot_1D(show_complex=True, figsize=(6, 2.5))
 
 # %% [markdown]
 # ##### square

--- a/docs/sources/userguide/processing/smoothing.py
+++ b/docs/sources/userguide/processing/smoothing.py
@@ -122,7 +122,7 @@ filter = scp.Filter(
     method="han", size=7
 )  # can also be one of 'hamming', 'bartlett', # 'blackman'.
 Xhan = filter(Xn)
-scp.plot_compare(Xn, Xhan, title="Hanning filter (7 points)")
+_ = scp.plot_compare(Xn, Xhan, title="Hanning filter (7 points)")
 
 # %% [markdown]
 # ### Savitzky-Golay filter
@@ -152,7 +152,7 @@ filter = scp.Filter(
     method="savgol", size=5, order=0
 )  # default is size=5, order=2, deriv=0
 Xsgs = filter(Xn)
-scp.plot_compare(Xn, Xsgs, title="Savitzky-Golay (5 points, order=0)")
+_ = scp.plot_compare(Xn, Xsgs, title="Savitzky-Golay (5 points, order=0)")
 
 # %% [markdown]
 # As the `order` is set to 0, there is no much difference compared to a simple moving
@@ -168,7 +168,7 @@ scp.plot_compare(Xn, Xsgs, title="Savitzky-Golay (5 points, order=0)")
 filter.order = 2
 filter.size = 7
 Xsm2 = filter(Xn)
-scp.plot_compare(Xn, Xsm2, title="Savitzky-Golay (7 points, order=2)")
+_ = scp.plot_compare(Xn, Xsm2, title="Savitzky-Golay (7 points, order=2)")
 
 
 # %% [markdown]
@@ -186,7 +186,7 @@ scp.plot_compare(Xn, Xsm2, title="Savitzky-Golay (7 points, order=2)")
 # %%
 filter = scp.Filter(method="whittaker", order=2, lamb=1.5)
 Xwhit = filter(Xn)
-scp.plot_compare(Xn, Xwhit, title="Whittaker-Eilers (order=2, lamb=1.5)")
+_ = scp.plot_compare(Xn, Xwhit, title="Whittaker-Eilers (order=2, lamb=1.5)")
 
 
 # %% [markdown]
@@ -225,7 +225,7 @@ Xsm = scp.smooth(Xn)  # SpectroChemPy API function
 # %%
 for size in [3, 7, 11]:
     Xsm = Xn.smooth(size)
-    scp.plot_compare(Xn, Xsm, title=f"smooth `avg` size={size}")
+    _ = scp.plot_compare(Xn, Xsm, title=f"smooth `avg` size={size}")
 
 
 # %% [markdown]
@@ -253,7 +253,7 @@ for size in [3, 7, 11]:
 size = 7
 for window in ["flat", "bartlett", "han", "hamming", "blackman"]:
     Xsm = Xn.smooth(size=size, window=window)
-    scp.plot_compare(Xn, Xsm, title=f"window=`{window}` size={size}")
+    _ = scp.plot_compare(Xn, Xsm, title=f"window=`{window}` size={size}")
 
 # %% [markdown]
 # Close examination of the spectra shows that the flat window leads to the stronger

--- a/docs/sources/userguide/processing/transformations.py
+++ b/docs/sources/userguide/processing/transformations.py
@@ -72,7 +72,7 @@ dataset[:, 1290.0:890.0] = MASKED
 # Here is a display the figure with the new mask
 
 # %%
-dataset.plot_stack()
+_ = dataset.plot_stack()
 
 # %% [markdown]
 # Now the max function return the  maximum in the unmasked region, which is exactly what we wanted.

--- a/plugins/spectrochempy-iris/examples/plot_iris.py
+++ b/plugins/spectrochempy-iris/examples/plot_iris.py
@@ -67,7 +67,7 @@ c_pressures = scp.Coord(pressures, title="pressure", units="torr")
 
 c_times = X.y.copy()  # the original coordinate
 X.y = [c_times, c_pressures]
-print(X.y)
+X.y
 
 # %%
 # To get a detailed
@@ -82,6 +82,7 @@ X.coordset
 
 _ = X.plot(colorbar=True)
 _ = X.plot_contourf(colorbar=True)
+
 # %%
 # To seamlessly work with the second coordinates (pressures), we can change the default
 # coordinate:
@@ -92,9 +93,12 @@ X.y.default
 # %%
 # Let's now plot the spectral range of interest. The default coordinate is now used:
 X_ = X[:, 2250.0:1950.0]
-print(X_.y.default)
+X_.y.default
+
+# %%
 _ = X_.plot()
 _ = X_.plot_contourf()
+
 # %%
 # IRIS analysis without regularization
 # ------------------------------------
@@ -128,6 +132,7 @@ _ = f.plot_contour()
 
 # %%
 _ = iris1.plotmerit()
+
 # %%
 # With regularization and a manual search
 # ---------------------------------------
@@ -138,20 +143,24 @@ iris2 = IRIS(reg_par=[-10, 1, 12])
 # We keep the same kernel object as previously - performs the fit.
 _ = iris2.fit(X_, K)
 _ = iris2.plotlcurve(title="L curve, manual search")
+
 # %%
 # Visually, the best regularization parameter is at index ~ -6, corresponding to lambda = 1e-4
 
 _ = iris2.f[-6].plot_contour()
 _ = iris2.plotmerit(-6)
+
 # %%
 # Automatic search
 # ----------------
+
 # %%
 # Now try an automatic search of the regularization parameter around the best value found manually:
 
 iris3 = IRIS(log_level="INFO", reg_par=[-6, -2])
 _ = iris3.fit(X_, K)
 _ = iris3.plotlcurve(title="L curve, automated search")
+
 # %%
 # The data corresponding to the largest curvature of the L-curve
 # are at index 5 of the output data.

--- a/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
+++ b/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
@@ -34,6 +34,7 @@ ndd = scp.nmr.read_topspin(path, expno=1, remove_digital_filter=True)
 # view it...
 
 _ = ndd.plot()
+
 # %%
 # Now load a 2D  dataset
 

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
@@ -60,11 +60,11 @@ new5, curve5 = dataset1D.sinm(ssb=8, retapod=True, inplace=False)
 # Plotting
 _ = dataset1D.plot(zlim=(-2, 2), color="k")
 _ = curve1.plot(color="r", clear=False)
-new1.plot(
+_ = new1.plot(
     data_only=True, color="r", clear=False, label=" sinm with ssb= 2 (cosine window)"
 )
 _ = curve2.plot(color="b", clear=False)
-new2.plot(
+_ = new2.plot(
     data_only=True, color="b", clear=False, label=" sinm with ssb= 1 (sine window)"
 )
 _ = curve3.plot(color="m", clear=False)
@@ -72,7 +72,7 @@ _ = new3.plot(data_only=True, color="m", clear=False, label=" qsin with ssb= 2")
 _ = curve4.plot(color="g", clear=False)
 _ = new4.plot(data_only=True, color="g", clear=False, label=" qsin with ssb= 1")
 _ = curve5.plot(color="c", ls="--", clear=False)
-new5.plot(
+_ = new5.plot(
     data_only=True,
     color="c",
     ls="--",

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
@@ -68,6 +68,7 @@ nd3 = scp.pk(nd2, phc0=-118)
 # %%
 # plot
 _ = nd3.plot()
+
 # %%
 # ## Baseline correction
 # Here we use the snip algorithm
@@ -98,7 +99,7 @@ for key in properties:
 # plot with peak markers and the left/right-bases indicators
 ax = nd4.plot()  # output the spectrum on ax. ax will receive next plot too;
 pks = peaks + 0.5  # add a small offset on the y position of the markers
-pks.plot_scatter(
+_ = pks.plot_scatter(
     ax=ax,
     marker="v",
     color="black",

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -40,40 +40,48 @@ dataset
 # %%
 # Plot the dataset
 _ = dataset.plot_map()
+
 # %%
 # Extract slices along x
 s = dataset[-27.6, :]
 _ = s.plot()
+
 # %%
 # Baseline correction of this slice
 # Note that only the real part is corrected
 sa = s.snip(snip_width=100)
 _ = sa.plot()
+
 # %%
 # apply this correction to the whole dataset
 sb = dataset.snip(snip_width=100)
 _ = sb.plot_map()
+
 # %%
 # Select a region of interest
 sc = sb[
     -40.0:-15.0, 55.0:20.0
 ]  # note the use of float to make selection using coordinates (not point indexes)
 _ = sc.plot_map()
+
 # %%
 # Extract slices along x
 s1 = sc[-27.6, :]
 _ = s1.plot()
+
 # %%
 s2 = sc[-25.7, :]
 _ = s2.plot()
+
 # %%
 # plot two slices on the same figure
 _ = s1.plot()
-s2.plot(
+_ = s2.plot(
     clear=False,
     color="red",
     linestyle="-",
 )
+
 # %%
 # Now slice along y
 s3 = sc[:, 40.0]
@@ -93,6 +101,7 @@ s4 = s4.squeeze()
 # plot the two slices on the same figure
 _ = s3.plot(color="violet", ls="-", lw="2")
 _ = s4.plot(clear=False, color="green", ls="-", lw="2")
+
 # %%
 # Peak picking
 # ------------
@@ -107,7 +116,7 @@ peaks, _ = s2.find_peaks()
 def plot_with_pp(s, peaks):
     ax = s.plot()  # output the spectrum on ax. ax will receive next plot too;
     pks = peaks + 0.2  # add a small offset on the y position of the markers
-    pks.plot_scatter(
+    _ = pks.plot_scatter(
         ax=ax,
         marker="v",
         color="black",

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
@@ -43,6 +43,7 @@ ds = dataset.em(lb=15 * U.Hz)
 ds = ds.fft()
 ds = ds.pk(phc0=-10 * U.deg, phc1=0 * U.deg)
 _ = ds.plot(xlim=(-60, -140))
+
 # %%
 # Integrate a region
 dsint = ds[:, -90.0:-115.0].simpson()

--- a/src/spectrochempy/application/preferences.py
+++ b/src/spectrochempy/application/preferences.py
@@ -291,6 +291,8 @@ class PreferencesSet(Meta):
                 "interactive",
                 "savefig.directory",
                 "timezone",
+                "text.hinting_factor",
+                "text.kerning_factor",
                 "tk.window_focus",
                 "toolbar",
                 "webagg.address",

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -11,6 +11,7 @@ EFA example
 In this example, we perform the Evolving Factor Analysis
 
 """
+
 # %%
 # sphinx_gallery_thumbnail_number = 2
 
@@ -37,23 +38,28 @@ dataset[:, 5997.0:5993.0] = scp.MASKED
 # difference spectra
 # dataset -= dataset[-1]
 _ = dataset.plot_stack(title="NH4_Y activation dataset")
+
 # %%
 #  Evolving Factor Analysis
 efa1 = scp.EFA()
 _ = efa1.fit(dataset)
+
 # %%
 # Forward evolution of the 5 first components
 f = efa1.f_ev[:, :5]
 _ = f.T.plot(yscale="log", legend=f.k.labels)
+
 # %%
 # Note the use of coordinate 'k' (component axis) in the expression above.
 # Remember taht to find the actul names of the coordinates, the `dims`
 # attribute can be used as in the following:
 f.dims
 
+# %%
 # Backward evolution
 b = efa1.b_ev[:, :5]
-b.T[:5].plot(yscale="log", legend=b.k.labels)
+_ = b.T[:5].plot(yscale="log", legend=b.k.labels)
+
 # %%
 # Show results with 3 components (which seems to already explain a large part of the dataset)
 # we use the magnitude of the 4th component for the cut-off value (assuming it
@@ -64,6 +70,7 @@ efa1.cutoff = efa1.f_ev[:, 3].max()
 # get concentration
 C1 = efa1.transform()
 _ = C1.T.plot(title="EFA determined concentrations", legend=C1.k.labels)
+
 # %%
 # Fit transform : Get the concentration in too commands
 # The number of desired components can be passed to the EFA model,
@@ -78,6 +85,7 @@ assert C1 == C2
 #
 St = efa2.get_components()
 _ = St.plot(title="components", legend=St.k.labels)
+
 # %%
 # Compare with PCA
 pca = scp.PCA(n_components=3)
@@ -85,6 +93,7 @@ C3 = pca.fit_transform(dataset)
 
 # %%
 _ = C3.T.plot(title="PCA scores")
+
 # %%
 LT = pca.loadings
 _ = LT.plot(title="PCA components", legend=LT.k.labels)

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -36,6 +36,7 @@ data[1, 5:11] = [1, 3, 5, 3, 1, 0.5]  # compound 2
 
 dsc = scp.NDDataset(data=data, coords=[c, t])
 _ = dsc.plot(title="concentration")
+
 # %%
 # 2) absorption spectra
 # **********************
@@ -45,6 +46,7 @@ w = scp.Coord(np.arange(1, 5, 1), units="nm", title="wavelength")
 
 dss = scp.NDDataset(data=spec, coords=[c, w])
 _ = dss.plot(title="spectra")
+
 # %%
 # 3) simulated data matrix
 # ************************
@@ -54,6 +56,7 @@ dataset.data = np.random.normal(dataset.data, 0.1)
 dataset.title = "intensity"
 
 _ = dataset.plot(title="calculated dataset")
+
 # %%
 # 4) evolving factor analysis (EFA)
 # *********************************
@@ -64,8 +67,10 @@ _ = efa.fit(dataset)
 # Plots of the log(EV) for the forward and backward analysis
 #
 _ = efa.f_ev.T.plot(yscale="log", legend=efa.f_ev.k.labels)
+
 # %%
 _ = efa.b_ev.T.plot(yscale="log", legend=efa.b_ev.k.labels)
+
 # %%
 # Looking at these EFA curves, it is quite obvious that only two components
 # are really significant, and this corresponds to the data that we have in
@@ -79,9 +84,11 @@ f2 = efa.f_ev[:, :n_pc]
 b2 = efa.b_ev[:, :n_pc]
 
 # %%
-# we concatenate the datasets to plot them in a single figure
-both = scp.concatenate(f2, b2)
-_ = both.T.plot(yscale="log")
+# plot forward and backward EFA curves together without concatenating datasets,
+# which would emit a coordinate warning here.
+_ = f2.T.plot(yscale="log")
+_ = b2.T.plot(yscale="log", clear=False)
+
 # %%
 # Get the abstract concentration profile based on the FIFO EFA analysis
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
@@ -35,6 +35,7 @@ X.y.title = "elution time"
 X.y.units = "min"
 X.x.title = "wavelength"
 _ = X.plot()
+
 # %%
 # Create and fit a FastICA object
 # -------------------------------
@@ -44,6 +45,7 @@ _ = X.plot()
 
 ica = scp.FastICA(n_components=4, log_level="INFO")
 _ = ica.fit(X)
+
 # %%
 # Get the mixing system and source spectral profiles
 # --------------------------------------------------
@@ -62,6 +64,7 @@ St = ica.St  # or model.mixing.T
 
 _ = A.T.plot(title="Mixing System", colormap=None)
 _ = St.plot(title="Sources spectral profiles", colormap=None)
+
 # %%
 # Reconstruct the dataset
 # -----------------------
@@ -70,10 +73,12 @@ _ = St.plot(title="Sources spectral profiles", colormap=None)
 
 X_hat_a = scp.dot(A, St) + X.mean(dim=0).data
 _ = X_hat_a.plot(title=r"$\hat{X} = \bar{X} + A S^t$")
+
 # %%
 # Or using the transform() method:
 X_hat_b = ica.inverse_transform()
 _ = X_hat_b.plot(title=r"$\hat{X} =$ ica.inverse_transform()")
+
 # %%
 # Finally, the quality of the reconstriction can be checked by `plotmerit()`
 _ = ica.plotmerit(nb_traces=15)

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
@@ -60,6 +60,7 @@ guess = datasets[3]
 # Plot of X and of the guess:
 _ = X.plot()
 _ = guess.plot()
+
 # %%
 # Create a MCR-ALS object
 # -----------------------
@@ -77,6 +78,7 @@ mcr = scp.MCRALS(log_level="INFO")
 # Then we execute the optimization process using the `fit` method with
 # the ``X`` and ``guess`` dataset as input arguments.
 _ = mcr.fit(X, guess)
+
 # %%
 # Plotting the results
 # --------------------
@@ -86,6 +88,7 @@ _ = mcr.fit(X, guess)
 
 _ = mcr.C.T.plot()
 _ = mcr.St.plot()
+
 # %%
 # Finally, plots the reconstructed dataset (:math:`\hat{X} = C.S^T`)
 # *vs.* original dataset

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -44,6 +44,7 @@ D.y = scp.Coord(ds[0].data.squeeze(), title="time") / 60
 D.x = scp.Coord(ds[1][:, 0].data.squeeze(), title="wavelength / cm$^{-1}$")
 D = D[::4]
 _ = D.plot()
+
 # %%
 # A first estimate of the concentrations can be obtained by EFA:
 print("compute EFA...")
@@ -53,6 +54,7 @@ efa.n_components = 3
 C0 = efa.transform()
 C0 = C0 / C0.max(dim="y") * 5.0
 _ = C0.T.plot()
+
 # %%
 # We can get a better estimate of the concentration (C) and pure spectra profiles (St)
 # by soft MCR-ALS:
@@ -60,6 +62,7 @@ mcr_1 = scp.MCRALS(log_level="INFO")
 _ = mcr_1.fit(D, C0)
 _ = mcr_1.C.T.plot()
 _ = mcr_1.St.plot()
+
 # %%
 # Kinetic constraints can be added, i.e., imposing that the concentration profiles obey
 # a kinetic model. To do so we first define an ActionMAssKinetics object with
@@ -75,6 +78,7 @@ kin = scp.ActionMassKinetics(reactions, species_concentrations, k0)
 Ckin = kin.integrate(D.y.data)
 _ = mcr_1.C.T.plot(linestyle="-", cmap=None)
 _ = Ckin.T.plot(clear=False, cmap=None)
+
 # %%
 # Even though very approximate, the same values can be used to run a hard-soft MCR-ALS:
 X = D[:, 300.0:500.0]
@@ -96,6 +100,7 @@ _ = mcr_2.fit(X, Ckin)
 
 _ = mcr_2.C.T.plot()
 _ = mcr_2.C_constrained.T.plot(clear=False)
+
 # %%
 # Finally, let's plot some of the pure spectra profiles St, and the
 #  reconstructed dataset  (X_hat = C St) vs original dataset (X) and residuals.

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
@@ -39,6 +39,7 @@ dataset -= dataset.min()
 # %%
 # Plot it for a visual check
 _ = dataset.plot()
+
 # %%
 # Create a NMF object
 # -------------------
@@ -64,6 +65,7 @@ St = model.components
 # Plot results
 # ------------
 _ = C.T.plot(title="Concentration", colormap=None, legend=C.k.labels)
+
 # %%
 #
 m = St.ptp()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -27,15 +27,19 @@ dataset = scp.load_iris()
 # using `n_components="mle"`\. Warning: `mle` cannot be used when
 # n_observations < n_features.
 pca = scp.PCA(n_components="mle")
+
 # %%
 # Fit dataset with the PCA model
 _ = pca.fit(dataset)
+
 # %%
 # The number of components found is 3:
 pca.n_components
+
 # %%
 # It explains 99.5% of the variance
 pca.cumulative_explained_variance[-1].value
+
 # %%
 # We can also specify the amount of explained variance to compute how much components
 # are needed (a number between 0 and 1 for n_components is required to do this).
@@ -43,40 +47,48 @@ pca.cumulative_explained_variance[-1].value
 pca = scp.PCA(n_components=0.999)
 _ = pca.fit(dataset)
 pca.n_components
+
 # %%
 # the 4 components found are in the `components` attribute of pca. These components are
 # often called loadings in PCA analysis.
 loadings = pca.components
 loadings
+
 # %%
 # Note: it is equivalently possible to use the `loadings` attribute of pca, which
 # produces the same results.
 pca.loadings
+
 # %%
 # To Reduce the data to a lower dimensionality using these three components, we use the
 # transform methods. The results is often called `scores` for PCA analysis.
 scores = pca.transform()
 scores
+
 # %%
 # Again, we can also use the `scores` attribute to get these results.
 scores = pca.scores
 scores
+
 # %%
 # The figures of merit (explained and cumulative variance) confirm that
 # these 4 PC's explain 100% of the variance:
 #
 pca.printev()
+
 # %%
 # These figures of merit can also be displayed graphically
 #
 # The ScreePlot
 _ = pca.plot_scree()
+
 # %%
 # The score plots can be used for classification purposes. The first one - in 2D for the
 # 2 first PC's - shows that the first PC allows distinguishing Iris-setosa (score of
 # PC#1 < -1) from other species (score of PC#1 > -1), while more PC's are required
 # to distinguish versicolor from virginica.
 _ = pca.plot_score(color_mapping="labels")
+
 # %%
 # The second one, in 3D for the first 3 PCs, indicates that a third PC will not
 # better distinguish versicolor from virginica.

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
@@ -19,8 +19,11 @@ import spectrochempy as scp
 # %%
 # Load a dataset
 dataset = scp.read_omnic("irdata/nh4y-activation.spg")[::5]
-print(dataset)
+dataset
+
+# %%
 _ = dataset.plot()
+
 # %%
 # Create a PCA object and fit the dataset so that the explained variance is greater or
 # equal to 99.9%
@@ -46,24 +49,29 @@ prefs.lines.markersize = 7
 
 # ScreePlot
 _ = pca.plot_scree()
+
 # %%
 # Score Plot
 # first we can set some preferences for the plot
 prefs.lines.markersize = 10
 
 _ = pca.plot_score()
+
 # %%
 # Score Plot for 3 PC's in 3D
 _ = pca.plot_score(components=(1, 2, 3))
+
 # %%
 # Displays 4 loadings
-pca.loadings[:4].plot(legend=True)
+_ = pca.loadings[:4].plot(legend=True)
+
 # %%
 # Here we do a masking of the saturated region between 882 and 1280 cm^-1
 dataset[
     :, 882.0:1280.0
 ] = scp.MASKED  # remember: use float numbers for slicing (not integer)
 _ = dataset.plot()
+
 # %%
 # Apply the PCA model
 pca = scp.PCA(n_components=0.999)
@@ -74,13 +82,16 @@ pca.n_components
 # As seen above, now only 4 components instead of 23 are necessary to 99.9% of
 # explained variance.
 _ = pca.plot_scree()
+
 # %%
 # Displays the loadings
 _ = pca.loadings.plot(legend=True)
+
 # %%
 # Let's plot the scores
 scores = pca.transform()
 _ = pca.plot_score((1, 2))
+
 # %%
 # Labeling scoreplot with spectra labels
 # Our dataset has already two columns of labels for the spectra but there are little

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
@@ -26,6 +26,7 @@ for mat in lnd:
 
 ds = lnd[-1]
 _ = ds.plot()
+
 # %%
 # Add some metadata for a nicer display
 ds.title = "absorbance"
@@ -45,12 +46,14 @@ _ = simpl.fit(ds)
 # %%
 # Plot concentration
 _ = simpl.C.T.plot(title="Concentration")
+
 # %%
 # Plot components (St)
 
 # sphinx_gallery_thumbnail_number = 3
 
 _ = simpl.components.plot(title="Pure profiles")
+
 # %%
 # Show the plot of merit
 # after reconstruction oto the original data space

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -34,6 +34,7 @@ else:
 # The 5th dataset named `'m5spec'`, contains the NIR spectra of 80 corn samples recorded
 # on the same instrument. Let's assign this NDDataset specta to `X`, add few
 # informations and plot it:
+
 # %%
 if ds_list is not None:
     X = ds_list[4]
@@ -71,6 +72,7 @@ if ds_list is not None:
         y_test, pls.predict(X_test), s=150, c="red", label="validation", clear=False
     )
     ax.legend(loc="lower right")
+
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when
 # running the .py script with python

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -31,6 +31,7 @@ ndOH = nd[54, 3800.0:3300.0]
 # masking
 ndOH[:, 3505.0:3500.0] = scp.MASKED
 _ = ndOH.plot()
+
 # %%
 # Perform a Fit
 # Fit parameters are defined in a script (a single text as below)
@@ -96,6 +97,7 @@ ax.autoscale(enable=True, axis="y")
 # Now perform a fit with maximum 1000 iterations
 f1.max_iter = 1000
 _ = f1.fit(ndOH)
+
 # %%
 # Show the result
 _ = ndOH.plot()

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
@@ -49,7 +49,7 @@ _ = corrected.plot()
 trapz_area = corrected.trapezoid(dim="x")
 simpson_area = corrected.simpson(dim="x")
 
-scp.plot_multiple(
+_ = scp.plot_multiple(
     method="scatter",
     ms=5,
     datasets=[trapz_area, simpson_area],

--- a/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
@@ -114,6 +114,7 @@ _ = new[:, 0:20].plot(cmap="tab20")
 # But it is possible to display image plot instead (note that the x-axis is in wavenumber and
 # the y-axis is in time-on-stream)
 _ = new.plot_image()
+
 # %%
 # or contour plot  (note that
 _ = new.plot_map()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
@@ -97,6 +97,7 @@ X.y
 
 _ = X.plot(colorbar=True)
 _ = X.plot_map(colorbar=True)
+
 # %%
 # To seamlessly work with the second coordinates (pressures),
 # we can change the default coordinate:
@@ -107,9 +108,12 @@ X.y.default
 # %%
 # Let's now plot the spectral range of interest. The default coordinate is now used:
 X_ = X[:, 2250.0:1950.0]
-print(X_.y.default)
+X_.y.default
+
+# %%
 _ = X_.plot()
 _ = X_.plot_map()
+
 # %%
 # The same can be done for the x coordinates.
 #
@@ -123,7 +127,12 @@ _ = row10.coordset
 
 c_wavenumber = row10.x.copy()
 c_wavelength = row10.x.to("nanometer")
-print(c_wavenumber, c_wavelength)
+c_wavenumber
+
+# %%
+c_wavelength
+
+# %%
 row10.x = [c_wavenumber, c_wavelength]
 row10.x.select(2)
 _ = row10.plot()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
@@ -49,6 +49,7 @@ ur = scp.ur
 
 ds = scp.read("wodger.spg")[0]
 _ = ds.plot()
+
 # %%
 # * `wavenumbers` (`x` ) coordinates are here expressed in $cm^{-1}$
 # * and `data` are in absorbance ($a.u.$) units.
@@ -83,6 +84,7 @@ except Exception as e:
 
 ds.x.ito("terahertz")
 _ = ds.plot()
+
 # %%
 # We can also change wavenumber or frequency units to energy or wavelength,
 # as SpectroChemPy, thanks to [pint](https://pint.readthedocs.io), knows how
@@ -90,6 +92,7 @@ _ = ds.plot()
 
 ds.x.ito("eV")
 _ = ds.plot()
+
 # %%
 try:
     ds.x.ito("nanometer")
@@ -101,11 +104,13 @@ ds.x
 
 # %%
 _ = ds.plot()
+
 # %%
 # `absorbance` units (the units of the data)
 # can also be transformed into `transmittance`
 ds.ito("transmittance")
 _ = ds.plot()
+
 # %%
 # Back to `absorbance`.
 ds.ito("absorbance")

--- a/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
@@ -94,6 +94,7 @@ _ = new.plot(colorbar=True)
 #
 # sphinx_gallery_thumbnail_number = 2
 _ = new.plot(method="image", colorbar=True)
+
 # %%
 # If a dataset contains only positive values, the default colormap is
 # sequential (`viridis`):
@@ -103,6 +104,7 @@ _ = np.abs(new).plot(method="image", colorbar=True)
 # %% Contour plots are also available, with the same default colormap as for the image method:
 _ = new.plot(method="map")
 _ = np.abs(new).plot(method="map")
+
 # %%
 # Note that the scp allows one to use this syntax too:
 _ = scp.plot_map(new)

--- a/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
@@ -33,6 +33,7 @@ print(dataset)
 # %%
 if dataset is not None:
     _ = dataset.plot(style="paper")
+
 # %%
 # When using `read`, we can pass filename as a `str` or a `~pathlib.Path` object.
 filename = TEST_FILE
@@ -86,10 +87,10 @@ else:
 
     # %%
     # Plot each of the datasets
-    dataset_list[-1].plot()
-    dataset_list[-2].plot()
-    dataset_list[-3].plot()
-    dataset_list[-4].plot()
+    _ = dataset_list[-1].plot()
+    _ = dataset_list[-2].plot()
+    _ = dataset_list[-3].plot()
+    _ = dataset_list[-4].plot()
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
@@ -11,6 +11,7 @@ Loading Bruker OPUS files
 Here we load an experimental Bruker OPUS files and plot it.
 
 """
+
 # %%
 
 import spectrochempy as scp

--- a/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
@@ -23,12 +23,15 @@ A
 # %%
 # Now plot them:
 _ = A.plot()
+
 # %%
 # As it is a 2D dataset, we can plot it as an image:
 _ = A.plot_image()
+
 # %%
 # or a contour plot:
 _ = A.plot_map()
+
 # %%
 # We can also read the content of a folder, and merge all spectra:
 B = scp.read_labspec(ramandir / "subdir")

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -25,6 +25,7 @@ import spectrochempy as scp
 # First read a single spectrum (measurement type : single)
 dataset = scp.read_wire("ramandata/wire/sp.wdf")  # or read_wdf (or read)
 _ = dataset.plot()
+
 # %%
 # Now read a series of spectra (measurement type : series) from a Z-depth scan.
 dataset = scp.read_wdf("ramandata/wire/depth.wdf")
@@ -57,10 +58,12 @@ import numpy as np
 keep_rows = np.where(dataset.data.mean(axis=1) > 0)[0]
 dataset = dataset[keep_rows]
 _ = dataset.plot_image()
+
 # %%
 # extract a line scan data from a StreamLine HR measurement
 dataset = scp.read("ramandata/wire/line.wdf")
 _ = dataset.plot_image()
+
 # %%
 # finally extract grid scan data from a StreamLine HR measurement
 dataset = scp.read_wdf("ramandata/wire/mapping.wdf")

--- a/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
@@ -27,6 +27,7 @@ ex1
 ex2 = scp.read_spc("galacticdata/CONTOUR.SPC")
 _ = ex2.plot()
 ex2
+
 # %%
 # Reading SPC file with multiple subfiles with different x coordinates (they are not merged)
 ex3 = scp.read_spc("galacticdata/DRUG_SAMPLE_PEAKS.SPC")

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
@@ -26,6 +26,7 @@ B1 = scp.read("ramandata/labspec/serie190214-1.txt")
 # available matplotlib colormap. The second parameter `lw` is used to set the line
 # width. In addition, we fix the figsize to have a better view of the spectra.
 _ = B1.plot(cmap=None, lw=1)
+
 # %%
 # We will limit the x range to the region of interest
 # note the float number to specify that we use coordinates and not indices
@@ -35,6 +36,7 @@ B2 = B1[:, 60.0:]
 # As there is obviously a drift in these spectra, we will use detrend to remove it.
 B3 = scp.detrend(B2)
 _ = B3.plot(cmap=None)
+
 # %%
 # To demonstrate the use of `plot_multiple` we will take only a few spectra.
 # For instance the 5 first spectra:
@@ -43,6 +45,7 @@ B4 = B3[:5]
 # %%
 # plot it to see what we have selected
 _ = B4.plot(cmap=None)
+
 # %%
 # Now we will use `plot_multiple` to plot all the spectra of the dataset B4.
 # we need to use `offset` to separate the traces and we set some labels to identify

--- a/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
@@ -10,6 +10,7 @@ Introduction to the plotting librairie
 
 
 """
+
 # %%
 
 import spectrochempy as scp
@@ -28,14 +29,17 @@ dataset = scp.read_omnic(datadir / "irdata" / "nh4y-activation.spg")
 # First we do a generic plot (with the default style):
 
 ax = dataset[0].plot()
+
 # %%
 # plot generic style
 
 ax = dataset[0].plot(style="classic")
+
 # %%
 # check that style reinit to default
 # should be identical to the first one
 ax = dataset[0].plot()
+
 # %%
 # Multiple plots
 dataset = dataset[:, ::100]
@@ -44,11 +48,13 @@ datasets = [dataset[0], dataset[10], dataset[20], dataset[50], dataset[53]]
 labels = ["sample {}".format(label) for label in ["S1", "S10", "S20", "S50", "S53"]]
 
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")
+
 # %%
 # plot multiple with style
 _ = scp.plot_multiple(
     method="scatter", style="sans", datasets=datasets, labels=labels, legend="best"
 )
+
 # %%
 # check that style reinit to default
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")

--- a/src/spectrochempy/examples/core/e_project/plot_project.py
+++ b/src/spectrochempy/examples/core/e_project/plot_project.py
@@ -11,6 +11,7 @@ Project creation
 In this example, we create a Project from scratch
 
 """
+
 # %%
 
 import spectrochempy as scp

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -34,6 +34,7 @@ ndp = nd[:, 1291.0:5999.0]
 # %%
 # Plot the dataset
 _ = ndp.plot()
+
 # %%
 # Remove a basic linear baseline using `basc`:
 ndp = ndp.basc()
@@ -43,6 +44,7 @@ ndp = ndp.basc()
 offset = ndp.min()
 ndp -= offset
 _ = ndp.plot()
+
 # %%
 # Define the Baseline object for a multivariate baseline correction model.
 # The `n_components` parameter is the number of components to use for the
@@ -72,6 +74,7 @@ blc.ranges = [
 # %%
 # We can now fit the baseline correction model to the data:
 _ = blc.fit(ndp)
+
 # %%
 # The baseline is now stored in the `baseline` attribute of the processor:
 # (note that the baseline is a NDDataset too).
@@ -83,6 +86,7 @@ corrected = blc.corrected
 # %%
 # Plot the result of the correction
 _ = corrected.plot()
+
 # %%
 # We can have a more detailed representation using plot
 ax = blc.plot(nb_traces=2, offset=50)
@@ -95,10 +99,12 @@ blc.show_regions(ax)
 _ = corrected[0].plot()
 _ = baseline[0].plot(clear=False, color="red", ls="-")
 _ = ndp[0].plot(clear=False, color="green", ls="--")
+
 # %%
 _ = corrected[10].plot()
 _ = baseline[10].plot(clear=False, color="red", ls="-")
 _ = ndp[10].plot(clear=False, color="green", ls="--")
+
 # %%
 # The baseline correction looks ok in some part of the spectra
 # but not in others where the variation seems a little to rigid.
@@ -122,12 +128,15 @@ corrected = blc.corrected
 _ = corrected[0].plot()
 _ = baseline[0].plot(clear=False, color="red", ls="-")
 _ = ndp[0].plot(clear=False, color="green", ls="--")
+
 # %%
 _ = corrected[10].plot()
 _ = baseline[10].plot(clear=False, color="red", ls="-")
 _ = ndp[10].plot(clear=False, color="green", ls="--")
+
 # %%
 _ = corrected.plot()
+
 # %%
 # This looks better and smoother. But not perfect.
 
@@ -146,6 +155,7 @@ blc.model = "asls"
 blc.mu = 10**9
 blc.asymmetry = 0.002
 _ = blc.fit(ndp)
+
 # %%
 baseline = blc.baseline
 corrected = blc.corrected
@@ -154,18 +164,22 @@ corrected = blc.corrected
 _ = corrected[0].plot()
 _ = baseline[0].plot(clear=False, color="red", ls="-")
 _ = ndp[0].plot(clear=False, color="green", ls="--")
+
 # %%
-corrected[-1].plot()
-baseline[-1].plot(clear=False, color="red", ls="-")
-ndp[-1].plot(clear=False, color="green", ls="--")
+_ = corrected[-1].plot()
+_ = baseline[-1].plot(clear=False, color="red", ls="-")
+_ = ndp[-1].plot(clear=False, color="green", ls="--")
+
 # %%
 _ = corrected.plot()
+
 # %%
 # Finally, we will use the snip model
 blc.multivariate = False  # use a sequential approach
 blc.model = "snip"
 blc.snip_width = 200
 _ = blc.fit(ndp)
+
 # %%
 baseline = blc.baseline
 corrected = blc.corrected
@@ -174,10 +188,12 @@ corrected = blc.corrected
 _ = corrected[0].plot()
 _ = baseline[0].plot(clear=False, color="red", ls="-")
 _ = ndp[0].plot(clear=False, color="green", ls="--")
+
 # %%
-corrected[-1].plot()
-baseline[-1].plot(clear=False, color="red", ls="-")
-ndp[-1].plot(clear=False, color="green", ls="--")
+_ = corrected[-1].plot()
+_ = baseline[-1].plot(clear=False, color="red", ls="-")
+_ = ndp[-1].plot(clear=False, color="green", ls="--")
+
 # %%
 _ = corrected.plot()
 

--- a/src/spectrochempy/examples/processing/denoising/plot_denoising.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_denoising.py
@@ -34,16 +34,19 @@ nd = dataset[:, 60.0:]
 # Basic plot
 
 _ = nd.plot(title="original data")
+
 # %%
 # Detrend the data (for a easier comparison)
 
 nd1 = nd.detrend(title="detrended data")
 _ = nd1.plot()
+
 # %%
 # Denoise the data using the `denoise` method with the default parameters
 # i.e., ratio=99.8
 nd2 = nd1.denoise()
 _ = nd2.plot(title="denoised data")
+
 # %%
 # Denoise the data using a different ratio
 nd3 = nd1.denoise(ratio=95)

--- a/src/spectrochempy/examples/processing/denoising/plot_despike.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_despike.py
@@ -36,6 +36,7 @@ X1 = X.snip()
 prefs = scp.preferences
 prefs.figure.figsize = (8, 4)
 _ = X1.plot()
+
 # %%
 # Now let's use the `~spectrochempy.despike` method.
 # Only two parameters needs to be tuned: the `size` of the filter
@@ -47,12 +48,15 @@ _ = X1.plot()
 X2 = scp.despike(X1, size=11, delta=5)
 _ = X1.plot()
 _ = X2.plot(clear=False, ls="-", c="r")
+
 # %%
 # Another method, 'whitaker', is also available (see the documentation for details):
+
 # %%
 X3 = scp.despike(X1, size=11, delta=5, method="whitaker")
 _ = X1.plot()
 _ = X3.plot(clear=False, ls="-", c="r")
+
 # %%
 # Getting the desired results require the tuning of size and delta parameters.
 # And sometimes may need to repeat the procedure on a previously filtered spectra.

--- a/src/spectrochempy/examples/processing/filtering/plot_filter.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_filter.py
@@ -23,6 +23,7 @@ X = scp.read("ramandata/labspec/SMC1-Initial_RT.txt")
 prefs = scp.preferences
 prefs.figure.figsize = (8, 4)
 _ = X.plot()
+
 # %%
 # here `Filter` processor is used to apply a Savitzky-Golay filter to the
 # spectrum.

--- a/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
@@ -37,7 +37,7 @@ smoothed = {size: region.smooth(size) for size in (3, 7, 11)}
 # narrow features.
 
 for size, smoothed_region in smoothed.items():
-    scp.plot_compare(
+    _ = scp.plot_compare(
         region,
         smoothed_region,
         title=f"Moving-average smoothing (size={size})",

--- a/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
+++ b/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
@@ -28,10 +28,12 @@ A = scp.read_labspec("SMC1-Initial_RT.txt", directory=ramandir)
 # %%
 # Plot the spectrum
 _ = A.plot()
+
 # %%
 # Crop the spectrum to a useful region
 B = A[60.0:]
 _ = B.plot()
+
 # %%
 # Baseline correction
 # -------------------
@@ -61,6 +63,7 @@ blc.order = "linear"
 # %%
 # Now we can fit the model to the data
 _ = blc.fit(B)
+
 # %%
 # The baseline is now stored in the `baseline` attribute of the processor
 corr = blc.transform()
@@ -76,9 +79,9 @@ def plot_result(X, Xc, bas):
     Xcm = Xc.min()
     Xcp = Xc.ptp()
     offset = Xcm + Xcp
-    (Xc - Xcm).plot()
-    (X + offset).plot(clear=False, color="g", linestyle="-")
-    (bas + offset).plot(clear=False, color="r", linestyle="--")
+    _ = (Xc - Xcm).plot()
+    _ = (X + offset).plot(clear=False, color="g", linestyle="-")
+    _ = (bas + offset).plot(clear=False, color="r", linestyle="--")
 
 
 plot_result(B, corr, baseline)
@@ -138,6 +141,7 @@ plot_result(Bs, corr, baseline)
 C = scp.read_labspec("Activation.txt", directory=ramandir)
 # C = C[20:]  # discard the first 20 spectra
 _ = C.plot()
+
 # %%
 # Now we apply the AsLS method on the series of spectra
 #
@@ -154,20 +158,22 @@ _ = blc.fit(C[::10])
 corr = blc.transform()
 baseline = blc.baseline
 _ = corr.plot()
+
 # %%
 # or the `snip` method (which is much faster)
 blc.model = "snip"
 _ = blc.fit(C)
 corr = blc.transform()
 baseline = blc.baseline
-corr[::10].plot()
+_ = corr[::10].plot()
+
 # %%
 # Denoising
 # ---------
 D = corr.copy()
 G = scp.denoise(D, ratio=98)
 
-G[::10].plot()
+_ = G[::10].plot()
 
 # %%
 # This ends the example ! The following line can be removed or commented

--- a/src/spectrochempy/plotting/stylesheets/mycustom.mplstyle
+++ b/src/spectrochempy/plotting/stylesheets/mycustom.mplstyle
@@ -272,8 +272,6 @@ svg.image_inline                         : True
 text.antialiased                         : True
 text.color                               : black
 text.hinting                             : force_autohint
-text.hinting_factor                      : 8
-text.kerning_factor                      : 0
 text.latex.preamble                      :
 text.parse_math                          : True
 text.usetex                              : False

--- a/tests/test_application/test_plot_preferences.py
+++ b/tests/test_application/test_plot_preferences.py
@@ -5,6 +5,8 @@
 # ======================================================================================
 # ruff: noqa
 
+from pathlib import Path
+
 import spectrochempy as scp
 
 
@@ -51,3 +53,18 @@ def test_plotpreferences(IR_dataset_2D):
     finally:
         # Always restore original style to prevent pollution
         prefs.style = original_style
+
+
+def test_makestyle_skips_deprecated_matplotlib_rcparams(monkeypatch, tmp_path):
+    prefs = scp.preferences
+    monkeypatch.setattr(prefs, "stylesheets", str(tmp_path))
+
+    stylename = prefs.makestyle("tmpstyle")
+
+    assert stylename == "tmpstyle"
+
+    stylesheet = Path(tmp_path) / "tmpstyle.mplstyle"
+    text = stylesheet.read_text()
+
+    assert "text.hinting_factor" not in text
+    assert "text.kerning_factor" not in text


### PR DESCRIPTION
## Summary

- suppress unused plot and fit return-value representations across the core gallery, official-plugin examples, and Jupytext user-guide notebooks;
- separate intentional rich displays from following plots so generated output remains in narrative order;
- consistently space gallery cell separators for readability;
- hide nbsphinx execution prompts in published notebook pages without affecting Sphinx-Gallery;
- avoid exporting Matplotlib rcParams that are deprecated in generated style files;
- remove the affected keys from the shipped custom stylesheet and add focused regression coverage;
- avoid the EFA Keller-Massart coordinate warning by overlaying the forward and backward curves directly.

## Out of scope

- no numerical or estimator behavior changes;
- no public API changes;
- no persistence or project changes;
- no broad tutorial or gallery rewrite.

## Validation

- `pre-commit run --all-files`
- `conda run -n scpy-core python -m pytest tests/test_application/test_plot_preferences.py -q`
- syntax parsing/compilation of the modified gallery and notebook sources
- repository-wide scans for remaining bare plot/fit calls in notebook sources and bare plot calls in gallery examples
- `git diff --check`

The focused test result was `1 passed, 1 skipped`.
