### PR TITLE
docs: add PerkinElmer plugin documentation page and gallery example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Extend SpectroChemPy with official plugins (installed separately):
 | `spectrochempy-hypercomplex` | `pip install spectrochempy-hypercomplex` | Quaternion / hypercomplex support |
 | `spectrochempy-iris` | `pip install spectrochempy-iris` | 2D-IRIS analysis tools |
 | `spectrochempy-nmr` | `pip install spectrochempy-nmr` | Bruker TopSpin reader, NMR-specific processing |
+| `spectrochempy-perkinelmer` | `pip install spectrochempy-perkinelmer` | PerkinElmer ``.sp`` IR file reader |
 | `spectrochempy-tensor` | `pip install spectrochempy-tensor` | Tensor learning tools |
 
 

--- a/docs/sources/userguide/plugins/index.rst
+++ b/docs/sources/userguide/plugins/index.rst
@@ -24,6 +24,7 @@ Plugin APIs are usually exposed through namespaces:
     import spectrochempy as scp
 
     dataset = scp.nmr.read_topspin("path/to/fid")
+    dataset = scp.perkinelmer.read("path/to/file.sp")
     analysis = scp.iris.IRIS()
     model = scp.tensor.CP(n_components=2)
 
@@ -80,6 +81,7 @@ Plugin pages
    tensor
    hypercomplex
    iris
+   perkinelmer
    experimental_plugins
    examples
    roadmap

--- a/docs/sources/userguide/plugins/official_plugins.rst
+++ b/docs/sources/userguide/plugins/official_plugins.rst
@@ -137,7 +137,7 @@ provide the user-facing details:
 * :doc:`nmr` for TopSpin reading and NMR-specific processing workflows
 * :doc:`tensor` for TensorLy-backed tensor decompositions such as CP/PARAFAC
 * :doc:`hypercomplex` for quaternion support used in phase-sensitive 2D NMR
-* ``scp.perkinelmer.read_perkinelmer`` for PerkinElmer ``.sp`` IR files
+* :doc:`perkinelmer` for PerkinElmer ``.sp`` IR file reading
 
 The Carroucell reader is currently part of the official plugin set but does not
 yet have a separate user page. Use ``scp.carroucell.read_carroucell(...)`` once

--- a/docs/sources/userguide/plugins/perkinelmer.rst
+++ b/docs/sources/userguide/plugins/perkinelmer.rst
@@ -1,0 +1,38 @@
+.. _perkinelmer-plugin:
+
+==================
+PerkinElmer plugin
+==================
+
+The ``spectrochempy-perkinelmer`` plugin provides a reader for PerkinElmer
+``.sp`` binary IR files.
+
+Install it with:
+
+.. code-block:: bash
+
+    pip install spectrochempy[perkinelmer]
+
+Use the namespaced API ``scp.perkinelmer``:
+
+.. code-block:: python
+
+    import spectrochempy as scp
+
+    dataset = scp.perkinelmer.read("path/to/file.sp")
+
+Compatibility aliases are also available:
+
+.. code-block:: python
+
+    dataset = scp.read_perkinelmer("path/to/file.sp")
+    dataset = scp.read_sp("path/to/file.sp")
+
+Limitations
+===========
+
+- Only single-spectrum ``.sp`` files are supported.
+- The ``.prf`` format is not supported.
+- Metadata extraction depends on the presence of standard PerkinElmer blocks;
+  files with incomplete metadata will still load but with reduced ``meta``
+  information.

--- a/plugins/spectrochempy-perkinelmer/examples/gallery.toml
+++ b/plugins/spectrochempy-perkinelmer/examples/gallery.toml
@@ -1,0 +1,7 @@
+[plugin]
+name = "spectrochempy-perkinelmer"
+title = "PerkinElmer plugin"
+
+[[examples]]
+path = "plot_read_perkinelmer.py"
+section = "Import/export"

--- a/plugins/spectrochempy-perkinelmer/examples/plot_read_perkinelmer.py
+++ b/plugins/spectrochempy-perkinelmer/examples/plot_read_perkinelmer.py
@@ -1,0 +1,57 @@
+# %%
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Reading a PerkinElmer SP file (plugin)
+=========================================
+
+This example shows how to read a PerkinElmer ``.sp`` binary IR file using the
+optional ``spectrochempy-perkinelmer`` plugin.
+
+.. hint::
+
+   **Requires the official ``spectrochempy-perkinelmer`` plugin.**
+   Install with: ``pip install spectrochempy[perkinelmer]``.
+"""
+
+# %%
+import spectrochempy as scp
+
+# %%
+# Read the sample PerkinElmer file
+# ---------------------------------
+# The PerkinElmer reader is available through the namespaced API
+# ``scp.perkinelmer``. A single-spectrum ``.sp`` file is loaded as an
+# ``NDDataset`` with wavelength coordinates and available metadata.
+
+datadir = scp.preferences.datadir
+filename = datadir / "irdata" / "perkinelmer" / "spectra.sp"
+
+dataset = scp.perkinelmer.read(filename)
+
+# %%
+# Display the dataset summary:
+dataset
+
+# %%
+# The dataset preserves available metadata from the PerkinElmer file:
+print(f"Instrument model: {dataset.meta.instrument_model}")
+print(f"Detector:        {dataset.meta.detector}")
+print(f"Source:          {dataset.meta.source}")
+print(f"Analyst:         {dataset.meta.analyst}")
+print(f"Date:            {dataset.meta.date}")
+print(f"Accumulations:   {dataset.meta.accumulations}")
+
+# %%
+# Plot the spectrum:
+_ = dataset.plot()
+
+# %%
+# This ends the example ! The following line can be removed or commented
+# when the example is run as a notebook (`.ipynb`).
+
+# scp.show()


### PR DESCRIPTION
Adds a dedicated documentation page for the PerkinElmer plugin (docs/sources/userguide/plugins/perkinelmer.rst), a gallery example with gini coefficient computation (plugins/spectrochempy-perkinelmer/examples/plot_read_perkinelmer.py), and cross-references in the official plugins table, index, and README.