### PR TITLE
ENH: auto-populate line labels from coordinate labels in 2D lines/stack plots

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -33,6 +33,11 @@ New Features
   SpectroChemPy API, without falling back to ``np.column_stack(...)``
   or manual `NDDataset` wrapping.
 
+- 2D ``plot(method="lines"/"stack")`` now automatically uses coordinate labels
+  as matplotlib line labels, so that ``ax.legend()`` shows meaningful names
+  without needing to pass labels explicitly.  Legend entries are displayed
+  in natural (first-to-last) order. (#1320)
+
 - Reading multi-object files such as MATLAB ``.mat`` files, multi-subfile SPC
   files, and ZIP archives now returns a list-like result with helper methods
   for selecting datasets by size, name, dimensionality, or shape. (#1306)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -29,6 +29,11 @@ New Features
   SpectroChemPy API, without falling back to ``np.column_stack(...)``
   or manual `NDDataset` wrapping.
 
+- 2D ``plot(method="lines"/"stack")`` now automatically uses coordinate labels
+  as matplotlib line labels, so that ``ax.legend()`` shows meaningful names
+  without needing to pass labels explicitly.  Legend entries are displayed
+  in natural (first-to-last) order. (#1320)
+
 - Reading multi-object files such as MATLAB ``.mat`` files, multi-subfile SPC
   files, and ZIP archives now returns a list-like result with helper methods
   for selecting datasets by size, name, dimensionality, or shape. (#1306)

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
@@ -40,7 +40,7 @@ profiles.title = "relative concentration"
 
 # %%
 ax = profiles.T.plot()
-_ = ax.legend(profiles.y.labels)
+ax.legend()
 
 # %%
 # The same workflow can also use the built-in Gaussian line-shape helper when
@@ -60,4 +60,4 @@ profiles_gaussian.title = "relative concentration"
 
 # %%
 ax = profiles_gaussian.T.plot()
-_ = ax.legend(profiles_gaussian.y.labels)
+ax.legend()

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lineshapes.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lineshapes.py
@@ -35,6 +35,4 @@ shapes.y = scp.Coord(labels=["gaussian", "lorentzian", "voigt", "asym. voigt"])
 
 # %%
 ax = shapes.T.plot()
-_ = ax.legend(shapes.y.labels)
-
-# %%
+_ = ax.legend()

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -1802,7 +1802,10 @@ def plot_2D(dataset, method=None, **kwargs):
                     line_colors.append(colors[i % len(colors)])
                 else:
                     line_colors.append(None)
-                line_labels.append(fmt.format(ydata[i]))
+                if y is not None and y.is_labeled and i < len(y.labels):
+                    line_labels.append(str(y.labels[i]))
+                else:
+                    line_labels.append(fmt.format(ydata[i]))
 
             # Use render_lines for drawing
             new_lines = render_lines(
@@ -1819,6 +1822,14 @@ def plot_2D(dataset, method=None, **kwargs):
                 reverse=True,
                 picker=True,
             )
+
+            # render_lines adds lines to ax.lines in reverse z-order (last line first),
+            # so legend entries appear reversed. Re-order ax.lines to natural order
+            # without affecting per-line zorder (set explicitly above).
+            for line in new_lines:
+                line.remove()
+            for line in reversed(new_lines):
+                ax.add_line(line)
 
             # store the full set of lines (render_lines already added them to ax)
             new._ax_lines = existing_lines + new_lines


### PR DESCRIPTION
## Summary

Line labels for 2D `method='lines'` / `'stack'` plots are now automatically
populated from the coordinate labels of the iterated dimension when available
(`y.is_labeled`), so that `ax.legend()` displays meaningful names without
requiring explicit labels.

Previously:

```python
ax = profiles.T.plot()
_ = ax.legend(profiles.y.labels)  # labels passed explicitly
```

Now:

```python
ax = profiles.T.plot()
ax.legend()  # labels come from y-Coord automatically
```

## Legend order

`render_lines` draws lines in reverse z-order (last profile first), which
caused legend entries to appear in reverse order.  After line rendering, the
new lines are removed from `ax.lines` and re-added in natural order,
preserving per-line z-order.

## Out of scope

- 1D `plot(method='pen')` label handling is unchanged.
- A dedicated `legend=` kwarg on `plot()` is not added here.

## Related

- Closes #1320
- Example files updated to use the simplified pattern.