### PR TITLE
DOC: surface namespace API in core I/O docstrings and import tutorials

### DIFF
--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -70,6 +70,39 @@ X
 # OPUS, JCAMP-DX, CSV, MATLAB, TOPSPIN, etc. or even a directory.
 
 # %% [markdown]
+# ## How the generic reader works
+
+# %% [markdown]
+# Under the hood, `scp.read(...)` acts as a **dispatcher** that inspects the
+# file extension (or the optional `protocol=` keyword) and delegates the actual
+# reading to the appropriate format-specific implementation:
+#
+#     scp.read(path)
+#             │
+#             ▼
+#     format detection
+#             │
+#             ▼
+#     appropriate namespace reader
+#             │
+#             ▼
+#     scp.omnic.read(path)
+#     scp.opus.read(path)
+#     scp.jcamp.read(path)
+#     ...
+#
+# The generic reader is convenient because you do not need to remember which
+# namespace or alias to use.  However, the namespace API (`scp.omnic.read`,
+# `scp.opus.read`, `scp.jcamp.read`, …) is useful when you want to make the
+# format explicit in your code, or when the automatic detection is ambiguous.
+#
+# You can also force a protocol manually:
+
+# %%
+X = scp.read("wodger.spg", protocol="omnic")
+X
+
+# %% [markdown]
 # ## Using a specific reader
 
 # %% [markdown]
@@ -143,6 +176,23 @@ X
 #
 # Further details on specific cases are provided below, especially in the
 # section on reading directories.
+
+# %% [markdown]
+# ## Using namespace APIs
+
+# %% [markdown]
+# Core I/O domains also expose a namespace-style API for explicit
+# domain-qualified access:
+#
+#     scp.omnic.read("wodger.spg")
+#     scp.opus.read("irdata/OPUS/test.0000")
+#     scp.csv.read("irdata/csv/iris.csv")
+#     scp.jcamp.read("irdata/jcamp/nh4y-activation.jdx")
+#
+# These are equivalent to their top-level aliases (`read_omnic`, `read_opus`,
+# `read_csv`, `read_jcamp`, etc.) and are provided for API clarity and
+# future-proofing.  The generic `scp.read(...)` entry point remains the
+# recommended default.
 
 # %% [markdown]
 # ## Using relative or absolute pathnames

--- a/docs/sources/userguide/importexport/importJCAMPDX.py
+++ b/docs/sources/userguide/importexport/importJCAMPDX.py
@@ -52,11 +52,24 @@ S0
 S0.write_jcamp("CO@Mo_Al2O3_0.jdx", confirm=False)
 
 # %% [markdown]
+# The namespace API is also available for writing:
+
+# %%
+S0.jcamp.write("CO@Mo_Al2O3_0.jdx", confirm=False)
+
+# %% [markdown]
 # Then used (and maybe changed) by a 3rd party software, and re-imported in
 # spectrochempy:
 
 # %%
 newS0 = scp.read_jcamp("CO@Mo_Al2O3_0.jdx")
+newS0
+
+# %% [markdown]
+# The namespace API works identically:
+
+# %%
+newS0 = scp.jcamp.read("CO@Mo_Al2O3_0.jdx")
 newS0
 
 # %% [markdown]

--- a/docs/sources/userguide/importexport/importOMNIC.py
+++ b/docs/sources/userguide/importexport/importOMNIC.py
@@ -56,6 +56,13 @@ X = scp.read_omnic("irdata/CO@Mo_Al2O3.SPG")
 X
 
 # %% [markdown]
+# The same result is obtained with the namespace API:
+
+# %%
+X = scp.omnic.read("irdata/CO@Mo_Al2O3.SPG")
+X
+
+# %% [markdown]
 # The displayed attributes are detailed in the following:
 #
 # - `name` is the name of the group of spectra as it appears in the .spg file. OMNIC

--- a/docs/sources/userguide/importexport/importOPUS.py
+++ b/docs/sources/userguide/importexport/importOPUS.py
@@ -51,6 +51,13 @@ import spectrochempy as scp
 Z = scp.read_opus("irdata/OPUS/test.0002")
 Z
 
+# %% [markdown]
+# The namespace API is equivalent:
+
+# %% {"editable": true, "slideshow": {"slide_type": ""}}
+Z = scp.opus.read("irdata/OPUS/test.0002")
+Z
+
 # %% [markdown] {"editable": true, "slideshow": {"slide_type": ""}}
 # <div class='alert alert-info'>
 # <b>Note:</b><br/>

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -285,6 +285,10 @@ def read(*paths, **kwargs):
     Read data from various file formats.
 
     This method is generally able to load experimental files based on extensions.
+    It acts as a dispatcher: after detecting the format it delegates to the
+    corresponding namespace reader (e.g. ``scp.omnic.read(...)``,
+    ``scp.opus.read(...)``, ``scp.jcamp.read(...)``).
+    You can bypass detection by passing the ``protocol`` keyword explicitly.
 
     Parameters
     ----------

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -240,6 +240,11 @@ def read_csv(*paths, **kwargs):
     >>> scp.read_csv('irdata/csv/iris.csv')
     NDDataset: [float64] a.u. (shape: (y:150, x:4))
 
+    Using the explicit namespace API
+
+    >>> scp.csv.read('irdata/csv/iris.csv')
+    NDDataset: [float64] a.u. (shape: (y:150, x:4))
+
     """
     kwargs["filetypes"] = ["CSV files (*.csv)"]
     kwargs["protocol"] = ["csv"]

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -117,10 +117,19 @@ def read_jcamp(*paths, **kwargs):
     read_soc : Read Surface Optics Corps. files (:file:`.ddr` , :file:`.hdr` or :file:`.sdr`).
     read_galactic : Read Galactic files (:file:`.spc`).
     read_quadera : Read a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
-
     read_csv : Read CSV files (:file:`.csv`).
     read_matlab : Read Matlab files (:file:`.mat`, :file:`.dso`).
     read_wire : Read Renishaw Wire files (:file:`.wdf`).
+
+    Examples
+    --------
+    Using the explicit namespace API
+
+    >>> scp.jcamp.read('irdata/jcamp/nh4y-activation.jdx')
+
+    Using the legacy top-level alias
+
+    >>> scp.read_jcamp('irdata/jcamp/nh4y-activation.jdx')
 
     """
 

--- a/src/spectrochempy/core/readers/read_labspec.py
+++ b/src/spectrochempy/core/readers/read_labspec.py
@@ -124,6 +124,11 @@ def read_labspec(*paths, **kwargs):
     >>> scp.read_labspec('irdata/labspec.txt')
     NDDataset: [float64] a.u. (shape: (y:1, x:1024))
 
+    Using the explicit namespace API
+
+    >>> scp.labspec.read('irdata/labspec.txt')
+    NDDataset: [float64] a.u. (shape: (y:1, x:1024))
+
     """
     kwargs["filetypes"] = ["Labspec files (*.txt)"]
     kwargs["protocol"] = ["labspec"]

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -138,6 +138,11 @@ def read_matlab(*paths, **kwargs):
     >>> scp.read_matlab('irdata/matlab/matlabdata.mat')
     NDDataset: [float64] a.u. (shape: (y:1, x:3))
 
+    Using the explicit namespace API
+
+    >>> scp.matlab.read('irdata/matlab/matlabdata.mat')
+    NDDataset: [float64] a.u. (shape: (y:1, x:3))
+
     """
     kwargs["filetypes"] = ["Matlab files (*.mat *.dso)"]
     kwargs["protocol"] = ["matlab"]

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -169,6 +169,11 @@ def read_omnic(*paths, **kwargs):
     >>> scp.read_omnic('irdata/nh4y-activation.spg')
     NDDataset: [float64] a.u. (shape: (y:55, x:5549))
 
+    Using the explicit namespace API
+
+    >>> scp.omnic.read('irdata/nh4y-activation.spg')
+    NDDataset: [float64] a.u. (shape: (y:55, x:5549))
+
     Single file specified with pathlib.Path object
 
     >>> from pathlib import Path

--- a/src/spectrochempy/core/readers/read_opus.py
+++ b/src/spectrochempy/core/readers/read_opus.py
@@ -171,6 +171,11 @@ def read_opus(*paths, **kwargs):
     >>> scp.read_opus(p)
     NDDataset: [float64] a.u. (shape: (y:1, x:2567))
 
+    Using the explicit namespace API
+
+    >>> scp.opus.read('irdata/OPUS/test.0000')
+    NDDataset: [float64] a.u. (shape: (y:1, x:2567))
+
     Multiple files not merged (return a list of datasets). Note that a directory is
     specified
 

--- a/src/spectrochempy/core/readers/read_quadera.py
+++ b/src/spectrochempy/core/readers/read_quadera.py
@@ -127,6 +127,11 @@ def read_quadera(*paths, **kwargs):
     >>> scp.read_quadera('irdata/quadera.QD')
     NDDataset: [float64] a.u. (shape: (y:1, x:16384))
 
+    Using the explicit namespace API
+
+    >>> scp.quadera.read('irdata/quadera.QD')
+    NDDataset: [float64] a.u. (shape: (y:1, x:16384))
+
     """
     kwargs["filetypes"] = ["QUADERA files (*.QD)"]
     kwargs["protocol"] = ["quadera"]

--- a/src/spectrochempy/core/readers/read_soc.py
+++ b/src/spectrochempy/core/readers/read_soc.py
@@ -102,6 +102,16 @@ def read_soc(*paths, **kwargs):
     --------
     read : Generic read function.
 
+    Examples
+    --------
+    Using the explicit namespace API
+
+    >>> scp.soc.read('irdata/soc/sample.hdr')
+
+    Using the legacy top-level alias
+
+    >>> scp.read_soc('irdata/soc/sample.hdr')
+
     """
     kwargs["filetypes"] = ["Surface Optics Corp. (*.ddr *.hdr *.sdr)"]
     kwargs["protocol"] = ["soc", "ddr", "hdr", "sdr"]

--- a/src/spectrochempy/core/readers/read_spc.py
+++ b/src/spectrochempy/core/readers/read_spc.py
@@ -129,6 +129,11 @@ def read_spc(*paths, **kwargs):
     >>> scp.read_spc('irdata/galactic/galactic.spe')
     NDDataset: [float64] a.u. (shape: (y:1, x:6144))
 
+    Using the explicit namespace API
+
+    >>> scp.spc.read('irdata/galactic/galactic.spe')
+    NDDataset: [float64] a.u. (shape: (y:1, x:6144))
+
     """
     kwargs["filetypes"] = ["Galactic files (*.spc)"]
     kwargs["protocol"] = ["spc"]

--- a/src/spectrochempy/core/readers/read_wire.py
+++ b/src/spectrochempy/core/readers/read_wire.py
@@ -899,6 +899,11 @@ def read_wire(*paths, **kwargs):
     >>> scp.read_wire('irdata/wire/white_light.wdf')
     NDDataset: [float64] a.u. (shape: (y:1, x:261))
 
+    Using the explicit namespace API
+
+    >>> scp.wire.read('irdata/wire/white_light.wdf')
+    NDDataset: [float64] a.u. (shape: (y:1, x:261))
+
     """
     kwargs["filetypes"] = ["Renishaw Wire files (*.wdf)"]
     kwargs["protocol"] = ["wire"]

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -53,6 +53,10 @@ def write_csv(*args, **kwargs):
     >>> ds = scp.read('irdata/nh4y-activation.spg')
     >>> f2 = ds[0].write_csv('single_spectrum.csv')
 
+    Using the explicit namespace API
+    >>> ds = scp.NDDataset([1, 2, 3])
+    >>> f3 = ds.csv.write('myfile')
+
     """
     exporter = Exporter()
     kwargs["filetypes"] = ["CSV files (*.csv)"]

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -46,6 +46,9 @@ def write_jcamp(*args, **kwargs):
     The extension will be added automatically
     >>> X.write_jcamp('myfile')
 
+    Using the explicit namespace API
+    >>> X.jcamp.write('myfile')
+
     """
     exporter = Exporter()
     kwargs["filetypes"] = ["JCAMP-DX files (*.jdx)"]

--- a/src/spectrochempy/core/writers/write_matlab.py
+++ b/src/spectrochempy/core/writers/write_matlab.py
@@ -41,6 +41,9 @@ def write_matlab(*args, **kwargs):
     The extension will be added automatically
     >>> X.write_matlab('myfile')
 
+    Using the explicit namespace API
+    >>> X.matlab.write('myfile')
+
     """
     exporter = Exporter()
     kwargs["filetypes"] = ["MATLAB files (*.mat)"]


### PR DESCRIPTION
Adds namespace API examples to all core I/O reader/writer docstrings and to the import/export user guide tutorials. Also documents the generic "scp.read(...)" dispatcher behaviour and its relationship to namespace readers.