### PR TITLE
DOC: document Official Plugin classifier for CI auto-discovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,13 @@ Each plugin:
 
 * has its own `pyproject.toml`;
 * registers through
-  `[project.entry-points."spectrochempy.plugins"]`.
+  `[project.entry-points."spectrochempy.plugins"]`;
+* if it is an **official plugin** (published and maintained by the
+  SpectroChemPy team), must add
+  ``Framework :: SpectroChemPy :: Official Plugin`` to the
+  ``classifiers`` list in ``pyproject.toml`` — this classifier is the
+  sole registration point for CI workflows (publishing, testing, docs
+  builds, release validation).
 
 See:
 

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -60,11 +60,18 @@ Key points:
 * The **entry point name** (``myplugin``) must match your plugin's
   ``name`` attribute.
 * ``spectrochempy`` must be listed as a dependency with a compatibility
-   range, e.g. ``spectrochempy>=0.9,<0.10``.
+   range, e.g. ``spectrochempy>=0.10,<0.11``.
 * Use ``requires-python = ">=3.11"`` to match SpectroChemPy's minimum.
 * Official plugins in the monorepo use a static ``version`` field.
   ``setuptools_scm`` is not used because plugin and core tags share the
   same Git repository, which would cause version collisions.
+* Official plugins must add the Trove classifier
+  ``Framework :: SpectroChemPy :: Official Plugin`` in their
+  ``pyproject.toml`` classifiers list.  This classifier is the single
+  source of truth for CI workflows (publishing, testing, documentation,
+  release validation) — any plugin with this classifier is automatically
+  picked up by all CI pipelines.  Adding a new official plugin requires
+  **no edits** to any workflow file.
 
 Local editable development
 ==========================
@@ -76,10 +83,8 @@ used by PyPI wheels:
 .. code-block:: bash
 
     pip install -e .
-    pip install -e plugins/spectrochempy-nmr
-    pip install -e plugins/spectrochempy-iris
-    pip install -e plugins/spectrochempy-tensor
-    pip install -e plugins/spectrochempy-cantera
+    python -m spectrochempy.ci.install_plugins --editable all
+    pip install -e plugins/spectrochempy-cantera  # experimental, not auto-discovered
 
 The bundled plugins can also be installed with the helper:
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -25,6 +25,8 @@ New Features
   preserves available metadata (instrument model, detector, source,
   date, etc.). The parsing logic is adapted from the BSD-3-Clause
   licensed specio project. (#897)
+  Includes a dedicated documentation page, a gallery example, and an
+  entry in the official plugins table.
 
 - ``read_omnic`` and ``read_spg`` can now read OMNIC SPG files containing
   spectra with non-identical x-axis definitions using
@@ -119,3 +121,10 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- Official plugins now use the ``Framework :: SpectroChemPy :: Official Plugin``
+  Trove classifier in ``pyproject.toml`` as the single source of truth for CI
+  auto-discovery.  Adding a new official plugin no longer requires editing
+  workflow files.  Documented in ``CONTRIBUTING.md`` and the plugin packaging
+  guide.  The plugin template (``plugins/plugin-template/pyproject.toml``)
+  includes a comment explaining the requirement.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -21,6 +21,8 @@ New Features
   preserves available metadata (instrument model, detector, source,
   date, etc.). The parsing logic is adapted from the BSD-3-Clause
   licensed specio project. (#897)
+  Includes a dedicated documentation page, a gallery example, and an
+  entry in the official plugins table.
 
 - ``read_omnic`` and ``read_spg`` can now read OMNIC SPG files containing
   spectra with non-identical x-axis definitions using
@@ -85,3 +87,13 @@ Bug Fixes
   ``dataset.meta`` as ``omnic_experiment_path``, ``omnic_experiment_file``,
   ``omnic_accessory``, and ``omnic_experiment_title`` (respectively).
   Malformed or missing blocks are handled defensively.
+
+Developer
+~~~~~~~~~
+
+- Official plugins now use the ``Framework :: SpectroChemPy :: Official Plugin``
+  Trove classifier in ``pyproject.toml`` as the single source of truth for CI
+  auto-discovery.  Adding a new official plugin no longer requires editing
+  workflow files.  Documented in ``CONTRIBUTING.md`` and the plugin packaging
+  guide.  The plugin template (``plugins/plugin-template/pyproject.toml``)
+  includes a comment explaining the requirement.

--- a/plugins/plugin-template/pyproject.toml
+++ b/plugins/plugin-template/pyproject.toml
@@ -7,6 +7,12 @@ name = "spectrochempy-myplugin"
 version = "0.1.0"
 description = "A SpectroChemPy plugin"
 requires-python = ">=3.11"
+# Official plugins (published by the SpectroChemPy team) must also list:
+#   "Framework :: SpectroChemPy :: Official Plugin"
+# in the classifiers below.  Adding this classifier is the only registration
+# step needed for all CI workflows to auto-discover the plugin.
+classifiers = [
+]
 dependencies = [
     "spectrochempy>=0.9,<0.11",
 ]


### PR DESCRIPTION
Official plugins now use the "Framework :: SpectroChemPy :: Official Plugin" Trove classifier in pyproject.toml as the single source of truth for CI auto-discovery. Adding a new official plugin no longer requires editing workflow files.

Documented in CONTRIBUTING.md and the plugin packaging guide. The plugin template includes a comment explaining the requirement.