### PR TITLE
FIX: revert Coord auto-promotion in stack/concatenate — Coord inputs now raise TypeError

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -31,12 +31,11 @@ New Features
   same workflow-oriented use cases: ``scp.exp(...)``, ``scp.log(...)``,
   ``scp.log10(...)``, ``scp.sin(...)``, and ``scp.cos(...)``. (#1301)
 
-- ``scp.concatenate`` and ``scp.stack`` now accept ``Coord`` inputs
-  (automatically promoted to 1D `NDDataset`), and ``stack(..., axis=1)``
-  is supported for stacking 1D profiles as columns into a 2D dataset.
-  These changes make the workflow for building synthetic concentration
-  or profile matrices fully native within the SpectroChemPy API, without
-  falling back to ``np.column_stack(...)`` or manual `NDDataset` wrapping.
+- ``stack(..., axis=1)`` is now supported for stacking 1D profiles as
+  columns into a 2D dataset.  This makes the workflow for building
+  synthetic concentration or profile matrices fully native within the
+  SpectroChemPy API, without falling back to ``np.column_stack(...)``
+  or manual `NDDataset` wrapping.
 
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,12 +27,11 @@ New Features
   same workflow-oriented use cases: ``scp.exp(...)``, ``scp.log(...)``,
   ``scp.log10(...)``, ``scp.sin(...)``, and ``scp.cos(...)``. (#1301)
 
-- ``scp.concatenate`` and ``scp.stack`` now accept ``Coord`` inputs
-  (automatically promoted to 1D `NDDataset`), and ``stack(..., axis=1)``
-  is supported for stacking 1D profiles as columns into a 2D dataset.
-  These changes make the workflow for building synthetic concentration
-  or profile matrices fully native within the SpectroChemPy API, without
-  falling back to ``np.column_stack(...)`` or manual `NDDataset` wrapping.
+- ``stack(..., axis=1)`` is now supported for stacking 1D profiles as
+  columns into a 2D dataset.  This makes the workflow for building
+  synthetic concentration or profile matrices fully native within the
+  SpectroChemPy API, without falling back to ``np.column_stack(...)``
+  or manual `NDDataset` wrapping.
 
 - Reading multi-object files (MATLAB ``.mat``, multi-subfile SPC, ZIP
   archives) now returns a list with convenience methods for selecting

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -87,8 +87,8 @@ def concatenate(*datasets, **kwargs):
 
     # get a copy of input datasets in order that input data are not modified
     datasets = _get_copy(datasets)
-    # Promote Coord inputs to 1D NDDataset
-    datasets = [_coord_to_nddataset(d) for d in datasets]
+    # Reject Coord inputs — Coord must be explicitly wrapped in NDDataset
+    datasets = [_reject_coord_input(d) for d in datasets]
 
     if _should_promote_1d_column_concatenation(datasets, kwargs):
         return _stack_1d_profiles_as_columns(datasets)
@@ -249,19 +249,21 @@ def stack(*datasets, **kwargs):
     >>> C.shape
     (5, 2)
 
-    ``Coord`` inputs are automatically promoted to 1D datasets.
+    Create 1D datasets from a coordinate and stack them as columns:
 
-    >>> time = scp.Coord.linspace(0, 1, 200)
-    >>> c1 = scp.exp(-0.5 * ((time - 0.25) / 0.10) ** 2)
-    >>> c2 = 0.8 * scp.exp(-0.5 * ((time - 0.55) / 0.12) ** 2)
+    >>> time = scp.Coord.linspace(0, 1, 200, title="time")
+    >>> data1 = scp.exp(-0.5 * ((time.data - 0.25) / 0.10) ** 2)
+    >>> data2 = 0.8 * scp.exp(-0.5 * ((time.data - 0.55) / 0.12) ** 2)
+    >>> c1 = scp.NDDataset(data1, coordset=[time], title="C1")
+    >>> c2 = scp.NDDataset(data2, coordset=[time], title="C2")
     >>> profiles = scp.stack([c1, c2], axis=1)
     >>> profiles.shape
     (200, 2)
 
     """
     datasets = _get_copy(datasets)
-    # Promote Coord inputs to 1D NDDataset
-    datasets = [_coord_to_nddataset(d) for d in datasets]
+    # Reject Coord inputs — Coord must be explicitly wrapped in NDDataset
+    datasets = [_reject_coord_input(d) for d in datasets]
     axis = kwargs.pop("axis", 0)
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
@@ -294,8 +296,8 @@ def _stack_1d_profiles_as_columns(datasets):
     if not datasets:
         raise ValueError("stack() requires at least one dataset")
 
-    # Promote Coord inputs to 1D NDDataset
-    datasets = [_coord_to_nddataset(d) for d in datasets]
+    # Reject Coord inputs — Coord must be explicitly wrapped in NDDataset
+    datasets = [_reject_coord_input(d) for d in datasets]
 
     shapes = {ds.shape for ds in datasets}
     if len(shapes) != 1:
@@ -351,24 +353,22 @@ def _should_promote_1d_column_concatenation(datasets, kwargs):
 
 # utility functions
 # --------------------
-def _coord_to_nddataset(obj):
+def _reject_coord_input(obj):
     """
-    Promote a Coord to a 1D NDDataset.
+    Reject Coord inputs in stack/concatenate.
 
     Parameters
     ----------
     obj : object
-        If a Coord, it is converted to a 1D NDDataset whose data are
-        the coordinate values and whose x-coordinate is the Coord itself.
+        If a Coord, raises TypeError with an explicit message.
         Otherwise the object is returned unchanged.
     """
-    if not isinstance(obj, Coord):
-        return obj
-    from spectrochempy.core.dataset.nddataset import NDDataset  # noqa: PLC0415
-
-    ds = NDDataset(obj.data)
-    ds.set_coordset(obj)
-    return ds
+    if isinstance(obj, Coord):
+        raise TypeError(
+            "Coord inputs are ambiguous in stack/concatenate. "
+            "Convert them explicitly to NDDataset with the intended coordinate axis.",
+        )
+    return obj
 
 
 def _get_copy(datasets):

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -337,6 +337,26 @@ def test_concatenate_rejects_incompatible_coord_units():
     assert "Convert the coordinates to compatible units before retrying." in message
 
 
+def test_stack_rejects_coord_input():
+    """stack should raise TypeError when Coord is passed directly."""
+    c = Coord.linspace(0.0, 1.0, 5)
+    with pytest.raises(TypeError, match="Coord inputs are ambiguous"):
+        stack(c, c)
+
+    with pytest.raises(TypeError, match="Coord inputs are ambiguous"):
+        stack([c, c], axis=1)
+
+
+def test_concatenate_rejects_coord_input():
+    """concatenate should raise TypeError when Coord is passed directly."""
+    c = Coord.linspace(0.0, 1.0, 5)
+    with pytest.raises(TypeError, match="Coord inputs are ambiguous"):
+        concatenate(c, c)
+
+    with pytest.raises(TypeError, match="Coord inputs are ambiguous"):
+        concatenate(c, c, axis=1)
+
+
 def test_stack_regression():
     """Stack creates prepended dimension and delegates to concatenate."""
     y = scp.Coord(np.arange(2.0), title="rows")


### PR DESCRIPTION
Commit 0ad40ce98d introduced automatic promotion of Coord inputs to 1D
NDDataset via _coord_to_nddataset() in stack() and concatenate().
This was a semantic mistake:
- _coord_to_nddataset creates NDDataset(obj.data) then sets the same
Coord as the dataset's coordinate — both data and coordinate axis are
identical.  For a gaussian computed from a time axis, this gives
NDDataset(time_data, coordset=time), which is exactly wrong (the data
are the time values, not a function evaluated on time).
- The conversion is silent and implicit, hiding what is fundamentally an
ambiguous operation: a Coord is an axis descriptor, not a data carrier.
Using it as data discards the semantic boundary between coordinate and
measurement.
This PR reverts the auto-promotion:
- _coord_to_nddataset is replaced by _reject_coord_input, which raises
TypeError with an explicit message:
"Coord inputs are ambiguous in stack/concatenate. Convert them explicitly
to NDDataset with the intended coordinate axis."
- The stack() docstring example is updated to show explicit NDDataset
construction from a Coord.
- The changelog entry for Coord promotion is removed (the independent
stack(..., axis=1) column-stacking feature is preserved).
- Two tests verify the TypeError is raised for both stack and
concatenate with Coord inputs.