### PR TITLE
FIX: handle 1D y NDDataset in PLSRegression coordinate wrapping

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,14 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
+  ``y`` (shape ``(n_obs,)``). Previously, the ``_set_output`` coordinate wrapping
+  decorator assumed the metadata source was always 2D, causing a ``ValueError``
+  on ``predict()``, ``y_scores``, ``y_loadings``, ``y_weights``, ``y_rotations``
+  and ``result`` when fitting with a 1D target.  Fixes the ``coef`` property
+  coordinate assignment which incorrectly used ``self._Y.x`` instead of
+  ``self._Y.y`` for the target dimension. (#1305)
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,3 +11,14 @@ What's New in Revision 0.10.3.dev
 
 These are the changes in SpectroChemPy-0.10.3.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Bug Fixes
+~~~~~~~~~
+
+- ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
+  ``y`` (shape ``(n_obs,)``). Previously, the ``_set_output`` coordinate wrapping
+  decorator assumed the metadata source was always 2D, causing a ``ValueError``
+  on ``predict()``, ``y_scores``, ``y_loadings``, ``y_weights``, ``y_rotations``
+  and ``result`` when fitting with a 1D target.  Fixes the ``coef`` property
+  coordinate assignment which incorrectly used ``self._Y.x`` instead of
+  ``self._Y.y`` for the target dimension. (#1305)

--- a/src/spectrochempy/analysis/crossdecomposition/pls.py
+++ b/src/spectrochempy/analysis/crossdecomposition/pls.py
@@ -261,8 +261,13 @@ class PLSRegression(CrossDecompositionAnalysis):
     @property
     def coef(self):
         coef = NDDataset(self._coef)
+        coef.dims = ["x", "y"]
+        try:
+            y_coord = self._Y.y
+        except (AttributeError, IndexError, TypeError):
+            y_coord = None
         coef.set_coordset(
-            y=self._Y.x,
+            y=y_coord,
             x=self._X.x,
         )
         return coef

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -470,6 +470,26 @@ class _set_output:
                 original_X if meta_from == "_X" and original_X is not None else X
             )
 
+            # Promote 1D metadata source (e.g., _Y with 1D y) to 2D for
+            # coordinate assignment so that dims[1], coord(1), shape[1] etc.
+            # are valid.  The wrapped method always returns 2D outputs.
+            if X.ndim == 1:
+                import numpy as np
+
+                dim0 = X.dims[0]
+                coord0 = (
+                    X.coordset[0].copy()
+                    if X.coordset is not None and X.coordset[0] is not None
+                    else None
+                )
+                X_new = NDDataset(np.empty((X.shape[0], 1)))
+                X_new.dims = [dim0, "v"]
+                X_new.set_coordset({dim0: coord0, "v": None})
+                X_new.units = X.units
+                X_new.title = X.title
+                X_new.name = X.name
+                X = X_new
+
             X_transf.meta = copy.deepcopy(metadata_source.meta)
             X_transf.author = copy.copy(metadata_source.author)
             X_transf.description = copy.copy(metadata_source.description)


### PR DESCRIPTION
## Description

Two fixes for PLSRegression when the response variable `y` is a 1D NDDataset (shape `(n_obs,)` instead of `(n_obs, n_targets)`):

### 1. `_set_output` decorator (`decorators.py`)

The `_set_output.__call__` method assumed the metadata source (`_Y`) was always 2D, unpacking `M, N = X.shape` at line 497. When `y` is 1D, `X.shape` is a 1-tuple and the unpacking raises `ValueError: not enough values to unpack`. All downstream coordinate/`dims` access also assumes 2D.

The fix promotes 1D metadata sources to 2D (with a synthetic trailing dimension `'v'`) before the coordinate assignment logic, matching the `atleast_2d` pattern already used for `_X` in `_X_validate`.

Affects: `predict()`, `y_scores`, `y_loadings`, `y_weights`, `y_rotations`, `result`.

### 2. `coef` property (`pls.py`)

The `coef` property used `self._Y.x` as the second-dimension coordinate (target axis), which is the observation coordinate (size `n_obs`), not the target coordinate. Changed to `self._Y.y` with a fallback to `None` for 1D `_Y` that has no second coordinate.

Also sets explicit `dims=['x', 'y']` to match NDDataset's default dimension ordering (`['y', 'x']` for 2D arrays), so that `set_coordset(x=..., y=...)` maps coordinates to the correct axes.

## Reproduction

```python
import numpy as np
import spectrochempy as scp

X = scp.NDDataset(np.random.rand(30, 20).astype(np.float32))
y = scp.NDDataset(np.random.rand(30).astype(np.float32))

pls = scp.PLSRegression(n_components=3)
pls.fit(X, y)

pls.predict(X)     # Before fix: ValueError
pls.y_scores       # Before fix: ValueError
pls.result         # Before fix: ValueError
```

## Testing

- `tests/test_analysis/test_crossdecomposition/`: 38/38 passed
- `tests/test_analysis/test_decomposition/`: 166/166 passed
- Manual repro script above: all operations succeed
- 2D `y` backward compatibility confirmed
