### PR TITLE
FIX: fix scatter plotting regressions

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -64,6 +64,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fixed plotting regressions introduced after 0.8.2 where
+  ``plot_multiple(..., method="scatter")`` could render as plain line plots
+  without markers, the single-dataset ``plot_multiple`` fallback dropped the
+  requested plotting method, and the documented ``plot(scatter=True)``
+  compatibility flag was accepted but ignored.
+
 - ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
   ``y`` (shape ``(n_obs,)``). Previously, the ``_set_output`` coordinate wrapping
   decorator assumed the metadata source was always 2D, causing a ``ValueError``

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -56,6 +56,12 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed plotting regressions introduced after 0.8.2 where
+  ``plot_multiple(..., method="scatter")`` could render as plain line plots
+  without markers, the single-dataset ``plot_multiple`` fallback dropped the
+  requested plotting method, and the documented ``plot(scatter=True)``
+  compatibility flag was accepted but ignored.
+
 - ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
   ``y`` (shape ``(n_obs,)``). Previously, the ``_set_output`` coordinate wrapping
   decorator assumed the metadata source was always 2D, causing a ``ValueError``

--- a/src/spectrochempy/plotting/_style.py
+++ b/src/spectrochempy/plotting/_style.py
@@ -421,7 +421,11 @@ def resolve_line_style(
     result["marker"] = kwargs.get("marker", kwargs.get("m", "auto"))
 
     # Deterministic fallback for scatter methods
-    if result["marker"] == "auto" and method in ("scatter", "scatter_pen"):
+    if (
+        isinstance(result["marker"], str)
+        and result["marker"].lower() == "auto"
+        and method in ("scatter", "scatter_pen")
+    ):
         result["marker"] = getattr(prefs, "scatter_marker", "o")
 
     # For 2D plotting (stack), marker should default to None, not "auto"

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -212,6 +212,9 @@ def plot_1D(dataset, method=None, **kwargs):
         # with the imaginary component
         show_complex = kwargs.pop("show_complex", False)
 
+        if kwargs.pop("scatter", False) and "scatter" not in (method or ""):
+            method = "scatter"
+
         # Resolve line/marker styles using centralized L1 function
         style_kwargs = resolve_line_style(
             dataset=new,
@@ -1024,7 +1027,15 @@ def plot_multiple(
     """
     if not is_sequence(datasets):
         # we need a sequence. Else it is a single plot.
-        return datasets.plot(**kwargs)
+        return datasets.plot(
+            method=method,
+            pen=pen,
+            marker=marker,
+            color=color,
+            ls=ls,
+            lw=lw,
+            **kwargs,
+        )
 
     def _valid(x, desc):
         if is_sequence(x) and len(x) != len(datasets):

--- a/tests/test_plotting/test_plot1d_legacy.py
+++ b/tests/test_plotting/test_plot1d_legacy.py
@@ -141,3 +141,64 @@ def test_plot_multiple_single_axes():
     assert len(ax.lines) == 3, f"Expected 3 lines, got {len(ax.lines)}"
 
     plt.close("all")
+
+
+def test_plot_multiple_scatter_uses_markers():
+    """plot_multiple(method='scatter') should not silently become a plain line plot."""
+    import matplotlib.pyplot as plt
+    from spectrochempy import NDDataset
+    from spectrochempy.plotting.plot1d import plot_multiple
+
+    datasets = [
+        NDDataset([1, 2, 3], name="A"),
+        NDDataset([2, 3, 4], name="B"),
+    ]
+
+    ax = plot_multiple(datasets, method="scatter", show=False)
+
+    assert len(ax.lines) == 2
+    assert len(ax.collections) == 0
+    for line in ax.lines:
+        assert line.get_marker() not in (None, "None", "")
+
+    plt.close("all")
+
+
+def test_plot_multiple_scatter_pen_false_has_no_connecting_lines():
+    """pen=False should keep plot_multiple scatter traces as marker-only lines."""
+    import matplotlib.pyplot as plt
+    from spectrochempy import NDDataset
+    from spectrochempy.plotting.plot1d import plot_multiple
+
+    datasets = [
+        NDDataset([1, 2, 3], name="A"),
+        NDDataset([2, 3, 4], name="B"),
+    ]
+
+    ax = plot_multiple(datasets, method="scatter", pen=False, show=False)
+
+    assert len(ax.lines) == 2
+    for line in ax.lines:
+        assert line.get_marker() not in (None, "None", "")
+        assert line.get_linestyle() == "None"
+
+    plt.close("all")
+
+
+def test_plot_multiple_single_dataset_forwards_method():
+    """The single-dataset fallback should keep the requested plotting method."""
+    import matplotlib.pyplot as plt
+    from spectrochempy import NDDataset
+    from spectrochempy.plotting.plot1d import plot_multiple
+
+    dataset = NDDataset([1, 2, 3], name="A")
+
+    ax = plot_multiple(dataset, method="scatter", pen=False, show=False)
+
+    assert len(ax.lines) >= 1
+    assert len(ax.collections) == 0
+    for line in ax.lines:
+        assert line.get_marker() not in (None, "None", "")
+        assert line.get_linestyle() == "None"
+
+    plt.close("all")

--- a/tests/test_plotting/test_stateless_plotting.py
+++ b/tests/test_plotting/test_stateless_plotting.py
@@ -175,6 +175,23 @@ class TestScatterMarkerBehavior:
 
         assert_dataset_state_unchanged(ds_before, sample_1d_dataset)
 
+    def test_scatter_boolean_kwarg_selects_scatter(self, sample_1d_dataset):
+        """Test the documented scatter=True compatibility flag."""
+        ds_before = sample_1d_dataset.__dict__.copy()
+
+        ax = sample_1d_dataset.plot(scatter=True)
+
+        assert len(ax.lines) > 0, "Scatter plot should have line objects"
+        line = ax.lines[0]
+        assert line.get_marker() not in (
+            None,
+            "None",
+            "",
+        ), "scatter=True should enable markers"
+        assert line.get_linestyle() == "None", "scatter=True should disable the line"
+
+        assert_dataset_state_unchanged(ds_before, sample_1d_dataset)
+
     def test_scatter_pen_has_line_and_marker(self, sample_1d_dataset):
         """Test that plot_scatter_pen shows both line and marker."""
         ds_before = sample_1d_dataset.__dict__.copy()


### PR DESCRIPTION
## Summary

Fixes focused plotting regressions introduced after 0.8.2 around scatter-style dispatch and wrapper kwarg propagation.

- Restore visible markers for `plot_multiple(..., method="scatter")` when the wrapper passes the default `marker="AUTO"`.
- Preserve plotting method/style kwargs in the single-dataset `plot_multiple` fallback.
- Restore the documented `plot(scatter=True)` compatibility flag for 1D plots.
- Add structural Matplotlib artist tests for marker and linestyle behavior.
- Add a changelog entry mentioning the regression fixes.
- Include the generated `docs/sources/whatsnew/latest.rst` update from pre-commit.

## Out of scope

- No broad plotting architecture redesign.
- No image-based gallery comparison tests.
- No changes to 2D plotting dispatch beyond the focused audit notes.

## Root Cause

`plot_multiple` explicitly forwarded uppercase `"AUTO"` for markers, while the centralized style resolver only treated lowercase `"auto"` as the sentinel that should select the scatter fallback marker. A separate fallback path also delegated to `datasets.plot(**kwargs)` without forwarding named plotting arguments consumed by `plot_multiple`. Finally, the `scatter=True` compatibility flag remained in `kwargs` and was never mapped back into method dispatch.

## Validation

- `MPLCONFIGDIR=/tmp/mpl-scp-audit PYTHONPATH=src python3 -m pytest -o addopts='' tests/test_plotting/test_plot1d_legacy.py tests/test_plotting/test_stateless_plotting.py -q`
- Result: `17 passed`
- `conda run -n scpy-core pre-commit run --all-files`
- Result: passed

Note: the targeted pytest command used `-o addopts=''` locally because this environment does not have the `pytest-doctestplus` plugin required by the project-level pytest options.