### PR TITLE
FIX: align plotting API fallback and kwarg propagation

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -49,6 +49,13 @@ Bug Fixes
   single-dataset ``plot_multiple`` calls preserve the requested plotting method,
   and ``plot(scatter=True)`` once again selects scatter-style plotting.
 
+- Fixed several plotting API inconsistencies: ``multiplot()`` now preserves the
+  requested plotting method for single datasets and accepts ``nrows`` /
+  ``ncols`` aliases; 1D artists now honor ``alpha``, ``markeredgewidth``, and
+  ``mew``; 2D contour-style plots accept ``alpha`` and ``levels`` consistently;
+  and ``use_plotly=True`` now fails with a clear error when Plotly support is
+  unavailable.
+
 - ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
   ``y``. This fixes failures in ``predict()``, ``y_scores``, ``y_loadings``,
   ``y_weights``, ``y_rotations``, ``result``, and ``coef`` when fitting with a

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -41,6 +41,13 @@ Bug Fixes
   single-dataset ``plot_multiple`` calls preserve the requested plotting method,
   and ``plot(scatter=True)`` once again selects scatter-style plotting.
 
+- Fixed several plotting API inconsistencies: ``multiplot()`` now preserves the
+  requested plotting method for single datasets and accepts ``nrows`` /
+  ``ncols`` aliases; 1D artists now honor ``alpha``, ``markeredgewidth``, and
+  ``mew``; 2D contour-style plots accept ``alpha`` and ``levels`` consistently;
+  and ``use_plotly=True`` now fails with a clear error when Plotly support is
+  unavailable.
+
 - ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
   ``y``. This fixes failures in ``predict()``, ``y_scores``, ``y_loadings``,
   ``y_weights``, ``y_rotations``, ``result``, and ``coef`` when fitting with a

--- a/src/spectrochempy/plotting/multiplot.py
+++ b/src/spectrochempy/plotting/multiplot.py
@@ -201,6 +201,13 @@ def plot_with_transposed(dataset, **kwargs):
 multiplot_with_transposed = plot_with_transposed
 
 
+def _normalize_multiplot_method_for_dataset(method, dataset):
+    """Normalize multiplot's generic method vocabulary per dataset dimensionality."""
+    if method == "lines" and getattr(dataset, "ndim", None) == 1:
+        return "pen"
+    return method
+
+
 def multiplot(
     datasets=None,
     labels=None,
@@ -305,6 +312,21 @@ def multiplot(
         from matplotlib._tight_layout import get_subplotspec_list
         from matplotlib._tight_layout import get_tight_layout_figure
 
+        nrows = kwargs.pop("nrows", None)
+        ncols = kwargs.pop("ncols", None)
+        if nrows is not None:
+            if nrow not in (1, nrows):
+                raise ValueError(
+                    "Specify either nrow or nrows, not conflicting values."
+                )
+            nrow = nrows
+        if ncols is not None:
+            if ncol not in (1, ncols):
+                raise ValueError(
+                    "Specify either ncol or ncols, not conflicting values."
+                )
+            ncol = ncols
+
         # some basic checking
         # ------------------------------------------------------------------------
         if labels is None:
@@ -346,7 +368,10 @@ def multiplot(
 
         if nrow == ncol and nrow == 1 and not show_transposed and single:
             # obviously a single plot, return it
-            return datasets[0].plot(**kwargs)
+            current_method = _normalize_multiplot_method_for_dataset(
+                method, datasets[0]
+            )
+            return datasets[0].plot(method=current_method, **kwargs)
         if nrow * ncol < len(datasets):
             nrow = ncol = len(datasets) // 2
             if nrow * ncol < len(datasets):
@@ -445,6 +470,9 @@ def multiplot(
 
                 # Determine method for this dataset
                 current_method = method[idx] if method_is_list else method
+                current_method = _normalize_multiplot_method_for_dataset(
+                    current_method, dataset
+                )
                 try:
                     label = labels[idx]
                 except Exception:

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -24,6 +24,26 @@ from spectrochempy.plotting._style import resolve_line_style
 from spectrochempy.utils.mplutils import make_label
 from spectrochempy.utils.typeutils import is_sequence
 
+_VALID_1D_METHODS = {"pen", "bar", "scatter", "scatter_pen", "scatter+pen"}
+_VALID_2D_PLUS_METHODS = {
+    "lines",
+    "stack",
+    "contour",
+    "map",
+    "contourf",
+    "image",
+    "surface",
+    "waterfall",
+}
+
+
+def _raise_incompatible_method(method, source, target):
+    raise ValueError(
+        f"method={method!r} is incompatible with {source}; "
+        f"use a {target} plotting method or call dataset.plot() for automatic dispatch."
+    )
+
+
 # --------------------------------------------------------------------------------------
 # plot_1D
 # --------------------------------------------------------------------------------------
@@ -188,11 +208,17 @@ def plot_1D(dataset, method=None, **kwargs):
         # ------------------------------------------------------------------------
         # should we redirect the plotting to another method
         if dataset._squeeze_ndim > 1:
-            return dataset.plot_2D(**kwargs)
+            if method is None:
+                return dataset.plot_2D(**kwargs)
+            if method in _VALID_2D_PLUS_METHODS:
+                return dataset.plot_2D(method=method, **kwargs)
+            _raise_incompatible_method(method, "plot_1D() with non-1D data", "2D/3D")
 
         # if plotly execute plotly routine not this one
         if kwargs.get("use_plotly", prefs.use_plotly):
-            return dataset.plotly(**kwargs)
+            raise NotImplementedError(
+                "Plotly plotting is not currently available. Use the default Matplotlib backend."
+            )
 
         # often we do need to plot only data
         # when plotting on top of a previous plot
@@ -231,6 +257,8 @@ def plot_1D(dataset, method=None, **kwargs):
         markersize = style_kwargs["markersize"]
         markerfacecolor = style_kwargs["markerfacecolor"]
         markeredgecolor = style_kwargs["markeredgecolor"]
+        alpha = style_kwargs["alpha"]
+        markeredgewidth = kwargs.get("markeredgewidth", kwargs.get("mew", 1.0))
 
         markevery = kwargs.get("markevery", kwargs.get("me", 1))
 
@@ -354,9 +382,13 @@ def plot_1D(dataset, method=None, **kwargs):
                 xdata,
                 zdata.squeeze(),
                 edgecolor="k",
+                color=None
+                if isinstance(color, str) and color.upper() == "AUTO"
+                else color,
                 align="center",
                 label=label,
                 width=kwargs.get("width", 0.1),
+                alpha=alpha,
             )
         else:
             # Unified Line2D path for pen, scatter, and scatter_pen
@@ -366,11 +398,12 @@ def plot_1D(dataset, method=None, **kwargs):
                 linestyle=effective_linestyle,
                 marker=effective_marker,
                 markersize=markersize,
-                markeredgewidth=1.0,
+                markeredgewidth=markeredgewidth,
                 markerfacecolor=markerfacecolor,
                 markeredgecolor=markeredgecolor,
                 markevery=markevery,
                 label=label,
+                alpha=alpha,
             )
 
             # Set color and linewidth if not auto

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -31,6 +31,26 @@ from spectrochempy.plotting._style import resolve_line_style
 from spectrochempy.plotting._style import resolve_stack_colors
 from spectrochempy.utils.mplutils import make_label
 
+_VALID_1D_METHODS = {"pen", "bar", "scatter", "scatter_pen", "scatter+pen"}
+_VALID_2D_PLUS_METHODS = {
+    "lines",
+    "stack",
+    "contour",
+    "map",
+    "contourf",
+    "image",
+    "surface",
+    "waterfall",
+}
+
+
+def _raise_incompatible_method(method, source, target):
+    raise ValueError(
+        f"method={method!r} is incompatible with {source}; "
+        f"use a {target} plotting method or call dataset.plot() for automatic dispatch."
+    )
+
+
 # ======================================================================================
 # Helper functions for aspect ratio control
 # ======================================================================================
@@ -1210,6 +1230,8 @@ def plot_2D(dataset, method=None, **kwargs):
     # Get preferences
     # ----------------------------------------------------------------------------------
     prefs = preferences
+    requested_alpha = kwargs.get("calpha", kwargs.get("alpha"))
+    requested_levels = kwargs.get("levels")
 
     # Resolve plotting style(s) locally (no global rcParams / no prefs.style mutation)
     style = kwargs.pop("style", None)
@@ -1266,11 +1288,17 @@ def plot_2D(dataset, method=None, **kwargs):
         # ----------------------------------------------------------------------------------
         # should we redirect the plotting to another method
         if dataset._squeeze_ndim < 2:
-            return dataset.plot_1D(**kwargs)
+            if method is None:
+                return dataset.plot_1D(**kwargs)
+            if method in _VALID_1D_METHODS:
+                return dataset.plot_1D(method=method, **kwargs)
+            _raise_incompatible_method(method, "plot_2D() with 1D data", "1D")
 
         # if plotly execute plotly routine not this one
         if kwargs.get("use_plotly", prefs.use_plotly):
-            return dataset.plotly(**kwargs)
+            raise NotImplementedError(
+                "Plotly plotting is not currently available. Use the default Matplotlib backend."
+            )
 
         # do not display colorbar if it's not a surface plot
         # except if we have asked to d so
@@ -1358,7 +1386,7 @@ def plot_2D(dataset, method=None, **kwargs):
             marker = None
         markersize = style_kwargs["markersize"]
 
-        alpha = kwargs.get("calpha", prefs.contour_alpha)
+        alpha = requested_alpha if requested_alpha is not None else prefs.contour_alpha
 
         number_x_labels = kwargs.get("n_x_labels", prefs.number_of_x_labels)
         number_y_labels = kwargs.get("n_y_labels", prefs.number_of_y_labels)
@@ -1483,6 +1511,8 @@ def plot_2D(dataset, method=None, **kwargs):
             zdata = new.real.masked_data
         else:
             zdata = new.imag.masked_data
+
+        levels = requested_levels
 
         zlim = kwargs.get("zlim", (np.ma.min(zdata), np.ma.max(zdata)))
 
@@ -1628,10 +1658,13 @@ def plot_2D(dataset, method=None, **kwargs):
                 method = "map"
 
             else:
-                kwargs["nlevels"] = 500
-                if not hasattr(new, "clevels") or new.clevels is None:
-                    new.clevels = _get_clevels(zdata, prefs, **kwargs)
-                mappable = ax.contourf(xdata, ydata, zdata, new.clevels, alpha=alpha)
+                contour_levels = levels
+                if contour_levels is None:
+                    kwargs["nlevels"] = 500
+                    if not hasattr(new, "clevels") or new.clevels is None:
+                        new.clevels = _get_clevels(zdata, prefs, **kwargs)
+                    contour_levels = new.clevels
+                mappable = ax.contourf(xdata, ydata, zdata, contour_levels, alpha=alpha)
                 mappable.set_cmap(cmap)
                 mappable.set_norm(norm)
 
@@ -1657,11 +1690,14 @@ def plot_2D(dataset, method=None, **kwargs):
             else:
                 # contour plot
                 # -------------
-                if not hasattr(new, "clevels") or new.clevels is None:
-                    new.clevels = _get_clevels(zdata, prefs, **kwargs)
+                contour_levels = levels
+                if contour_levels is None:
+                    if not hasattr(new, "clevels") or new.clevels is None:
+                        new.clevels = _get_clevels(zdata, prefs, **kwargs)
+                    contour_levels = new.clevels
 
                 mappable = ax.contour(
-                    xdata, ydata, zdata, new.clevels, linewidths=lw, alpha=alpha
+                    xdata, ydata, zdata, contour_levels, linewidths=lw, alpha=alpha
                 )
                 mappable.set_cmap(cmap)
                 mappable.set_norm(norm)

--- a/tests/test_plotting/test_contract_plot2d.py
+++ b/tests/test_plotting/test_contract_plot2d.py
@@ -102,3 +102,22 @@ def test_plot2d_interpolation(synthetic_2d):
     """Test plot2d with interpolation."""
     ax = synthetic_2d.plot(interpolation="bilinear", show=False)
     assert ax is not None
+
+
+def test_plot2d_alpha_alias_applies_to_contour_artists(synthetic_2d):
+    """Test alpha= behaves like calpha= for contour-like plots."""
+    ax = synthetic_2d.plot(method="contour", alpha=0.3, show=False)
+
+    contour_sets = [child for child in ax.get_children() if hasattr(child, "levels")]
+    assert contour_sets
+    assert contour_sets[0].get_alpha() == pytest.approx(0.3)
+
+
+def test_plot2d_levels_parameter_controls_contour_levels(synthetic_2d):
+    """Test levels= is propagated to contour plots."""
+    levels = [0.2, 0.4, 0.6]
+    ax = synthetic_2d.plot(method="contour", levels=levels, show=False)
+
+    contour_sets = [child for child in ax.get_children() if hasattr(child, "levels")]
+    assert contour_sets
+    assert list(contour_sets[0].levels) == pytest.approx(levels)

--- a/tests/test_plotting/test_multiplot_stateless.py
+++ b/tests/test_plotting/test_multiplot_stateless.py
@@ -89,6 +89,27 @@ class TestMultiplotStateless:
         # Verify dataset unchanged
         assert_dataset_state_unchanged(ds_before, sample_1d_dataset)
 
+    def test_multiplot_single_dataset_preserves_requested_method(
+        self, sample_1d_dataset
+    ):
+        """Single-dataset multiplot should preserve an explicit method."""
+        ax = multiplot(sample_1d_dataset, method="scatter", nrow=1, ncol=1, show=False)
+
+        assert isinstance(ax, plt.Axes)
+        assert len(ax.lines) > 0
+        line = ax.lines[0]
+        assert line.get_marker() not in (None, "None", "")
+        assert line.get_linestyle() == "None"
+
+    def test_multiplot_supports_nrows_ncols_aliases(self, sample_1d_dataset):
+        """nrows/ncols aliases should behave like nrow/ncol."""
+        datasets = [sample_1d_dataset, sample_1d_dataset]
+
+        axes = multiplot(datasets, nrows=1, ncols=2, show=False)
+
+        assert isinstance(axes, np.ndarray)
+        assert axes.shape == (2,)
+
     def test_multiplot_method_selection(self, sample_1d_dataset):
         """Test 12: Multiplot with mixed method selection."""
         # Use two 1D datasets with different methods

--- a/tests/test_plotting/test_stateless_plotting.py
+++ b/tests/test_plotting/test_stateless_plotting.py
@@ -263,3 +263,73 @@ class TestColorbarParameter:
 
         # Verify dataset unchanged
         assert_dataset_state_unchanged(ds_before, sample_2d_dataset)
+
+
+class TestPlotParameterPropagation:
+    """Test propagation of public plotting kwargs."""
+
+    def test_line_alpha_is_applied(self, sample_1d_dataset):
+        ax = sample_1d_dataset.plot(alpha=0.25, show=False)
+
+        assert len(ax.lines) > 0
+        assert ax.lines[0].get_alpha() == pytest.approx(0.25)
+
+    def test_bar_alpha_is_applied(self):
+        from spectrochempy import NDDataset
+
+        ax = NDDataset([1, 2, 3]).plot_bar(alpha=0.4, show=False)
+
+        assert len(ax.patches) == 3
+        assert ax.patches[0].get_alpha() == pytest.approx(0.4)
+
+    def test_markeredgewidth_is_applied(self, sample_1d_dataset):
+        ax = sample_1d_dataset.plot_scatter(markeredgewidth=3.5, show=False)
+
+        assert len(ax.lines) > 0
+        assert ax.lines[0].get_markeredgewidth() == pytest.approx(3.5)
+
+    def test_mew_alias_is_applied(self, sample_1d_dataset):
+        ax = sample_1d_dataset.plot_scatter(mew=2.0, show=False)
+
+        assert len(ax.lines) > 0
+        assert ax.lines[0].get_markeredgewidth() == pytest.approx(2.0)
+
+
+class TestDimensionalFallbacks:
+    """Test dimensional fallback behavior for direct plot_1D/plot_2D calls."""
+
+    def test_plot_1d_forwards_valid_2d_method(self, sample_2d_dataset):
+        ax = sample_2d_dataset.plot_1D(method="contour", show=False)
+
+        assert len(ax.collections) > 0
+
+    def test_plot_1d_rejects_incompatible_method(self, sample_2d_dataset):
+        with pytest.raises(ValueError, match="incompatible"):
+            sample_2d_dataset.plot_1D(method="scatter", show=False)
+
+    def test_plot_2d_forwards_valid_1d_method(self, sample_1d_dataset):
+        ax = sample_1d_dataset.plot_2D(method="scatter", show=False)
+
+        assert len(ax.lines) > 0
+        assert ax.lines[0].get_marker() not in (None, "None", "")
+        assert ax.lines[0].get_linestyle() == "None"
+
+    def test_plot_2d_rejects_incompatible_method(self, sample_1d_dataset):
+        with pytest.raises(ValueError, match="incompatible"):
+            sample_1d_dataset.plot_2D(method="contour", show=False)
+
+
+class TestPlotlyCompatibility:
+    """Test explicit Plotly compatibility failure mode."""
+
+    def test_plotly_request_fails_clearly_for_1d(self, sample_1d_dataset):
+        with pytest.raises(
+            NotImplementedError, match="Plotly plotting is not currently available"
+        ):
+            sample_1d_dataset.plot(use_plotly=True, show=False)
+
+    def test_plotly_request_fails_clearly_for_2d(self, sample_2d_dataset):
+        with pytest.raises(
+            NotImplementedError, match="Plotly plotting is not currently available"
+        ):
+            sample_2d_dataset.plot(use_plotly=True, show=False)


### PR DESCRIPTION
## Summary
This PR fixes a focused set of confirmed plotting API inconsistencies identified by the plotting regression and architecture audits.

## Fixed inconsistencies
- preserve `method` in `multiplot()` single-dataset fallback
- support explicit `nrows` / `ncols` aliases in `multiplot()`
- propagate explicit methods through `plot_1D()` / `plot_2D()` dimensional fallbacks when semantically valid
- raise a clear error when an explicit fallback method is incompatible with the target dimensionality
- propagate `alpha`, `markeredgewidth`, and `mew` to 1D artists
- accept `alpha` and `levels` consistently in the main 2D contour-style plotting path
- fail clearly for `use_plotly=True` when Plotly support is not active

## Behavior preserved
- no plotting redesign or backend rewrite
- legacy public plotting entry points remain in place
- compatibility behavior stays focused on the existing Matplotlib plotting stack

## Behavior clarified
- incompatible explicit methods are no longer silently dropped during dimensional fallback
- `use_plotly=True` now raises `NotImplementedError` with an explanatory message instead of failing later through a missing dataset method

## Tests
- added structural regression tests for multiplot single-dataset scatter behavior, `nrows` / `ncols`, dimensional fallback behavior, 1D alpha / marker edge width propagation, 2D contour alpha / levels handling, and explicit Plotly failure mode
- `pre-commit run --all-files`
- targeted plotting test run: `75 passed, 2 skipped`

## Remaining follow-up
Broader plotting architecture cleanup is intentionally left to follow-up work from the architecture audit; this PR only addresses the confirmed public API inconsistencies.
