### PR TITLE
DOC: clarify reader import API discoverability

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -166,6 +166,13 @@ Import/export
 
 Import a NDDataset from external source
 ======================================
+
+Reader functions may return either a single ``NDDataset`` or a list-like
+``ScpObjectList`` when several datasets are discovered and not merged. In that
+case, helper methods such as ``datasets.names``,
+``datasets.select_largest(ndim=2)``, and ``datasets.select_by_name("spectra")``
+make it easier to pick the dataset you want while staying in the public API.
+
 .. autosummary::
     :nosignatures:
     :toctree: generated/

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -34,6 +34,11 @@ New Features
   This makes it much easier to work with files that contain multiple
   variables or spectra. (#1306)
 
+- The generic ``scp.read(...)`` API and the main explicit reader entry points
+  now document the namespace-based import convention more clearly, including
+  when readers may return a list-like ``ScpObjectList`` and which helper
+  methods are available to select datasets from multi-object imports.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -30,6 +30,11 @@ New Features
   This makes it much easier to work with files that contain multiple
   variables or spectra. (#1306)
 
+- The generic ``scp.read(...)`` API and the main explicit reader entry points
+  now document the namespace-based import convention more clearly, including
+  when readers may return a list-like ``ScpObjectList`` and which helper
+  methods are available to select datasets from multi-object imports.
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -284,11 +284,24 @@ def read(*paths, **kwargs):
     r"""
     Read data from various file formats.
 
-    This method is generally able to load experimental files based on extensions.
-    It acts as a dispatcher: after detecting the format it delegates to the
-    corresponding namespace reader (e.g. ``scp.omnic.read(...)``,
-    ``scp.opus.read(...)``, ``scp.jcamp.read(...)``).
-    You can bypass detection by passing the ``protocol`` keyword explicitly.
+    This is the central user-facing entry point for SpectroChemPy file import.
+    In the current API convention, ``read()`` is the generic dispatcher while
+    namespace readers such as ``scp.omnic.read(...)``, ``scp.opus.read(...)``,
+    ``scp.matlab.read(...)``, or plugin readers provide the explicit
+    format-specific forms. Use ``read()`` when automatic format detection is
+    desired and use a namespace reader when the data source is already known.
+
+    `read()` generally detects the file format from the filename extension and
+    then delegates to the corresponding public reader implementation. You can
+    bypass detection by passing the ``protocol`` keyword explicitly.
+
+    Depending on the input, `read()` may return either a single `NDDataset` or
+    a list-like `ScpObjectList`. The latter occurs when several datasets are
+    discovered and not merged into one result. In that case, helper features
+    such as ``.names``, ``.select_largest()``, ``.select_by_name()``,
+    ``.filter_by_ndim()``, and ``.filter_by_shape()`` provide an idiomatic
+    public way to inspect and select the desired dataset without dropping down
+    to ad hoc list-handling code.
 
     Parameters
     ----------
@@ -311,7 +324,10 @@ def read(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned without
-        merging, the result is a list-like `ScpObjectList`.
+        merging, the result is a list-like `ScpObjectList` with convenience
+        helpers such as ``.names``, ``.select_largest()``,
+        ``.select_by_name()``, ``.filter_by_ndim()``, and
+        ``.filter_by_shape()``.
 
     Other Parameters
     ----------------
@@ -404,7 +420,7 @@ def read(*paths, **kwargs):
     >>> scp.read(p)
     NDDataset: [float64] a.u. (shape: (y:1, x:2567))
 
-    Multiple files not merged (return a list of datasets).
+    Multiple files not merged (return a list-like multi-dataset result).
     Note that a directory is specified
 
     >>> le = scp.read('test.0000', 'test.0001', 'test.0002', directory='irdata/OPUS')
@@ -431,6 +447,9 @@ def read(*paths, **kwargs):
     >>> le = scp.read(['test.0000', 'test.0001', 'test.0002'], directory='irdata/OPUS', merge=False)
     >>> len(le)
     3
+    >>> largest = le.select_largest()
+    >>> largest.shape
+    (1, 2567)
 
     Read without a filename. This has the effect of opening a dialog for file(s)
     selection
@@ -509,7 +528,10 @@ def read_dir(directory=None, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned without
-        merging, the result is a list-like `ScpObjectList`.
+        merging, the result is a list-like `ScpObjectList` with convenience
+        helpers such as ``.names``, ``.select_largest()``,
+        ``.select_by_name()``, ``.filter_by_ndim()``, and
+        ``.filter_by_shape()``.
         Depending on the python version, the order of the datasets in the list
         may change.
 

--- a/src/spectrochempy/core/readers/read_csv.py
+++ b/src/spectrochempy/core/readers/read_csv.py
@@ -141,6 +141,16 @@ def read_csv(*paths, **kwargs):
     r"""
     Open CSV (comma-separated values) files.
 
+    This is the explicit CSV reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.csv.read(...)`` or :func:`spectrochempy.read_csv` when the CSV format
+    is already known.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object objects or valid urls, optional
@@ -162,7 +172,9 @@ def read_csv(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -28,6 +28,16 @@ def read_jcamp(*paths, **kwargs):
     r"""
     Open Infrared ``JCAMP-DX`` files with extension :file:`.jdx` or :file:`.dx`.
 
+    This is the explicit JCAMP reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.jcamp.read(...)`` or :func:`spectrochempy.read_jcamp` when the JCAMP
+    format is already known.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Limited to AFFN encoding (see :cite:t:`mcdonald:1988`)
 
     Parameters
@@ -51,7 +61,9 @@ def read_jcamp(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_labspec.py
+++ b/src/spectrochempy/core/readers/read_labspec.py
@@ -25,6 +25,16 @@ def read_labspec(*paths, **kwargs):
     r"""
     Open Raman LABSPEC files.
 
+    This is the explicit LABSPEC reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.labspec.read(...)`` or :func:`spectrochempy.read_labspec` when the
+    LABSPEC format is already known.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object objects or valid urls, optional
@@ -46,7 +56,9 @@ def read_labspec(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -29,6 +29,18 @@ def read_matlab(*paths, **kwargs):
     r"""
     Open Matlab files.
 
+    This is the explicit Matlab reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.matlab.read(...)`` or :func:`spectrochempy.read_matlab` when the
+    Matlab format is already known.
+
+    A Matlab file may contain one or several numeric variables. Compatible
+    variables can be grouped into a single dataset, while non-merged multi-file
+    or multi-variable reads may return a list-like `ScpObjectList` with helper
+    methods for dataset selection. See :func:`spectrochempy.read` for the
+    complete description of the generic import convention and multi-object
+    return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object objects or valid urls, optional
@@ -51,7 +63,8 @@ def read_matlab(*paths, **kwargs):
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
         result is a list-like `ScpObjectList` with helper attributes such as
-        ``.names``, ``.select_largest()``, and ``.select_by_name()``.
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------
@@ -134,7 +147,8 @@ def read_matlab(*paths, **kwargs):
 
     When several datasets are returned, the result keeps the Matlab variable
     names and can be queried directly, for example with ``.names``,
-    ``.select_largest()``, or ``.select_by_name()``.
+    ``.select_largest()``, ``.select_by_name()``, ``.filter_by_ndim()``, or
+    ``.filter_by_shape()``.
 
     Examples
     --------
@@ -157,6 +171,9 @@ def read_matlab(*paths, **kwargs):
     >>> largest = datasets.select_largest()
     >>> largest.ndim
     2
+    >>> filtered = datasets.filter_by_ndim(2)
+    >>> len(filtered)
+    1
     >>> datasets.select_by_name('data').name
     'data'
 

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -37,6 +37,11 @@ def read_omnic(*paths, **kwargs):
     r"""
     Open a Thermo Nicolet OMNIC file.
 
+    This is the explicit OMNIC reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.omnic.read(...)`` or :func:`spectrochempy.read_omnic` when the OMNIC
+    format is already known.
+
     Open Omnic file or a list of :file:`.spg`, :file:`.spa` or
     :file:`.srs` files and set data/metadata in the current dataset.
 
@@ -53,6 +58,11 @@ def read_omnic(*paths, **kwargs):
     An error is generated when an SPG file contains spectra with inconsistent
     x-axis definitions, unless ``allow_inconsistent_x=True`` is specified. In
     that case, a list containing one `NDDataset` per spectrum is returned.
+
+    Non-merged multi-file reads may also return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
 
     Parameters
     ----------
@@ -76,7 +86,8 @@ def read_omnic(*paths, **kwargs):
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
         result is a list-like `ScpObjectList` with helper attributes such as
-        ``.names`` and ``.select_largest()``.
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------
@@ -208,7 +219,12 @@ def read_omnic(*paths, **kwargs):
     >>> l2 = scp.read_omnic(['irdata/nh4y-activation.spg', 'wodger.spg'], merge=False)
     >>> len(l2)
     2
-    >>> l2.names
+    >>> names = l2.names
+    >>> len(names)
+    2
+    >>> largest = l2.select_largest()
+    >>> largest.ndim
+    2
 
     Read without a filename. This has the effect of opening a dialog for file(s)
     selection

--- a/src/spectrochempy/core/readers/read_opus.py
+++ b/src/spectrochempy/core/readers/read_opus.py
@@ -32,7 +32,18 @@ def read_opus(*paths, **kwargs):
     r"""
     Open Bruker OPUS file(s).
 
-    Eventually group them in a single dataset. Returns an error if dimensions are incompatibles.
+    This is the explicit OPUS reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.opus.read(...)`` or :func:`spectrochempy.read_opus` when the OPUS
+    format is already known.
+
+    Eventually group them in a single dataset. Returns an error if dimensions
+    are incompatibles.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
 
 
     Parameters
@@ -80,7 +91,8 @@ def read_opus(*paths, **kwargs):
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
         result is a list-like `ScpObjectList` with helper attributes such as
-        ``.names`` and ``.select_largest()``.
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------
@@ -206,7 +218,12 @@ def read_opus(*paths, **kwargs):
     >>>                    directory='irdata/OPUS', merge=False)
     >>> len(le)
     3
-    >>> le.names
+    >>> names = le.names
+    >>> len(names)
+    3
+    >>> largest = le.select_largest()
+    >>> largest.ndim
+    2
 
     Read without a filename. This has the effect of opening a dialog for file(s)
     selection

--- a/src/spectrochempy/core/readers/read_quadera.py
+++ b/src/spectrochempy/core/readers/read_quadera.py
@@ -28,6 +28,16 @@ def read_quadera(*paths, **kwargs):
     r"""
     Open a Pfeiffer Vacuum's QUADERA mass spectrometer software file.
 
+    This is the explicit QUADERA reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.quadera.read(...)`` or :func:`spectrochempy.read_quadera` when the
+    QUADERA format is already known.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object objects or valid urls, optional
@@ -49,7 +59,9 @@ def read_quadera(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_soc.py
+++ b/src/spectrochempy/core/readers/read_soc.py
@@ -20,6 +20,16 @@ def read_soc(*paths, **kwargs):
     r"""
     Read a Surface Optics Corp. file or a list of files with extension :file:`.ddr`, :file:`.hdr` or :file:`.sdr`.
 
+    This is the explicit SOC reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.soc.read(...)`` or :func:`spectrochempy.read_soc` when the SOC format
+    is already known.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object or valid urls, optional
@@ -41,7 +51,9 @@ def read_soc(*paths, **kwargs):
     -------
     `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------
@@ -128,6 +140,16 @@ def read_ddr(*paths, **kwargs):
     r"""
     Open a Surface Optics Corp. file or a list of files with extension :file:`.ddr`.
 
+    This is the explicit DDR reader in the public SOC import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    :func:`spectrochempy.read_soc` or ``scp.soc.read(...)`` for the broader SOC
+    entry point.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object or valid urls, optional
@@ -149,7 +171,9 @@ def read_ddr(*paths, **kwargs):
     -------
     `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------
@@ -226,6 +250,16 @@ def read_hdr(*paths, **kwargs):
     r"""
     Open a Surface Optics Corp. file or a list of files with extension :file:`.hdr`.
 
+    This is the explicit HDR reader in the public SOC import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    :func:`spectrochempy.read_soc` or ``scp.soc.read(...)`` for the broader SOC
+    entry point.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object or valid urls, optional
@@ -247,7 +281,9 @@ def read_hdr(*paths, **kwargs):
     -------
     `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------
@@ -324,6 +360,16 @@ def read_sdr(*paths, **kwargs):
     r"""
     Open a Surface Optics Corp. file or a list of files with extension :file:`.sdr`.
 
+    This is the explicit SDR reader in the public SOC import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    :func:`spectrochempy.read_soc` or ``scp.soc.read(...)`` for the broader SOC
+    entry point.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object or valid urls, optional
@@ -345,7 +391,9 @@ def read_sdr(*paths, **kwargs):
     -------
     `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_spc.py
+++ b/src/spectrochempy/core/readers/read_spc.py
@@ -29,6 +29,16 @@ def read_spc(*paths, **kwargs):
     r"""
     Open Galactic files.
 
+    This is the explicit SPC reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.spc.read(...)`` or :func:`spectrochempy.read_spc` when the SPC format
+    is already known.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object objects or valid urls, optional
@@ -50,7 +60,9 @@ def read_spc(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_wire.py
+++ b/src/spectrochempy/core/readers/read_wire.py
@@ -800,6 +800,16 @@ def read_wire(*paths, **kwargs):
     r"""
     Open Renishaw Wire files.
 
+    This is the explicit WiRE reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection and
+    ``scp.wire.read(...)`` or :func:`spectrochempy.read_wire` when the WiRE
+    format is already known.
+
+    Non-merged multi-file reads may return a list-like `ScpObjectList`
+    exposing helper methods for dataset selection. See
+    :func:`spectrochempy.read` for the complete description of the generic
+    import convention and multi-object return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object objects or valid urls, optional
@@ -821,7 +831,9 @@ def read_wire(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------

--- a/src/spectrochempy/core/readers/read_zip.py
+++ b/src/spectrochempy/core/readers/read_zip.py
@@ -22,6 +22,17 @@ def read_zip(*paths, **kwargs):
     r"""
     Read Zip archives (containing spectrochempy readable files).
 
+    This is the explicit ZIP reader in the public import API. Use
+    :func:`spectrochempy.read` for generic format autodetection when you want
+    one generic entry point, and use :func:`spectrochempy.read_zip` when the
+    archive format is already known.
+
+    A ZIP archive may expose one or several readable datasets. Non-merged
+    archive reads may return a list-like `ScpObjectList` exposing helper
+    methods for dataset selection. See :func:`spectrochempy.read` for the
+    complete description of the generic import convention and multi-object
+    return behavior.
+
     Parameters
     ----------
     *paths : `str`, `~pathlib.Path` object objects or valid urls, optional
@@ -43,7 +54,9 @@ def read_zip(*paths, **kwargs):
     -------
     object : `NDDataset` or `ScpObjectList` of `NDDataset`
         The returned dataset(s). When several datasets are returned, the
-        result is a list-like `ScpObjectList`.
+        result is a list-like `ScpObjectList` with helper attributes such as
+        ``.names``, ``.select_largest()``, ``.select_by_name()``,
+        ``.filter_by_ndim()``, and ``.filter_by_shape()``.
 
     Other Parameters
     ----------------


### PR DESCRIPTION
## Summary

Clarifies the public reader import API documentation around `scp.read(...)`,
explicit namespace readers such as `scp.omnic.read(...)`, and legacy
`scp.read_<format>(...)` aliases.

The PR also documents when reader calls may return a list-like `ScpObjectList`
and surfaces the helper methods available for selecting datasets from
multi-object imports.

## Changes

- Expand `read()` and `read_dir()` docstrings with the generic import convention.
- Add consistent reader-level wording for explicit core readers.
- Document `ScpObjectList` helpers such as `names`, `select_largest()`,
  `select_by_name()`, `filter_by_ndim()`, and `filter_by_shape()`.
- Update the import/export reference page and release notes.
