### PR TITLE
DOC: document multi-dataset reader helpers

### DIFF
--- a/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/read_carroucell.py
+++ b/plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/read_carroucell.py
@@ -46,8 +46,8 @@ def read_carroucell(directory=None, **kwargs):
 
     Returns
     -------
-    list of `NDDataset`
-        List of datasets read from the carroucell files.
+    `ScpObjectList` of `NDDataset`
+        A list-like multi-dataset result containing the imported datasets.
 
     Other Parameters
     ----------------

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
@@ -903,8 +903,9 @@ def read_topspin(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/plugins/spectrochempy-perkinelmer/src/spectrochempy_perkinelmer/read_perkinelmer.py
+++ b/plugins/spectrochempy-perkinelmer/src/spectrochempy_perkinelmer/read_perkinelmer.py
@@ -335,8 +335,9 @@ def read_perkinelmer(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -309,8 +309,9 @@ def read(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned without
+        merging, the result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------
@@ -409,6 +410,9 @@ def read(*paths, **kwargs):
     >>> le = scp.read('test.0000', 'test.0001', 'test.0002', directory='irdata/OPUS')
     >>> len(le)
     3
+    >>> names = le.names
+    >>> len(names)
+    3
     >>> le[0]
     NDDataset: [float64] a.u. (shape: (y:1, x:2567))
 
@@ -438,6 +442,9 @@ def read(*paths, **kwargs):
 
     >>> le = scp.read(directory='irdata/OPUS')
     >>> len(le)
+    2
+    >>> largest = le.select_largest()
+    >>> largest.ndim
     2
 
     Again we can use merge to stack all 4 spectra if they have compatible dimensions.
@@ -500,8 +507,9 @@ def read_dir(directory=None, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned without
+        merging, the result is a list-like `ScpObjectList`.
         Depending on the python version, the order of the datasets in the list
         may change.
 
@@ -525,6 +533,12 @@ def read_dir(directory=None, **kwargs):
     >>> A = scp.read_dir('irdata')
     >>> len(A)
     4
+    >>> names = A.names
+    >>> len(names)
+    4
+    >>> largest = A.select_largest()
+    >>> largest.ndim
+    2
 
     >>> B = scp.read_dir()
 

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -160,8 +160,9 @@ def read_csv(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -49,8 +49,9 @@ def read_jcamp(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_labspec.py
+++ b/src/spectrochempy/core/readers/read_labspec.py
@@ -44,8 +44,9 @@ def read_labspec(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -48,8 +48,10 @@ def read_matlab(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, and ``.select_by_name()``.
 
     Other Parameters
     ----------------
@@ -130,6 +132,10 @@ def read_matlab(*paths, **kwargs):
     (``__header__``, ``__version__``, ``__globals__``) are skipped.  When a file
     holds a single numeric variable a lone `NDDataset` is returned.
 
+    When several datasets are returned, the result keeps the Matlab variable
+    names and can be queried directly, for example with ``.names``,
+    ``.select_largest()``, or ``.select_by_name()``.
+
     Examples
     --------
     Reading a single Matlab file
@@ -141,6 +147,18 @@ def read_matlab(*paths, **kwargs):
 
     >>> scp.matlab.read('irdata/matlab/matlabdata.mat')
     NDDataset: [float64] a.u. (shape: (y:1, x:3))
+
+    Selecting datasets from a multi-variable Matlab file
+
+    >>> datasets = scp.read_matlab('irdata/matlab/matlabdata.mat', merge=False)
+    >>> names = datasets.names
+    >>> len(names)
+    1
+    >>> largest = datasets.select_largest()
+    >>> largest.ndim
+    2
+    >>> datasets.select_by_name('data').name
+    'data'
 
     """
     kwargs["filetypes"] = ["Matlab files (*.mat *.dso)"]

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -73,8 +73,10 @@ def read_omnic(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names`` and ``.select_largest()``.
 
     Other Parameters
     ----------------
@@ -181,7 +183,7 @@ def read_omnic(*paths, **kwargs):
     >>> scp.read_omnic(p)
     NDDataset: [float64] a.u. (shape: (y:55, x:5549))
 
-    Multiple files not merged (return a list of datasets).
+    Multiple files not merged (return a list-like multi-dataset result).
     Note that a directory is specified
 
     >>> le = scp.read_omnic('irdata/nh4y-activation.spg', 'wodger.spg')
@@ -206,6 +208,7 @@ def read_omnic(*paths, **kwargs):
     >>> l2 = scp.read_omnic(['irdata/nh4y-activation.spg', 'wodger.spg'], merge=False)
     >>> len(l2)
     2
+    >>> l2.names
 
     Read without a filename. This has the effect of opening a dialog for file(s)
     selection
@@ -254,8 +257,9 @@ def read_spg(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-    The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+    The returned dataset(s). When several datasets are returned, the
+    result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------
@@ -372,8 +376,9 @@ def read_spa(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-    The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+    The returned dataset(s). When several datasets are returned, the
+    result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------
@@ -486,8 +491,9 @@ def read_srs(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-    The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+    The returned dataset(s). When several datasets are returned, the
+    result is a list-like `ScpObjectList`.
         When return_bg is set to 'True', the series background is returned.
 
     Other Parameters

--- a/src/spectrochempy/core/readers/read_opus.py
+++ b/src/spectrochempy/core/readers/read_opus.py
@@ -77,8 +77,10 @@ def read_opus(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names`` and ``.select_largest()``.
 
     Other Parameters
     ----------------
@@ -175,7 +177,7 @@ def read_opus(*paths, **kwargs):
     >>> scp.opus.read('irdata/OPUS/test.0000')
     NDDataset: [float64] a.u. (shape: (y:1, x:2567))
 
-    Multiple files not merged (return a list of datasets). Note that a directory is
+    Multiple files not merged (return a list-like multi-dataset result). Note that a directory is
     specified
 
     >>> le = scp.read_opus('test.0000', 'test.0001', 'test.0002',
@@ -204,6 +206,7 @@ def read_opus(*paths, **kwargs):
     >>>                    directory='irdata/OPUS', merge=False)
     >>> len(le)
     3
+    >>> le.names
 
     Read without a filename. This has the effect of opening a dialog for file(s)
     selection

--- a/src/spectrochempy/core/readers/read_quadera.py
+++ b/src/spectrochempy/core/readers/read_quadera.py
@@ -47,8 +47,9 @@ def read_quadera(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_soc.py
+++ b/src/spectrochempy/core/readers/read_soc.py
@@ -39,8 +39,9 @@ def read_soc(*paths, **kwargs):
 
     Returns
     -------
-    `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------
@@ -146,8 +147,9 @@ def read_ddr(*paths, **kwargs):
 
     Returns
     -------
-    `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------
@@ -243,8 +245,9 @@ def read_hdr(*paths, **kwargs):
 
     Returns
     -------
-    `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------
@@ -340,8 +343,9 @@ def read_sdr(*paths, **kwargs):
 
     Returns
     -------
-    `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_spc.py
+++ b/src/spectrochempy/core/readers/read_spc.py
@@ -48,8 +48,9 @@ def read_spc(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_wire.py
+++ b/src/spectrochempy/core/readers/read_wire.py
@@ -819,8 +819,9 @@ def read_wire(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_zip.py
+++ b/src/spectrochempy/core/readers/read_zip.py
@@ -41,8 +41,9 @@ def read_zip(*paths, **kwargs):
 
     Returns
     -------
-    object : `NDDataset` or list of `NDDataset`
-        The returned dataset(s).
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s). When several datasets are returned, the
+        result is a list-like `ScpObjectList`.
 
     Other Parameters
     ----------------
@@ -124,6 +125,15 @@ def read_zip(*paths, **kwargs):
 
     >>> scp.read_zip('irdata/zip/zipfile.zip')
     NDDataset: [float64] a.u. (shape: (y:2, x:5549))
+
+    Keeping separate datasets from an archive
+
+    >>> datasets = scp.read_zip('irdata/zip/agirdata.zip', merge=False)
+    >>> count = len(datasets)
+    >>> names = datasets.names
+    >>> _ = len(names)
+    >>> largest = datasets.select_largest()
+    >>> _ = largest.ndim
 
     """
     kwargs["filetypes"] = ["Zip archives (*.zip)"]

--- a/src/spectrochempy/utils/objects.py
+++ b/src/spectrochempy/utils/objects.py
@@ -310,7 +310,31 @@ class ReadOnlyDict(dict):
 
 
 class ScpObjectList(list):
-    """A list subclass that allows html representation of the list of spectrochempy objects."""
+    """
+    A list subclass for groups of SpectroChemPy objects returned by public APIs.
+
+    `ScpObjectList` behaves like a regular Python list while exposing a few
+    helpers that are especially useful when a reader returns several datasets
+    instead of a single merged `NDDataset`.
+
+    Available helpers include:
+
+    - `names`: list the dataset names when available.
+    - `select_largest()`: pick the largest dataset, optionally for a given
+      number of dimensions.
+    - `select_by_name()`: pick the first dataset whose name matches a
+      substring.
+    - `filter_by_ndim()`: keep only datasets with a given number of
+      dimensions.
+    - `filter_by_shape()`: keep only datasets with an exact shape.
+
+    Examples
+    --------
+    >>> datasets = scp.read_matlab("data.mat", merge=False)
+    >>> datasets.names
+    >>> X = datasets.select_largest(ndim=2)
+    >>> C = datasets.select_by_name("conc")
+    """
 
     def _repr_html_(self):
         """


### PR DESCRIPTION
## Summary

This PR improves reader documentation around multi-dataset returns.

- document `ScpObjectList` as the concrete list-like return type for multi-dataset reader results;
- clarify the return sections of core and plugin readers that may return multiple datasets;
- add small, user-facing examples showing helper usage such as `.names`, `.select_largest()`, and `.select_by_name()` where those helpers are useful in practice.

## Why

Several reader docstrings still described multi-dataset results as plain Python lists. That was technically inaccurate and also made the useful helper API easy to miss, especially for readers such as `read_matlab()`, `read_dir()`, `read()`, and `read_zip()`.

## Validation

- `pre-commit run --all-files`

## Notes

This stays documentation-focused. It does not change reader behavior or the public return objects themselves.