### PR TITLE
ENH: implement Phase 1 namespace-based I/O API

### DIFF
--- a/docs/sources/devguide/plugins/api_policy.rst
+++ b/docs/sources/devguide/plugins/api_policy.rst
@@ -70,6 +70,11 @@ represent the scientific or technical domain exposed to users, for example
 Avoid creating a second namespace
 for the same domain unless there is a clear migration plan.
 
+Core I/O namespaces such as ``jcamp``, ``csv``, ``omnic``, ``opus``,
+``matlab``, ``spc``, ``soc``, ``wire``, ``quadera``, and ``labspec``
+are reserved.  Plugins must not claim these names, to prevent shadowing
+and keep ``scp.<domain>`` unambiguous.
+
 Documentation and examples should prefer namespace APIs, such as
 ``scp.iris.IRIS()``, over root-level compatibility
 aliases such as ``scp.IRIS``. Compatibility aliases may remain in

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -40,6 +40,15 @@ New Features
   exchange using `scipy.io.savemat`. This is an exchange format, not
   native SpectroChemPy persistence.
 
+- Added namespace-based I/O API for core readers and writers.
+  Domains such as ``jcamp``, ``csv``, ``matlab``, ``omnic``, ``opus``,
+  ``quadera``, ``soc``, ``spc``, ``wire``, and ``labspec``
+  now expose ``scp.<domain>.read(...)``.  Domains with existing writers
+  (``jcamp``, ``csv``, ``matlab``) also expose ``scp.<domain>.write(...)``.
+  These namespaces delegate to the existing public ``read_*`` and ``write_*``
+  functions; no behavior has changed.  This is the first phase of the
+  Namespace API Convention (see ``maintainers/rfcs/namespace-api-convention.md``).
+
 .. section
 
 Bug Fixes

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -36,6 +36,15 @@ New Features
   exchange using `scipy.io.savemat`. This is an exchange format, not
   native SpectroChemPy persistence.
 
+- Added namespace-based I/O API for core readers and writers.
+  Domains such as ``jcamp``, ``csv``, ``matlab``, ``omnic``, ``opus``,
+  ``quadera``, ``soc``, ``spc``, ``wire``, and ``labspec``
+  now expose ``scp.<domain>.read(...)``.  Domains with existing writers
+  (``jcamp``, ``csv``, ``matlab``) also expose ``scp.<domain>.write(...)``.
+  These namespaces delegate to the existing public ``read_*`` and ``write_*``
+  functions; no behavior has changed.  This is the first phase of the
+  Namespace API Convention (see ``maintainers/rfcs/namespace-api-convention.md``).
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/maintainers/api-conventions.md
+++ b/maintainers/api-conventions.md
@@ -74,6 +74,14 @@ Top-level aliases such as `scp.read_jcamp(...)` and `scp.write_jcamp(...)`
 remain as compatibility shims.  They may stay indefinitely; deprecation is
 optional and unlikely.
 
+### 7. Core namespace reservation
+
+Core I/O namespaces (`jcamp`, `csv`, `omnic`, `opus`, `matlab`, `spc`,
+`soc`, `wire`, `quadera`, `labspec`) are reserved.  Official plugins must
+not use these names as plugin namespaces.  This prevents shadowing and
+ensures that `scp.<domain>` always resolves to a single, unambiguous API
+surface.
+
 ## Summary
 
 ```python

--- a/maintainers/api-conventions.md
+++ b/maintainers/api-conventions.md
@@ -74,13 +74,11 @@ Top-level aliases such as `scp.read_jcamp(...)` and `scp.write_jcamp(...)`
 remain as compatibility shims.  They may stay indefinitely; deprecation is
 optional and unlikely.
 
-### 7. Core namespace reservation
+### 7. Reserved namespaces
 
-Core I/O namespaces (`jcamp`, `csv`, `omnic`, `opus`, `matlab`, `spc`,
-`soc`, `wire`, `quadera`, `labspec`) are reserved.  Official plugins must
-not use these names as plugin namespaces.  This prevents shadowing and
-ensures that `scp.<domain>` always resolves to a single, unambiguous API
-surface.
+A set of public namespaces is reserved by the project.  See the RFC for the
+authoritative list:
+[`maintainers/rfcs/namespace-api-convention.md#reserved-public-namespaces`](../rfcs/namespace-api-convention.md#reserved-public-namespaces).
 
 ## Summary
 

--- a/maintainers/rfcs/namespace-api-convention.md
+++ b/maintainers/rfcs/namespace-api-convention.md
@@ -279,6 +279,22 @@ scp.xyz.write("file.xyz", dataset)
 The plugin MAY also request top-level aliases (`scp.read_xyz`, `scp.write_xyz`)
 for consistency, but the namespace form is the canonical API.
 
+## Reserved Public Namespaces
+
+The following namespaces are part of SpectroChemPy's public API and are
+reserved:
+
+```text
+csv, jcamp, matlab, omnic, opus, quadera, soc, spc, wire, labspec
+```
+
+They may be implemented either by the core package or by an official
+SpectroChemPy plugin when a namespace is migrated out of the core.
+
+Third-party plugins, and official plugins unrelated to that namespace, must not
+claim these names.  Doing so would shadow the public API and create ambiguity
+for users.
+
 ## Migration Strategy
 
 The migration is split into four phases.  No public code is broken during any

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -213,8 +213,8 @@ def __getattr__(name):
             return sys.modules[module_key]
 
     # Handle core I/O namespaces (e.g., scp.jcamp, scp.csv)
-    from spectrochempy.core.io_namespaces import _is_io_namespace
     from spectrochempy.core.io_namespaces import _IONamespace
+    from spectrochempy.core.io_namespaces import _is_io_namespace
 
     if _is_io_namespace(name):
         return _IONamespace(name)
@@ -290,5 +290,3 @@ def __getattr__(name):
 from spectrochempy.plugins.namespace import register_namespace_modules
 
 register_namespace_modules()
-
-

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -102,6 +102,7 @@ def __dir__():
     names = set(original_dir()) if callable(original_dir) else set()
     names.update(_PLOT_PROFILE_FUNCTIONS)
     names.update(_namespace_names())
+    names.update(_io_namespace_names())
     # Include already-discovered plugin readers and extensions
     # without triggering entry-point scanning (dir() should be side-effect free).
     names.update(_reader_names())
@@ -118,6 +119,12 @@ def _namespace_names():
     from spectrochempy.plugins.features import EXPERIMENTAL_PLUGIN_NAMESPACES
 
     return set(KNOWN_PLUGIN_NAMESPACES) | set(EXPERIMENTAL_PLUGIN_NAMESPACES)
+
+
+def _io_namespace_names():
+    from spectrochempy.core.io_namespaces import _CORE_IO_NAMESPACES
+
+    return set(_CORE_IO_NAMESPACES)
 
 
 def _extension_names():
@@ -205,6 +212,13 @@ def __getattr__(name):
         ):
             return sys.modules[module_key]
 
+    # Handle core I/O namespaces (e.g., scp.jcamp, scp.csv)
+    from spectrochempy.core.io_namespaces import _is_io_namespace
+    from spectrochempy.core.io_namespaces import _IONamespace
+
+    if _is_io_namespace(name):
+        return _IONamespace(name)
+
     # Ensure external plugins are discovered (before lazy imports so
     # plugin-provided functions take precedence over core stubs)
     plugin_manager.discover()
@@ -276,3 +290,5 @@ def __getattr__(name):
 from spectrochempy.plugins.namespace import register_namespace_modules
 
 register_namespace_modules()
+
+

--- a/src/spectrochempy/core/__init__.pyi
+++ b/src/spectrochempy/core/__init__.pyi
@@ -9,6 +9,7 @@
 
 __all__ = [
     "dataset",
+    "io_namespaces",
     "plotters",
     "project",
     "readers",
@@ -17,6 +18,7 @@ __all__ = [
 ]
 
 from . import dataset
+from . import io_namespaces
 from . import plotters
 from . import project
 from . import readers

--- a/src/spectrochempy/core/io_namespaces.py
+++ b/src/spectrochempy/core/io_namespaces.py
@@ -1,0 +1,79 @@
+"""Core I/O namespace wrappers for the namespace-based API.
+
+This module provides lightweight namespace objects that expose
+``scp.<domain>.read(...)`` and ``scp.<domain>.write(...)`` for core
+I/O operations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# Single source of truth for core I/O namespace configuration.
+#
+# To add a new namespace, append an entry here:
+#   "<domain>": ("read_<domain>", "write_<domain>" or None)
+#
+# The namespace object will automatically delegate ``scp.<domain>.read()``
+# and ``scp.<domain>.write()`` to the corresponding top-level functions.
+# No other code changes are required.
+_CORE_IO_NAMESPACES: dict[str, tuple[str | None, str | None]] = {
+    "jcamp": ("read_jcamp", "write_jcamp"),
+    "csv": ("read_csv", "write_csv"),
+    "matlab": ("read_matlab", "write_matlab"),
+    "omnic": ("read_omnic", None),
+    "opus": ("read_opus", None),
+    "quadera": ("read_quadera", None),
+    "soc": ("read_soc", None),
+    "spc": ("read_spc", None),
+    "wire": ("read_wire", None),
+    "labspec": ("read_labspec", None),
+}
+
+
+def _resolve_func(func_name: str) -> Any:
+    """Lazy-resolve a top-level function by name."""
+    import spectrochempy as scp
+
+    return getattr(scp, func_name)
+
+
+class _IONamespace:
+    """Lightweight namespace for core I/O operations.
+
+    Instances are returned for names such as ``scp.jcamp`` and delegate
+    ``read()`` / ``write()`` to the existing public ``read_*`` / ``write_*``
+    functions.
+    """
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._read_name, self._write_name = _CORE_IO_NAMESPACES[name]
+
+    def __dir__(self) -> list[str]:
+        names = ["read"] if self._read_name else []
+        if self._write_name:
+            names.append("write")
+        return names
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "read" and self._read_name:
+            return _resolve_func(self._read_name)
+        if name == "write" and self._write_name:
+            return _resolve_func(self._write_name)
+        raise AttributeError(
+            f"namespace '{self._name}' has no attribute '{name}'"
+        )
+
+    def __repr__(self) -> str:
+        ops = []
+        if self._read_name:
+            ops.append("read")
+        if self._write_name:
+            ops.append("write")
+        return f"<IONamespace '{self._name}' ({', '.join(ops)})>"
+
+
+def _is_io_namespace(name: str) -> bool:
+    return name in _CORE_IO_NAMESPACES

--- a/src/spectrochempy/core/io_namespaces.py
+++ b/src/spectrochempy/core/io_namespaces.py
@@ -1,4 +1,5 @@
-"""Core I/O namespace wrappers for the namespace-based API.
+"""
+Core I/O namespace wrappers for the namespace-based API.
 
 This module provides lightweight namespace objects that expose
 ``scp.<domain>.read(...)`` and ``scp.<domain>.write(...)`` for core
@@ -8,7 +9,6 @@ I/O operations.
 from __future__ import annotations
 
 from typing import Any
-
 
 # Single source of truth for core I/O namespace configuration.
 #
@@ -40,7 +40,8 @@ def _resolve_func(func_name: str) -> Any:
 
 
 class _IONamespace:
-    """Lightweight namespace for core I/O operations.
+    """
+    Lightweight namespace for core I/O operations.
 
     Instances are returned for names such as ``scp.jcamp`` and delegate
     ``read()`` / ``write()`` to the existing public ``read_*`` / ``write_*``
@@ -62,9 +63,7 @@ class _IONamespace:
             return _resolve_func(self._read_name)
         if name == "write" and self._write_name:
             return _resolve_func(self._write_name)
-        raise AttributeError(
-            f"namespace '{self._name}' has no attribute '{name}'"
-        )
+        raise AttributeError(f"namespace '{self._name}' has no attribute '{name}'")
 
     def __repr__(self) -> str:
         ops = []

--- a/tests/test_core/test_readers/test_io_namespaces.py
+++ b/tests/test_core/test_readers/test_io_namespaces.py
@@ -1,0 +1,122 @@
+"""Tests for the namespace-based I/O API.
+
+These tests verify that ``scp.<namespace>.read(...)`` and
+``scp.<namespace>.write(...)`` delegate correctly to the existing
+public API without changing behavior.
+"""
+
+import pytest
+
+import spectrochempy as scp
+
+
+class TestIONamespacesExist:
+    """Verify that I/O namespaces are exposed on the spectrochempy package."""
+
+    @pytest.mark.parametrize(
+        "ns",
+        [
+            "jcamp",
+            "csv",
+            "matlab",
+            "omnic",
+            "opus",
+            "quadera",
+            "soc",
+            "spc",
+            "wire",
+            "labspec",
+        ],
+    )
+    def test_namespace_exists(self, ns):
+        assert hasattr(scp, ns), f"scp.{ns} should exist"
+
+    def test_namespace_names_in_dir(self):
+        names = dir(scp)
+        assert "jcamp" in names
+        assert "csv" in names
+        assert "omnic" in names
+
+
+class TestIONamespaceRead:
+    """Verify that namespace ``read()`` delegates to the top-level reader."""
+
+    def test_jcamp_read_delegates(self):
+        assert scp.jcamp.read is scp.read_jcamp
+
+    def test_csv_read_delegates(self):
+        assert scp.csv.read is scp.read_csv
+
+    def test_matlab_read_delegates(self):
+        assert scp.matlab.read is scp.read_matlab
+
+    def test_omnic_read_delegates(self):
+        assert scp.omnic.read is scp.read_omnic
+
+    def test_opus_read_delegates(self):
+        assert scp.opus.read is scp.read_opus
+
+    def test_quadera_read_delegates(self):
+        assert scp.quadera.read is scp.read_quadera
+
+    def test_soc_read_delegates(self):
+        assert scp.soc.read is scp.read_soc
+
+    def test_spc_read_delegates(self):
+        assert scp.spc.read is scp.read_spc
+
+    def test_wire_read_delegates(self):
+        assert scp.wire.read is scp.read_wire
+
+    def test_labspec_read_delegates(self):
+        assert scp.labspec.read is scp.read_labspec
+
+
+class TestIONamespaceWrite:
+    """Verify that namespace ``write()`` delegates to the top-level writer."""
+
+    def test_jcamp_write_delegates(self):
+        assert scp.jcamp.write is scp.write_jcamp
+
+    def test_csv_write_delegates(self):
+        assert scp.csv.write is scp.write_csv
+
+    def test_matlab_write_delegates(self):
+        assert scp.matlab.write is scp.write_matlab
+
+
+class TestIONamespaceReadOnly:
+    """Verify that read-only namespaces do not expose ``write()``."""
+
+    @pytest.mark.parametrize(
+        "ns",
+        ["omnic", "opus", "quadera", "soc", "spc", "wire", "labspec"],
+    )
+    def test_read_only_namespace_no_write(self, ns):
+        namespace = getattr(scp, ns)
+        with pytest.raises(AttributeError):
+            namespace.write
+
+
+class TestExistingAPIUnchanged:
+    """Verify that all existing public aliases remain intact."""
+
+    def test_top_level_read_aliases_still_exist(self):
+        assert callable(scp.read_jcamp)
+        assert callable(scp.read_csv)
+        assert callable(scp.read_omnic)
+        assert callable(scp.read_opus)
+
+    def test_top_level_write_aliases_still_exist(self):
+        assert callable(scp.write_jcamp)
+        assert callable(scp.write_csv)
+        assert callable(scp.write_matlab)
+
+    def test_generic_read_untouched(self):
+        assert callable(scp.read)
+
+    def test_generic_write_untouched(self):
+        assert callable(scp.write)
+
+    def test_reader_aliases_untouched(self):
+        assert scp.read_mat is scp.read_matlab

--- a/tests/test_core/test_readers/test_io_namespaces.py
+++ b/tests/test_core/test_readers/test_io_namespaces.py
@@ -1,4 +1,5 @@
-"""Tests for the namespace-based I/O API.
+"""
+Tests for the namespace-based I/O API.
 
 These tests verify that ``scp.<namespace>.read(...)`` and
 ``scp.<namespace>.write(...)`` delegate correctly to the existing
@@ -95,7 +96,7 @@ class TestIONamespaceReadOnly:
     def test_read_only_namespace_no_write(self, ns):
         namespace = getattr(scp, ns)
         with pytest.raises(AttributeError):
-            namespace.write
+            _ = namespace.write
 
 
 class TestExistingAPIUnchanged:


### PR DESCRIPTION
Implements Phase 1 of the accepted Namespace API Convention (maintainers/rfcs/namespace-api-convention.md).

## Summary

Adds lightweight namespace wrappers so that core I/O domains expose `scp.<domain>.read(...)` and, when applicable, `scp.<domain>.write(...)`.

## Namespaces introduced (10)

| Namespace | read | write |
|---|---|---|
| jcamp | yes | yes |
| csv | yes | yes |
| matlab | yes | yes |
| omnic | yes | no |
| opus | yes | no |
| quadera | yes | no |
| soc | yes | no |
| spc | yes | no |
| wire | yes | no |
| labspec | yes | no |

## Design choices

- Single table to maintain: `_CORE_IO_NAMESPACES` in `io_namespaces.py` is the only place to edit when adding a namespace.
- No `sys.modules` injection: `from spectrochempy.jcamp import read` is intentionally not supported; the RFC targets `scp.jcamp.read(...)`.
- No generic utilities: `zip` excluded (not a functional domain).
- Core namespaces resolved before plugin discovery: avoids expensive entry-point scanning for known domains.
- Pure delegation: `scp.jcamp.read is scp.read_jcamp`.

## Tests

36 focused tests added in `tests/test_core/test_readers/test_io_namespaces.py`.

## Documentation

- `docs/sources/whatsnew/changelog.rst` updated.
- `docs/sources/devguide/plugins/api_policy.rst` updated with core namespace reservation convention.
- `maintainers/api-conventions.md` updated with reservation rule.

## Compatibility

Additive only. All existing top-level aliases, generic dispatchers, and plugin namespaces remain unchanged.