### PR TITLE
MAINT: raise plugin bounds to >=0.10, add official classifier, add perkinelmer extras

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -128,3 +128,9 @@ Developer
   workflow files.  Documented in ``CONTRIBUTING.md`` and the plugin packaging
   guide.  The plugin template (``plugins/plugin-template/pyproject.toml``)
   includes a comment explaining the requirement.
+
+- Raised all plugin lower bounds from ``>=0.9`` to ``>=0.10`` across
+  ``pyproject.toml`` and ``recipe.yaml`` files.  Added the
+  ``Framework :: SpectroChemPy :: Official Plugin`` classifier to each
+  official plugin's ``pyproject.toml``.  Added ``spectrochempy-perkinelmer``
+  to the core ``[plugins]`` extra and related requirement files.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -97,3 +97,9 @@ Developer
   workflow files.  Documented in ``CONTRIBUTING.md`` and the plugin packaging
   guide.  The plugin template (``plugins/plugin-template/pyproject.toml``)
   includes a comment explaining the requirement.
+
+- Raised all plugin lower bounds from ``>=0.9`` to ``>=0.10`` across
+  ``pyproject.toml`` and ``recipe.yaml`` files.  Added the
+  ``Framework :: SpectroChemPy :: Official Plugin`` classifier to each
+  official plugin's ``pyproject.toml``.  Added ``spectrochempy-perkinelmer``
+  to the core ``[plugins]`` extra and related requirement files.

--- a/environments/environment_plugins.yml
+++ b/environments/environment_plugins.yml
@@ -51,3 +51,4 @@ dependencies:
     - spectrochempy-tensor>=0.1,<0.2
     - spectrochempy-hypercomplex>=0.1,<0.2
     - spectrochempy-carroucell>=0.1,<0.2
+    - spectrochempy-perkinelmer>=0.1,<0.2

--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -9,7 +9,7 @@ description = "Cantera-based thermodynamics and reactive chemistry for SpectroCh
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.9,<0.11",
+    "spectrochempy>=0.10,<0.11",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-cantera/recipe.yaml
+++ b/plugins/spectrochempy-cantera/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.11
+    - spectrochempy >=0.10,<0.11
     - cantera >=3.0
     - numpy
     - scipy

--- a/plugins/spectrochempy-carroucell/pyproject.toml
+++ b/plugins/spectrochempy-carroucell/pyproject.toml
@@ -8,8 +8,11 @@ version = "0.1.4"
 description = "Carroucell experiment reader for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
+classifiers = [
+    "Framework :: SpectroChemPy :: Official Plugin",
+]
 dependencies = [
-    "spectrochempy>=0.9,<0.11",
+    "spectrochempy>=0.10,<0.11",
     "xlrd",
     "scipy",
 ]

--- a/plugins/spectrochempy-carroucell/recipe.yaml
+++ b/plugins/spectrochempy-carroucell/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.11
+    - spectrochempy >=0.10,<0.11
     - xlrd
     - scipy
 

--- a/plugins/spectrochempy-hypercomplex/pyproject.toml
+++ b/plugins/spectrochempy-hypercomplex/pyproject.toml
@@ -8,8 +8,11 @@ version = "0.1.4"
 description = "Hypercomplex / quaternion support plugin for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
+classifiers = [
+    "Framework :: SpectroChemPy :: Official Plugin",
+]
 dependencies = [
-    "spectrochempy>=0.9,<0.11",
+    "spectrochempy>=0.10,<0.11",
     "numpy",
     "numpy-quaternion>=2024.0.7",
 ]

--- a/plugins/spectrochempy-hypercomplex/recipe.yaml
+++ b/plugins/spectrochempy-hypercomplex/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.11
+    - spectrochempy >=0.10,<0.11
     - numpy
     - quaternion >=2024.0.7
 

--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -8,8 +8,11 @@ version = "0.1.4"
 description = "IRIS analysis extension for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
+classifiers = [
+    "Framework :: SpectroChemPy :: Official Plugin",
+]
 dependencies = [
-    "spectrochempy>=0.9,<0.11",
+    "spectrochempy>=0.10,<0.11",
     "scipy",
     "osqp",
 ]

--- a/plugins/spectrochempy-iris/recipe.yaml
+++ b/plugins/spectrochempy-iris/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.11
+    - spectrochempy >=0.10,<0.11
     - scipy
     - osqp
 

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -8,8 +8,11 @@ version = "0.1.5"
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
+classifiers = [
+    "Framework :: SpectroChemPy :: Official Plugin",
+]
 dependencies = [
-    "spectrochempy>=0.9,<0.11",
+    "spectrochempy>=0.10,<0.11",
     "numpy",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.
 ]

--- a/plugins/spectrochempy-nmr/recipe.yaml
+++ b/plugins/spectrochempy-nmr/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.11
+    - spectrochempy >=0.10,<0.11
     - numpy
 
 tests:

--- a/plugins/spectrochempy-perkinelmer/pyproject.toml
+++ b/plugins/spectrochempy-perkinelmer/pyproject.toml
@@ -8,8 +8,11 @@ version = "0.1.0"
 description = "PerkinElmer file reader plugin for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
+classifiers = [
+    "Framework :: SpectroChemPy :: Official Plugin",
+]
 dependencies = [
-    "spectrochempy>=0.9,<0.11",
+    "spectrochempy>=0.10,<0.11",
     "numpy",
 ]
 

--- a/plugins/spectrochempy-tensor/pyproject.toml
+++ b/plugins/spectrochempy-tensor/pyproject.toml
@@ -8,8 +8,11 @@ version = "0.1.1"
 description = "Tensor decompositions plugin for SpectroChemPy"
 requires-python = ">=3.11"
 readme = "README.md"
+classifiers = [
+    "Framework :: SpectroChemPy :: Official Plugin",
+]
 dependencies = [
-    "spectrochempy>=0.9,<0.11",
+    "spectrochempy>=0.10,<0.11",
     "tensorly",
 ]
 

--- a/plugins/spectrochempy-tensor/recipe.yaml
+++ b/plugins/spectrochempy-tensor/recipe.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools >=64
   run:
     - python >=3.11
-    - spectrochempy >=0.9,<0.11
+    - spectrochempy >=0.10,<0.11
     - tensorly
 
 tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ plugins = [
     "spectrochempy[tensor]",
     "spectrochempy-hypercomplex>=0.1,<0.2",
     "spectrochempy-carroucell>=0.1,<0.2",
+    "spectrochempy-perkinelmer>=0.1,<0.2",
 ]
 test = [
   "coverage",

--- a/requirements/requirements_plugins.txt
+++ b/requirements/requirements_plugins.txt
@@ -26,3 +26,4 @@ spectrochempy[iris]
 spectrochempy[tensor]
 spectrochempy-hypercomplex>=0.1,<0.2
 spectrochempy-carroucell>=0.1,<0.2
+spectrochempy-perkinelmer>=0.1,<0.2


### PR DESCRIPTION
Raise all plugin dependencies from >=0.9 to >=0.10. Add the "Framework :: SpectroChemPy :: Official Plugin" classifier to all 6 official plugin pyproject.toml files. Add spectrochempy-perkinelmer to the core [plugins] extra, requirement files, and conda environment.