### PR TITLE
ENH: accept Coord inputs in scp.stack(axis=1)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -37,6 +37,11 @@ New Features
   concentration or profile matrices without falling back to
   ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
 
+- ``scp.stack(..., axis=1)`` now accepts ``Coord`` inputs and
+  automatically promotes them to ``NDDataset`` before stacking.
+  This makes it easier to build profile matrices directly from
+  coordinate objects. (#1313)
+
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting
   the dataset you need. After ``datasets = scp.read(...)``:

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -33,6 +33,11 @@ New Features
   concentration or profile matrices without falling back to
   ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
 
+- ``scp.stack(..., axis=1)`` now accepts ``Coord`` inputs and
+  automatically promotes them to ``NDDataset`` before stacking.
+  This makes it easier to build profile matrices directly from
+  coordinate objects. (#1313)
+
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting
   the dataset you need. After ``datasets = scp.read(...)``:


### PR DESCRIPTION
`scp.stack(..., axis=1)` now accepts `Coord` inputs and automatically promotes them to `NDDataset` before stacking. This makes it easier to build profile matrices directly from coordinate objects, matching the intuitive workflow where `scp.Coord.linspace` is used as the abscissa.

Changes:
- `_stack_1d_profiles_as_columns` converts plain `Coord` inputs to `NDDataset` at the start of the path.
- Added `NDDataset` import to `concatenate.py`.
