### PR TITLE
ENH: replace install-plugins-dev.sh with install-plugins.sh in src/spectrochempy/ci/

### DIFF
--- a/src/spectrochempy/ci/install-plugins.sh
+++ b/src/spectrochempy/ci/install-plugins.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # Install all local spectrochempy plugins in editable mode.
 # Excludes plugin-template (scaffolding template, not a plugin).
+#
+# Prefer the more flexible Python alternative:
+#   python -m spectrochempy.ci.install_plugins --editable all
 
 set -euo pipefail
 
-plugins_dir="$(cd "$(dirname "$0")/../plugins" && pwd)"
+plugins_dir="$(cd "$(dirname "$0")/../../.." && pwd)/plugins"
 
 for pkg in "$plugins_dir"/spectrochempy-*/; do
     echo "Installing $(basename "$pkg") in editable mode..."


### PR DESCRIPTION
Move the convenience script from `scripts/` to `src/spectrochempy/ci/`, alongside the more flexible Python alternative (`python -m spectrochempy.ci.install_plugins --editable all`).

The script now mentions the Python alternative in its header comment.