### PR TITLE
MAINT: Centralize plotting kwargs normalization

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -95,6 +95,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- Centralized internal plotting kwargs normalization in a private helper
+  module to reduce duplication across plotting entry points while preserving
+  public plotting aliases and rendering behavior.
+
 - Centralized internal plotting method normalization in a private helper
   module to reduce duplication across backend dispatch, multiplot handling,
   and 1D/2D fallback validation, without changing the public plotting API.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -62,6 +62,10 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- Centralized internal plotting kwargs normalization in a private helper
+  module to reduce duplication across plotting entry points while preserving
+  public plotting aliases and rendering behavior.
+
 - Centralized internal plotting method normalization in a private helper
   module to reduce duplication across backend dispatch, multiplot handling,
   and 1D/2D fallback validation, without changing the public plotting API.

--- a/src/spectrochempy/plotting/__init__.pyi
+++ b/src/spectrochempy/plotting/__init__.pyi
@@ -8,6 +8,7 @@
 
 __all__ = [
     "_colorbar_utils",
+    "_kwargs",
     "_methods",
     "_mpl_assets",
     "_render",
@@ -23,6 +24,7 @@ __all__ = [
 ]
 
 from . import _colorbar_utils
+from . import _kwargs
 from . import _methods
 from . import _mpl_assets
 from . import _render

--- a/src/spectrochempy/plotting/_kwargs.py
+++ b/src/spectrochempy/plotting/_kwargs.py
@@ -1,0 +1,50 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Internal plotting kwargs normalization helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_PLOTTING_KWARG_ALIASES = {
+    "c": "color",
+    "lw": "linewidth",
+    "ls": "linestyle",
+    "m": "marker",
+    "ms": "markersize",
+    "mew": "markeredgewidth",
+    "mec": "markeredgecolor",
+    "mfc": "markerfacecolor",
+    "colormap": "cmap",
+    "nc": "nlevels",
+    "calpha": "alpha",
+}
+
+
+def normalize_plot_kwargs(kwargs: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a copy of *kwargs* with plotting aliases normalized."""
+    if kwargs is None:
+        return {}
+
+    normalized = dict(kwargs)
+    for alias, canonical in _PLOTTING_KWARG_ALIASES.items():
+        if canonical not in normalized and alias in normalized:
+            normalized[canonical] = normalized[alias]
+        normalized.pop(alias, None)
+    return normalized
+
+
+def normalize_style_argument(
+    style: Any,
+    *,
+    default: Any,
+) -> Any:
+    """Normalize a style argument to the local plotting convention."""
+    if style is None:
+        style = default
+    if isinstance(style, str):
+        return [style]
+    return style

--- a/src/spectrochempy/plotting/_style.py
+++ b/src/spectrochempy/plotting/_style.py
@@ -36,6 +36,8 @@ __all__ = [
 import matplotlib as mpl
 import numpy as np
 
+from spectrochempy.plotting._kwargs import normalize_plot_kwargs
+
 _MPL_DEFAULT_IMAGE_CMAP = mpl.rcParamsDefault["image.cmap"]
 
 # ======================================================================================
@@ -404,6 +406,7 @@ def resolve_line_style(
     """
     if kwargs is None:
         kwargs = {}
+    kwargs = normalize_plot_kwargs(kwargs)
 
     if prefs is None:
         from spectrochempy.application.preferences import preferences
@@ -412,13 +415,13 @@ def resolve_line_style(
 
     result = {}
 
-    result["color"] = kwargs.get("color", kwargs.get("c", "auto"))
+    result["color"] = kwargs.get("color", "auto")
 
-    result["linewidth"] = kwargs.get("linewidth", kwargs.get("lw", "auto"))
+    result["linewidth"] = kwargs.get("linewidth", "auto")
 
-    result["linestyle"] = kwargs.get("linestyle", kwargs.get("ls", "auto"))
+    result["linestyle"] = kwargs.get("linestyle", "auto")
 
-    result["marker"] = kwargs.get("marker", kwargs.get("m", "auto"))
+    result["marker"] = kwargs.get("marker", "auto")
 
     # Deterministic fallback for scatter methods
     if (
@@ -432,13 +435,11 @@ def resolve_line_style(
     # The caller (plot2d.py) will handle None appropriately
     # For 1D plotting, "auto" is used to detect scatter vs pen
 
-    result["markersize"] = kwargs.get(
-        "markersize", kwargs.get("ms", prefs.lines_markersize)
-    )
+    result["markersize"] = kwargs.get("markersize", prefs.lines_markersize)
 
-    result["markerfacecolor"] = kwargs.get("markerfacecolor", kwargs.get("mfc", "auto"))
+    result["markerfacecolor"] = kwargs.get("markerfacecolor", "auto")
 
-    result["markeredgecolor"] = kwargs.get("markeredgecolor", kwargs.get("mec", "k"))
+    result["markeredgecolor"] = kwargs.get("markeredgecolor", "k")
 
     result["alpha"] = kwargs.get("alpha")
 

--- a/src/spectrochempy/plotting/backends/matplotlib_backend.py
+++ b/src/spectrochempy/plotting/backends/matplotlib_backend.py
@@ -12,6 +12,7 @@ wrapping the plotting functions from the spectrochempy.plotting module.
 
 from typing import Any
 
+from spectrochempy.plotting._kwargs import normalize_plot_kwargs
 from spectrochempy.plotting._methods import get_default_method_for_ndim
 from spectrochempy.plotting._methods import get_dispatch_method_key
 from spectrochempy.plotting._methods import normalize_backend_method
@@ -85,6 +86,7 @@ def plot_dataset_impl(
     """
     # Initialize matplotlib lazily
     lazy_ensure_mpl_config()
+    kwargs = normalize_plot_kwargs(kwargs)
 
     # Initialize plot profile lazily (loads defaults into PlotPreferences)
     ensure_plot_profile_loaded()

--- a/src/spectrochempy/plotting/multiplot.py
+++ b/src/spectrochempy/plotting/multiplot.py
@@ -25,6 +25,8 @@ import warnings
 
 import numpy as np
 
+from spectrochempy.plotting._kwargs import normalize_plot_kwargs
+from spectrochempy.plotting._kwargs import normalize_style_argument
 from spectrochempy.plotting._methods import normalize_multiplot_method
 from spectrochempy.utils.mplutils import _Axes
 from spectrochempy.utils.typeutils import is_sequence
@@ -294,12 +296,10 @@ def multiplot(
     from spectrochempy.application.preferences import preferences as prefs
     from spectrochempy.utils.mplutils import get_figure
 
+    kwargs = normalize_plot_kwargs(kwargs)
+
     # Resolve plotting style(s) locally (do not mutate global rcParams)
-    style = kwargs.pop("style", None)
-    if style is None:
-        style = ["scpy"]
-    if isinstance(style, str):
-        style = [style]
+    style = normalize_style_argument(kwargs.pop("style", None), default=["scpy"])
 
     with plt.style.context(style):
         # todo:_tight_layout deprecated

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from spectrochempy.application.preferences import preferences
 from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.plotting._kwargs import normalize_plot_kwargs
+from spectrochempy.plotting._kwargs import normalize_style_argument
 from spectrochempy.plotting._methods import validate_method_for_target_dimension
 from spectrochempy.plotting._style import resolve_line_style
 from spectrochempy.utils.mplutils import make_label
@@ -162,13 +164,13 @@ def plot_1D(dataset, method=None, **kwargs):
     # Get preferences
     # ----------------------------------------------------------------------------------
     prefs = preferences
+    kwargs = normalize_plot_kwargs(kwargs)
 
     # Resolve plotting style(s) locally (no global rcParams / no prefs.style mutation)
-    style = kwargs.pop("style", None)
-    if style is None:
-        style = getattr(prefs, "style", None) or ["scpy"]
-    if isinstance(style, str):
-        style = [style]
+    style = normalize_style_argument(
+        kwargs.pop("style", None),
+        default=getattr(prefs, "style", None) or ["scpy"],
+    )
 
     # Build font rc overrides from prefs (L1 helper - no mutation)
     from spectrochempy.plotting._style import build_font_rc_overrides
@@ -242,7 +244,7 @@ def plot_1D(dataset, method=None, **kwargs):
         markerfacecolor = style_kwargs["markerfacecolor"]
         markeredgecolor = style_kwargs["markeredgecolor"]
         alpha = style_kwargs["alpha"]
-        markeredgewidth = kwargs.get("markeredgewidth", kwargs.get("mew", 1.0))
+        markeredgewidth = kwargs.get("markeredgewidth", 1.0)
 
         markevery = kwargs.get("markevery", kwargs.get("me", 1))
 
@@ -1042,6 +1044,8 @@ def plot_multiple(
         Other parameters that will be passed to the plot1D function.
 
     """
+    kwargs = normalize_plot_kwargs(kwargs)
+
     if not is_sequence(datasets):
         # we need a sequence. Else it is a single plot.
         return datasets.plot(

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -25,6 +25,8 @@ from spectrochempy.application.application import info_
 from spectrochempy.application.preferences import preferences
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.plotting._colorbar_utils import _apply_colorbar_tick_policy
+from spectrochempy.plotting._kwargs import normalize_plot_kwargs
+from spectrochempy.plotting._kwargs import normalize_style_argument
 from spectrochempy.plotting._methods import validate_method_for_target_dimension
 from spectrochempy.plotting._render import render_lines
 from spectrochempy.plotting._style import resolve_2d_colormap
@@ -1211,15 +1213,15 @@ def plot_2D(dataset, method=None, **kwargs):
     # Get preferences
     # ----------------------------------------------------------------------------------
     prefs = preferences
-    requested_alpha = kwargs.get("calpha", kwargs.get("alpha"))
+    kwargs = normalize_plot_kwargs(kwargs)
+    requested_alpha = kwargs.get("alpha")
     requested_levels = kwargs.get("levels")
 
     # Resolve plotting style(s) locally (no global rcParams / no prefs.style mutation)
-    style = kwargs.pop("style", None)
-    if style is None:
-        style = getattr(prefs, "style", None) or ["scpy"]
-    if isinstance(style, str):
-        style = [style]
+    style = normalize_style_argument(
+        kwargs.pop("style", None),
+        default=getattr(prefs, "style", None) or ["scpy"],
+    )
 
     # Resolve rc_overrides for font settings (will be applied in the style context)
     rc_overrides = prefs.set_latex_font(prefs.font.family)
@@ -1663,7 +1665,7 @@ def plot_2D(dataset, method=None, **kwargs):
                 mappable = scalarMap
 
                 # marker = kwargs.get('marker', kwargs.get('m', None))
-                markersize = kwargs.get("markersize", kwargs.get("ms", 5.0))
+                markersize = kwargs.get("markersize", 5.0)
                 # markevery = kwargs.get('markevery', kwargs.get('me', 1))
 
                 for i in ydata:
@@ -1727,7 +1729,7 @@ def plot_2D(dataset, method=None, **kwargs):
 
             # Check if user explicitly provided color or cmap (backward compatibility)
             explicit_color = kwargs.get("color")
-            explicit_cmap = kwargs.get("colormap") or kwargs.get("cmap")
+            explicit_cmap = kwargs.get("cmap")
 
             if explicit_color is not None:
                 # User explicitly passed color - could be a single color or a list
@@ -2290,12 +2292,13 @@ def _plot_waterfall_3d(new, prefs, **kwargs):
 # ======================================================================================
 def _get_clevels(data, prefs, **kwargs):
     # Utility function to determine contours levels
+    kwargs = normalize_plot_kwargs(kwargs)
 
     # contours
     maximum = data.max()
     minimum = data.min()
 
-    nlevels = kwargs.get("nlevels", kwargs.get("nc", prefs.number_of_contours))
+    nlevels = kwargs.get("nlevels", prefs.number_of_contours)
     start = kwargs.get("start", prefs.contour_start) * maximum
     negative = kwargs.get("negative", True)
     if negative < 0:

--- a/tests/test_plotting/test_contract_plot1d.py
+++ b/tests/test_plotting/test_contract_plot1d.py
@@ -83,3 +83,24 @@ def test_plot1d_with_ylim(synthetic_1d):
     """Test plot1d with y-axis limits."""
     ax = synthetic_1d.plot(ylim=(0, 1), show=False)
     assert ax is not None
+
+
+def test_plot1d_alias_kwargs_normalize_to_canonical_artists(synthetic_1d):
+    """Legacy line-style aliases should still drive the final Line2D artist."""
+    ax = synthetic_1d.plot(
+        c="red",
+        lw=2.5,
+        ls="--",
+        marker="o",
+        ms=7,
+        mew=1.5,
+        show=False,
+    )
+
+    line = ax.lines[0]
+    assert line.get_color() == "red"
+    assert line.get_linewidth() == pytest.approx(2.5)
+    assert line.get_linestyle() == "--"
+    assert line.get_marker() == "o"
+    assert line.get_markersize() == pytest.approx(7)
+    assert line.get_markeredgewidth() == pytest.approx(1.5)

--- a/tests/test_plotting/test_contract_plot2d.py
+++ b/tests/test_plotting/test_contract_plot2d.py
@@ -121,3 +121,29 @@ def test_plot2d_levels_parameter_controls_contour_levels(synthetic_2d):
     contour_sets = [child for child in ax.get_children() if hasattr(child, "levels")]
     assert contour_sets
     assert list(contour_sets[0].levels) == pytest.approx(levels)
+
+
+def test_plot2d_colormap_alias_still_sets_cmap(synthetic_2d):
+    """Legacy colormap= should normalize to cmap= without changing the artist."""
+    ax = synthetic_2d.plot(method="image", colormap="plasma", show=False)
+
+    contour_sets = [child for child in ax.get_children() if hasattr(child, "get_cmap")]
+    assert contour_sets
+    assert contour_sets[0].get_cmap().name == "plasma"
+
+
+def test_plot2d_nc_and_calpha_aliases_still_work():
+    """Legacy contour aliases should normalize before rendering."""
+    import spectrochempy as scp
+
+    x = np.linspace(0, 1, 4)
+    y = np.linspace(0, 1, 3)
+    data = np.arange(1, 13, dtype=float).reshape(3, 4)
+    dataset = scp.NDDataset(data, coords=[y, x], units="dimensionless")
+
+    ax = dataset.plot(method="contour", nc=4, calpha=0.25, show=False)
+
+    contour_sets = [child for child in ax.get_children() if hasattr(child, "levels")]
+    assert contour_sets
+    assert len(contour_sets[0].levels) == 4
+    assert contour_sets[0].get_alpha() == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
- add a private plotting kwargs normalization helper module
- centralize common plotting kwarg aliases across plotting entry points and style resolution
- preserve public plotting aliases and rendering behavior while reducing duplication

## Validation
- pre-commit run --all-files
- pytest tests/test_plotting/test_contract_plot1d.py tests/test_plotting/test_contract_plot2d.py tests/test_plotting/test_multiplot_stateless.py tests/test_plotting/test_stateless_plotting.py tests/test_plotting/test_multiplot_refactored.py tests/test_plotting/test_plot2d_refactored.py tests/test_plotting/test_plot1d_refactored.py tests/test_plotting/test_plot1d_legacy.py tests/test_core/test_dataset/test_mixins/test_ndplot.py -q