### PR TITLE
 FIX: harmonize OMNIC acquisition metadata across SPG and SRS readers

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -77,7 +77,13 @@ Bug Fixes
   ``ir_accessory``, and ``image_name``.
   When ``image_name`` is present and ``dataset.description`` is empty,
   ``image_name`` is used as the dataset description.
-  All existing metadata fields remain unchanged.
+   All existing metadata fields remain unchanged.
+
+- Harmonized acquisition metadata attachment across OMNIC SPG and SRS readers.
+  ``collection_length``, ``optical_velocity``, and ``laser_frequency``
+  are now consistently exposed in ``dataset.meta`` for all three OMNIC
+  formats (SPA, SPG, SRS).  Previously, SPG attached none of these fields
+  and SRS omitted ``optical_velocity``.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -70,4 +70,10 @@ Bug Fixes
   ``ir_accessory``, and ``image_name``.
   When ``image_name`` is present and ``dataset.description`` is empty,
   ``image_name`` is used as the dataset description.
-  All existing metadata fields remain unchanged.
+   All existing metadata fields remain unchanged.
+
+- Harmonized acquisition metadata attachment across OMNIC SPG and SRS readers.
+  ``collection_length``, ``optical_velocity``, and ``laser_frequency``
+  are now consistently exposed in ``dataset.meta`` for all three OMNIC
+  formats (SPA, SPG, SRS).  Previously, SPG attached none of these fields
+  and SRS omitted ``optical_velocity``.

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -838,6 +838,15 @@ def _read_spg(*args, **kwargs):
 
     dataset.history = f"Imported from spg file {filename}."
 
+    # Attach acquisition metadata from the header.
+    # Acquisition parameters (collection_length, reference_frequency,
+    # optical_velocity) are global to the SPG file — the header at
+    # position02 stores them once, not per spectrum.  Reusing the last
+    # parsed header is therefore intentional.
+    dataset.meta.collection_length = info["collection_length"] / 100 * ur("s")
+    dataset.meta.optical_velocity = info["optical_velocity"]
+    dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
+
     if kwargs.pop("sortbydate", True):
         dataset.sort(dim="y", inplace=True)
         dataset.history = "Sorted by date"
@@ -1411,6 +1420,7 @@ def _read_srs(*args, **kwargs):
 
     dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
     dataset.meta.collection_length = info["collection_length"] * ur("s")
+    dataset.meta.optical_velocity = info["optical_velocity"]
 
     if dataset.x.units is None and dataset.x.title == "data points":
         # interferogram

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -321,6 +321,13 @@ class TestOmnicCharacterization:
         assert isinstance(labels[1, 0], datetime)
         assert x.labels is None
 
+        assert_meta_keys_present(
+            dataset,
+            "collection_length",
+            "optical_velocity",
+            "laser_frequency",
+        )
+
     def test_spa_uses_omnic_origin_and_label_rows(self, omnic_spa_dataset):
         dataset = omnic_spa_dataset
 
@@ -360,6 +367,7 @@ class TestOmnicCharacterization:
             assert_label_structure(dataset.y)
         assert "laser_frequency" in dataset.meta
         assert "collection_length" in dataset.meta
+        assert "optical_velocity" in dataset.meta
 
 
 class TestOpusCharacterization:


### PR DESCRIPTION
Attach `collection_length`, `optical_velocity`, and `laser_frequency`
to `dataset.meta` in the SPG reader (previously missing all acquisition
metadata) and add `optical_velocity` to the SRS reader (previously
omitted only this field).

All three OMNIC formats (SPA, SPG, SRS) now consistently expose the
same acquisition parameters from `_read_header()`.

Changes are purely additive — no parser changes, no new binary decoding,
no public API changes.