### PR TITLE
FIX: preserve plotting alias compatibility across fallbacks

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -58,8 +58,9 @@ Bug Fixes
   requested plotting method for single datasets and accepts ``nrows`` /
   ``ncols`` aliases; 1D artists now honor ``alpha``, ``markeredgewidth``, and
   ``mew``; 2D contour-style plots accept ``alpha`` and ``levels`` consistently;
-  and ``use_plotly=True`` now fails with a clear error when Plotly support is
-  unavailable.
+  ``use_plotly=True`` now fails with a clear error when Plotly support is
+  unavailable; and legacy ``lines`` / ``pen`` aliases continue to work across
+  dimensional fallbacks.
 
 - ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
   ``y``. This fixes failures in ``predict()``, ``y_scores``, ``y_loadings``,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -50,8 +50,9 @@ Bug Fixes
   requested plotting method for single datasets and accepts ``nrows`` /
   ``ncols`` aliases; 1D artists now honor ``alpha``, ``markeredgewidth``, and
   ``mew``; 2D contour-style plots accept ``alpha`` and ``levels`` consistently;
-  and ``use_plotly=True`` now fails with a clear error when Plotly support is
-  unavailable.
+  ``use_plotly=True`` now fails with a clear error when Plotly support is
+  unavailable; and legacy ``lines`` / ``pen`` aliases continue to work across
+  dimensional fallbacks.
 
 - ``PLSRegression`` now works with a 1D ``NDDataset`` as the response variable
   ``y``. This fixes failures in ``predict()``, ``y_scores``, ``y_loadings``,

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -35,6 +35,9 @@ _VALID_2D_PLUS_METHODS = {
     "surface",
     "waterfall",
 }
+_FALLBACK_1D_TO_2D_METHOD_ALIASES = {
+    "pen": "lines",
+}
 
 
 def _raise_incompatible_method(method, source, target):
@@ -210,6 +213,7 @@ def plot_1D(dataset, method=None, **kwargs):
         if dataset._squeeze_ndim > 1:
             if method is None:
                 return dataset.plot_2D(**kwargs)
+            method = _FALLBACK_1D_TO_2D_METHOD_ALIASES.get(method, method)
             if method in _VALID_2D_PLUS_METHODS:
                 return dataset.plot_2D(method=method, **kwargs)
             _raise_incompatible_method(method, "plot_1D() with non-1D data", "2D/3D")

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -42,6 +42,9 @@ _VALID_2D_PLUS_METHODS = {
     "surface",
     "waterfall",
 }
+_FALLBACK_2D_TO_1D_METHOD_ALIASES = {
+    "lines": "pen",
+}
 
 
 def _raise_incompatible_method(method, source, target):
@@ -1290,6 +1293,7 @@ def plot_2D(dataset, method=None, **kwargs):
         if dataset._squeeze_ndim < 2:
             if method is None:
                 return dataset.plot_1D(**kwargs)
+            method = _FALLBACK_2D_TO_1D_METHOD_ALIASES.get(method, method)
             if method in _VALID_1D_METHODS:
                 return dataset.plot_1D(method=method, **kwargs)
             _raise_incompatible_method(method, "plot_2D() with 1D data", "1D")

--- a/tests/test_plotting/test_stateless_plotting.py
+++ b/tests/test_plotting/test_stateless_plotting.py
@@ -298,6 +298,17 @@ class TestPlotParameterPropagation:
 class TestDimensionalFallbacks:
     """Test dimensional fallback behavior for direct plot_1D/plot_2D calls."""
 
+    def test_plot_lines_alias_still_works_for_1d_dataset(self, sample_1d_dataset):
+        ax = sample_1d_dataset.plot(method="lines", show=False)
+
+        assert len(ax.lines) > 0
+        assert ax.lines[0].get_linestyle() not in (None, "None", "")
+
+    def test_plot_pen_alias_still_works_for_2d_dataset(self, sample_2d_dataset):
+        ax = sample_2d_dataset.plot(method="pen", show=False)
+
+        assert len(ax.lines) > 0
+
     def test_plot_1d_forwards_valid_2d_method(self, sample_2d_dataset):
         ax = sample_2d_dataset.plot_1D(method="contour", show=False)
 


### PR DESCRIPTION
## Summary
This follow-up restores the public alias behavior that PR #1321 made too strict during dimensional fallbacks.

## Fixed
- `dataset.plot(method="lines")` on 1D datasets works again
- `dataset.plot(method="pen")` on 2D datasets works again
- direct `plot_2D(method="lines")` and `plot_1D(method="pen")` keep the same semantic alias behavior

## Scope
- keep the internal `multiplot` normalization introduced in #1321
- keep clear errors for genuinely incompatible explicit methods
- restore only the historical semantic aliases `lines -> pen` and `pen -> lines` across fallback boundaries

## Validation
- `pre-commit run --all-files`
- plotting subset: `77 passed, 2 skipped`
