### PR TITLE
ENH: add dataset selection methods to ScpObjectList

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,22 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- ``ScpObjectList`` gains four convenience methods for selecting and
+  filtering datasets when reading multi-object files (MATLAB ``.mat``,
+  multi-subfile SPC, ZIP archives):
+
+  - ``select_largest(ndim=None)`` — select the dataset with the most
+    elements, optionally restricted to a given number of dimensions.
+  - ``select_by_name(name)`` — select the first dataset whose name
+    contains the given substring (case-insensitive).
+  - ``filter_by_ndim(ndim)`` — return a new ``ScpObjectList`` with only
+    datasets of the given dimensionality.
+  - ``filter_by_shape(shape)`` — return a new ``ScpObjectList`` with only
+    datasets matching the exact shape.
+
+  A ``names`` property is also added to quickly inspect all dataset
+  names. (#1306)
+
 
 .. section
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,21 +19,20 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
-- ``ScpObjectList`` gains four convenience methods for selecting and
-  filtering datasets when reading multi-object files (MATLAB ``.mat``,
-  multi-subfile SPC, ZIP archives):
+- Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
+  archives) now returns a list with convenience methods for selecting
+  the dataset you need. After ``datasets = scp.read(...)``:
 
-  - ``select_largest(ndim=None)`` — select the dataset with the most
-    elements, optionally restricted to a given number of dimensions.
-  - ``select_by_name(name)`` — select the first dataset whose name
-    contains the given substring (case-insensitive).
-  - ``filter_by_ndim(ndim)`` — return a new ``ScpObjectList`` with only
-    datasets of the given dimensionality.
-  - ``filter_by_shape(shape)`` — return a new ``ScpObjectList`` with only
-    datasets matching the exact shape.
+  - ``datasets.select_largest(ndim=2)`` picks the biggest 2D dataset.
+  - ``datasets.select_by_name("spectra")`` picks the first dataset whose
+    name contains the given word.
+  - ``datasets.filter_by_ndim(2)`` keeps only 2D datasets.
+  - ``datasets.filter_by_shape((80, 700))`` keeps only datasets of that
+    exact shape.
+  - ``datasets.names`` lists all dataset names at a glance.
 
-  A ``names`` property is also added to quickly inspect all dataset
-  names. (#1306)
+  This makes it much easier to work with files that contain multiple
+  variables or spectra. (#1306)
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,25 @@ What's New in Revision 0.10.3.dev
 These are the changes in SpectroChemPy-0.10.3.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+New Features
+~~~~~~~~~~~~
+
+- ``ScpObjectList`` gains four convenience methods for selecting and
+  filtering datasets when reading multi-object files (MATLAB ``.mat``,
+  multi-subfile SPC, ZIP archives):
+
+  - ``select_largest(ndim=None)`` — select the dataset with the most
+    elements, optionally restricted to a given number of dimensions.
+  - ``select_by_name(name)`` — select the first dataset whose name
+    contains the given substring (case-insensitive).
+  - ``filter_by_ndim(ndim)`` — return a new ``ScpObjectList`` with only
+    datasets of the given dimensionality.
+  - ``filter_by_shape(shape)`` — return a new ``ScpObjectList`` with only
+    datasets matching the exact shape.
+
+  A ``names`` property is also added to quickly inspect all dataset
+  names. (#1306)
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,21 +15,20 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
-- ``ScpObjectList`` gains four convenience methods for selecting and
-  filtering datasets when reading multi-object files (MATLAB ``.mat``,
-  multi-subfile SPC, ZIP archives):
+- Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
+  archives) now returns a list with convenience methods for selecting
+  the dataset you need. After ``datasets = scp.read(...)``:
 
-  - ``select_largest(ndim=None)`` — select the dataset with the most
-    elements, optionally restricted to a given number of dimensions.
-  - ``select_by_name(name)`` — select the first dataset whose name
-    contains the given substring (case-insensitive).
-  - ``filter_by_ndim(ndim)`` — return a new ``ScpObjectList`` with only
-    datasets of the given dimensionality.
-  - ``filter_by_shape(shape)`` — return a new ``ScpObjectList`` with only
-    datasets matching the exact shape.
+  - ``datasets.select_largest(ndim=2)`` picks the biggest 2D dataset.
+  - ``datasets.select_by_name("spectra")`` picks the first dataset whose
+    name contains the given word.
+  - ``datasets.filter_by_ndim(2)`` keeps only 2D datasets.
+  - ``datasets.filter_by_shape((80, 700))`` keeps only datasets of that
+    exact shape.
+  - ``datasets.names`` lists all dataset names at a glance.
 
-  A ``names`` property is also added to quickly inspect all dataset
-  names. (#1306)
+  This makes it much easier to work with files that contain multiple
+  variables or spectra. (#1306)
 
 Bug Fixes
 ~~~~~~~~~

--- a/src/spectrochempy/utils/objects.py
+++ b/src/spectrochempy/utils/objects.py
@@ -321,7 +321,7 @@ class ScpObjectList(list):
         str
             The html representation of the list of spectrochempy objects.
         """
-        from spectrochempy.utils.print import convert_to_html
+        from spectrochempy.utils.print import convert_to_html  # noqa: PLC0415
 
         # Handle empty list
         if not self:
@@ -357,10 +357,7 @@ class ScpObjectList(list):
     @property
     def names(self):
         """Return a list of dataset names."""
-        return [
-            ds.name if hasattr(ds, "name") else str(ds)
-            for ds in self
-        ]
+        return [ds.name if hasattr(ds, "name") else str(ds) for ds in self]
 
     def select_largest(self, ndim=None):
         """
@@ -419,8 +416,10 @@ class ScpObjectList(list):
 
     def filter_by_ndim(self, ndim):
         """
-        Return a new ScpObjectList containing only datasets with *ndim*
-        dimensions.
+        Return a new ScpObjectList containing only datasets with *ndim* dimensions.
+
+        Filters the list to include only datasets that have the specified
+        number of dimensions.
 
         Parameters
         ----------
@@ -438,8 +437,10 @@ class ScpObjectList(list):
 
     def filter_by_shape(self, shape):
         """
-        Return a new ScpObjectList containing only datasets whose shape
-        equals *shape*.
+        Return a new ScpObjectList containing only datasets with a given shape.
+
+        Filters the list to include only datasets whose shape exactly
+        matches the provided tuple.
 
         Parameters
         ----------

--- a/src/spectrochempy/utils/objects.py
+++ b/src/spectrochempy/utils/objects.py
@@ -354,6 +354,111 @@ class ScpObjectList(list):
         html += "</details></div>"
         return html
 
+    @property
+    def names(self):
+        """Return a list of dataset names."""
+        return [
+            ds.name if hasattr(ds, "name") else str(ds)
+            for ds in self
+        ]
+
+    def select_largest(self, ndim=None):
+        """
+        Select the dataset with the largest number of elements.
+
+        Parameters
+        ----------
+        ndim : int, optional
+            If given, restrict selection to datasets with this number of
+            dimensions.
+
+        Returns
+        -------
+        object
+            The largest matching dataset.
+
+        Raises
+        ------
+        ValueError
+            If the list is empty or no matching dataset is found.
+        """
+        if not self:
+            raise ValueError("ScpObjectList is empty")
+        candidates = self
+        if ndim is not None:
+            candidates = [ds for ds in self if hasattr(ds, "ndim") and ds.ndim == ndim]
+        if not candidates:
+            raise ValueError(f"No dataset with ndim={ndim} found")
+        return max(candidates, key=lambda ds: ds.size if hasattr(ds, "size") else 0)
+
+    def select_by_name(self, name):
+        """
+        Select the first dataset whose name contains *name* (case-insensitive).
+
+        Parameters
+        ----------
+        name : str
+            Substring to match against dataset names.
+
+        Returns
+        -------
+        object
+            The first matching dataset.
+
+        Raises
+        ------
+        ValueError
+            If no matching dataset is found.
+        """
+        name_lower = name.lower()
+        for ds in self:
+            ds_name = getattr(ds, "name", "")
+            if ds_name and name_lower in ds_name.lower():
+                return ds
+        raise ValueError(f"No dataset with name containing '{name}' found")
+
+    def filter_by_ndim(self, ndim):
+        """
+        Return a new ScpObjectList containing only datasets with *ndim*
+        dimensions.
+
+        Parameters
+        ----------
+        ndim : int
+            Number of dimensions to filter by.
+
+        Returns
+        -------
+        ScpObjectList
+            A new list with matching datasets.
+        """
+        return ScpObjectList(
+            [ds for ds in self if hasattr(ds, "ndim") and ds.ndim == ndim]
+        )
+
+    def filter_by_shape(self, shape):
+        """
+        Return a new ScpObjectList containing only datasets whose shape
+        equals *shape*.
+
+        Parameters
+        ----------
+        shape : tuple
+            Shape to match exactly.
+
+        Returns
+        -------
+        ScpObjectList
+            A new list with matching datasets.
+        """
+        return ScpObjectList(
+            [
+                ds
+                for ds in self
+                if hasattr(ds, "shape") and tuple(ds.shape) == tuple(shape)
+            ]
+        )
+
 
 class OrderedSet(collections.abc.MutableSet):
     # https://code.activestate.com/recipes/576694/

--- a/tests/test_utils/test_objects.py
+++ b/tests/test_utils/test_objects.py
@@ -196,6 +196,7 @@ class TestScpObjectList:
 
     def test_names_property(self):
         """Test extracting names from a list of objects."""
+
         class MockDS:
             def __init__(self, name, ndim=2, shape=(10, 20), size=200):
                 self.name = name
@@ -208,6 +209,7 @@ class TestScpObjectList:
 
     def test_select_largest(self):
         """Test selecting the largest dataset."""
+
         class MockDS:
             def __init__(self, name, ndim=2, shape=(10, 20), size=200):
                 self.name = name
@@ -215,13 +217,12 @@ class TestScpObjectList:
                 self.shape = shape
                 self.size = size
 
-        datasets = ScpObjectList(
-            [MockDS("small", size=50), MockDS("large", size=500)]
-        )
+        datasets = ScpObjectList([MockDS("small", size=50), MockDS("large", size=500)])
         assert datasets.select_largest().name == "large"
 
     def test_select_largest_with_ndim(self):
         """Test selecting the largest dataset with a specific ndim."""
+
         class MockDS:
             def __init__(self, name, ndim=2, shape=(10, 20), size=200):
                 self.name = name
@@ -246,6 +247,7 @@ class TestScpObjectList:
 
     def test_select_largest_no_match_raises(self):
         """Test that select_largest raises when no dataset matches ndim."""
+
         class MockDS:
             def __init__(self):
                 self.ndim = 2
@@ -256,6 +258,7 @@ class TestScpObjectList:
 
     def test_select_by_name(self):
         """Test selecting a dataset by name substring."""
+
         class MockDS:
             def __init__(self, name):
                 self.name = name
@@ -268,6 +271,7 @@ class TestScpObjectList:
 
     def test_select_by_name_no_match_raises(self):
         """Test that select_by_name raises when no name matches."""
+
         class MockDS:
             def __init__(self, name):
                 self.name = name
@@ -277,6 +281,7 @@ class TestScpObjectList:
 
     def test_filter_by_ndim(self):
         """Test filtering datasets by dimensionality."""
+
         class MockDS:
             def __init__(self, name, ndim=2):
                 self.name = name
@@ -296,6 +301,7 @@ class TestScpObjectList:
 
     def test_filter_by_shape(self):
         """Test filtering datasets by exact shape."""
+
         class MockDS:
             def __init__(self, name, shape):
                 self.name = name

--- a/tests/test_utils/test_objects.py
+++ b/tests/test_utils/test_objects.py
@@ -3,6 +3,7 @@ import pytest
 from spectrochempy.utils.objects import Adict
 from spectrochempy.utils.objects import OrderedSet
 from spectrochempy.utils.objects import ReadOnlyDict
+from spectrochempy.utils.objects import ScpObjectList
 
 
 def test_orderedset():
@@ -188,6 +189,128 @@ class TestReadOnlyDict:
 
         with pytest.raises(ValueError):
             d["meta"] = MockMeta()
+
+
+class TestScpObjectList:
+    """Test suite for ScpObjectList selection methods."""
+
+    def test_names_property(self):
+        """Test extracting names from a list of objects."""
+        class MockDS:
+            def __init__(self, name, ndim=2, shape=(10, 20), size=200):
+                self.name = name
+                self.ndim = ndim
+                self.shape = shape
+                self.size = size
+
+        datasets = ScpObjectList([MockDS("a"), MockDS("b")])
+        assert datasets.names == ["a", "b"]
+
+    def test_select_largest(self):
+        """Test selecting the largest dataset."""
+        class MockDS:
+            def __init__(self, name, ndim=2, shape=(10, 20), size=200):
+                self.name = name
+                self.ndim = ndim
+                self.shape = shape
+                self.size = size
+
+        datasets = ScpObjectList(
+            [MockDS("small", size=50), MockDS("large", size=500)]
+        )
+        assert datasets.select_largest().name == "large"
+
+    def test_select_largest_with_ndim(self):
+        """Test selecting the largest dataset with a specific ndim."""
+        class MockDS:
+            def __init__(self, name, ndim=2, shape=(10, 20), size=200):
+                self.name = name
+                self.ndim = ndim
+                self.shape = shape
+                self.size = size
+
+        datasets = ScpObjectList(
+            [
+                MockDS("1d", ndim=1, shape=(100,), size=100),
+                MockDS("2d_small", ndim=2, shape=(5, 5), size=25),
+                MockDS("2d_large", ndim=2, shape=(20, 20), size=400),
+            ]
+        )
+        assert datasets.select_largest(ndim=2).name == "2d_large"
+        assert datasets.select_largest(ndim=1).name == "1d"
+
+    def test_select_largest_empty_raises(self):
+        """Test that select_largest raises on an empty list."""
+        with pytest.raises(ValueError, match="empty"):
+            ScpObjectList().select_largest()
+
+    def test_select_largest_no_match_raises(self):
+        """Test that select_largest raises when no dataset matches ndim."""
+        class MockDS:
+            def __init__(self):
+                self.ndim = 2
+                self.size = 10
+
+        with pytest.raises(ValueError, match="ndim=3"):
+            ScpObjectList([MockDS()]).select_largest(ndim=3)
+
+    def test_select_by_name(self):
+        """Test selecting a dataset by name substring."""
+        class MockDS:
+            def __init__(self, name):
+                self.name = name
+
+        datasets = ScpObjectList(
+            [MockDS("concentration"), MockDS("spectra"), MockDS("reference")]
+        )
+        assert datasets.select_by_name("spec").name == "spectra"
+        assert datasets.select_by_name("CONC").name == "concentration"
+
+    def test_select_by_name_no_match_raises(self):
+        """Test that select_by_name raises when no name matches."""
+        class MockDS:
+            def __init__(self, name):
+                self.name = name
+
+        with pytest.raises(ValueError, match="nonexistent"):
+            ScpObjectList([MockDS("a")]).select_by_name("nonexistent")
+
+    def test_filter_by_ndim(self):
+        """Test filtering datasets by dimensionality."""
+        class MockDS:
+            def __init__(self, name, ndim=2):
+                self.name = name
+                self.ndim = ndim
+
+        datasets = ScpObjectList(
+            [
+                MockDS("1d", ndim=1),
+                MockDS("2d_a", ndim=2),
+                MockDS("2d_b", ndim=2),
+            ]
+        )
+        filtered = datasets.filter_by_ndim(2)
+        assert len(filtered) == 2
+        assert all(ds.ndim == 2 for ds in filtered)
+        assert isinstance(filtered, ScpObjectList)
+
+    def test_filter_by_shape(self):
+        """Test filtering datasets by exact shape."""
+        class MockDS:
+            def __init__(self, name, shape):
+                self.name = name
+                self.shape = shape
+
+        datasets = ScpObjectList(
+            [
+                MockDS("a", (10, 20)),
+                MockDS("b", (10, 20)),
+                MockDS("c", (5, 5)),
+            ]
+        )
+        filtered = datasets.filter_by_shape((10, 20))
+        assert len(filtered) == 2
+        assert isinstance(filtered, ScpObjectList)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reading multi-object files (MATLAB .mat, multi-subfile SPC, ZIP archives) now returns a list with convenience methods for selecting the dataset you need.

## Motivation

When  encounters a file containing multiple datasets, users currently have to manually inspect the list (e.g. , ) to find the one they need. There is no built-in way to select by size, name, or dimensionality.

This is especially common with:
- MATLAB  files containing multiple variables
- SPC files with multiple subfiles
- ZIP archives of spectra

## What's new

After  on a multi-object file, you can now select objects.

 After ``datasets = scp.read(...)``:

  - ``datasets.select_largest(ndim=2)`` picks the biggest 2D dataset.
  - ``datasets.select_by_name("spectra")`` picks the first dataset whose
    name contains the given word.
  - ``datasets.filter_by_ndim(2)`` keeps only 2D datasets.
  - ``datasets.filter_by_shape((80, 700))`` keeps only datasets of that
    exact shape.
  - ``datasets.names`` lists all dataset names at a glance.


## Backward compatibility

Fully backward compatible. The returned object is still a  subclass; the new methods do not affect existing behavior.

