### PR TITLE
ENH: support 1D column concatenation

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,10 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- ``scp.concatenate(..., axis=1)`` now supports promoting 1D datasets into
+  column-wise 2D `NDDataset` results. This makes it easier to assemble profile
+  or concentration matrices directly within the SpectroChemPy API.
+
 - ``scp.stack(..., axis=1)`` now supports stacking 1D datasets as columns
   into a 2D `NDDataset`. This makes it easier to build workflow-style
   concentration or profile matrices without falling back to

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,10 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- ``scp.concatenate(..., axis=1)`` now supports promoting 1D datasets into
+  column-wise 2D `NDDataset` results. This makes it easier to assemble profile
+  or concentration matrices directly within the SpectroChemPy API.
+
 - ``scp.stack(..., axis=1)`` now supports stacking 1D datasets as columns
   into a 2D `NDDataset`. This makes it easier to build workflow-style
   concentration or profile matrices without falling back to

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -54,6 +54,9 @@ def concatenate(*datasets, **kwargs):
     axis : int, optional
         The axis along which the operation is applied.
 
+        For 1D datasets, ``axis=1`` promotes inputs to a 2D dataset and
+        concatenates them as columns.
+
     See Also
     --------
     stack : Stack of `NDDataset` objects along a new dimension.
@@ -84,6 +87,9 @@ def concatenate(*datasets, **kwargs):
 
     # get a copy of input datasets in order that input data are not modified
     datasets = _get_copy(datasets)
+
+    if _should_promote_1d_column_concatenation(datasets, kwargs):
+        return _stack_1d_profiles_as_columns(datasets)
 
     # get axis from arguments
     axis, dim = datasets[0].get_axis(**kwargs)
@@ -308,6 +314,23 @@ def _stack_1d_profiles_as_columns(datasets):
         promoted.append(dataset)
 
     return concatenate(*promoted, dims=newdim)
+
+
+def _should_promote_1d_column_concatenation(datasets, kwargs):
+    if not datasets:
+        return False
+    if any(ds.ndim != 1 for ds in datasets):
+        return False
+
+    axis = kwargs.get("axis")
+    dims = kwargs.get("dims")
+    dim = kwargs.get("dim")
+
+    if axis in (1, -1):
+        return True
+    if dims == 1 or dim == 1:
+        return True
+    return False
 
 
 # utility functions

--- a/tests/test_core/test_dataset/test_workflow_api_ergonomics_baseline.py
+++ b/tests/test_core/test_dataset/test_workflow_api_ergonomics_baseline.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import spectrochempy as scp
 from spectrochempy.core.dataset.nddataset import NDDataset
@@ -22,8 +21,8 @@ class TestWorkflowMathBaseline:
     - unary NumPy ufuncs like ``np.exp`` dispatch to ``NDDataset``;
     - SpectroChemPy does not expose a matching top-level ``scp.exp`` alias;
     - a native ``scp.stack(..., axis=1)`` path now exists for 1D profiles;
-    - ``scp.concatenate(..., axis=1)`` still does not provide the same
-      promotion behavior.
+    - ``scp.concatenate(..., axis=1)`` now provides the same narrow promotion
+      behavior for 1D profiles.
     """
 
     def test_numpy_exp_dispatches_to_nddataset(self):
@@ -60,8 +59,13 @@ class TestWorkflowMathBaseline:
         assert result.y.labels is not None
         assert len(result.y.labels) == 3
 
-    def test_concatenate_1d_profiles_axis_1_raises_index_error(self):
+    def test_concatenate_1d_profiles_axis_1_returns_2d_dataset(self):
         _, profiles = _gaussian_profiles()
 
-        with pytest.raises(IndexError, match="list index out of range"):
-            scp.concatenate(*profiles, axis=1)
+        result = scp.concatenate(*profiles, axis=1)
+
+        assert isinstance(result, NDDataset)
+        assert result.shape == (5, 3)
+        assert result.dims == ["x", "y"]
+        assert result.y.labels is not None
+        assert len(result.y.labels) == 3

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -172,6 +172,17 @@ def test_stack_axis_1_for_1d_profiles():
     assert result.y.labels is not None
 
 
+def test_concatenate_axis_1_for_1d_profiles():
+    t = scp.linspace(0.0, 1.0, 5)
+    profiles = [np.exp(-((t - c) ** 2) / 0.05) for c in (0.2, 0.5, 0.8)]
+
+    result = concatenate(*profiles, axis=1)
+
+    assert result.shape == (5, 3)
+    assert result.dims == ["x", "y"]
+    assert result.y.labels is not None
+
+
 # ==============================================================================
 # CoordSet lifecycle — concatenate dimension coordinate propagation
 # ==============================================================================


### PR DESCRIPTION
## Summary

Add support for promoting 1D datasets into column-wise 2D results with
`scp.concatenate(..., axis=1)`.

This makes it possible to assemble a 2D `NDDataset` directly from a series of
1D datasets while staying within the SpectroChemPy API.

## Changes

- add `axis=1` support to `scp.concatenate()` for 1D datasets
- preserve the historical `concatenate()` behavior in existing cases
- add targeted tests for 1D column concatenation behavior

## Notes

This PR keeps the change intentionally narrow.

It only adds 1D-to-2D column promotion for the `axis=1` case and does not
broaden the general concatenation semantics beyond that.

Closes #1300