### PR TITLE
ENH: align official plugins with namespace API convention

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -49,6 +49,14 @@ New Features
   functions; no behavior has changed.  This is the first phase of the
   Namespace API Convention (see ``maintainers/rfcs/namespace-api-convention.md``).
 
+- Aligned official plugins with the namespace API convention.
+  The ``nmr`` and ``carroucell`` plugins now expose the short canonical
+  ``scp.nmr.read(...)`` and ``scp.carroucell.read(...)`` aliases,
+  in addition to the existing ``scp.nmr.read_topspin(...)`` and
+  ``scp.carroucell.read_carroucell(...)`` names.  The ``perkinelmer``
+  plugin already exposed ``scp.perkinelmer.read(...)`` and is unchanged.
+  All legacy names remain supported.
+
 .. section
 
 Bug Fixes

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -45,6 +45,14 @@ New Features
   functions; no behavior has changed.  This is the first phase of the
   Namespace API Convention (see ``maintainers/rfcs/namespace-api-convention.md``).
 
+- Aligned official plugins with the namespace API convention.
+  The ``nmr`` and ``carroucell`` plugins now expose the short canonical
+  ``scp.nmr.read(...)`` and ``scp.carroucell.read(...)`` aliases,
+  in addition to the existing ``scp.nmr.read_topspin(...)`` and
+  ``scp.carroucell.read_carroucell(...)`` names.  The ``perkinelmer``
+  plugin already exposed ``scp.perkinelmer.read(...)`` and is unchanged.
+  All legacy names remain supported.
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/__init__.py
+++ b/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/__init__.py
@@ -73,7 +73,7 @@ class CarroucellPlugin(SpectroChemPyPlugin):
 
 
 def __getattr__(name: str):
-    if name == "read_carroucell":
+    if name in ("read_carroucell", "read"):
         from .read_carroucell import read_carroucell  # noqa: PLC0415
 
         return read_carroucell
@@ -82,4 +82,4 @@ def __getattr__(name: str):
 
 
 def __dir__() -> list[str]:
-    return ["CarroucellPlugin", "read_carroucell"]
+    return ["CarroucellPlugin", "read", "read_carroucell"]

--- a/plugins/spectrochempy-carroucell/tests/test_carroucell.py
+++ b/plugins/spectrochempy-carroucell/tests/test_carroucell.py
@@ -115,6 +115,17 @@ def test_namespace_exposes_reader():
     assert callable(scp.carroucell.read_carroucell)
 
 
+def test_namespace_exposes_short_read_alias():
+    """scp.carroucell.read is a short alias for scp.carroucell.read_carroucell."""
+    assert hasattr(scp, "carroucell")
+    assert callable(scp.carroucell.read)
+    # Both names must resolve to the same underlying reader.  They may be
+    # different objects (module attribute vs registry proxy) so we check
+    # functional equivalence rather than identity.
+    assert scp.carroucell.read.__name__ == scp.carroucell.read_carroucell.__name__
+    assert scp.carroucell.read.__name__ == "read_carroucell"
+
+
 # ------------------------------------------------------------------
 # Error behaviour when data is unavailable
 # ------------------------------------------------------------------

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
@@ -254,7 +254,7 @@ class NMRPlugin(SpectroChemPyPlugin):
 
 
 def __getattr__(name: str):
-    if name == "read_topspin":
+    if name in ("read_topspin", "read"):
         from .read_topspin import read_topspin  # noqa: PLC0415
 
         return read_topspin
@@ -267,4 +267,4 @@ def __getattr__(name: str):
 
 
 def __dir__() -> list[str]:
-    return ["NMRPlugin", "read_topspin", "set_nmr_context"]
+    return ["NMRPlugin", "read", "read_topspin", "set_nmr_context"]

--- a/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
@@ -154,6 +154,23 @@ def test_package_namespace_exposes_topspin_reader(monkeypatch):
     assert top_level_reader.__module__.startswith("spectrochempy_nmr")
 
 
+def test_package_namespace_exposes_short_read_alias(monkeypatch):
+    """scp.nmr.read is a short alias for scp.nmr.read_topspin."""
+    _require_reader_dependencies()
+
+    pm, _registry = _isolate_scp_plugins(monkeypatch, scp)
+    pm.register(NMRPlugin())
+
+    short_reader = scp.nmr.read
+    long_reader = scp.nmr.read_topspin
+
+    assert callable(short_reader)
+    # Both names must resolve to the same underlying reader.  They may be
+    # different objects (module attribute vs registry proxy) so we check
+    # functional equivalence rather than identity.
+    assert short_reader.__name__ == long_reader.__name__ == "read_topspin"
+
+
 def test_top_level_stub_is_actionable_without_registered_nmr(monkeypatch):
     """scp.read_topspin is a callable MissingPluginError stub without NMR."""
     _isolate_scp_plugins(monkeypatch, scp)


### PR DESCRIPTION
Aligns official SpectroChemPy plugins with the accepted Namespace API Convention (maintainers/rfcs/namespace-api-convention.md).

## Summary

Adds short canonical read() aliases to plugin namespaces that provide readers.

## Plugins changed

| Plugin | Alias added | Delegates to |
|---|---|---|
| nmr | scp.nmr.read | scp.nmr.read_topspin |
| carroucell | scp.carroucell.read | scp.carroucell.read_carroucell |

## Plugins unchanged

| Plugin | Reason |
|---|---|
| perkinelmer | Already exposes scp.perkinelmer.read (no change needed) |
| iris | No I/O reader (analysis plugin only) |
| tensor | No I/O reader (analysis plugin only) |

## Design

- Modified only __getattr__ and __dir__ in each plugin's __init__.py
- read returns the exact same function object as the legacy name
- No new imports, no new dependencies, no behavior change

## Tests

- test_nmr_plugin.py: test_package_namespace_exposes_short_read_alias
- test_carroucell.py: test_namespace_exposes_short_read_alias

## Compatibility

All legacy names (read_topspin, read_carroucell, read_perkinelmer) and top-level aliases (scp.read_topspin, scp.read_carroucell) remain unchanged.
