### PR TITLE
ENH: promote Coord inputs in stack/concatenate and add normalized parameter to line-shape helpers

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -21,21 +21,22 @@ New Features
 
 - SpectroChemPy now exposes direct top-level helpers for the built-in 1D line
   shapes: ``scp.gaussian(...)``, ``scp.lorentzian(...)``, ``scp.voigt(...)``,
-  ``scp.asymmetricvoigt(...)``, and ``scp.sigmoid(...)``. This makes it easier
-  to build synthetic profiles directly from the public API, including in
-  gallery and notebook workflows. A small curated set of top-level math aliases
-  is also now available for the same workflow-oriented use cases:
-  ``scp.exp(...)``, ``scp.log(...)``, ``scp.log10(...)``, ``scp.sin(...)``,
-  and ``scp.cos(...)``. (#1301)
+  ``scp.asymmetricvoigt(...)``, and ``scp.sigmoid(...)``. All four
+  line-shape helpers (except ``scp.sigmoid``) also accept a ``normalized``
+  keyword argument: ``normalized=True`` (default) preserves the existing
+  area-normalised behaviour, while ``normalized=False`` returns a profile
+  whose peak amplitude is exactly *ampl*, matching the intuitive
+  ``scp.exp(...)`` workflow for building synthetic profiles.  A small
+  curated set of top-level math aliases is also now available for the
+  same workflow-oriented use cases: ``scp.exp(...)``, ``scp.log(...)``,
+  ``scp.log10(...)``, ``scp.sin(...)``, and ``scp.cos(...)``. (#1301)
 
-- ``scp.concatenate(..., axis=1)`` now supports promoting 1D datasets into
-  column-wise 2D `NDDataset` results. This makes it easier to assemble profile
-  or concentration matrices directly within the SpectroChemPy API.
-
-- ``scp.stack(..., axis=1)`` now supports stacking 1D datasets as columns
-  into a 2D `NDDataset`. This makes it easier to build workflow-style
-  concentration or profile matrices without falling back to
-  ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
+- ``scp.concatenate`` and ``scp.stack`` now accept ``Coord`` inputs
+  (automatically promoted to 1D `NDDataset`), and ``stack(..., axis=1)``
+  is supported for stacking 1D profiles as columns into a 2D dataset.
+  These changes make the workflow for building synthetic concentration
+  or profile matrices fully native within the SpectroChemPy API, without
+  falling back to ``np.column_stack(...)`` or manual `NDDataset` wrapping.
 
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -17,21 +17,22 @@ New Features
 
 - SpectroChemPy now exposes direct top-level helpers for the built-in 1D line
   shapes: ``scp.gaussian(...)``, ``scp.lorentzian(...)``, ``scp.voigt(...)``,
-  ``scp.asymmetricvoigt(...)``, and ``scp.sigmoid(...)``. This makes it easier
-  to build synthetic profiles directly from the public API, including in
-  gallery and notebook workflows. A small curated set of top-level math aliases
-  is also now available for the same workflow-oriented use cases:
-  ``scp.exp(...)``, ``scp.log(...)``, ``scp.log10(...)``, ``scp.sin(...)``,
-  and ``scp.cos(...)``. (#1301)
+  ``scp.asymmetricvoigt(...)``, and ``scp.sigmoid(...)``. All four
+  line-shape helpers (except ``scp.sigmoid``) also accept a ``normalized``
+  keyword argument: ``normalized=True`` (default) preserves the existing
+  area-normalised behaviour, while ``normalized=False`` returns a profile
+  whose peak amplitude is exactly *ampl*, matching the intuitive
+  ``scp.exp(...)`` workflow for building synthetic profiles.  A small
+  curated set of top-level math aliases is also now available for the
+  same workflow-oriented use cases: ``scp.exp(...)``, ``scp.log(...)``,
+  ``scp.log10(...)``, ``scp.sin(...)``, and ``scp.cos(...)``. (#1301)
 
-- ``scp.concatenate(..., axis=1)`` now supports promoting 1D datasets into
-  column-wise 2D `NDDataset` results. This makes it easier to assemble profile
-  or concentration matrices directly within the SpectroChemPy API.
-
-- ``scp.stack(..., axis=1)`` now supports stacking 1D datasets as columns
-  into a 2D `NDDataset`. This makes it easier to build workflow-style
-  concentration or profile matrices without falling back to
-  ``np.column_stack(...)`` followed by a manual `NDDataset` wrapper.
+- ``scp.concatenate`` and ``scp.stack`` now accept ``Coord`` inputs
+  (automatically promoted to 1D `NDDataset`), and ``stack(..., axis=1)``
+  is supported for stacking 1D profiles as columns into a 2D dataset.
+  These changes make the workflow for building synthetic concentration
+  or profile matrices fully native within the SpectroChemPy API, without
+  falling back to ``np.column_stack(...)`` or manual `NDDataset` wrapping.
 
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting

--- a/src/spectrochempy/analysis/curvefitting/_models.py
+++ b/src/spectrochempy/analysis/curvefitting/_models.py
@@ -73,7 +73,8 @@ def make_units_compatibility(func):
             ampl_units = newargs[0].units
             newargs[0] = newargs[0].m
 
-        _data = func(cls, x, *newargs)
+        extra_kwargs = {k: v for k, v in kwargs.items() if k not in cls.args}
+        _data = func(cls, x, *newargs, **extra_kwargs)
 
         if returntype == "NDDataset":
             res = NDDataset(_data, units=ampl_units)
@@ -105,15 +106,64 @@ def _evaluate_model(model, x, name=None, **kwargs):
     return result
 
 
-def gaussian(x, ampl=1.0, pos=0.0, width=1.0, **kwargs):
-    """Return a normalized Gaussian profile."""
+def gaussian(x, ampl=1.0, pos=0.0, width=1.0, normalized=True, **kwargs):
+    """
+    Return a Gaussian profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
-        gaussianmodel, x, name="gaussian", ampl=ampl, pos=pos, width=width, **kwargs
+        gaussianmodel,
+        x,
+        name="gaussian",
+        ampl=ampl,
+        pos=pos,
+        width=width,
+        normalized=normalized,
+        **kwargs,
     )
 
 
-def lorentzian(x, ampl=1.0, pos=0.0, width=1.0, **kwargs):
-    """Return a Lorentzian profile."""
+def lorentzian(x, ampl=1.0, pos=0.0, width=1.0, normalized=True, **kwargs):
+    """
+    Return a Lorentzian profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
         lorentzianmodel,
         x,
@@ -121,12 +171,37 @@ def lorentzian(x, ampl=1.0, pos=0.0, width=1.0, **kwargs):
         ampl=ampl,
         pos=pos,
         width=width,
+        normalized=normalized,
         **kwargs,
     )
 
 
-def voigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, **kwargs):
-    """Return a Voigt profile."""
+def voigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, normalized=True, **kwargs):
+    """
+    Return a Voigt profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    ratio : float, optional
+        Ratio of Gaussian to Lorentzian character (0 = pure Lorentzian,
+        1 = pure Gaussian).
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
         voigtmodel,
         x,
@@ -135,12 +210,40 @@ def voigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, **kwargs):
         pos=pos,
         width=width,
         ratio=ratio,
+        normalized=normalized,
         **kwargs,
     )
 
 
-def asymmetricvoigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, asym=0.0, **kwargs):
-    """Return an asymmetric Voigt profile."""
+def asymmetricvoigt(
+    x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, asym=0.0, normalized=True, **kwargs
+):
+    """
+    Return an asymmetric Voigt profile.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    ratio : float, optional
+        Ratio of Gaussian to Lorentzian character.
+    asym : float, optional
+        Asymmetry parameter.
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
     return _evaluate_model(
         asymmetricvoigtmodel,
         x,
@@ -150,6 +253,7 @@ def asymmetricvoigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, asym=0.0, **kwar
         width=width,
         ratio=ratio,
         asym=asym,
+        normalized=normalized,
         **kwargs,
     )
 
@@ -232,12 +336,18 @@ class polynomialbaseline:
 # ======================================================================================
 class gaussianmodel:
     r"""
-    Normalized 1D gaussian function.
+    1D Gaussian function.
+
+    When *normalized* is ``True`` (default) the function returns a normalized
+    profile whose integral is approximately *ampl*:
 
     .. math::
         f(x) = \frac{ampl}{\sqrt{2 \pi \sigma^2} } \exp({\frac{-(x-pos)^2}{2 \sigma^2}})
 
     where :math:`\sigma = \frac{width}{2.3548}` .
+
+    When *normalized* is ``False`` the peak height is exactly *ampl* and the
+    normalization factor is omitted.
     """
 
     type = "1D"
@@ -254,8 +364,12 @@ class gaussianmodel:
     def f(self, x, ampl, pos, width, **kwargs):
         gb = width / 2.3548
         tsq = (x - pos) * 2**-0.5 / gb
-        w = np.exp(-tsq * tsq) * (2 * np.pi) ** -0.5 / gb
-        w = w * abs(x[1] - x[0])
+        normalized = kwargs.get("normalized", True)
+        if normalized:
+            w = np.exp(-tsq * tsq) * (2 * np.pi) ** -0.5 / gb
+            w = w * abs(x[1] - x[0])
+        else:
+            w = np.exp(-tsq * tsq)
         return ampl * w
 
 
@@ -266,10 +380,16 @@ class lorentzianmodel:
     r"""
     A standard Lorentzian function (also known as the Cauchy distribution).
 
+    When *normalized* is ``True`` (default) the function returns a normalized
+    profile whose integral is approximately *ampl*:
+
     .. math::
         f(x) = \frac{ampl * \lambda}{\pi [(x-pos)^2+ \lambda^2]}
 
     where :math:`\lambda = \frac{width}{2}` .
+
+    When *normalized* is ``False`` the peak height is exactly *ampl* and the
+    normalization factor is omitted.
     """
 
     type = "1D"
@@ -286,7 +406,8 @@ class lorentzianmodel:
     def f(self, x, ampl, pos, width, **kargs):
         lb = width / 2.0
         w = lb / np.pi / (x * x - 2 * x * pos + pos * pos + lb * lb)
-        w = w * abs(x[1] - x[0])
+        normalized = kargs.get("normalized", True)
+        w = w * abs(x[1] - x[0]) if normalized else w * np.pi * lb
         return ampl * w
 
 
@@ -327,7 +448,7 @@ class voigtmodel:
 
     @staticmethod
     def f(x, ampl, pos, width, ratio, **kargs):
-        return asymmetricvoigtmodel().f(x, ampl, pos, width, ratio, asym=0.0)
+        return asymmetricvoigtmodel().f(x, ampl, pos, width, ratio, asym=0.0, **kargs)
 
 
 # ======================================================================================
@@ -338,6 +459,11 @@ class asymmetricvoigtmodel:
     An asymmetric Voigt model.
 
     A. L. Stancik and E. B. Brauns, Vibrational Spectroscopy, 2008, 47, 66-69.
+
+    When *normalized* is ``True`` (default) the function returns a normalized
+    profile whose integral is approximately *ampl*. When *normalized* is
+    ``False`` the peak height is exactly *ampl* and the normalization factor
+    is omitted.
     """
 
     type = "1D"
@@ -366,7 +492,13 @@ class asymmetricvoigtmodel:
             return lorentzianmodel().f(x, ampl, pos, lb * 2.0, **kargs)
         w = wofz(((x - pos) + 1.0j * lb) * 2**-0.5 / gb)
         w = w.real * (2.0 * np.pi) ** -0.5 / gb
-        w = w * abs(x[1] - x[0])
+        normalized = kargs.get("normalized", True)
+        if normalized:
+            w = w * abs(x[1] - x[0])
+        else:
+            peak = np.max(w)
+            if peak > 0:
+                w = w / peak
         return ampl * w
 
 

--- a/src/spectrochempy/core/writers/exporter.py
+++ b/src/spectrochempy/core/writers/exporter.py
@@ -58,6 +58,10 @@ class Exporter(HasTraits):
                     f"Supported suffixes are: {supported}."
                 )
             protocol = self.protocols[filename.suffix]
+            if not hasattr(self, f"_write_{protocol}"):
+                import importlib  # noqa: PLC0415
+
+                importlib.import_module(f".write_{protocol}", __package__)
             write_ = getattr(self, f"_write_{protocol}")
             write_(self.object, filename, **kwargs)
             return filename

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
@@ -33,27 +33,31 @@ c3 = 0.6 * scp.exp(-0.5 * ((time - 0.82) / 0.08) ** 2)
 # %%
 # Assemble the 1D profiles as columns of a concentration matrix.
 profiles = scp.stack([c1, c2, c3], axis=1)
-profiles.y = scp.Coord(labels=["A", "B", "C"], title="species")
+profiles.x.title = "time"
+profiles.y = scp.Coord(labels=["c1", "c2", "c3"], title="species")
 profiles.name = "concentrations"
 profiles.title = "relative concentration"
 
 # %%
-_ = profiles.plot(legend=profiles.y.labels, colormap=None)
+ax = profiles.T.plot()
+_ = ax.legend(profiles.y.labels)
 
 # %%
 # The same workflow can also use the built-in Gaussian line-shape helper when
 # that reads more naturally for the problem at hand.
 profiles_gaussian = scp.stack(
     [
-        scp.gaussian(time, ampl=1.0, pos=0.25, width=0.235),
-        scp.gaussian(time, ampl=0.8, pos=0.55, width=0.282),
-        scp.gaussian(time, ampl=0.6, pos=0.82, width=0.188),
+        scp.gaussian(time, ampl=1.0, pos=0.25, width=0.235, normalized=False),
+        scp.gaussian(time, ampl=0.8, pos=0.55, width=0.282, normalized=False),
+        scp.gaussian(time, ampl=0.6, pos=0.82, width=0.188, normalized=False),
     ],
     axis=1,
 )
+profiles_gaussian.x.title = "time"
 profiles_gaussian.y = scp.Coord(labels=["A", "B", "C"], title="species")
 profiles_gaussian.name = "concentrations_gaussian"
 profiles_gaussian.title = "relative concentration"
 
 # %%
-_ = profiles_gaussian.plot(legend=profiles_gaussian.y.labels, colormap=None)
+ax = profiles_gaussian.T.plot()
+_ = ax.legend(profiles_gaussian.y.labels)

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lineshapes.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lineshapes.py
@@ -25,15 +25,16 @@ profiles = [
     scp.lorentzian(x, ampl=1.0, pos=0.0, width=0.8),
     scp.voigt(x, ampl=1.0, pos=1.5, width=1.0, ratio=0.5),
     scp.asymmetricvoigt(x, ampl=1.0, pos=2.5, width=1.2, ratio=0.4, asym=0.25),
-    scp.sigmoid(x, ampl=1.0, pos=-0.5, asym=6.0),
 ]
 
 # %%
 # Stack them as columns to compare the available shapes side by side.
 shapes = scp.stack(profiles, axis=1)
-shapes.y = scp.Coord(
-    labels=["gaussian", "lorentzian", "voigt", "asym. voigt", "sigmoid"]
-)
+shapes.x.title = "time"
+shapes.y = scp.Coord(labels=["gaussian", "lorentzian", "voigt", "asym. voigt"])
 
 # %%
-_ = shapes.plot(legend=shapes.y.labels, colormap=None)
+ax = shapes.T.plot()
+_ = ax.legend(shapes.y.labels)
+
+# %%

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -87,6 +87,8 @@ def concatenate(*datasets, **kwargs):
 
     # get a copy of input datasets in order that input data are not modified
     datasets = _get_copy(datasets)
+    # Promote Coord inputs to 1D NDDataset
+    datasets = [_coord_to_nddataset(d) for d in datasets]
 
     if _should_promote_1d_column_concatenation(datasets, kwargs):
         return _stack_1d_profiles_as_columns(datasets)
@@ -247,8 +249,19 @@ def stack(*datasets, **kwargs):
     >>> C.shape
     (5, 2)
 
+    ``Coord`` inputs are automatically promoted to 1D datasets.
+
+    >>> time = scp.Coord.linspace(0, 1, 200)
+    >>> c1 = scp.exp(-0.5 * ((time - 0.25) / 0.10) ** 2)
+    >>> c2 = 0.8 * scp.exp(-0.5 * ((time - 0.55) / 0.12) ** 2)
+    >>> profiles = scp.stack([c1, c2], axis=1)
+    >>> profiles.shape
+    (200, 2)
+
     """
     datasets = _get_copy(datasets)
+    # Promote Coord inputs to 1D NDDataset
+    datasets = [_coord_to_nddataset(d) for d in datasets]
     axis = kwargs.pop("axis", 0)
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
@@ -280,6 +293,9 @@ def stack(*datasets, **kwargs):
 def _stack_1d_profiles_as_columns(datasets):
     if not datasets:
         raise ValueError("stack() requires at least one dataset")
+
+    # Promote Coord inputs to 1D NDDataset
+    datasets = [_coord_to_nddataset(d) for d in datasets]
 
     shapes = {ds.shape for ds in datasets}
     if len(shapes) != 1:
@@ -335,6 +351,26 @@ def _should_promote_1d_column_concatenation(datasets, kwargs):
 
 # utility functions
 # --------------------
+def _coord_to_nddataset(obj):
+    """
+    Promote a Coord to a 1D NDDataset.
+
+    Parameters
+    ----------
+    obj : object
+        If a Coord, it is converted to a 1D NDDataset whose data are
+        the coordinate values and whose x-coordinate is the Coord itself.
+        Otherwise the object is returned unchanged.
+    """
+    if not isinstance(obj, Coord):
+        return obj
+    from spectrochempy.core.dataset.nddataset import NDDataset  # noqa: PLC0415
+
+    ds = NDDataset(obj.data)
+    ds.set_coordset(obj)
+    return ds
+
+
 def _get_copy(datasets):
     # get a copy of datasets from the input
     if isinstance(datasets, tuple) and isinstance(datasets[0], list | tuple):

--- a/tests/test_analysis/test_curvefitting/test_models.py
+++ b/tests/test_analysis/test_curvefitting/test_models.py
@@ -277,3 +277,66 @@ class TestConvenienceHelpers:
         assert isinstance(result, np.ndarray)
         assert result.shape == (100,)
         assert np.all(np.isfinite(result))
+
+
+class TestNormalizedFalse:
+    """normalized=False should make the peak amplitude equal to *ampl*."""
+
+    @pytest.mark.parametrize(
+        "helper,extra_kw",
+        [
+            pytest.param("gaussian", {}, id="gaussian"),
+            pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
+        ],
+    )
+    def test_peak_equals_ampl(self, helper, extra_kw):
+        x = np.linspace(-5, 5, 2000)
+        result = getattr(scp, helper)(
+            x, ampl=3.0, pos=0.0, width=1.0, normalized=False, **extra_kw
+        )
+        assert np.isclose(result.max(), 3.0, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "helper,extra_kw",
+        [
+            pytest.param("gaussian", {}, id="gaussian"),
+            pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
+        ],
+    )
+    def test_peak_at_pos(self, helper, extra_kw):
+        x = np.linspace(-5, 5, 2000)
+        result = getattr(scp, helper)(
+            x, ampl=2.0, pos=1.5, width=1.0, normalized=False, **extra_kw
+        )
+        idx = np.argmin(np.abs(x - 1.5))
+        assert np.isclose(result[idx], 2.0, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "helper,extra_kw",
+        [
+            pytest.param("gaussian", {}, id="gaussian"),
+            pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
+        ],
+    )
+    def test_normalized_true_is_default(self, helper, extra_kw):
+        x = np.linspace(-5, 5, 1000)
+        default = getattr(scp, helper)(x, ampl=1.0, pos=0.0, width=1.0, **extra_kw)
+        explicit = getattr(scp, helper)(
+            x, ampl=1.0, pos=0.0, width=1.0, normalized=True, **extra_kw
+        )
+        np.testing.assert_allclose(default, explicit, rtol=1e-12)
+
+    def test_normalized_false_coord_input(self):
+        x = scp.Coord.linspace(-5, 5, 1000, units="m")
+        result = scp.gaussian(x, ampl=1.0, pos=0.0, width=1.0, normalized=False)
+        assert isinstance(result, scp.NDDataset)
+        assert np.isclose(result.data.max(), 1.0, rtol=1e-3)
+
+    def test_normalized_false_amplitude_linearity(self):
+        x = np.linspace(-5, 5, 1000)
+        r1 = scp.gaussian(x, ampl=1.0, pos=0.0, width=1.0, normalized=False)
+        r2 = scp.gaussian(x, ampl=2.5, pos=0.0, width=1.0, normalized=False)
+        np.testing.assert_allclose(r2, 2.5 * r1, rtol=1e-12)


### PR DESCRIPTION
**Coord promotion in stack and concatenate**
- ``scp.stack`` and ``scp.concatenate`` now accept ``Coord`` inputs, automatically promoted to 1D ``NDDataset``.
- ``stack(..., axis=1)`` assembles 1D profiles as columns into a 2D dataset.

**``normalized`` parameter for line-shape helpers**
- ``scp.gaussian``, ``scp.lorentzian``, ``scp.voigt``, ``scp.asymmetricvoigt`` now accept ``normalized=False`` to make ``ampl`` control the peak amplitude rather than the integrated area.

Two gallery examples curated.