### PR TITLE
DOC: move read_topspin docs from core reference to NMR plugin

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -172,7 +172,6 @@ Import a NDataset from external source
 
     load
     read
-    read_topspin
     read_csv
     read_ddr
     read_dir
@@ -771,10 +770,3 @@ File
     :toctree: generated/
 
     pathclean
-
-.. rst-class:: small
-
-.. note::
-
-   ``read_topspin`` requires the official ``spectrochempy[nmr]`` plugin
-   (i.e. ``pip install spectrochempy[nmr]``).

--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -21,6 +21,19 @@ Use the NMR namespace:
 
     dataset = scp.nmr.read_topspin("path/to/fid")
 
+The plugin-owned TopSpin reader is documented here rather than in the core API
+reference because it is provided by ``spectrochempy-nmr``, not by the core
+package itself. The recommended public entry point is
+``scp.nmr.read_topspin(...)``. The legacy compatibility alias
+``scp.read_topspin(...)`` is still available when the plugin is installed, but
+new documentation and examples should prefer the namespaced API.
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.read_topspin
+
 For phase-sensitive 2D NMR workflows, install hypercomplex support as well:
 
 .. code-block:: bash


### PR DESCRIPTION
Superseded by #1304, which uses the short same-repository branch `docs/topspin` so the docs preview workflow publishes the branch preview under the upstream repository as intended.