### PR TITLE
OMNIC: decode Experiment Information block (key 0x82, subtype 0x79) i…

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -85,6 +85,14 @@ Bug Fixes
   formats (SPA, SPG, SRS).  Previously, SPG attached none of these fields
   and SRS omitted ``optical_velocity``.
 
+- Decoded OMNIC Experiment Information blocks (block-directory key 0x82,
+  subtype 0x79) in SPA and SPG readers.  The reader now extracts the
+  experiment file path and short name, accessory/compartment name, and
+  experiment description from the binary block and stores them in
+  ``dataset.meta`` as ``omnic_experiment_path``, ``omnic_experiment_file``,
+  ``omnic_accessory``, and ``omnic_experiment_title`` (respectively).
+  Malformed or missing blocks are handled defensively.
+
 .. section
 
 Dependency Updates

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -77,3 +77,11 @@ Bug Fixes
   are now consistently exposed in ``dataset.meta`` for all three OMNIC
   formats (SPA, SPG, SRS).  Previously, SPG attached none of these fields
   and SRS omitted ``optical_velocity``.
+
+- Decoded OMNIC Experiment Information blocks (block-directory key 0x82,
+  subtype 0x79) in SPA and SPG readers.  The reader now extracts the
+  experiment file path and short name, accessory/compartment name, and
+  experiment description from the binary block and stores them in
+  ``dataset.meta`` as ``omnic_experiment_path``, ``omnic_experiment_file``,
+  ``omnic_accessory``, and ``omnic_experiment_title`` (respectively).
+  Malformed or missing blocks are handled defensively.

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -643,6 +643,24 @@ def _read_spg(*args, **kwargs):
         keys[i] = fromfile(fid, dtype="uint8", count=1)
         pos += 16
 
+    # Extract experiment info blocks (key 0x82, subtype 0x79).
+    experiment_infos = []
+    key_is_82 = keys == 130
+    for idx in np.nonzero(key_is_82)[0]:
+        entry_pos = 304 + 16 * idx
+        fid.seek(entry_pos + 2)
+        blk_pos = fromfile(fid, "uint32", 1)
+        fid.seek(entry_pos + 6)
+        blk_len = fromfile(fid, "uint32", 1)
+        if blk_len >= 50:
+            cur = fid.tell()
+            fid.seek(blk_pos)
+            blk_data = fid.read(blk_len)
+            fid.seek(cur)
+            exp = _decode_experiment_info_block(blk_data)
+            if exp:
+                experiment_infos.append(exp)
+
     # the number of occurrences of the key '02' is number of spectra
     nspec = np.count_nonzero(keys == 2)
 
@@ -847,6 +865,16 @@ def _read_spg(*args, **kwargs):
     dataset.meta.optical_velocity = info["optical_velocity"]
     dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
 
+    # Attach experiment info if available.
+    # If all decoded 0x79 blocks are identical, attach once; if different,
+    # attach the first set only (conservative).
+    if experiment_infos:
+        first = experiment_infos[0]
+        for meta_key, val in first.items():
+            setattr(dataset.meta, f"omnic_{meta_key}", val)
+        if not dataset.description.strip() and first.get("experiment_title"):
+            dataset.description = first["experiment_title"]
+
     if kwargs.pop("sortbydate", True):
         dataset.sort(dim="y", inplace=True)
         dataset.history = "Sorted by date"
@@ -922,6 +950,7 @@ def _read_spa(*args, **kwargs):
     # scan "key values"
     pos = 304
     spa_comments = []  # several custom comments can be present
+    _exp_info = None
     while "continue":
         fid.seek(pos)
         key = fromfile(fid, dtype="uint8", count=1)
@@ -957,6 +986,18 @@ def _read_spa(*args, **kwargs):
 
         elif key == 103 and return_ifg == "background":
             b_ifg_intensities = _getintensities(fid, pos)
+
+        elif key == 130 and _exp_info is None:
+            fid.seek(pos + 2)
+            blk_pos = fromfile(fid, "uint32", 1)
+            fid.seek(pos + 6)
+            blk_len = fromfile(fid, "uint32", 1)
+            if blk_len >= 50:
+                cur = fid.tell()
+                fid.seek(blk_pos)
+                blk_data = fid.read(blk_len)
+                fid.seek(cur)
+                _exp_info = _decode_experiment_info_block(blk_data)
 
         elif key == 00 or key == 1:
             break
@@ -1058,6 +1099,12 @@ def _read_spa(*args, **kwargs):
     dataset.meta.collection_length = info["collection_length"] / 100 * ur("s")
     dataset.meta.optical_velocity = info["optical_velocity"]
     dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
+
+    if _exp_info is not None:
+        for meta_key, val in _exp_info.items():
+            setattr(dataset.meta, f"omnic_{meta_key}", val)
+        if not dataset.description.strip() and _exp_info.get("experiment_title"):
+            dataset.description = _exp_info["experiment_title"]
 
     if dataset.x.units is None and dataset.x.title == "data points":
         # interferogram
@@ -1723,3 +1770,53 @@ def _getintensities(fid, pos):
     # Read and return spectral intensities
     fid.seek(intensity_pos)
     return fromfile(fid, "float32", int(nintensities))
+
+
+def _decode_experiment_info_block(data: bytes) -> dict | None:
+    """
+    Decode an OMNIC Experiment Information block (key 0x82, subtype 0x79).
+
+    Parameters
+    ----------
+    data : bytes
+        Raw block data read from the file.
+
+    Returns
+    -------
+    dict or None
+        Dictionary with keys ``experiment_path``, ``experiment_file``,
+        ``accessory_name``, and/or ``experiment_title``, or None if the
+        block is not a valid subtype 0x79 block.
+    """
+    if len(data) < 50 or data[0] != 0x79:
+        return None
+
+    # Payload starts at byte 10 (10-byte header).
+    # Null-terminated fields appear sequentially:
+    #   [0] experiment_path   — full Windows path
+    #   [1] experiment_file   — experiment file name stored in the 0x79 block
+    #   [2] accessory_name    — accessory / compartment name
+    #   [3] experiment_title  — experiment description
+    payload = data[10:]
+    raw = payload.split(b"\x00")
+
+    decoded = [
+        f.decode("utf-8", errors="replace").strip("\x00").strip() for f in raw if f
+    ]
+
+    if not decoded:
+        return None
+
+    _FIELD_NAMES = [
+        "experiment_path",
+        "experiment_file",
+        "accessory_name",
+        "experiment_title",
+    ]
+
+    result: dict[str, str] = {}
+    for i in range(min(len(decoded), len(_FIELD_NAMES))):
+        if decoded[i]:
+            result[_FIELD_NAMES[i]] = decoded[i]
+
+    return result

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -145,6 +145,72 @@ def test_allow_inconsistent_x_parameter_documented():
     assert "allow_inconsistent_x=True" in scp.read_omnic.__doc__
 
 
+def test_decode_experiment_info_block():
+    """_decode_experiment_info_block correctly decodes 0x79 blocks."""
+    from spectrochempy.core.readers.read_omnic import _decode_experiment_info_block
+
+    # Helper to build a 0x79 block
+    def _build_block(*fields):
+        payload = b"\x00".join(f.encode("utf-8") for f in fields) + b"\x00"
+        header = bytes([0x79, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00])
+        block = header + payload
+        if len(block) < 60:
+            block += b"\x00" * (60 - len(block))
+        return block
+
+    # Normal 4-field block
+    block = _build_block(
+        r"C:\MYDOCU~1\omnic\Param\CARROU~2.EXP",
+        "CARROU~2.EXP",
+        "iS50 Main Sample",
+        "Default experiment for iS50 Main Sample Compartment",
+    )
+    result = _decode_experiment_info_block(block)
+    assert result is not None
+    assert result["experiment_path"] == r"C:\MYDOCU~1\omnic\Param\CARROU~2.EXP"
+    assert result["experiment_file"] == "CARROU~2.EXP"
+    assert result["accessory_name"] == "iS50 Main Sample"
+    assert (
+        result["experiment_title"]
+        == "Default experiment for iS50 Main Sample Compartment"
+    )
+
+    # Subtype 0x9e (System Status) -> None
+    bad = bytearray(block)
+    bad[0] = 0x9E
+    assert _decode_experiment_info_block(bytes(bad)) is None
+
+    # Too short -> None
+    assert _decode_experiment_info_block(b"\x00" * 40) is None
+
+    # Single field -> experiment_path only
+    block = _build_block(r"C:\path\to\file.spa")
+    result = _decode_experiment_info_block(block)
+    assert result is not None
+    assert result["experiment_path"] == r"C:\path\to\file.spa"
+    assert "experiment_file" not in result
+    assert "accessory_name" not in result
+    assert "experiment_title" not in result
+
+    # Three fields without title
+    block = _build_block(r"C:\ATR\crystal.exp", "crystal.exp", "ATR Crystal")
+    result = _decode_experiment_info_block(block)
+    assert result is not None
+    assert result["experiment_path"] == r"C:\ATR\crystal.exp"
+    assert result["experiment_file"] == "crystal.exp"
+    assert result["accessory_name"] == "ATR Crystal"
+    assert "experiment_title" not in result
+
+    # Unix-style path in field 0
+    block = _build_block("/home/omnic/param/test.exp", "test.exp", "iS50 Sample")
+    result = _decode_experiment_info_block(block)
+    assert result is not None
+    assert result["experiment_path"] == "/home/omnic/param/test.exp"
+    assert result["experiment_file"] == "test.exp"
+    assert result["accessory_name"] == "iS50 Sample"
+    assert "experiment_title" not in result
+
+
 @pytest.mark.skip(reason="Requires an SPG file with inconsistent x-axes (#863)")
 def test_allow_inconsistent_x_with_real_file():
     """Exercise both return paths once a representative sample is available."""

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -327,6 +327,18 @@ class TestOmnicCharacterization:
             "optical_velocity",
             "laser_frequency",
         )
+        # Experiment info metadata (key 0x82 subtype 0x79) — present in
+        # most real-world OMNIC files.  If the fixture lacks this block
+        # the assertions below raise, and the new keys should be removed
+        # from the expected list.
+        if hasattr(dataset.meta, "omnic_experiment_path"):
+            assert isinstance(dataset.meta.omnic_experiment_path, str)
+        if hasattr(dataset.meta, "omnic_experiment_file"):
+            assert isinstance(dataset.meta.omnic_experiment_file, str)
+        if hasattr(dataset.meta, "omnic_accessory"):
+            assert isinstance(dataset.meta.omnic_accessory, str)
+        if hasattr(dataset.meta, "omnic_experiment_title"):
+            assert isinstance(dataset.meta.omnic_experiment_title, str)
 
     def test_spa_uses_omnic_origin_and_label_rows(self, omnic_spa_dataset):
         dataset = omnic_spa_dataset
@@ -349,6 +361,14 @@ class TestOmnicCharacterization:
             "optical_velocity",
             "laser_frequency",
         )
+        if hasattr(dataset.meta, "omnic_experiment_path"):
+            assert isinstance(dataset.meta.omnic_experiment_path, str)
+        if hasattr(dataset.meta, "omnic_experiment_file"):
+            assert isinstance(dataset.meta.omnic_experiment_file, str)
+        if hasattr(dataset.meta, "omnic_accessory"):
+            assert isinstance(dataset.meta.omnic_accessory, str)
+        if hasattr(dataset.meta, "omnic_experiment_title"):
+            assert isinstance(dataset.meta.omnic_experiment_title, str)
 
     def test_srs_currently_sets_origin_and_history(self, omnic_srs_dataset):
         dataset = omnic_srs_dataset

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -331,13 +331,13 @@ class TestOmnicCharacterization:
         # most real-world OMNIC files.  If the fixture lacks this block
         # the assertions below raise, and the new keys should be removed
         # from the expected list.
-        if hasattr(dataset.meta, "omnic_experiment_path"):
+        if dataset.meta.omnic_experiment_path is not None:
             assert isinstance(dataset.meta.omnic_experiment_path, str)
-        if hasattr(dataset.meta, "omnic_experiment_file"):
+        if dataset.meta.omnic_experiment_file is not None:
             assert isinstance(dataset.meta.omnic_experiment_file, str)
-        if hasattr(dataset.meta, "omnic_accessory"):
+        if dataset.meta.omnic_accessory is not None:
             assert isinstance(dataset.meta.omnic_accessory, str)
-        if hasattr(dataset.meta, "omnic_experiment_title"):
+        if dataset.meta.omnic_experiment_title is not None:
             assert isinstance(dataset.meta.omnic_experiment_title, str)
 
     def test_spa_uses_omnic_origin_and_label_rows(self, omnic_spa_dataset):
@@ -361,13 +361,13 @@ class TestOmnicCharacterization:
             "optical_velocity",
             "laser_frequency",
         )
-        if hasattr(dataset.meta, "omnic_experiment_path"):
+        if dataset.meta.omnic_experiment_path is not None:
             assert isinstance(dataset.meta.omnic_experiment_path, str)
-        if hasattr(dataset.meta, "omnic_experiment_file"):
+        if dataset.meta.omnic_experiment_file is not None:
             assert isinstance(dataset.meta.omnic_experiment_file, str)
-        if hasattr(dataset.meta, "omnic_accessory"):
+        if dataset.meta.omnic_accessory is not None:
             assert isinstance(dataset.meta.omnic_accessory, str)
-        if hasattr(dataset.meta, "omnic_experiment_title"):
+        if dataset.meta.omnic_experiment_title is not None:
             assert isinstance(dataset.meta.omnic_experiment_title, str)
 
     def test_srs_currently_sets_origin_and_history(self, omnic_srs_dataset):


### PR DESCRIPTION
This PR adds decoding of the OMNIC Experiment Information block (block-directory key 0x82, subtype 0x79) for SPA and SPG files.
## Changes:
- _decode_experiment_info_block(data) — new private helper that extracts fields sequentially from null-terminated payload at offset +10: experiment_path, experiment_file, accessory_name, experiment_title. Returns None for non-0x79 blocks or malformed data.
- _read_spa() — handle key 130 in the block-directory scan; attach decoded metadata to dataset.meta (prefix omnic_). Falls back to experiment_title for dataset.description when empty.
- _read_spg() — scan keys array for 0x82 entries, decode subtype 0x79 blocks, attach first result to dataset.meta. Same fallback logic.
- Unit test test_decode_experiment_info_block with 6 sub-tests covering normal block, subtype 0x9e, too-short, single-field, three-field, and Unix-path variants. No test data dependency.
- Semantic characterization tests updated with conditional omnic_* meta key checks for SPG and SPA.
## Notes:
- .srs files do not contain key 0x82 (confirmed by audit).
- allow_inconsistent_x=True path in SPG does not attach experiment info (corner case, deferred).
- Classification is purely positional — no heuristics, matching the sequential structure established by the audit.