### PR TITLE
MAINT: Centralize plotting method normalization

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -94,3 +94,7 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- Centralized internal plotting method normalization in a private helper
+  module to reduce duplication across backend dispatch, multiplot handling,
+  and 1D/2D fallback validation, without changing the public plotting API.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -58,3 +58,10 @@ Bug Fixes
   ``y``. This fixes failures in ``predict()``, ``y_scores``, ``y_loadings``,
   ``y_weights``, ``y_rotations``, ``result``, and ``coef`` when fitting with a
   1D target. (#1305)
+
+Developer
+~~~~~~~~~
+
+- Centralized internal plotting method normalization in a private helper
+  module to reduce duplication across backend dispatch, multiplot handling,
+  and 1D/2D fallback validation, without changing the public plotting API.

--- a/src/spectrochempy/plotting/__init__.pyi
+++ b/src/spectrochempy/plotting/__init__.pyi
@@ -8,6 +8,7 @@
 
 __all__ = [
     "_colorbar_utils",
+    "_methods",
     "_mpl_assets",
     "_render",
     "_style",
@@ -22,6 +23,7 @@ __all__ = [
 ]
 
 from . import _colorbar_utils
+from . import _methods
 from . import _mpl_assets
 from . import _render
 from . import _style

--- a/src/spectrochempy/plotting/_methods.py
+++ b/src/spectrochempy/plotting/_methods.py
@@ -1,0 +1,143 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Internal plotting method normalization helpers."""
+
+from __future__ import annotations
+
+import warnings
+
+CANONICAL_1D_METHODS = frozenset(
+    {
+        "pen",
+        "bar",
+        "scatter",
+        "scatter_pen",
+        "scatter+pen",
+    }
+)
+
+CANONICAL_2D_PLUS_METHODS = frozenset(
+    {
+        "lines",
+        "stack",
+        "contour",
+        "map",
+        "contourf",
+        "image",
+        "surface",
+        "waterfall",
+    }
+)
+
+_DEFAULT_METHODS_BY_NDIM = {
+    1: "pen",
+    2: "lines",
+    3: "surface",
+}
+
+_BACKEND_METHOD_ALIASES = {
+    "stack": "lines",
+    "map": "contour",
+}
+
+_SEMANTIC_METHOD_ALIASES = {
+    "image": "contourf",
+}
+
+_MULTIPLOT_METHOD_ALIASES_BY_NDIM = {
+    1: {"lines": "pen"},
+}
+
+_FALLBACK_METHOD_ALIASES = {
+    "1d": {
+        "lines": "pen",
+    },
+    "2d+": {
+        "pen": "lines",
+    },
+}
+
+
+def get_default_method_for_ndim(ndim: int) -> str | None:
+    """Return the default plotting method for a squeezed dimensionality."""
+    return _DEFAULT_METHODS_BY_NDIM.get(ndim)
+
+
+def get_dispatch_method_key(method: str | None) -> str | None:
+    """Normalize a method name for dispatch-table lookup."""
+    if method is None:
+        return None
+    return method.replace("+", "_")
+
+
+def normalize_backend_method(
+    method: str | None,
+    *,
+    warned_aliases: set[str] | None = None,
+    stacklevel: int = 3,
+) -> str | None:
+    """
+    Normalize backend-facing method names.
+
+    Preserves current behavior:
+    - ``image`` is a silent semantic alias for ``contourf``
+    - ``stack`` and ``map`` emit a deprecation warning once per session
+    """
+    if method is None:
+        return None
+
+    if method in _SEMANTIC_METHOD_ALIASES:
+        return _SEMANTIC_METHOD_ALIASES[method]
+
+    if method in _BACKEND_METHOD_ALIASES:
+        canonical = _BACKEND_METHOD_ALIASES[method]
+        if warned_aliases is not None and method not in warned_aliases:
+            warned_aliases.add(method)
+            warnings.warn(
+                f'method="{method}" is deprecated and will be removed in 0.11.0. '
+                f'Use method="{canonical}" instead.',
+                DeprecationWarning,
+                stacklevel=stacklevel,
+            )
+        return canonical
+
+    return method
+
+
+def normalize_multiplot_method(method: str | None, ndim: int | None) -> str | None:
+    """Normalize multiplot's internal default method vocabulary."""
+    if method is None or ndim is None:
+        return method
+    return _MULTIPLOT_METHOD_ALIASES_BY_NDIM.get(ndim, {}).get(method, method)
+
+
+def normalize_fallback_method_for_target(
+    method: str | None,
+    *,
+    target: str,
+) -> str | None:
+    """Normalize public compatibility aliases for cross-dimensional fallbacks."""
+    if method is None:
+        return None
+    return _FALLBACK_METHOD_ALIASES.get(target, {}).get(method, method)
+
+
+def validate_method_for_target_dimension(
+    method: str,
+    *,
+    target: str,
+    source: str,
+) -> str:
+    """Validate an explicit fallback method against the target dimensional family."""
+    method = normalize_fallback_method_for_target(method, target=target)
+    if target == "1d" and method in CANONICAL_1D_METHODS:
+        return method
+    if target == "2d+" and method in CANONICAL_2D_PLUS_METHODS:
+        return method
+    raise ValueError(
+        f"method={method!r} is incompatible with {source}; "
+        f"use a {target} plotting method or call dataset.plot() for automatic dispatch."
+    )

--- a/src/spectrochempy/plotting/backends/matplotlib_backend.py
+++ b/src/spectrochempy/plotting/backends/matplotlib_backend.py
@@ -10,55 +10,17 @@ This module provides the matplotlib implementation of plotting functions,
 wrapping the plotting functions from the spectrochempy.plotting module.
 """
 
-import warnings
 from typing import Any
 
+from spectrochempy.plotting._methods import get_default_method_for_ndim
+from spectrochempy.plotting._methods import get_dispatch_method_key
+from spectrochempy.plotting._methods import normalize_backend_method
 from spectrochempy.plotting.plot_setup import lazy_ensure_mpl_config
 from spectrochempy.plotting.profile import ensure_plot_profile_loaded
 from spectrochempy.utils.mplutils import show as mpl_show
 
-# Method aliases for backward compatibility
-# Legacy names are normalized to canonical geometry-based names
-# Note: "image" is a semantic alias and does NOT emit deprecation warning
-_METHOD_ALIASES = {
-    "stack": "lines",
-    "map": "contour",
-}
-
 # Track which aliases we've warned about (warn once per session)
 _WARNED_ALIASES = set()
-
-
-def _normalize_method(method: str | None) -> str | None:
-    """
-    Normalize method name from legacy to canonical.
-
-    Emits a DeprecationWarning once per session for each deprecated method name.
-    Semantic aliases (like "image") are normalized without warning.
-    """
-    global _WARNED_ALIASES
-
-    if method is None:
-        return None
-
-    # Semantic aliases - normalize without warning
-    if method == "image":
-        return "contourf"
-
-    # Deprecated aliases - normalize with warning
-    if method in _METHOD_ALIASES:
-        canonical = _METHOD_ALIASES[method]
-        if method not in _WARNED_ALIASES:
-            _WARNED_ALIASES.add(method)
-            warnings.warn(
-                f'method="{method}" is deprecated and will be removed in 0.11.0. '
-                f'Use method="{canonical}" instead.',
-                DeprecationWarning,
-                stacklevel=3,
-            )
-        return canonical
-
-    return method
 
 
 # Mapping of method names to standalone plot functions
@@ -92,12 +54,10 @@ def _get_plot_function(method: str):
                 # 3D methods
                 "surface": plot3d.plot_surface,
                 "waterfall": plot3d.plot_waterfall,
-                # Handle '+' in method names by replacing with '_'
-                "scatter_pen".replace("+", "_"): plot1d.plot_scatter_pen,
             }
         )
 
-    return _PLOT_FUNCTIONS.get(method.replace("+", "_") if method else method)
+    return _PLOT_FUNCTIONS.get(get_dispatch_method_key(method))
 
 
 def plot_dataset_impl(
@@ -131,15 +91,10 @@ def plot_dataset_impl(
 
     # Determine default method based on dimensionality
     if method is None:
-        if dataset._squeeze_ndim == 1:
-            method = "pen"
-        elif dataset._squeeze_ndim == 2:
-            method = "lines"  # Canonical default for 2D
-        elif dataset._squeeze_ndim == 3:
-            method = "surface"
+        method = get_default_method_for_ndim(dataset._squeeze_ndim)
 
     # NORMALIZE METHOD - Convert legacy names to canonical BEFORE dispatch
-    method = _normalize_method(method)
+    method = normalize_backend_method(method, warned_aliases=_WARNED_ALIASES)
 
     # Get the standalone plot function
     plot_func = _get_plot_function(method) if method else None

--- a/src/spectrochempy/plotting/multiplot.py
+++ b/src/spectrochempy/plotting/multiplot.py
@@ -25,6 +25,7 @@ import warnings
 
 import numpy as np
 
+from spectrochempy.plotting._methods import normalize_multiplot_method
 from spectrochempy.utils.mplutils import _Axes
 from spectrochempy.utils.typeutils import is_sequence
 
@@ -201,13 +202,6 @@ def plot_with_transposed(dataset, **kwargs):
 multiplot_with_transposed = plot_with_transposed
 
 
-def _normalize_multiplot_method_for_dataset(method, dataset):
-    """Normalize multiplot's generic method vocabulary per dataset dimensionality."""
-    if method == "lines" and getattr(dataset, "ndim", None) == 1:
-        return "pen"
-    return method
-
-
 def multiplot(
     datasets=None,
     labels=None,
@@ -368,8 +362,8 @@ def multiplot(
 
         if nrow == ncol and nrow == 1 and not show_transposed and single:
             # obviously a single plot, return it
-            current_method = _normalize_multiplot_method_for_dataset(
-                method, datasets[0]
+            current_method = normalize_multiplot_method(
+                method, getattr(datasets[0], "ndim", None)
             )
             return datasets[0].plot(method=current_method, **kwargs)
         if nrow * ncol < len(datasets):
@@ -470,8 +464,8 @@ def multiplot(
 
                 # Determine method for this dataset
                 current_method = method[idx] if method_is_list else method
-                current_method = _normalize_multiplot_method_for_dataset(
-                    current_method, dataset
+                current_method = normalize_multiplot_method(
+                    current_method, getattr(dataset, "ndim", None)
                 )
                 try:
                     label = labels[idx]

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -20,32 +20,10 @@ import numpy as np
 
 from spectrochempy.application.preferences import preferences
 from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.plotting._methods import validate_method_for_target_dimension
 from spectrochempy.plotting._style import resolve_line_style
 from spectrochempy.utils.mplutils import make_label
 from spectrochempy.utils.typeutils import is_sequence
-
-_VALID_1D_METHODS = {"pen", "bar", "scatter", "scatter_pen", "scatter+pen"}
-_VALID_2D_PLUS_METHODS = {
-    "lines",
-    "stack",
-    "contour",
-    "map",
-    "contourf",
-    "image",
-    "surface",
-    "waterfall",
-}
-_FALLBACK_1D_TO_2D_METHOD_ALIASES = {
-    "pen": "lines",
-}
-
-
-def _raise_incompatible_method(method, source, target):
-    raise ValueError(
-        f"method={method!r} is incompatible with {source}; "
-        f"use a {target} plotting method or call dataset.plot() for automatic dispatch."
-    )
-
 
 # --------------------------------------------------------------------------------------
 # plot_1D
@@ -213,10 +191,12 @@ def plot_1D(dataset, method=None, **kwargs):
         if dataset._squeeze_ndim > 1:
             if method is None:
                 return dataset.plot_2D(**kwargs)
-            method = _FALLBACK_1D_TO_2D_METHOD_ALIASES.get(method, method)
-            if method in _VALID_2D_PLUS_METHODS:
-                return dataset.plot_2D(method=method, **kwargs)
-            _raise_incompatible_method(method, "plot_1D() with non-1D data", "2D/3D")
+            method = validate_method_for_target_dimension(
+                method,
+                target="2d+",
+                source="plot_1D() with non-1D data",
+            )
+            return dataset.plot_2D(method=method, **kwargs)
 
         # if plotly execute plotly routine not this one
         if kwargs.get("use_plotly", prefs.use_plotly):

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -25,34 +25,12 @@ from spectrochempy.application.application import info_
 from spectrochempy.application.preferences import preferences
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.plotting._colorbar_utils import _apply_colorbar_tick_policy
+from spectrochempy.plotting._methods import validate_method_for_target_dimension
 from spectrochempy.plotting._render import render_lines
 from spectrochempy.plotting._style import resolve_2d_colormap
 from spectrochempy.plotting._style import resolve_line_style
 from spectrochempy.plotting._style import resolve_stack_colors
 from spectrochempy.utils.mplutils import make_label
-
-_VALID_1D_METHODS = {"pen", "bar", "scatter", "scatter_pen", "scatter+pen"}
-_VALID_2D_PLUS_METHODS = {
-    "lines",
-    "stack",
-    "contour",
-    "map",
-    "contourf",
-    "image",
-    "surface",
-    "waterfall",
-}
-_FALLBACK_2D_TO_1D_METHOD_ALIASES = {
-    "lines": "pen",
-}
-
-
-def _raise_incompatible_method(method, source, target):
-    raise ValueError(
-        f"method={method!r} is incompatible with {source}; "
-        f"use a {target} plotting method or call dataset.plot() for automatic dispatch."
-    )
-
 
 # ======================================================================================
 # Helper functions for aspect ratio control
@@ -1293,10 +1271,12 @@ def plot_2D(dataset, method=None, **kwargs):
         if dataset._squeeze_ndim < 2:
             if method is None:
                 return dataset.plot_1D(**kwargs)
-            method = _FALLBACK_2D_TO_1D_METHOD_ALIASES.get(method, method)
-            if method in _VALID_1D_METHODS:
-                return dataset.plot_1D(method=method, **kwargs)
-            _raise_incompatible_method(method, "plot_2D() with 1D data", "1D")
+            method = validate_method_for_target_dimension(
+                method,
+                target="1d",
+                source="plot_2D() with 1D data",
+            )
+            return dataset.plot_1D(method=method, **kwargs)
 
         # if plotly execute plotly routine not this one
         if kwargs.get("use_plotly", prefs.use_plotly):


### PR DESCRIPTION
## Summary
- add a private plotting method normalization helper module
- centralize backend alias handling, multiplot method normalization, and 1D/2D fallback validation
- preserve the public plotting API and recently restored lines/pen compatibility

## Validation
- pre-commit run --all-files
- pytest tests/test_plotting/test_multiplot_stateless.py tests/test_plotting/test_stateless_plotting.py tests/test_plotting/test_contract_plot2d.py tests/test_plotting/test_multiplot_refactored.py tests/test_plotting/test_plot2d_refactored.py tests/test_plotting/test_plot1d_legacy.py tests/test_core/test_dataset/test_mixins/test_ndplot.py -q