### PR TITLE
fix: use module-level namespace API for writer examples

### DIFF
--- a/docs/sources/userguide/importexport/importJCAMPDX.py
+++ b/docs/sources/userguide/importexport/importJCAMPDX.py
@@ -55,7 +55,7 @@ S0.write_jcamp("CO@Mo_Al2O3_0.jdx", confirm=False)
 # The namespace API is also available for writing:
 
 # %%
-S0.jcamp.write("CO@Mo_Al2O3_0.jdx", confirm=False)
+scp.jcamp.write(S0, "CO@Mo_Al2O3_0.jdx", confirm=False)
 
 # %% [markdown]
 # Then used (and maybe changed) by a 3rd party software, and re-imported in

--- a/docs/sources/userguide/importexport/importJCAMPDX.py
+++ b/docs/sources/userguide/importexport/importJCAMPDX.py
@@ -55,7 +55,7 @@ S0.write_jcamp("CO@Mo_Al2O3_0.jdx", confirm=False)
 # The namespace API is also available for writing:
 
 # %%
-scp.jcamp.write(S0, "CO@Mo_Al2O3_0.jdx", confirm=False)
+scp.jcamp.write(S0, "CO@Mo_Al2O3_0.jdx", confirm=False, overwrite=True)
 
 # %% [markdown]
 # Then used (and maybe changed) by a 3rd party software, and re-imported in

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -54,8 +54,7 @@ def write_csv(*args, **kwargs):
     >>> f2 = ds[0].write_csv('single_spectrum.csv')
 
     Using the explicit namespace API
-    >>> ds = scp.NDDataset([1, 2, 3])
-    >>> f3 = ds.csv.write('myfile')
+    >>> f3 = scp.csv.write(ds, 'myfile')
 
     """
     exporter = Exporter()

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -47,7 +47,7 @@ def write_jcamp(*args, **kwargs):
     >>> X.write_jcamp('myfile')
 
     Using the explicit namespace API
-    >>> X.jcamp.write('myfile')
+    >>> scp.jcamp.write(X, 'myfile')
 
     """
     exporter = Exporter()

--- a/src/spectrochempy/core/writers/write_matlab.py
+++ b/src/spectrochempy/core/writers/write_matlab.py
@@ -42,7 +42,7 @@ def write_matlab(*args, **kwargs):
     >>> X.write_matlab('myfile')
 
     Using the explicit namespace API
-    >>> X.matlab.write('myfile')
+    >>> scp.matlab.write(X, 'myfile')
 
     """
     exporter = Exporter()


### PR DESCRIPTION
Fixes CI failure on Ubuntu 3.14 caused by instance-level namespace access in tutorials and docstrings (e.g. S0.jcamp.write(...)). Writers are accessed module-level: scp.jcamp.write(S0, ...).