### PR TITLE
ENH: support column stacking for 1D datasets

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,11 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- ``scp.stack(..., axis=1)`` now supports stacking 1D datasets as columns
+  into a 2D `NDDataset`. This makes it easier to build workflow-style
+  concentration or profile matrices without falling back to
+  ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
+
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting
   the dataset you need. After ``datasets = scp.read(...)``:

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,11 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- ``scp.stack(..., axis=1)`` now supports stacking 1D datasets as columns
+  into a 2D `NDDataset`. This makes it easier to build workflow-style
+  concentration or profile matrices without falling back to
+  ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
+
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting
   the dataset you need. After ``datasets = scp.read(...)``:

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -188,7 +188,7 @@ def concatenate(*datasets, **kwargs):
     return out
 
 
-def stack(*datasets):
+def stack(*datasets, **kwargs):
     """
     Stack of `NDDataset` objects along a new dimension.
 
@@ -203,6 +203,18 @@ def stack(*datasets):
     ----------
     *datasets : a series of `NDDataset`
         The dataset to be stacked to the current dataset.
+    **kwargs
+        Optional keyword parameters.
+
+    Other Parameters
+    ----------------
+    axis : int, optional, default=0
+        Stacking axis.
+
+        - ``axis=0`` preserves the historical behavior and stacks datasets
+          along a new leading dimension.
+        - ``axis=1`` is supported for 1D datasets and promotes them to a 2D
+          dataset with profiles stacked as columns.
 
     Returns
     -------
@@ -221,8 +233,25 @@ def stack(*datasets):
     >>> print(C)
     NDDataset: [float64] a.u. (shape: (z:2, y:55, x:5549))
 
+    Stack 1D profiles as columns in a 2D dataset
+
+    >>> t = scp.linspace(0, 1, 5)
+    >>> profiles = [np.exp(-((t - c) ** 2) / 0.05) for c in (0.2, 0.5)]
+    >>> C = scp.stack(profiles, axis=1)
+    >>> C.shape
+    (5, 2)
+
     """
     datasets = _get_copy(datasets)
+    axis = kwargs.pop("axis", 0)
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise TypeError(f"stack() got unexpected keyword argument(s): {unexpected}")
+
+    if axis in (1, -1):
+        return _stack_1d_profiles_as_columns(datasets)
+    if axis not in (0, None):
+        raise NotImplementedError("stack() currently supports only axis=0 or axis=1")
 
     shapes = {ds.shape for ds in datasets}
     if len(shapes) != 1:
@@ -240,6 +269,45 @@ def stack(*datasets):
         dataset.dims = [newcoord.name] + dataset.dims
 
     return concatenate(*datasets, dims=0)
+
+
+def _stack_1d_profiles_as_columns(datasets):
+    if not datasets:
+        raise ValueError("stack() requires at least one dataset")
+
+    shapes = {ds.shape for ds in datasets}
+    if len(shapes) != 1:
+        raise exceptions.DimensionsCompatibilityError(
+            "all input arrays must have the same shape",
+        )
+
+    ndim = {ds.ndim for ds in datasets}
+    if ndim != {1}:
+        raise NotImplementedError(
+            "stack(axis=1) is currently implemented only for 1D datasets",
+        )
+
+    source_dims = {ds.dims[0] for ds in datasets}
+    if len(source_dims) != 1:
+        raise exceptions.DimensionsCompatibilityError(
+            "all input 1D datasets must use the same dimension name",
+        )
+
+    promoted = []
+    source_dim = datasets[0].dims[0]
+    for i, dataset in enumerate(datasets):
+        xcoord = dataset.coord(source_dim)
+        newdim = (OrderedSet(DEFAULT_DIM_NAME) - dataset._dims).pop()
+        masked = dataset.masked_data
+        dataset._data = np.asarray(masked)[:, np.newaxis]
+        dataset._mask = np.ma.getmaskarray(masked)[:, np.newaxis]
+        dataset.dims = [source_dim, newdim]
+        column_coord = Coord([i], labels=[dataset.name])
+        column_coord.name = newdim
+        dataset.set_coordset({source_dim: xcoord, newdim: column_coord})
+        promoted.append(dataset)
+
+    return concatenate(*promoted, dims=newdim)
 
 
 # utility functions

--- a/tests/test_core/test_dataset/test_workflow_api_ergonomics_baseline.py
+++ b/tests/test_core/test_dataset/test_workflow_api_ergonomics_baseline.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.core.dataset.nddataset import NDDataset
+
+
+def _gaussian_profiles():
+    time = scp.linspace(0.0, 1.0, 5)
+    centers = (0.2, 0.5, 0.8)
+    profiles = [np.exp(-((time - center) ** 2) / 0.05) for center in centers]
+    return time, profiles
+
+
+class TestWorkflowMathBaseline:
+    """
+    Characterize the current public behavior seen by workflow-style notebooks.
+
+    This suite documents the exact gap observed during Workflow Assistant
+    notebook generation:
+
+    - unary NumPy ufuncs like ``np.exp`` dispatch to ``NDDataset``;
+    - SpectroChemPy does not expose a matching top-level ``scp.exp`` alias;
+    - a native ``scp.stack(..., axis=1)`` path now exists for 1D profiles;
+    - ``scp.concatenate(..., axis=1)`` still does not provide the same
+      promotion behavior.
+    """
+
+    def test_numpy_exp_dispatches_to_nddataset(self):
+        time = scp.linspace(0.0, 1.0, 5)
+        result = np.exp(-((time - 0.5) ** 2) / 0.05)
+
+        assert isinstance(result, NDDataset)
+        assert result.shape == (5,)
+        assert result.dims == ["x"]
+        np.testing.assert_allclose(
+            result.data,
+            np.exp(-((time.data - 0.5) ** 2) / 0.05),
+        )
+
+    def test_top_level_scp_exp_is_not_exposed(self):
+        assert not hasattr(scp, "exp")
+
+    def test_numpy_column_stack_returns_plain_ndarray(self):
+        _, profiles = _gaussian_profiles()
+
+        result = np.column_stack(profiles)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (5, 3)
+
+    def test_stack_of_1d_profiles_axis_1_returns_2d_dataset(self):
+        _, profiles = _gaussian_profiles()
+
+        result = scp.stack(profiles, axis=1)
+
+        assert isinstance(result, NDDataset)
+        assert result.shape == (5, 3)
+        assert result.dims == ["x", "y"]
+        assert result.y.labels is not None
+        assert len(result.y.labels) == 3
+
+    def test_concatenate_1d_profiles_axis_1_raises_index_error(self):
+        _, profiles = _gaussian_profiles()
+
+        with pytest.raises(IndexError, match="list index out of range"):
+            scp.concatenate(*profiles, axis=1)

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -161,6 +161,17 @@ def test_bug_243():
     assert D12.x.data[-1] == D2.x.data[-1]
 
 
+def test_stack_axis_1_for_1d_profiles():
+    t = scp.linspace(0.0, 1.0, 5)
+    profiles = [np.exp(-((t - c) ** 2) / 0.05) for c in (0.2, 0.5, 0.8)]
+
+    result = stack(profiles, axis=1)
+
+    assert result.shape == (5, 3)
+    assert result.dims == ["x", "y"]
+    assert result.y.labels is not None
+
+
 # ==============================================================================
 # CoordSet lifecycle — concatenate dimension coordinate propagation
 # ==============================================================================


### PR DESCRIPTION
## Summary

Add support for stacking 1D datasets as columns with
`scp.stack(..., axis=1)`.

related to #1300
## Changes

- add `axis=1` support to `scp.stack()` for 1D datasets
- preserve the historical `stack()` behavior for the default axis
- document the new `axis` behavior in the `stack()` docstring
- add targeted tests for 1D column stacking behavior

## Notes

The change is intentionally limited to `scp.stack(..., axis=1)`.
`scp.concatenate(..., axis=1)` is unchanged in this PR.