### PR TITLE
ENH: add normalized parameter to line-shape helpers

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -28,6 +28,15 @@ New Features
   ``scp.exp(...)``, ``scp.log(...)``, ``scp.log10(...)``, ``scp.sin(...)``,
   and ``scp.cos(...)``. (#1301)
 
+- The top-level line-shape helpers ``scp.gaussian(...)``,
+  ``scp.lorentzian(...)``, ``scp.voigt(...)``, and
+  ``scp.asymmetricvoigt(...)`` now accept a ``normalized`` keyword
+  argument.  ``normalized=True`` (default) preserves the existing
+  area-normalized behaviour.  ``normalized=False`` returns a profile
+  whose peak amplitude is exactly *ampl*, matching the intuitive
+  ``scp.exp(...)`` workflow for building synthetic profiles.
+  ``scp.sigmoid(...)`` is unaffected. (#1314)
+
 - ``scp.concatenate(..., axis=1)`` now supports promoting 1D datasets into
   column-wise 2D `NDDataset` results. This makes it easier to assemble profile
   or concentration matrices directly within the SpectroChemPy API.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -37,6 +37,11 @@ New Features
   concentration or profile matrices without falling back to
   ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
 
+- ``scp.stack(..., axis=1)`` now accepts ``Coord`` inputs and
+  automatically promotes them to ``NDDataset`` before stacking.
+  This makes it easier to build profile matrices directly from
+  coordinate objects. (#1313)
+
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting
   the dataset you need. After ``datasets = scp.read(...)``:

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -33,6 +33,11 @@ New Features
   concentration or profile matrices without falling back to
   ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
 
+- ``scp.stack(..., axis=1)`` now accepts ``Coord`` inputs and
+  automatically promotes them to ``NDDataset`` before stacking.
+  This makes it easier to build profile matrices directly from
+  coordinate objects. (#1313)
+
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting
   the dataset you need. After ``datasets = scp.read(...)``:

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -24,6 +24,15 @@ New Features
   ``scp.exp(...)``, ``scp.log(...)``, ``scp.log10(...)``, ``scp.sin(...)``,
   and ``scp.cos(...)``. (#1301)
 
+- The top-level line-shape helpers ``scp.gaussian(...)``,
+  ``scp.lorentzian(...)``, ``scp.voigt(...)``, and
+  ``scp.asymmetricvoigt(...)`` now accept a ``normalized`` keyword
+  argument.  ``normalized=True`` (default) preserves the existing
+  area-normalized behaviour.  ``normalized=False`` returns a profile
+  whose peak amplitude is exactly *ampl*, matching the intuitive
+  ``scp.exp(...)`` workflow for building synthetic profiles.
+  ``scp.sigmoid(...)`` is unaffected. (#1314)
+
 - ``scp.concatenate(..., axis=1)`` now supports promoting 1D datasets into
   column-wise 2D `NDDataset` results. This makes it easier to assemble profile
   or concentration matrices directly within the SpectroChemPy API.

--- a/src/spectrochempy/analysis/curvefitting/_models.py
+++ b/src/spectrochempy/analysis/curvefitting/_models.py
@@ -73,7 +73,8 @@ def make_units_compatibility(func):
             ampl_units = newargs[0].units
             newargs[0] = newargs[0].m
 
-        _data = func(cls, x, *newargs)
+        extra_kwargs = {k: v for k, v in kwargs.items() if k not in cls.args}
+        _data = func(cls, x, *newargs, **extra_kwargs)
 
         if returntype == "NDDataset":
             res = NDDataset(_data, units=ampl_units)
@@ -105,15 +106,64 @@ def _evaluate_model(model, x, name=None, **kwargs):
     return result
 
 
-def gaussian(x, ampl=1.0, pos=0.0, width=1.0, **kwargs):
-    """Return a normalized Gaussian profile."""
+def gaussian(x, ampl=1.0, pos=0.0, width=1.0, normalized=True, **kwargs):
+    """
+    Return a Gaussian profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
-        gaussianmodel, x, name="gaussian", ampl=ampl, pos=pos, width=width, **kwargs
+        gaussianmodel,
+        x,
+        name="gaussian",
+        ampl=ampl,
+        pos=pos,
+        width=width,
+        normalized=normalized,
+        **kwargs,
     )
 
 
-def lorentzian(x, ampl=1.0, pos=0.0, width=1.0, **kwargs):
-    """Return a Lorentzian profile."""
+def lorentzian(x, ampl=1.0, pos=0.0, width=1.0, normalized=True, **kwargs):
+    """
+    Return a Lorentzian profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
         lorentzianmodel,
         x,
@@ -121,12 +171,37 @@ def lorentzian(x, ampl=1.0, pos=0.0, width=1.0, **kwargs):
         ampl=ampl,
         pos=pos,
         width=width,
+        normalized=normalized,
         **kwargs,
     )
 
 
-def voigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, **kwargs):
-    """Return a Voigt profile."""
+def voigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, normalized=True, **kwargs):
+    """
+    Return a Voigt profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    ratio : float, optional
+        Ratio of Gaussian to Lorentzian character (0 = pure Lorentzian,
+        1 = pure Gaussian).
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
         voigtmodel,
         x,
@@ -135,12 +210,40 @@ def voigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, **kwargs):
         pos=pos,
         width=width,
         ratio=ratio,
+        normalized=normalized,
         **kwargs,
     )
 
 
-def asymmetricvoigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, asym=0.0, **kwargs):
-    """Return an asymmetric Voigt profile."""
+def asymmetricvoigt(
+    x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, asym=0.0, normalized=True, **kwargs
+):
+    """
+    Return an asymmetric Voigt profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    ratio : float, optional
+        Ratio of Gaussian to Lorentzian character.
+    asym : float, optional
+        Asymmetry parameter.
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
         asymmetricvoigtmodel,
         x,
@@ -150,6 +253,7 @@ def asymmetricvoigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, asym=0.0, **kwar
         width=width,
         ratio=ratio,
         asym=asym,
+        normalized=normalized,
         **kwargs,
     )
 
@@ -232,12 +336,18 @@ class polynomialbaseline:
 # ======================================================================================
 class gaussianmodel:
     r"""
-    Normalized 1D gaussian function.
+    1D Gaussian function.
+
+    When *normalized* is ``True`` (default) the function returns a normalized
+    profile whose integral is approximately *ampl*:
 
     .. math::
         f(x) = \frac{ampl}{\sqrt{2 \pi \sigma^2} } \exp({\frac{-(x-pos)^2}{2 \sigma^2}})
 
     where :math:`\sigma = \frac{width}{2.3548}` .
+
+    When *normalized* is ``False`` the peak height is exactly *ampl* and the
+    normalization factor is omitted.
     """
 
     type = "1D"
@@ -254,8 +364,12 @@ class gaussianmodel:
     def f(self, x, ampl, pos, width, **kwargs):
         gb = width / 2.3548
         tsq = (x - pos) * 2**-0.5 / gb
-        w = np.exp(-tsq * tsq) * (2 * np.pi) ** -0.5 / gb
-        w = w * abs(x[1] - x[0])
+        normalized = kwargs.get("normalized", True)
+        if normalized:
+            w = np.exp(-tsq * tsq) * (2 * np.pi) ** -0.5 / gb
+            w = w * abs(x[1] - x[0])
+        else:
+            w = np.exp(-tsq * tsq)
         return ampl * w
 
 
@@ -266,10 +380,16 @@ class lorentzianmodel:
     r"""
     A standard Lorentzian function (also known as the Cauchy distribution).
 
+    When *normalized* is ``True`` (default) the function returns a normalized
+    profile whose integral is approximately *ampl*:
+
     .. math::
         f(x) = \frac{ampl * \lambda}{\pi [(x-pos)^2+ \lambda^2]}
 
     where :math:`\lambda = \frac{width}{2}` .
+
+    When *normalized* is ``False`` the peak height is exactly *ampl* and the
+    normalization factor is omitted.
     """
 
     type = "1D"
@@ -286,7 +406,8 @@ class lorentzianmodel:
     def f(self, x, ampl, pos, width, **kargs):
         lb = width / 2.0
         w = lb / np.pi / (x * x - 2 * x * pos + pos * pos + lb * lb)
-        w = w * abs(x[1] - x[0])
+        normalized = kargs.get("normalized", True)
+        w = w * abs(x[1] - x[0]) if normalized else w * np.pi * lb
         return ampl * w
 
 
@@ -327,7 +448,7 @@ class voigtmodel:
 
     @staticmethod
     def f(x, ampl, pos, width, ratio, **kargs):
-        return asymmetricvoigtmodel().f(x, ampl, pos, width, ratio, asym=0.0)
+        return asymmetricvoigtmodel().f(x, ampl, pos, width, ratio, asym=0.0, **kargs)
 
 
 # ======================================================================================
@@ -338,6 +459,11 @@ class asymmetricvoigtmodel:
     An asymmetric Voigt model.
 
     A. L. Stancik and E. B. Brauns, Vibrational Spectroscopy, 2008, 47, 66-69.
+
+    When *normalized* is ``True`` (default) the function returns a normalized
+    profile whose integral is approximately *ampl*. When *normalized* is
+    ``False`` the peak height is exactly *ampl* and the normalization factor
+    is omitted.
     """
 
     type = "1D"
@@ -366,7 +492,13 @@ class asymmetricvoigtmodel:
             return lorentzianmodel().f(x, ampl, pos, lb * 2.0, **kargs)
         w = wofz(((x - pos) + 1.0j * lb) * 2**-0.5 / gb)
         w = w.real * (2.0 * np.pi) ** -0.5 / gb
-        w = w * abs(x[1] - x[0])
+        normalized = kargs.get("normalized", True)
+        if normalized:
+            w = w * abs(x[1] - x[0])
+        else:
+            peak = np.max(w)
+            if peak > 0:
+                w = w / peak
         return ampl * w
 
 

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
@@ -45,9 +45,9 @@ _ = profiles.plot(legend=profiles.y.labels, colormap=None)
 # that reads more naturally for the problem at hand.
 profiles_gaussian = scp.stack(
     [
-        scp.gaussian(time, ampl=1.0, pos=0.25, width=0.235),
-        scp.gaussian(time, ampl=0.8, pos=0.55, width=0.282),
-        scp.gaussian(time, ampl=0.6, pos=0.82, width=0.188),
+        scp.gaussian(time, ampl=1.0, pos=0.25, width=0.235, normalized=False),
+        scp.gaussian(time, ampl=0.8, pos=0.55, width=0.282, normalized=False),
+        scp.gaussian(time, ampl=0.6, pos=0.82, width=0.188, normalized=False),
     ],
     axis=1,
 )

--- a/tests/test_analysis/test_curvefitting/test_models.py
+++ b/tests/test_analysis/test_curvefitting/test_models.py
@@ -277,3 +277,66 @@ class TestConvenienceHelpers:
         assert isinstance(result, np.ndarray)
         assert result.shape == (100,)
         assert np.all(np.isfinite(result))
+
+
+class TestNormalizedFalse:
+    """normalized=False should make the peak amplitude equal to *ampl*."""
+
+    @pytest.mark.parametrize(
+        "helper,extra_kw",
+        [
+            pytest.param("gaussian", {}, id="gaussian"),
+            pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
+        ],
+    )
+    def test_peak_equals_ampl(self, helper, extra_kw):
+        x = np.linspace(-5, 5, 2000)
+        result = getattr(scp, helper)(
+            x, ampl=3.0, pos=0.0, width=1.0, normalized=False, **extra_kw
+        )
+        assert np.isclose(result.max(), 3.0, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "helper,extra_kw",
+        [
+            pytest.param("gaussian", {}, id="gaussian"),
+            pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
+        ],
+    )
+    def test_peak_at_pos(self, helper, extra_kw):
+        x = np.linspace(-5, 5, 2000)
+        result = getattr(scp, helper)(
+            x, ampl=2.0, pos=1.5, width=1.0, normalized=False, **extra_kw
+        )
+        idx = np.argmin(np.abs(x - 1.5))
+        assert np.isclose(result[idx], 2.0, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "helper,extra_kw",
+        [
+            pytest.param("gaussian", {}, id="gaussian"),
+            pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
+        ],
+    )
+    def test_normalized_true_is_default(self, helper, extra_kw):
+        x = np.linspace(-5, 5, 1000)
+        default = getattr(scp, helper)(x, ampl=1.0, pos=0.0, width=1.0, **extra_kw)
+        explicit = getattr(scp, helper)(
+            x, ampl=1.0, pos=0.0, width=1.0, normalized=True, **extra_kw
+        )
+        np.testing.assert_allclose(default, explicit, rtol=1e-12)
+
+    def test_normalized_false_coord_input(self):
+        x = scp.Coord.linspace(-5, 5, 1000, units="m")
+        result = scp.gaussian(x, ampl=1.0, pos=0.0, width=1.0, normalized=False)
+        assert isinstance(result, scp.NDDataset)
+        assert np.isclose(result.data.max(), 1.0, rtol=1e-3)
+
+    def test_normalized_false_amplitude_linearity(self):
+        x = np.linspace(-5, 5, 1000)
+        r1 = scp.gaussian(x, ampl=1.0, pos=0.0, width=1.0, normalized=False)
+        r2 = scp.gaussian(x, ampl=2.5, pos=0.0, width=1.0, normalized=False)
+        np.testing.assert_allclose(r2, 2.5 * r1, rtol=1e-12)


### PR DESCRIPTION
The top-level line-shape helpers `scp.gaussian(...)`, `scp.lorentzian(...)`, `scp.voigt(...)`, and `scp.asymmetricvoigt(...)` now accept a `normalized` keyword argument.

- `normalized=True` (default) preserves the existing area-normalized behaviour.
- `normalized=False` returns a profile whose peak amplitude is exactly `ampl`, matching the intuitive `scp.exp(...)` workflow for building synthetic profiles.

The `make_units_compatibility` decorator was updated to forward extra kwargs transparently (via `extra_kwargs`), enabling this for all peak models without changing their fitting interfaces.

This PR depends on #1314 (`scp.stack` Coord support) and should be merged after it.
