### PR TITLE
CI: auto-discover official plugins via classifier instead of hardcoded allowlists

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -119,12 +119,9 @@ jobs:
           set -e
           . .venv/bin/activate
           start=$SECONDS
-          uv pip install --no-deps -e plugins/spectrochempy-nmr
-          uv pip install --no-deps -e plugins/spectrochempy-iris
-          uv pip install --no-deps -e plugins/spectrochempy-tensor
-          uv pip install --no-deps -e plugins/spectrochempy-hypercomplex
-          uv pip install --no-deps -e plugins/spectrochempy-carroucell
-          uv pip install --no-deps -e plugins/spectrochempy-perkinelmer
+          for name in $(python -m spectrochempy.ci.install_plugins --list-names); do
+            uv pip install --no-deps -e "plugins/$name"
+          done
           # Install plugin runtime dependencies that --no-deps skips
           uv pip install osqp scipy numpy-quaternion tensorly
           duration=$((SECONDS - start))

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -300,10 +300,6 @@ jobs:
       - name: Set plugin matrix
         id: set-matrix
         run: |
-          # Official plugins are explicitly listed. Experimental plugins may live in
-          # the repository but are NOT auto-published by this workflow.
-          OFFICIAL_PLUGINS="spectrochempy-nmr spectrochempy-iris spectrochempy-tensor spectrochempy-hypercomplex spectrochempy-carroucell"
-
           plugins=()
           for dir in plugins/*/; do
             name=$(basename "$dir")
@@ -311,8 +307,9 @@ jobs:
               echo "Skipping $name (developer template, not publishable)"
               continue
             fi
-            if ! echo "$OFFICIAL_PLUGINS" | grep -qw "$name"; then
-              echo "Skipping $name (not in official plugin allowlist)"
+            # Check for the Official Plugin classifier.
+            if ! grep -q 'Framework :: SpectroChemPy :: Official Plugin' "${dir}pyproject.toml" 2>/dev/null; then
+              echo "Skipping $name (no Official Plugin classifier)"
               continue
             fi
             if [ -f "${dir}recipe.yaml" ] || [ -f "${dir}meta.yaml" ]; then

--- a/.github/workflows/install_on_colab.yml
+++ b/.github/workflows/install_on_colab.yml
@@ -86,10 +86,10 @@ jobs:
               SETUPTOOLS_SCM_PRETEND_VERSION=${SCPY_COLAB_PRETEND_VERSION} \
                 pip install --no-build-isolation --no-deps /workspace && \
               pip install -q colorama pint numpy-quaternion tensorly && \
-              pip install --no-build-isolation --no-deps /workspace/plugins/spectrochempy-iris && \
-              pip install --no-build-isolation --no-deps /workspace/plugins/spectrochempy-nmr && \
-              pip install --no-build-isolation --no-deps /workspace/plugins/spectrochempy-tensor && \
-              pip install --no-build-isolation --no-deps /workspace/plugins/spectrochempy-hypercomplex && \
-              pip install --no-build-isolation --no-deps /workspace/plugins/spectrochempy-carroucell && \
+              for dir in /workspace/plugins/spectrochempy-*/; do
+                if grep -q 'Official Plugin' \"\${dir}pyproject.toml\" 2>/dev/null; then
+                  pip install --no-build-isolation --no-deps \"\$dir\"
+                fi
+              done && \
               python3 /workspace/.github/workflows/scripts/test_colab_plugins.py --mode with-plugins
             "

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -84,7 +84,7 @@ jobs:
           for d in sorted(Path('plugins').glob('*/')):
               name = d.name
               if name == 'plugin-template':
-                  print(f'Skipping {name} (developer template, not publishable)')
+                  print(f'Skipping {name} (developer template, not publishable)', file=sys.stderr)
                   continue
               pyproject = d / 'pyproject.toml'
               if not pyproject.is_file():
@@ -93,7 +93,7 @@ jobs:
                   data = tomllib.loads(pyproject.read_text())
                   classifiers = data.get('project', {}).get('classifiers', [])
                   if OFFICIAL not in classifiers:
-                      print(f'Skipping {name} (no Official Plugin classifier)')
+                      print(f'Skipping {name} (no Official Plugin classifier)', file=sys.stderr)
                       continue
               except Exception:
                   continue
@@ -105,7 +105,7 @@ jobs:
 
           j = json.dumps({'plugin': plugins})
           print(f'matrix={j}')
-          print(f'Discovered official plugins: {j}')
+          print(f'Discovered official plugins: {j}', file=sys.stderr)
           " >> "$GITHUB_OUTPUT"
 
   build-and-publish_plugins:

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -97,7 +97,7 @@ jobs:
                       continue
               except Exception:
                   continue
-              plugins.append({'name': name, 'path': f'{name}/'})
+              plugins.append({'name': name, 'path': f'plugins/{name}'})
 
           if not plugins:
               print('::error::No official plugins discovered in plugins/')

--- a/.github/workflows/publish_plugins.yml
+++ b/.github/workflows/publish_plugins.yml
@@ -2,10 +2,10 @@
 # - TestPyPI on pushes to test branches
 # - PyPI on published releases
 #
-# Official plugins are explicitly listed in the allowlist below.
-# Experimental plugins (e.g. spectrochempy-cantera) live in the repository
-# but are NOT auto-published by this workflow — they must be published
-# manually or through a separate publish workflow.
+# Official plugins are identified by the "Framework :: SpectroChemPy :: Official Plugin"
+# classifier in their pyproject.toml. Experimental plugins (e.g. spectrochempy-cantera)
+# live in the repository but are NOT auto-published by this workflow — they must be
+# published manually or through a separate publish workflow.
 #
 # Release policy:
 #   - Official plugins are released independently from the core package.
@@ -75,35 +75,38 @@ jobs:
       - name: Set plugin matrix
         id: set-matrix
         run: |
-          # Official plugins are explicitly listed. Experimental plugins may live in
-          # the repository but are NOT auto-published by this workflow.
-          OFFICIAL_PLUGINS="spectrochempy-nmr spectrochempy-iris spectrochempy-tensor spectrochempy-hypercomplex spectrochempy-carroucell"
+          python3 -c "
+          import json, tomllib, sys
+          from pathlib import Path
 
-          plugins=()
-          for dir in plugins/*/; do
-            name=$(basename "$dir")
-            if [ "$name" = "plugin-template" ]; then
-              echo "Skipping $name (developer template, not publishable)"
-              continue
-            fi
-            if ! echo "$OFFICIAL_PLUGINS" | grep -qw "$name"; then
-              echo "Skipping $name (not in official plugin allowlist)"
-              continue
-            fi
-            if [ -f "${dir}pyproject.toml" ]; then
-              plugins+=("{\"name\":\"$name\",\"path\":\"$dir\"}")
-            fi
-          done
+          OFFICIAL = 'Framework :: SpectroChemPy :: Official Plugin'
+          plugins = []
+          for d in sorted(Path('plugins').glob('*/')):
+              name = d.name
+              if name == 'plugin-template':
+                  print(f'Skipping {name} (developer template, not publishable)')
+                  continue
+              pyproject = d / 'pyproject.toml'
+              if not pyproject.is_file():
+                  continue
+              try:
+                  data = tomllib.loads(pyproject.read_text())
+                  classifiers = data.get('project', {}).get('classifiers', [])
+                  if OFFICIAL not in classifiers:
+                      print(f'Skipping {name} (no Official Plugin classifier)')
+                      continue
+              except Exception:
+                  continue
+              plugins.append({'name': name, 'path': f'{name}/'})
 
-          if [ ${#plugins[@]} -eq 0 ]; then
-            echo "::error::No official plugins discovered in plugins/"
-            exit 1
-          fi
+          if not plugins:
+              print('::error::No official plugins discovered in plugins/')
+              sys.exit(1)
 
-          # Join with commas and wrap in JSON array
-          joined=$(IFS=,; echo "${plugins[*]}")
-          echo "matrix={\"plugin\":[$joined]}" >> "$GITHUB_OUTPUT"
-          echo "Discovered official plugins: $joined"
+          j = json.dumps({'plugin': plugins})
+          print(f'matrix={j}')
+          print(f'Discovered official plugins: {j}')
+          " >> "$GITHUB_OUTPUT"
 
   build-and-publish_plugins:
     name: Build and publish plugin distributions

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -89,14 +89,8 @@ jobs:
 
       - name: Validate plugin name
         run: |
-          # Official plugins are explicitly listed. Experimental plugins should be
-          # released manually and are not handled by this workflow.
-          OFFICIAL_PLUGINS="spectrochempy-nmr spectrochempy-iris spectrochempy-tensor spectrochempy-hypercomplex spectrochempy-carroucell"
-          if ! echo "$OFFICIAL_PLUGINS" | grep -qw "${{ inputs.plugin_name }}"; then
-            echo "::error::${{ inputs.plugin_name }} is not in the official plugin allowlist. Experimental plugins must be released manually."
-            exit 1
-          fi
-          plugin_dir="plugins/${{ inputs.plugin_name }}"
+          plugin_name="${{ inputs.plugin_name }}"
+          plugin_dir="plugins/$plugin_name"
           if [ ! -d "$plugin_dir" ]; then
             echo "::error::Plugin directory $plugin_dir does not exist"
             exit 1
@@ -105,6 +99,19 @@ jobs:
             echo "::error::$plugin_dir/pyproject.toml not found"
             exit 1
           fi
+          # Verify the plugin has the Official Plugin classifier.
+          if ! python3 -c "
+          import sys, tomllib
+          data = tomllib.load(open('$plugin_dir/pyproject.toml', 'rb'))
+          cls = data.get('project', {}).get('classifiers', [])
+          if 'Framework :: SpectroChemPy :: Official Plugin' not in cls:
+              sys.exit(1)
+          "; then
+            echo "::error::$plugin_name is not an official plugin (missing Official Plugin classifier)."
+            echo "::error::Experimental plugins must be released manually."
+            exit 1
+          fi
+          echo "Plugin $plugin_name validated as official."
 
       - name: Bump version in pyproject.toml
         run: |

--- a/.github/workflows/scripts/ci_diagnostics.py
+++ b/.github/workflows/scripts/ci_diagnostics.py
@@ -29,13 +29,34 @@ OPTIONAL_DEPENDENCIES = [
     "traitlets",
 ]
 
-OFFICIAL_PLUGIN_DISTRIBUTIONS = [
-    "spectrochempy-iris",
-    "spectrochempy-nmr",
-    "spectrochempy-tensor",
-    "spectrochempy-hypercomplex",
-    "spectrochempy-carroucell",
-]
+OFFICIAL_CLASSIFIER = "Framework :: SpectroChemPy :: Official Plugin"
+
+
+def _discover_official_plugins() -> list[str]:
+    """Return official plugin distribution names by checking classifiers."""
+    plugins_dir = Path("plugins")
+    if not plugins_dir.is_dir():
+        return []
+
+    results: list[str] = []
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    for pyproject in sorted(plugins_dir.glob("spectrochempy-*/pyproject.toml")):
+        try:
+            data = tomllib.loads(pyproject.read_text())
+            classifiers = data.get("project", {}).get("classifiers", [])
+            if OFFICIAL_CLASSIFIER in classifiers:
+                results.append(pyproject.parent.name)
+        except Exception as exc:
+            print(f"Warning: could not read {pyproject}: {exc}", file=sys.stderr)
+            continue
+    return results
+
+
+OFFICIAL_PLUGIN_DISTRIBUTIONS = _discover_official_plugins()
 
 PYTEST_STATUSES = [
     "passed",

--- a/.github/workflows/scripts/plugin_version_status.py
+++ b/.github/workflows/scripts/plugin_version_status.py
@@ -14,13 +14,34 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from pathlib import Path
 
-OFFICIAL_PLUGINS = (
-    "spectrochempy-nmr",
-    "spectrochempy-iris",
-    "spectrochempy-tensor",
-    "spectrochempy-hypercomplex",
-    "spectrochempy-carroucell",
-)
+OFFICIAL_CLASSIFIER = "Framework :: SpectroChemPy :: Official Plugin"
+
+
+def _discover_official_plugins() -> tuple[str, ...]:
+    """Return official plugin directory names by checking classifier in pyproject.toml."""
+    plugins_dir = Path("plugins")
+    if not plugins_dir.is_dir():
+        return ()
+
+    results: list[str] = []
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    for pyproject in sorted(plugins_dir.glob("spectrochempy-*/pyproject.toml")):
+        try:
+            data = tomllib.loads(pyproject.read_text())
+            classifiers = data.get("project", {}).get("classifiers", [])
+            if OFFICIAL_CLASSIFIER in classifiers:
+                results.append(pyproject.parent.name)
+        except Exception as exc:
+            print(f"Warning: could not read {pyproject}: {exc}", file=sys.stderr)
+            continue
+    return tuple(results)
+
+
+OFFICIAL_PLUGINS = _discover_official_plugins()
 
 TAG_RE = re.compile(
     r"^(?P<plugin>spectrochempy-[a-z0-9-]+)-v" r"(?P<version>\d+\.\d+\.\d+)$"

--- a/.github/workflows/scripts/select_test_targets.py
+++ b/.github/workflows/scripts/select_test_targets.py
@@ -11,22 +11,47 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Official plugins with stable lifecycle tests (import, metadata,
-# compatibility, registration, state transitions, reader/accessor checks).
-# Cantera stays excluded: experimental, heavy external dependency, no
-# lifecycle tests yet.
-PLUGIN_TESTS = {
-    "spectrochempy-cantera": "plugins/spectrochempy-cantera/tests",
-    "spectrochempy-carroucell": "plugins/spectrochempy-carroucell/tests",
-    "spectrochempy-hypercomplex": "plugins/spectrochempy-hypercomplex/tests",
-    "spectrochempy-iris": "plugins/spectrochempy-iris/tests",
-    "spectrochempy-nmr": "plugins/spectrochempy-nmr/tests",
-    "spectrochempy-tensor": "plugins/spectrochempy-tensor/tests",
-}
+OFFICIAL_CLASSIFIER = "Framework :: SpectroChemPy :: Official Plugin"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_classifiers(plugin_dir: Path) -> list[str]:
+    """Return classifiers from a plugin's pyproject.toml, or empty list."""
+    pyproject = plugin_dir / "pyproject.toml"
+    if not pyproject.is_file():
+        return []
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    try:
+        data = tomllib.loads(pyproject.read_text())
+        return data.get("project", {}).get("classifiers", [])
+    except Exception:
+        return []
+
+
+def _discover_plugins() -> dict[str, str]:
+    """Build {package_name: test_path} for all plugins that have a tests/ dir."""
+    mapping: dict[str, str] = {}
+    for p in sorted((REPO_ROOT / "plugins").glob("spectrochempy-*/")):
+        test_dir = p / "tests"
+        if test_dir.is_dir():
+            mapping[p.name] = str(test_dir.relative_to(REPO_ROOT))
+    return mapping
+
+
+def _is_official(plugin_name: str) -> bool:
+    classifiers = _read_classifiers(REPO_ROOT / "plugins" / plugin_name)
+    return OFFICIAL_CLASSIFIER in classifiers
+
+
+# Build mappings dynamically.
+PLUGIN_TESTS = _discover_plugins()
 FULL_PLUGIN_TARGETS = [
-    target
-    for plugin, target in PLUGIN_TESTS.items()
-    if plugin not in {"spectrochempy-cantera"}  # cantera = experimental
+    target for plugin, target in PLUGIN_TESTS.items() if _is_official(plugin)
 ]
 ALL_PLUGIN_TARGETS = list(PLUGIN_TESTS.values())
 FULL_TARGETS = ["tests", *FULL_PLUGIN_TARGETS]

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -191,11 +191,7 @@ jobs:
         run: |
           set -e
           start=$SECONDS
-          python -m pip install -e plugins/spectrochempy-hypercomplex
-          python -m pip install -e plugins/spectrochempy-nmr
-          python -m pip install -e plugins/spectrochempy-iris
-          python -m pip install -e plugins/spectrochempy-tensor
-          python -m pip install -e plugins/spectrochempy-carroucell
+          python -m spectrochempy.ci.install_plugins --editable all
           duration=$((SECONDS - start))
           echo "plugin installation: ${duration}s" | tee -a "$CI_TIMING_FILE"
 
@@ -210,21 +206,25 @@ jobs:
           python - <<'PY'
           from importlib import metadata
           from importlib.util import find_spec
+          from pathlib import Path
+          import tomllib
 
-          official_plugins = [
-              "spectrochempy-hypercomplex",
-              "spectrochempy-nmr",
-              "spectrochempy-iris",
-              "spectrochempy-tensor",
-              "spectrochempy-carroucell",
-          ]
-          import_names = {
-              "spectrochempy-hypercomplex": "spectrochempy_hypercomplex",
-              "spectrochempy-nmr": "spectrochempy_nmr",
-              "spectrochempy-iris": "spectrochempy_iris",
-              "spectrochempy-tensor": "spectrochempy_tensor",
-              "spectrochempy-carroucell": "spectrochempy_carroucell",
-          }
+          OFFICIAL = "Framework :: SpectroChemPy :: Official Plugin"
+
+          official_plugins = []
+          import_names = {}
+          for d in sorted(Path("plugins").glob("spectrochempy-*/")):
+              pyproject = d / "pyproject.toml"
+              if not pyproject.is_file():
+                  continue
+              try:
+                  data = tomllib.loads(pyproject.read_text())
+                  if OFFICIAL not in data.get("project", {}).get("classifiers", []):
+                      continue
+              except Exception:
+                  continue
+              official_plugins.append(d.name)
+              import_names[d.name] = d.name.replace("-", "_")
 
           installed = []
           importable = []

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -134,3 +134,13 @@ Developer
   ``Framework :: SpectroChemPy :: Official Plugin`` classifier to each
   official plugin's ``pyproject.toml``.  Added ``spectrochempy-perkinelmer``
   to the core ``[plugins]`` extra and related requirement files.
+
+- Refactored CI auto-discovery for official plugins.  ``publish_plugins.yml``,
+  ``release_plugin.yml``, ``build_package.yml``, ``test_package.yml``,
+  ``build_docs.yml``, and ``install_on_colab.yml`` now discover plugins
+  dynamically via the classifier instead of hardcoded allowlists.
+  ``select_test_targets.py``, ``ci_diagnostics.py``, and
+  ``plugin_version_status.py`` use the same mechanism.  Added
+  ``src/spectrochempy/ci/install_plugins.py`` helper with
+  ``--editable``, ``--list-names``, and pip flags for CI and local
+  development.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -103,3 +103,13 @@ Developer
   ``Framework :: SpectroChemPy :: Official Plugin`` classifier to each
   official plugin's ``pyproject.toml``.  Added ``spectrochempy-perkinelmer``
   to the core ``[plugins]`` extra and related requirement files.
+
+- Refactored CI auto-discovery for official plugins.  ``publish_plugins.yml``,
+  ``release_plugin.yml``, ``build_package.yml``, ``test_package.yml``,
+  ``build_docs.yml``, and ``install_on_colab.yml`` now discover plugins
+  dynamically via the classifier instead of hardcoded allowlists.
+  ``select_test_targets.py``, ``ci_diagnostics.py``, and
+  ``plugin_version_status.py`` use the same mechanism.  Added
+  ``src/spectrochempy/ci/install_plugins.py`` helper with
+  ``--editable``, ``--list-names``, and pip flags for CI and local
+  development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ exclude = ["~*"] # Exclude files and directories. "tests/**"
   "N816",
 ] # accept "useless expression", "print", "mixed-case variables" in *.ipynb or py:percent files.
 "src/spectrochempy/extern/brukeropus/**/*" = ["T201", "D"]
+"src/spectrochempy/ci/install_plugins.py" = ["T201", "S603", "PLC0415", "S112"]
 "tests/**/*" = [
   "S101", # Use of assert detected. The enclosed code will be executed only when the assertion fails.
   "S603", # subprocess call with shell=True identified, security issue.

--- a/src/spectrochempy/ci/install_plugins.py
+++ b/src/spectrochempy/ci/install_plugins.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""Install SpectroChemPy plugins from the local source tree.
+
+Usage::
+
+    python -m spectrochempy.ci.install_plugins --editable all
+    python -m spectrochempy.ci.install_plugins nmr iris
+    python -m spectrochempy.ci.install_plugins --editable perkinelmer
+    python -m spectrochempy.ci.install_plugins --list-names
+    python -m spectrochempy.ci.install_plugins --list-names --root /workspace
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+OFFICIAL_CLASSIFIER = "Framework :: SpectroChemPy :: Official Plugin"
+
+
+def _find_root() -> Path:
+    """Discover repository root by walking up from cwd or script location."""
+    for start in (Path.cwd(), Path(__file__).resolve().parent):
+        for candidate in [start, *start.parents]:
+            if (candidate / "plugins").is_dir() and list(
+                (candidate / "plugins").glob("spectrochempy-*/pyproject.toml")
+            ):
+                return candidate
+    msg = "Cannot find repository root (no plugins/ with spectrochempy-* subdirs)"
+    raise SystemExit(msg)
+
+
+def _discover_plugins(plugins_dir: Path, *, official_only: bool = False) -> list[str]:
+    """Return sorted list of plugin directory names, optionally filtered by classifier."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    plugins: list[str] = []
+    for p in sorted(plugins_dir.glob("spectrochempy-*/pyproject.toml")):
+        name = p.parent.name
+        if official_only:
+            try:
+                data = tomllib.loads(p.read_text())
+                classifiers = data.get("project", {}).get("classifiers", [])
+                if OFFICIAL_CLASSIFIER not in classifiers:
+                    continue
+            except Exception:
+                continue
+        plugins.append(name)
+    return plugins
+
+
+def _pip_install(
+    plugin: str,
+    plugins_dir: Path,
+    *,
+    editable: bool = False,
+    pip_cmd: list[str] | None = None,
+    no_deps: bool = False,
+    no_build_isolation: bool = False,
+) -> int:
+    plugin_path = plugins_dir / plugin
+    if not plugin_path.is_dir():
+        print(f"Error: plugin directory not found: {plugin_path}", file=sys.stderr)
+        return 1
+
+    pip = pip_cmd or [sys.executable, "-m", "pip"]
+    cmd = [*pip, "install"]
+    if editable:
+        cmd.append("-e")
+    if no_deps:
+        cmd.append("--no-deps")
+    if no_build_isolation:
+        cmd.append("--no-build-isolation")
+    cmd.append(str(plugin_path))
+
+    print(f"Installing {plugin} {'(editable)' if editable else ''}...")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    print(result.stdout)
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+    return result.returncode
+
+
+def _resolve_name(name: str) -> str:
+    if name.startswith("spectrochempy-"):
+        return name
+    return f"spectrochempy-{name}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Install or list SpectroChemPy plugins from the local source tree.",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="Repository root (auto-detected by default).",
+    )
+    parser.add_argument(
+        "--editable",
+        "-e",
+        action="store_true",
+        help="Install in editable/development mode (pip install -e).",
+    )
+    parser.add_argument(
+        "--no-deps",
+        action="store_true",
+        help="Pass --no-deps to pip.",
+    )
+    parser.add_argument(
+        "--no-build-isolation",
+        action="store_true",
+        help="Pass --no-build-isolation to pip.",
+    )
+    parser.add_argument(
+        "--pip",
+        default=None,
+        help="Pip command (default: python -m pip). Example: --pip 'uv pip'",
+    )
+    parser.add_argument(
+        "--list-names",
+        action="store_true",
+        help="Print official plugin directory names (one per line) and exit.",
+    )
+    parser.add_argument(
+        "plugins",
+        nargs="*",
+        default=["all"],
+        metavar="PLUGIN",
+        help="Plugin name(s) to install (e.g. nmr, iris). Default: all (official plugins).",
+    )
+    parsed = parser.parse_args()
+
+    root = Path(parsed.root) if parsed.root else _find_root()
+    plugins_dir = root / "plugins"
+
+    if parsed.list_names:
+        for name in _discover_plugins(plugins_dir, official_only=True):
+            print(name)
+        return 0
+
+    pip_cmd = parsed.pip.split() if parsed.pip else None
+
+    if "all" in parsed.plugins:
+        targets = _discover_plugins(plugins_dir, official_only=True)
+        if not targets:
+            print("Error: no official plugins discovered.", file=sys.stderr)
+            return 1
+    else:
+        all_known = _discover_plugins(plugins_dir, official_only=False)
+        targets = [_resolve_name(p) for p in parsed.plugins]
+        for t in targets:
+            if t not in all_known:
+                print(f"Warning: unknown plugin {t!r}, skipping", file=sys.stderr)
+
+    errors = 0
+    for plugin in targets:
+        errors += _pip_install(
+            plugin,
+            plugins_dir,
+            editable=parsed.editable,
+            pip_cmd=pip_cmd,
+            no_deps=parsed.no_deps,
+            no_build_isolation=parsed.no_build_isolation,
+        )
+
+    if errors:
+        print(f"\n{errors} plugin(s) failed to install.", file=sys.stderr)
+        return errors
+    print("\nAll plugins installed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/spectrochempy/ci/install_plugins.py
+++ b/src/spectrochempy/ci/install_plugins.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Install SpectroChemPy plugins from the local source tree.
+"""
+Install SpectroChemPy plugins from the local source tree.
 
 Usage::
 


### PR DESCRIPTION
All CI workflows and scripts now discover official plugins dynamically by checking for the "Framework :: SpectroChemPy :: Official Plugin" classifier in pyproject.toml. Removes all hardcoded allowlists from: publish_plugins.yml, release_plugin.yml, build_package.yml, test_package.yml, build_docs.yml, install_on_colab.yml, select_test_targets.py, ci_diagnostics.py, plugin_version_status.py.

Adds src/spectrochempy/ci/install_plugins.py helper with --editable, --list-names, --no-deps, --no-build-isolation, and --pip flags, replacing hardcoded pip install commands in CI.