### PR TITLE
ENH: attach additional PerkinElmer metadata fields (instrument serial, software, accessory, image name)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -71,6 +71,14 @@ Bug Fixes
   `write_csv()`, `write_jcamp()`, and `write_matlab()` no longer advertise the
   generic multi-protocol export options documented on `write()`.
 
+- Enriched PerkinElmer `.sp` reader metadata.
+  The reader now preserves additional acquisition metadata fields:
+  ``instrument_serial_number``, ``instrument_software_version``,
+  ``ir_accessory``, and ``image_name``.
+  When ``image_name`` is present and ``dataset.description`` is empty,
+  ``image_name`` is used as the dataset description.
+  All existing metadata fields remain unchanged.
+
 .. section
 
 Dependency Updates

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -63,3 +63,11 @@ Bug Fixes
 - Clarified specialized writer docstrings so format-specific APIs such as
   `write_csv()`, `write_jcamp()`, and `write_matlab()` no longer advertise the
   generic multi-protocol export options documented on `write()`.
+
+- Enriched PerkinElmer `.sp` reader metadata.
+  The reader now preserves additional acquisition metadata fields:
+  ``instrument_serial_number``, ``instrument_software_version``,
+  ``ir_accessory``, and ``image_name``.
+  When ``image_name`` is present and ``dataset.description`` is empty,
+  ``image_name`` is used as the dataset description.
+  All existing metadata fields remain unchanged.

--- a/plugins/spectrochempy-perkinelmer/src/spectrochempy_perkinelmer/read_perkinelmer.py
+++ b/plugins/spectrochempy-perkinelmer/src/spectrochempy_perkinelmer/read_perkinelmer.py
@@ -411,7 +411,7 @@ def _read_sp(*args, **kwargs):
     dataset.set_coordset(y=y, x=x)
 
     # Metadata — keep only well-defined, useful fields.
-    for key in [
+    _CORE_META_KEYS = (
         "analyst",
         "date",
         "instrument_model",
@@ -419,10 +419,22 @@ def _read_sp(*args, **kwargs):
         "source",
         "accumulations",
         "spectrum_type",
-    ]:
+    )
+    _EXTRA_META_KEYS = (
+        "instrument_serial_number",
+        "instrument_software_version",
+        "ir_accessory",
+        "image_name",
+    )
+    for key in _CORE_META_KEYS + _EXTRA_META_KEYS:
         value = spf.meta.get(key)
         if value not in (None, ""):
             setattr(dataset.meta, key, value)
+
+    # Use the vendor image_name as a fallback description when none is provided.
+    image_name = spf.meta.get("image_name")
+    if image_name and not dataset.description:
+        dataset.description = str(image_name)
 
     dataset.meta.readonly = True
 

--- a/plugins/spectrochempy-perkinelmer/tests/test_perkinelmer_plugin.py
+++ b/plugins/spectrochempy-perkinelmer/tests/test_perkinelmer_plugin.py
@@ -233,6 +233,142 @@ def test_read_perkinelmer_content_kwarg() -> None:
 
 
 # ------------------------------------------------------------------------------
+# Metadata enrichment tests
+# ------------------------------------------------------------------------------
+
+
+def test_read_perkinelmer_extra_meta_fields(monkeypatch) -> None:
+    """New metadata fields are copied when present in the parser output."""
+    from spectrochempy_perkinelmer.read_perkinelmer import _read_sp
+
+    class FakeSpFile:
+        spectrum = np.array([1.0, 2.0, 3.0])
+        wavelength = np.array([4000.0, 3500.0, 3000.0])
+        meta = {
+            "analyst": "Test Analyst",
+            "date": "Mon Jan 01 00:00:00 2024",
+            "instrument_model": "Spectrum Two",
+            "detector": "MCT",
+            "source": "MIR",
+            "accumulations": 16,
+            "spectrum_type": "Spectrum",
+            "instrument_serial_number": "12345",
+            "instrument_software_version": "v1.0",
+            "ir_accessory": "Universal ATR",
+            "image_name": "Sample 001",
+        }
+
+    monkeypatch.setattr(
+        "spectrochempy_perkinelmer.read_perkinelmer._SpFile",
+        lambda content: FakeSpFile(),
+    )
+
+    ds = scp.NDDataset()
+    result = _read_sp(ds, "dummy.sp", content=b"PEPE")
+
+    assert result.meta.instrument_serial_number == "12345"
+    assert result.meta.instrument_software_version == "v1.0"
+    assert result.meta.ir_accessory == "Universal ATR"
+    assert result.meta.image_name == "Sample 001"
+    # Core fields should still be present
+    assert result.meta.analyst == "Test Analyst"
+    assert result.meta.instrument_model == "Spectrum Two"
+
+
+def test_read_perkinelmer_image_name_fallback_description(monkeypatch) -> None:
+    """image_name is used as dataset.description when description is empty."""
+    from spectrochempy_perkinelmer.read_perkinelmer import _read_sp
+
+    class FakeSpFile:
+        spectrum = np.array([1.0, 2.0, 3.0])
+        wavelength = np.array([4000.0, 3500.0, 3000.0])
+        meta = {
+            "analyst": "",
+            "date": "",
+            "instrument_model": "",
+            "detector": "",
+            "source": "",
+            "accumulations": "",
+            "spectrum_type": "",
+            "image_name": "Sample 001 By Analyst Date Monday",
+        }
+
+    monkeypatch.setattr(
+        "spectrochempy_perkinelmer.read_perkinelmer._SpFile",
+        lambda content: FakeSpFile(),
+    )
+
+    ds = scp.NDDataset()
+    result = _read_sp(ds, "dummy.sp", content=b"PEPE")
+    assert result.description == "Sample 001 By Analyst Date Monday"
+
+
+def test_read_perkinelmer_description_not_overwritten(monkeypatch) -> None:
+    """image_name does NOT overwrite an existing description."""
+    from spectrochempy_perkinelmer.read_perkinelmer import _read_sp
+
+    class FakeSpFile:
+        spectrum = np.array([1.0, 2.0, 3.0])
+        wavelength = np.array([4000.0, 3500.0, 3000.0])
+        meta = {
+            "analyst": "",
+            "date": "",
+            "instrument_model": "",
+            "detector": "",
+            "source": "",
+            "accumulations": "",
+            "spectrum_type": "",
+            "image_name": "Sample 001",
+        }
+
+    monkeypatch.setattr(
+        "spectrochempy_perkinelmer.read_perkinelmer._SpFile",
+        lambda content: FakeSpFile(),
+    )
+
+    ds = scp.NDDataset()
+    ds.description = "Existing description"
+    result = _read_sp(ds, "dummy.sp", content=b"PEPE")
+    assert result.description == "Existing description"
+
+
+def test_read_perkinelmer_empty_extra_fields_ignored(monkeypatch) -> None:
+    """Empty or missing extra metadata values are not attached."""
+    from spectrochempy_perkinelmer.read_perkinelmer import _read_sp
+
+    class FakeSpFile:
+        spectrum = np.array([1.0, 2.0, 3.0])
+        wavelength = np.array([4000.0, 3500.0, 3000.0])
+        meta = {
+            "analyst": "Analyst",
+            "date": "Mon Jan 01 00:00:00 2024",
+            "instrument_model": "Spectrum Two",
+            "detector": "MCT",
+            "source": "MIR",
+            "accumulations": 16,
+            "spectrum_type": "Spectrum",
+            "instrument_serial_number": "",
+            "instrument_software_version": None,
+            # ir_accessory and image_name deliberately absent
+        }
+
+    monkeypatch.setattr(
+        "spectrochempy_perkinelmer.read_perkinelmer._SpFile",
+        lambda content: FakeSpFile(),
+    )
+
+    ds = scp.NDDataset()
+    result = _read_sp(ds, "dummy.sp", content=b"PEPE")
+
+    assert getattr(result.meta, "instrument_serial_number", None) in (None, "")
+    assert getattr(result.meta, "instrument_software_version", None) in (None, "")
+    assert getattr(result.meta, "ir_accessory", None) in (None, "")
+    assert getattr(result.meta, "image_name", None) in (None, "")
+    # Core fields should still be present
+    assert result.meta.analyst == "Analyst"
+
+
+# ------------------------------------------------------------------------------
 # Namespace exposure tests
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Conservative metadata enrichment for the PerkinElmer `.sp` reader. The parser already extracts these fields; this PR copies four additional high-value fields to `dataset.meta` and uses `image_name` as a fallback for `dataset.description` when empty.

**Added metadata fields:**
- `instrument_serial_number` → `dataset.meta`
- `instrument_software_version` → `dataset.meta`
- `ir_accessory` → `dataset.meta`
- `image_name` → `dataset.meta` (and `dataset.description` fallback)

**Behavior preservation:**
- All 7 existing metadata fields remain unchanged.
- `image_name` only fills `description` when it is empty.
- Empty or missing values are not attached.

**Tests:** 4 new focused unit tests (monkeypatched parser), all passing.

related to : #897 , #1281 