### PR TITLE
DOC: normalize official plugin pages around the NMR pilot

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -172,7 +172,6 @@ Import a NDataset from external source
 
     load
     read
-    read_topspin
     read_csv
     read_ddr
     read_dir
@@ -771,10 +770,3 @@ File
     :toctree: generated/
 
     pathclean
-
-.. rst-class:: small
-
-.. note::
-
-   ``read_topspin`` requires the official ``spectrochempy[nmr]`` plugin
-   (i.e. ``pip install spectrochempy[nmr]``).

--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -770,3 +770,15 @@ File
     :toctree: generated/
 
     pathclean
+
+*******************
+Official plugins
+*******************
+
+Plugin-owned public API pages are documented separately from the User Guide on
+the dedicated reference page below.
+
+.. toctree::
+   :maxdepth: 1
+
+   plugins

--- a/docs/sources/reference/plugins.rst
+++ b/docs/sources/reference/plugins.rst
@@ -1,0 +1,62 @@
+.. _plugin_public_api_reference:
+
+###########################
+Plugin public API reference
+###########################
+
+This page collects the generated public API pages owned by official
+SpectroChemPy plugins.
+
+Workflow-oriented plugin guides remain in :doc:`/userguide/plugins/index`.
+
+NMR plugin
+==========
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.nmr.read
+
+PerkinElmer plugin
+==================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.perkinelmer.read
+
+Carroucell plugin
+=================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.carroucell.read
+
+IRIS plugin
+===========
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.iris.IRIS
+
+Tensor plugin
+=============
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.tensor.CP
+
+Hypercomplex plugin
+===================
+
+The hypercomplex plugin currently exposes its public user API primarily through
+the ``dataset.hyper`` accessor documented in
+:doc:`/userguide/plugins/hypercomplex`.

--- a/docs/sources/reference/plugins.rst
+++ b/docs/sources/reference/plugins.rst
@@ -30,11 +30,14 @@ PerkinElmer plugin
 Carroucell plugin
 =================
 
+Recommended public entry point:
+:func:`spectrochempy.carroucell.read`.
+
 .. autosummary::
     :nosignatures:
     :toctree: generated/
 
-    spectrochempy.carroucell.read
+    spectrochempy.carroucell.read_carroucell
 
 IRIS plugin
 ===========
@@ -57,6 +60,27 @@ Tensor plugin
 Hypercomplex plugin
 ===================
 
-The hypercomplex plugin currently exposes its public user API primarily through
-the ``dataset.hyper`` accessor documented in
+The recommended public API is the ``dataset.hyper`` accessor.
+
+All hypercomplex operations are accessed through ``dataset.hyper``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Operation
+     - Example
+   * - Convert to quaternion
+     - ``dataset.hyper.set_quaternion(inplace=True)``
+   * - Check type
+     - ``dataset.hyper.is_quaternion``
+   * - Extract RR component
+     - ``dataset.hyper.RR``
+   * - Extract RI component
+     - ``dataset.hyper.component("RI")``
+   * - Extract IR component
+     - ``dataset.hyper.IR``
+   * - Extract II component
+     - ``dataset.hyper.II``
+
+For workflow-oriented explanations and examples, see
 :doc:`/userguide/plugins/hypercomplex`.

--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -122,18 +122,18 @@ X
 # | read_csv      | Comma-Separated Values (CSV) files             | .csv           |
 # | read_jcamp, <br/>read_dx| JCAMP-DX spectral data files                   | .dx, .jdx      |
 # | read_matlab,<br/>read_mat   | MATLAB files                                   | .mat, .dso     |
-# | read_topspin  | Bruker TopSpin NMR files   (requires spectrochempy-nmr plugin)  | fid, ser, 1r, 1i, 2rr... |
+# | scp.nmr.read  | Bruker TopSpin NMR files   (requires spectrochempy-nmr plugin)  | fid, ser, 1r, 1i, 2rr... |
 # | read_labspec  | LABSPEC6 spectral data files                   | .txt           |
 # | read_wire,<br/>read_wdf | Renishaw Wire files                     | .wdf           |
 # | read_scp      | SpectroChemPy-specific files                   | .scp           |
 # | read_soc,<br/>read_ddr,<br/>read_hdr,<br/>read_sdr     | Surface Optics Corporation files               | .ddr, .hdr, .sdr |
 # | read_galactic | Galactic spectral files                        | .spc           |
 # | read_quadera  | Pfeiffer Vacuum QUADERA mass spectrometer files | .txt           |
-# | read_perkinelmer | PerkinElmer SP files   (requires spectrochempy-perkinelmer plugin) | .sp |
+# | scp.perkinelmer.read | PerkinElmer SP files   (requires spectrochempy-perkinelmer plugin) | .sp |
 # | read          | Generic reader (automatically detects format)  | -              |
 # | read_dir      | Reads all supported files in a directory       | -              |
 # | read_zip      | Reads files from a ZIP archive                 | .zip           |
-# | read_carroucell | Reads files from a carroucell experiment directory | -          | (requires spectrochempy-carroucell plugin)
+# | scp.carroucell.read | Reads files from a carroucell experiment directory | -          | (requires spectrochempy-carroucell plugin)
 #
 # The `read_dir` function scans a directory and reads all supported files,
 # returning a list of `NDDataset` objects.

--- a/docs/sources/userguide/objects/dataset/dataset.py
+++ b/docs/sources/userguide/objects/dataset/dataset.py
@@ -862,7 +862,7 @@ _ = nd.plot()
 path = datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d"
 
 # load the data directly (no need to create the dataset first)
-nd2 = scp.nmr.read_topspin(path, expno=1, remove_digital_filter=True)
+nd2 = scp.nmr.read(path, expno=1, remove_digital_filter=True)
 
 # view it...
 nd2.x.to("s")

--- a/docs/sources/userguide/objects/project/project.py
+++ b/docs/sources/userguide/objects/project/project.py
@@ -77,7 +77,7 @@ proj
 datadir = scp.pathclean(scp.preferences.datadir)
 path = datadir / "nmrdata" / "bruker" / "tests" / "nmr"
 
-nd1 = scp.nmr.read_topspin(
+nd1 = scp.nmr.read(
     path / "topspin_1d", expno=1, remove_digital_filter=True, name="NMR_1D"
 )
 # Use the same dataset twice for the example (real projects would use different data)

--- a/docs/sources/userguide/plugins/carroucell.rst
+++ b/docs/sources/userguide/plugins/carroucell.rst
@@ -40,11 +40,8 @@ available, but new documentation and examples should prefer the shorter
 API Reference
 =============
 
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    spectrochempy.carroucell.read
+The generated public API page for the Carroucell plugin is listed in
+:doc:`/reference/plugins`. See :func:`spectrochempy.carroucell.read`.
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/carroucell.rst
+++ b/docs/sources/userguide/plugins/carroucell.rst
@@ -1,0 +1,59 @@
+.. _carroucell-plugin:
+
+==================
+Carroucell plugin
+==================
+
+Introduction
+============
+
+The ``spectrochempy-carroucell`` plugin provides a reader for carroucell
+experiment directories.
+
+Installation
+============
+
+Install it directly:
+
+.. code-block:: bash
+
+    pip install spectrochempy-carroucell
+
+Recommended API
+===============
+
+Use the recommended namespaced API:
+
+.. code-block:: python
+
+    import spectrochempy as scp
+
+    dataset = scp.carroucell.read_carroucell("path/to/carroucell-directory")
+
+Compatibility aliases
+=====================
+
+The short namespaced alias ``scp.carroucell.read(...)`` is also available, but
+the explicit ``scp.carroucell.read_carroucell(...)`` form is clearer in
+documentation and examples.
+
+API Reference
+=============
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.carroucell.read_carroucell
+
+Examples
+========
+
+Use the same namespaced reader shown above when importing a carroucell
+experiment directory.
+
+Limitations
+===========
+
+Currently, the user-facing documentation for this plugin focuses on directory
+imports for carroucell experiment workflows.

--- a/docs/sources/userguide/plugins/carroucell.rst
+++ b/docs/sources/userguide/plugins/carroucell.rst
@@ -28,14 +28,14 @@ Use the recommended namespaced API:
 
     import spectrochempy as scp
 
-    dataset = scp.carroucell.read_carroucell("path/to/carroucell-directory")
+    dataset = scp.carroucell.read("path/to/carroucell-directory")
 
 Compatibility aliases
 =====================
 
-The short namespaced alias ``scp.carroucell.read(...)`` is also available, but
-the explicit ``scp.carroucell.read_carroucell(...)`` form is clearer in
-documentation and examples.
+The explicit historical alias ``scp.carroucell.read_carroucell(...)`` remains
+available, but new documentation and examples should prefer the shorter
+``scp.carroucell.read(...)`` form.
 
 API Reference
 =============
@@ -44,7 +44,7 @@ API Reference
     :nosignatures:
     :toctree: generated/
 
-    spectrochempy.carroucell.read_carroucell
+    spectrochempy.carroucell.read
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/examples.rst
+++ b/docs/sources/userguide/plugins/examples.rst
@@ -17,7 +17,7 @@ example and use the recommended namespaced API:
     import spectrochempy as scp
 
     analysis = scp.iris.IRIS()
-    dataset = scp.nmr.read_topspin("path/to/fid")
+    dataset = scp.nmr.read("path/to/fid")
 
 Plugin-dependent examples should use short, consistent notes such as:
 

--- a/docs/sources/userguide/plugins/hypercomplex.rst
+++ b/docs/sources/userguide/plugins/hypercomplex.rst
@@ -94,25 +94,8 @@ quaternion arrays.
 API Reference
 =============
 
-All hypercomplex operations are accessed through ``dataset.hyper``:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Operation
-     - Example
-   * - Convert to quaternion
-     - ``dataset.hyper.set_quaternion(inplace=True)``
-   * - Check type
-     - ``dataset.hyper.is_quaternion``
-   * - Extract RR component
-     - ``dataset.hyper.RR``
-   * - Extract RI component
-     - ``dataset.hyper.component("RI")``
-   * - Extract IR component
-     - ``dataset.hyper.IR``
-   * - Extract II component
-     - ``dataset.hyper.II``
+The public API reference for the hypercomplex plugin is listed in
+:doc:`/reference/plugins`.
 
 .. _hypercomplex-nmr-example:
 

--- a/docs/sources/userguide/plugins/hypercomplex.rst
+++ b/docs/sources/userguide/plugins/hypercomplex.rst
@@ -4,6 +4,9 @@
 Hypercomplex (quaternion) plugin
 ================================
 
+Introduction
+============
+
 The ``spectrochempy-hypercomplex`` plugin extends SpectroChemPy with
 quaternion/hypercomplex data support. It is designed for scientific
 domains that need complex numbers in more than one dimension, most
@@ -32,7 +35,7 @@ By extracting hypercomplex support into an official plugin:
 .. _hypercomplex-install:
 
 Installation
-==============
+============
 
 Install the plugin directly or through the NMR extra:
 
@@ -45,6 +48,17 @@ Install the plugin directly or through the NMR extra:
 
 The plugin is discovered automatically once installed. No explicit loading
 step is required.
+
+Recommended API
+===============
+
+The recommended public API is the ``dataset.hyper`` accessor:
+
+.. code-block:: python
+
+    dataset.hyper.set_quaternion(inplace=True)
+    rr = dataset.hyper.RR
+    ri = dataset.hyper.component("RI")
 
 .. _hypercomplex-concepts:
 
@@ -77,8 +91,8 @@ quaternion arrays.
 
 .. _hypercomplex-api:
 
-API overview
-============
+API Reference
+=============
 
 All hypercomplex operations are accessed through ``dataset.hyper``:
 
@@ -102,8 +116,8 @@ All hypercomplex operations are accessed through ``dataset.hyper``:
 
 .. _hypercomplex-nmr-example:
 
-2D NMR example
-==============
+Examples
+========
 
 After reading a 2D TopSpin dataset, the NMR plugin can optionally
 convert the data to hypercomplex form (this happens automatically when
@@ -130,18 +144,11 @@ both the NMR and hypercomplex plugins are installed):
 
 .. _hypercomplex-future:
 
-Future directions
-=================
+Limitations and scope
+=====================
 
 The hypercomplex plugin is intentionally narrow at this stage:
 
 * it supports quaternion data in ``NDDataset``;
 * it provides the numeric hooks needed by the core math framework;
 * it enables 2D NMR phase-sensitive workflows.
-
-Possible future extensions (not yet planned):
-
-* octonion or other Clifford-algebra types for higher-dimensional data;
-* non-NMR uses of hypercomplex arrays (e.g. certain radar or optics
-  signal-processing workflows);
-* additional component-extraction convenience methods.

--- a/docs/sources/userguide/plugins/hypercomplex.rst
+++ b/docs/sources/userguide/plugins/hypercomplex.rst
@@ -128,7 +128,7 @@ both the NMR and hypercomplex plugins are installed):
     import spectrochempy as scp
 
     # Requires spectrochempy-nmr and spectrochempy-hypercomplex
-    dataset = scp.nmr.read_topspin("path/to/ser", expno=1)
+    dataset = scp.nmr.read("path/to/ser", expno=1)
 
     # The NMR reader may already have called set_quaternion;
     # if not, you can do it explicitly:

--- a/docs/sources/userguide/plugins/index.rst
+++ b/docs/sources/userguide/plugins/index.rst
@@ -81,6 +81,7 @@ Plugin pages
    tensor
    hypercomplex
    iris
+   carroucell
    perkinelmer
    experimental_plugins
    examples

--- a/docs/sources/userguide/plugins/index.rst
+++ b/docs/sources/userguide/plugins/index.rst
@@ -23,7 +23,7 @@ Plugin APIs are usually exposed through namespaces:
 
     import spectrochempy as scp
 
-    dataset = scp.nmr.read_topspin("path/to/fid")
+    dataset = scp.nmr.read("path/to/fid")
     dataset = scp.perkinelmer.read("path/to/file.sp")
     analysis = scp.iris.IRIS()
     model = scp.tensor.CP(n_components=2)
@@ -37,7 +37,7 @@ Operations that act on an existing dataset use dataset accessors:
     ri = dataset.hyper.component("RI")
 
 Some former top-level names remain as compatibility aliases. New code should
-prefer namespaced APIs such as ``scp.nmr.read_topspin``, ``scp.iris.IRIS``,
+prefer namespaced APIs such as ``scp.nmr.read``, ``scp.iris.IRIS``,
 and ``scp.tensor.CP``.
 
 Install and inspect plugins

--- a/docs/sources/userguide/plugins/index.rst
+++ b/docs/sources/userguide/plugins/index.rst
@@ -40,6 +40,8 @@ Some former top-level names remain as compatibility aliases. New code should
 prefer namespaced APIs such as ``scp.nmr.read``, ``scp.iris.IRIS``,
 and ``scp.tensor.CP``.
 
+Generated plugin API pages are collected in :doc:`/reference/plugins`.
+
 Install and inspect plugins
 ===========================
 

--- a/docs/sources/userguide/plugins/iris.rst
+++ b/docs/sources/userguide/plugins/iris.rst
@@ -48,11 +48,8 @@ The existing direct accessors, such as ``analysis.f``, ``analysis.K``,
 API Reference
 =============
 
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    spectrochempy.iris.IRIS
+The generated public API page for the IRIS plugin is listed in
+:doc:`/reference/plugins`. See :class:`spectrochempy.iris.IRIS`.
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/iris.rst
+++ b/docs/sources/userguide/plugins/iris.rst
@@ -4,14 +4,23 @@
 IRIS plugin
 ===========
 
+Introduction
+============
+
 The ``spectrochempy-iris`` plugin provides 2D-IRIS analysis tools for
 spectroscopic adsorption and diffusion studies.
+
+Installation
+============
 
 Install it with:
 
 .. code-block:: bash
 
     pip install spectrochempy[iris]
+
+Recommended API
+===============
 
 Use package-level classes from ``scp.iris`` and dataset-bound helpers from
 ``dataset.iris``:
@@ -27,8 +36,32 @@ Use package-level classes from ``scp.iris`` and dataset-bound helpers from
     distribution = analysis.result.f
     residual_sum_squares = analysis.result.RSS
 
+Compatibility aliases
+=====================
+
+The compatibility alias ``scp.IRIS`` remains available for older scripts, but
+new documentation and examples should prefer ``scp.iris.IRIS``.
+
 The existing direct accessors, such as ``analysis.f``, ``analysis.K``,
 ``analysis.RSS``, and ``analysis.SM``, remain supported.
 
-New code should prefer the namespaced API. Compatibility aliases may be
-available for older scripts during the transition.
+API Reference
+=============
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.iris.IRIS
+
+Examples
+========
+
+Use dataset-bound helpers such as ``dataset.iris.kernel_matrix(...)`` together
+with the package-level ``scp.iris.IRIS()`` estimator shown above.
+
+Limitations
+===========
+
+Currently, this user-facing page focuses on the main IRIS estimator and the
+most common dataset-bound IRIS helper workflow.

--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -21,6 +21,19 @@ Use the NMR namespace:
 
     dataset = scp.nmr.read_topspin("path/to/fid")
 
+The plugin-owned TopSpin reader is documented here rather than in the core API
+reference because it is provided by ``spectrochempy-nmr``, not by the core
+package itself. The recommended public entry point is
+``scp.nmr.read_topspin(...)``. The legacy compatibility alias
+``scp.read_topspin(...)`` is still available when the plugin is installed, but
+new documentation and examples should prefer the namespaced API.
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.read_topspin
+
 For phase-sensitive 2D NMR workflows, install hypercomplex support as well:
 
 .. code-block:: bash

--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -51,11 +51,8 @@ New documentation and examples should prefer the shorter
 API Reference
 =============
 
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    spectrochempy.nmr.read
+The generated public API page for the NMR plugin is listed in
+:doc:`/reference/plugins`. See :func:`spectrochempy.nmr.read`.
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -4,8 +4,14 @@
 NMR plugin
 ==========
 
+Introduction
+============
+
 The ``spectrochempy-nmr`` plugin provides NMR-specific readers and processing
 workflows, including the Bruker TopSpin reader.
+
+Installation
+============
 
 Install it with:
 
@@ -13,7 +19,10 @@ Install it with:
 
     pip install spectrochempy[nmr]
 
-Use the NMR namespace:
+Recommended API
+===============
+
+Use the recommended namespaced API:
 
 .. code-block:: python
 
@@ -21,12 +30,25 @@ Use the NMR namespace:
 
     dataset = scp.nmr.read_topspin("path/to/fid")
 
+The NMR plugin owns Bruker/TopSpin conventions such as experiment directory
+resolution, processed-data defaults, acquisition metadata, and NMR unit
+contexts. Core SpectroChemPy remains responsible for generic datasets, units,
+plotting, and ordinary FFT operations.
+
+Compatibility aliases
+=====================
+
 The plugin-owned TopSpin reader is documented here rather than in the core API
 reference because it is provided by ``spectrochempy-nmr``, not by the core
-package itself. The recommended public entry point is
-``scp.nmr.read_topspin(...)``. The legacy compatibility alias
-``scp.read_topspin(...)`` is still available when the plugin is installed, but
-new documentation and examples should prefer the namespaced API.
+package itself.
+
+Compatibility alias:
+
+``scp.read_topspin(...)`` remains available when the plugin is installed, but
+new documentation and examples should prefer ``scp.nmr.read_topspin(...)``.
+
+API Reference
+=============
 
 .. autosummary::
     :nosignatures:
@@ -34,13 +56,20 @@ new documentation and examples should prefer the namespaced API.
 
     spectrochempy.read_topspin
 
+Examples
+========
+
 For phase-sensitive 2D NMR workflows, install hypercomplex support as well:
 
 .. code-block:: bash
 
     pip install spectrochempy[nmr,hypercomplex]
 
-The NMR plugin owns Bruker/TopSpin conventions such as experiment directory
-resolution, processed-data defaults, acquisition metadata, and NMR unit
-contexts. Core SpectroChemPy remains responsible for generic datasets, units,
-plotting, and ordinary FFT operations.
+See also the hypercomplex plugin guide for phase-sensitive 2D NMR workflows
+built on TopSpin datasets.
+
+Limitations
+===========
+
+Currently, the user-facing documentation for this plugin focuses on TopSpin
+datasets and related NMR workflows.

--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -28,7 +28,7 @@ Use the recommended namespaced API:
 
     import spectrochempy as scp
 
-    dataset = scp.nmr.read_topspin("path/to/fid")
+    dataset = scp.nmr.read("path/to/fid")
 
 The NMR plugin owns Bruker/TopSpin conventions such as experiment directory
 resolution, processed-data defaults, acquisition metadata, and NMR unit
@@ -42,10 +42,15 @@ The plugin-owned TopSpin reader is documented here rather than in the core API
 reference because it is provided by ``spectrochempy-nmr``, not by the core
 package itself.
 
-Compatibility alias:
+Compatibility aliases:
 
-``scp.read_topspin(...)`` remains available when the plugin is installed, but
-new documentation and examples should prefer ``scp.nmr.read_topspin(...)``.
+- ``scp.nmr.read_topspin(...)`` remains available as the explicit historical
+  namespaced form.
+- ``scp.read_topspin(...)`` remains available as the root-level compatibility
+  alias when the plugin is installed.
+
+New documentation and examples should prefer the shorter
+``scp.nmr.read(...)`` form.
 
 API Reference
 =============
@@ -54,7 +59,7 @@ API Reference
     :nosignatures:
     :toctree: generated/
 
-    spectrochempy.read_topspin
+    spectrochempy.nmr.read
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -38,10 +38,6 @@ plotting, and ordinary FFT operations.
 Compatibility aliases
 =====================
 
-The plugin-owned TopSpin reader is documented here rather than in the core API
-reference because it is provided by ``spectrochempy-nmr``, not by the core
-package itself.
-
 Compatibility aliases:
 
 - ``scp.nmr.read_topspin(...)`` remains available as the explicit historical

--- a/docs/sources/userguide/plugins/official_plugins.rst
+++ b/docs/sources/userguide/plugins/official_plugins.rst
@@ -137,11 +137,8 @@ provide the user-facing details:
 * :doc:`nmr` for TopSpin reading and NMR-specific processing workflows
 * :doc:`tensor` for TensorLy-backed tensor decompositions such as CP/PARAFAC
 * :doc:`hypercomplex` for quaternion support used in phase-sensitive 2D NMR
+* :doc:`carroucell` for carroucell experiment directory imports
 * :doc:`perkinelmer` for PerkinElmer ``.sp`` IR file reading
-
-The Carroucell reader is currently part of the official plugin set but does not
-yet have a separate user page. Use ``scp.carroucell.read_carroucell(...)`` once
-the plugin is installed.
 
 Examples and gallery convention
 ===============================

--- a/docs/sources/userguide/plugins/official_plugins.rst
+++ b/docs/sources/userguide/plugins/official_plugins.rst
@@ -127,6 +127,9 @@ Some official plugins may expose limited root-level compatibility aliases, such
 as ``scp.IRIS``. New examples should prefer the namespaced form,
 ``scp.iris.IRIS`` or ``scp.tensor.CP``.
 
+Generated plugin-owned public API pages are collected in
+:doc:`/reference/plugins`.
+
 Plugin summaries
 ================
 

--- a/docs/sources/userguide/plugins/official_plugins.rst
+++ b/docs/sources/userguide/plugins/official_plugins.rst
@@ -115,7 +115,7 @@ The recommended form is namespaced:
 
     analysis = scp.iris.IRIS()
     model = scp.tensor.CP(n_components=2)
-    dataset = scp.nmr.read_topspin("path/to/fid")
+    dataset = scp.nmr.read("path/to/fid")
 
 Dataset accessors are reserved for operations that act on an existing dataset:
 

--- a/docs/sources/userguide/plugins/perkinelmer.rst
+++ b/docs/sources/userguide/plugins/perkinelmer.rst
@@ -44,11 +44,8 @@ Compatibility aliases are also available for older scripts:
 API Reference
 =============
 
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    spectrochempy.perkinelmer.read
+The generated public API page for the PerkinElmer plugin is listed in
+:doc:`/reference/plugins`. See :func:`spectrochempy.perkinelmer.read`.
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/perkinelmer.rst
+++ b/docs/sources/userguide/plugins/perkinelmer.rst
@@ -37,6 +37,7 @@ Compatibility aliases are also available for older scripts:
 
 .. code-block:: python
 
+    dataset = scp.perkinelmer.read_perkinelmer("path/to/file.sp")
     dataset = scp.read_perkinelmer("path/to/file.sp")
     dataset = scp.read_sp("path/to/file.sp")
 
@@ -47,7 +48,7 @@ API Reference
     :nosignatures:
     :toctree: generated/
 
-    spectrochempy.read_perkinelmer
+    spectrochempy.perkinelmer.read
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/perkinelmer.rst
+++ b/docs/sources/userguide/plugins/perkinelmer.rst
@@ -4,8 +4,14 @@
 PerkinElmer plugin
 ==================
 
+Introduction
+============
+
 The ``spectrochempy-perkinelmer`` plugin provides a reader for PerkinElmer
 ``.sp`` binary IR files.
+
+Installation
+============
 
 Install it with:
 
@@ -13,7 +19,10 @@ Install it with:
 
     pip install spectrochempy[perkinelmer]
 
-Use the namespaced API ``scp.perkinelmer``:
+Recommended API
+===============
+
+Use the recommended namespaced API:
 
 .. code-block:: python
 
@@ -21,12 +30,30 @@ Use the namespaced API ``scp.perkinelmer``:
 
     dataset = scp.perkinelmer.read("path/to/file.sp")
 
-Compatibility aliases are also available:
+Compatibility aliases
+=====================
+
+Compatibility aliases are also available for older scripts:
 
 .. code-block:: python
 
     dataset = scp.read_perkinelmer("path/to/file.sp")
     dataset = scp.read_sp("path/to/file.sp")
+
+API Reference
+=============
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.read_perkinelmer
+
+Examples
+========
+
+Use the same namespaced reader shown above for ordinary PerkinElmer ``.sp``
+import workflows.
 
 Limitations
 ===========

--- a/docs/sources/userguide/plugins/tensor.rst
+++ b/docs/sources/userguide/plugins/tensor.rst
@@ -49,11 +49,8 @@ Direct accessors such as ``model.A``, ``model.B``, ``model.C``, and
 API Reference
 =============
 
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    spectrochempy.tensor.CP
+The generated public API page for the Tensor plugin is listed in
+:doc:`/reference/plugins`. See :class:`spectrochempy.tensor.CP`.
 
 Examples
 ========

--- a/docs/sources/userguide/plugins/tensor.rst
+++ b/docs/sources/userguide/plugins/tensor.rst
@@ -4,13 +4,16 @@
 Tensor plugin
 =============
 
+Introduction
+============
+
 The ``spectrochempy-tensor`` plugin provides tensor decomposition classes backed
 by TensorLy. Keeping these algorithms in a plugin lets the core package remain
 independent from tensor-specific dependencies while preserving integrated access
 when the plugin is installed.
 
-Install
-=======
+Installation
+============
 
 .. code-block:: bash
 
@@ -22,8 +25,8 @@ or directly:
 
     pip install spectrochempy-tensor
 
-Use
-===
+Recommended API
+===============
 
 .. code-block:: python
 
@@ -34,16 +37,33 @@ Use
     factors = model.result.factors
     weights = model.result.weights
 
-The historical ``scp.CP`` alias is kept as a deprecated compatibility path.
-New code should use ``scp.tensor.CP``.
+Compatibility aliases
+=====================
+
+The historical ``scp.CP`` alias is kept as a deprecated compatibility path, but
+new documentation and examples should use ``scp.tensor.CP``.
+
 Direct accessors such as ``model.A``, ``model.B``, ``model.C``, and
 ``model.weights`` remain available.
 
-Extensibility
+API Reference
 =============
 
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    spectrochempy.tensor.CP
+
+Examples
+========
+
+Use the package-level ``scp.tensor.CP(...)`` estimator shown above for
+TensorLy-backed CP/PARAFAC workflows on existing datasets.
+
+Limitations
+===========
+
 Tensor decomposition implementations live under
-``spectrochempy_tensor.decompositions``. Shared bridges between TensorLy objects
-and SpectroChemPy datasets should live under ``spectrochempy_tensor.adapters``
-so future classes such as Tucker or TensorTrain can reuse them without adding
-tensor concepts back to the core package.
+``spectrochempy_tensor.decompositions``. This page currently focuses on the
+main CP/PARAFAC workflow exposed through ``scp.tensor.CP(...)``.

--- a/docs/sources/userguide/processing/apodization.py
+++ b/docs/sources/userguide/processing/apodization.py
@@ -50,7 +50,7 @@ from spectrochempy.core.units import ur
 path = scp.pathclean("nmrdata/bruker/tests/nmr/topspin_1d")
 
 # the method pathclean allow to write pth in linux or window style indifferently
-dataset = scp.nmr.read_topspin(path, expno=1, remove_digital_filter=True)
+dataset = scp.nmr.read(path, expno=1, remove_digital_filter=True)
 dataset = dataset / dataset.max()  # normalization
 
 # store original data

--- a/docs/sources/userguide/processing/fourier.py
+++ b/docs/sources/userguide/processing/fourier.py
@@ -51,7 +51,7 @@ import spectrochempy as scp
 
 # %%
 path = scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d"
-fid = scp.nmr.read_topspin(path)
+fid = scp.nmr.read(path)
 fid
 
 # %% [markdown]

--- a/docs/sources/userguide/processing/td_baseline.py
+++ b/docs/sources/userguide/processing/td_baseline.py
@@ -49,7 +49,7 @@ import spectrochempy as scp
 
 # %%
 path = scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "h3po4"
-fid = scp.nmr.read_topspin(path, expno=4)
+fid = scp.nmr.read(path, expno=4)
 prefs = scp.preferences
 prefs.figure.figsize = (7, 3)
 _ = fid.plot(show_complex=True)
@@ -71,7 +71,7 @@ _ = spec.plot(xlim=(5, -5))
 
 # %%
 path = scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "cadmium"
-fid2 = scp.nmr.read_topspin(path, expno=100)
+fid2 = scp.nmr.read(path, expno=100)
 _ = fid2.plot(show_complex=True)
 
 # %%

--- a/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/read_carroucell.py
+++ b/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/read_carroucell.py
@@ -14,7 +14,6 @@ import warnings
 
 import numpy as np
 import scipy.interpolate
-import xlrd
 
 import spectrochempy as scp
 from spectrochempy.core.dataset.coord import Coord
@@ -25,6 +24,7 @@ from spectrochempy.utils._logging import info_
 from spectrochempy.utils.datetimeutils import UTC
 from spectrochempy.utils.file import get_directory_name
 from spectrochempy.utils.file import get_filenames
+from spectrochempy.utils.optional import import_optional_dependency
 
 
 def read_carroucell(directory=None, **kwargs):
@@ -163,6 +163,13 @@ def _read_carroucell(*args, **kwargs):
     else:
         Tfile = Tfile[0]
         if Tfile[-4:].lower() == ".xls":
+            xlrd = import_optional_dependency(
+                "xlrd",
+                extra=(
+                    "Temperature metadata from Carroucell '.xls' files requires "
+                    "the optional xlrd dependency."
+                ),
+            )
             book = xlrd.open_workbook(os.path.join(directory, Tfile))
 
             # determine experiment start and end time (thermocouple clock)

--- a/plugins/spectrochempy-perkinelmer/examples/plot_read_perkinelmer.py
+++ b/plugins/spectrochempy-perkinelmer/examples/plot_read_perkinelmer.py
@@ -51,6 +51,10 @@ print(f"Accumulations:   {dataset.meta.accumulations}")
 _ = dataset.plot()
 
 # %%
+# Use the plotted spectrum as the gallery thumbnail.
+# sphinx_gallery_thumbnail_number = 1
+
+# %%
 # This ends the example ! The following line can be removed or commented
 # when the example is run as a notebook (`.ipynb`).
 


### PR DESCRIPTION
## Summary
Start the Plugin Documentation campaign by moving `read_topspin` out of the core API reference and using the NMR page as a small pilot for a standardized official-plugin page shape.

This PR then applies the same lightweight standardization to the remaining official plugin pages, while keeping the changes documentation-only and intentionally modest.

## What Changed
- remove `read_topspin` from the core reference autosummary
- remove the plugin-install note from the core reference page
- document the plugin-owned TopSpin reader in the NMR plugin guide
- generate the `spectrochempy.nmr.read` page from the plugin documentation via autosummary
- restructure the NMR plugin page into a lightweight plugin-standard shape: introduction, installation, recommended API, compatibility aliases, API reference, examples, and limitations
- normalize the PerkinElmer, IRIS, Tensor, and Hypercomplex plugin pages around the same lightweight structure where appropriate
- add a minimal Carroucell plugin page so the official plugin set no longer has a missing dedicated user page
- align the Carroucell, PerkinElmer, and NMR pages with the namespace I/O rule by recommending `scp.<plugin>.read(...)` where that short namespaced form exists, while treating longer repeated forms as explicit historical aliases
- update the plugin overview pages so the official plugin set links consistently to the dedicated plugin pages

## Why
`read_topspin` remains available as a root-level compatibility alias, but the implementation is plugin-owned and resolved dynamically through the plugin reader registry. Documenting it in the core reference mixes core and plugin APIs and can produce an incomplete experience when the NMR plugin is not installed.

More broadly, upcoming vendor-like reader migration will be easier to review and easier for users to navigate if official plugin pages already follow a small shared structure. This PR keeps that standardization deliberately small: it does not add global catalogs, reorganize the documentation tree, or invent unsupported plugin capabilities.

It also stays aligned with the existing namespace I/O rule used in the import/export documentation: within a namespace, the preferred public form should be the short method name such as `scp.perkinelmer.read(...)`, `scp.carroucell.read(...)`, or `scp.nmr.read(...)` when that form exists, while repeated historical forms remain documented only as compatibility paths.

## Validation
- `rg -n "read_topspin|autosummary::|toctree: generated/|legacy compatibility alias|plugin-owned TopSpin" docs/sources/reference/index.rst docs/sources/userguide/plugins/nmr.rst`
- `rg -n "scp\.nmr\.read_topspin|scp\.nmr\.read\(|scp\.perkinelmer\.read_perkinelmer|scp\.perkinelmer\.read\(|spectrochempy\.nmr\.read|spectrochempy\.perkinelmer\.read|spectrochempy\.carroucell\.read" docs/sources/userguide/plugins -g '*.rst'`