### PR TITLE
MAINT: Remove obsolete plotting lifecycle infrastructure

### DIFF
--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -2211,17 +2211,22 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         return plot_dataset(self, method=method, **kwargs)
 
     # ======================================================================================
-    # Deprecated plot-related stubs (no-op for backward compatibility)
+    # Plot lifecycle helpers and compatibility stubs
     # ======================================================================================
-    # These stubs exist for backward compatibility but do NOT store any state on the dataset.
-    # The plotting functions in spectrochempy.plotting now use local variables instead.
+    # Dataset plotting is stateless: figures and axes are not stored on the dataset.
+    # The backend and plotter layers own rendering, while this helper centralizes the
+    # figure / axes setup policy used by the core dataset plotting path.
 
     def _figure_setup(self, ndim=1, method=None, **kwargs):
         """
-        Set up figure and axes (deprecated; now handled by spectrochempy.plotting functions).
+        Set up figure and axes for the core dataset plotting path.
 
-        This method exists for backward compatibility.
-        For internal use by plot functions only - creates figure and returns axes.
+        This internal helper does not store state on the dataset. It applies the
+        current axes ownership policy used by the 1D and 2D plotters:
+
+        - explicit ``ax`` reuses the caller-provided axes;
+        - ``clear=False`` reuses the current figure when possible;
+        - ``clear=True`` creates a new figure.
         """
         from spectrochempy.application.preferences import preferences as prefs
         from spectrochempy.plotting.plot_setup import lazy_ensure_mpl_config
@@ -2295,23 +2300,17 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             ax.name = "main"
             ndaxes["main"] = ax
 
-        # Return method string and the created axes for use by plot functions
+        # Return the resolved method string together with the figure/axes mapping
+        # used by the core plotters.
         return method or "", fig, ndaxes
-
-    def _plot_resume(self, origin: Any, **kwargs: Any) -> None:
-        """
-        Resume plot cleanup (deprecated; now handled by spectrochempy.plotting functions).
-
-        This method exists for backward compatibility but does nothing.
-        The plot functions now handle cleanup internally.
-        """
-        pass
 
     def close_figure(self):
         """
-        Close figure (deprecated; now handled by spectrochempy.plotting functions).
+        Provide a deprecated plotting compatibility stub.
 
-        This method exists for backward compatibility but does nothing.
+        Figure ownership is no longer stored on the dataset, so this method has
+        no managed figure to close. Callers should close matplotlib figures via
+        the returned axes or figure object instead.
         """
         pass
 

--- a/src/spectrochempy/plotting/backends/matplotlib_backend.py
+++ b/src/spectrochempy/plotting/backends/matplotlib_backend.py
@@ -6,8 +6,13 @@
 """
 Matplotlib backend for SpectroChemPy.
 
-This module provides the matplotlib implementation of plotting functions,
-wrapping the plotting functions from the spectrochempy.plotting module.
+Current responsibility split:
+
+- `_methods.py` normalizes plotting vocabulary;
+- `_kwargs.py` normalizes plotting keyword arguments;
+- this backend selects the plotter and owns the final `show` step for the
+  main dataset plotting path;
+- `plot1d.py`, `plot2d.py`, and `plot3d.py` create matplotlib artists.
 """
 
 from typing import Any
@@ -24,7 +29,7 @@ from spectrochempy.utils.mplutils import show as mpl_show
 _WARNED_ALIASES = set()
 
 
-# Mapping of method names to standalone plot functions
+# Mapping of canonical dispatch keys to standalone plot functions.
 _PLOT_FUNCTIONS = {}
 
 

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -3,7 +3,13 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-"""Module containing 1D plotting function(s)."""
+"""
+Module containing 1D plotting functions.
+
+This module consumes normalized plotting methods/kwargs and focuses on artist
+creation plus 1D axis policy. Backend dispatch and final display ownership live
+above this layer.
+"""
 
 __all__ = [
     "plot_1D",
@@ -250,34 +256,26 @@ def plot_1D(dataset, method=None, **kwargs):
 
         # Figure setup
         # ------------------------------------------------------------------------
-        _figure_result = new._figure_setup(
+        method, fig, ndaxes = new._figure_setup(
             ndim=1,
             method=method,
             style=style,
             **kwargs,
         )
-        # Handle both old (method string) and new (method, fig, ndaxes) return values
-        if isinstance(_figure_result, tuple):
-            method, fig, ndaxes = _figure_result
-        else:
-            # Fallback for any code that still uses old behavior
-            method = _figure_result
-            ndaxes = {}
 
         pen = "pen" in (method or "") or kwargs.pop("pen", False)
         scatter = "scatter" in method or marker != "auto"
         bar = "bar" in method
 
-        # Use ndaxes from figure_setup if available, otherwise try to get from figure
+        # Use the axes mapping from _figure_setup(). The fallback only covers
+        # defensive recovery if a future change returns an incomplete mapping.
         if "main" in ndaxes:
             ax = ndaxes["main"]
         else:
-            # Try to get axes from the figure
             if fig.get_axes():
                 ax = fig.get_axes()[0]
                 ax.name = "main"
             else:
-                # This shouldn't happen if _figure_setup worked correctly
                 ax = fig.add_subplot(1, 1, 1)
                 ax.name = "main"
 
@@ -481,7 +479,6 @@ def plot_1D(dataset, method=None, **kwargs):
         if data_only:
             # if data only (we will not set axes and labels
             # it was probably done already in a previous plot
-            new._plot_resume(dataset, **kwargs)
             return ax
 
         # ------------------------------------------------------------------------
@@ -535,8 +532,6 @@ def plot_1D(dataset, method=None, **kwargs):
             ax.set_title(title)
         elif kwargs.get("plottitle", False):
             ax.set_title(new.name)
-
-        new._plot_resume(dataset, **kwargs)
 
         # masks
         if kwargs.get("show_mask", False):
@@ -1084,9 +1079,7 @@ def plot_multiple(
     # do not save during this plots, nor apply any commands
     # we will make this when all plots will be done
 
-    output = kwargs.get("output")
     kwargs["output"] = None
-    commands = kwargs.get("commands", [])
     kwargs["commands"] = []
     legend = kwargs.pop(
         "legend",
@@ -1153,9 +1146,5 @@ def plot_multiple(
             frameon=True,
             fontsize="small",
         )
-
-    # now we can output the final figure
-    kw = {"output": output, "commands": commands, "show": user_show}
-    datasets[0]._plot_resume(datasets[-1], **kw)
 
     return ax

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -3,7 +3,13 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-"""Plotters."""
+"""
+2D plotting functions.
+
+This module consumes normalized plotting methods/kwargs and focuses on artist
+creation, colorbar policy, and 2D/3D axis policy for the dataset plotting
+path. Backend dispatch and final display ownership live above this layer.
+"""
 
 __all__ = [
     "plot_2D",
@@ -1324,30 +1330,22 @@ def plot_2D(dataset, method=None, **kwargs):
 
         # Figure setup
         # ------------------------------------------------------------------------
-        _figure_result = new._figure_setup(
+        method, fig, ndaxes = new._figure_setup(
             ndim=2,
             method=method,
             style=style,
             **kwargs,
         )
-        # Handle both old (method string) and new (method, fig, ndaxes) return values
-        if isinstance(_figure_result, tuple):
-            method, fig, ndaxes = _figure_result
-        else:
-            # Fallback for any code that still uses old behavior
-            method = _figure_result
-            ndaxes = {}
 
-        # Use ndaxes from figure_setup if available, otherwise try to get from figure
+        # Use the axes mapping from _figure_setup(). The fallback only covers
+        # defensive recovery if a future change returns an incomplete mapping.
         if "main" in ndaxes:
             ax = ndaxes["main"]
         else:
-            # Try to get axes from the figure
             if fig.get_axes():
                 ax = fig.get_axes()[0]
                 ax.name = "main"
             else:
-                # This shouldn't happen if _figure_setup worked correctly
                 ax = fig.add_subplot(1, 1, 1)
                 ax.name = "main"
 
@@ -1859,7 +1857,6 @@ def plot_2D(dataset, method=None, **kwargs):
         if data_only:
             # if data only (we will not set axes and labels
             # it was probably done already in a previous plot
-            new._plot_resume(dataset, **kwargs)
             return ax
 
         # display a title
@@ -2021,8 +2018,6 @@ def plot_2D(dataset, method=None, **kwargs):
             ax.set_xlim(user_xlim)
         if user_ylim is not None:
             ax.set_ylim(user_ylim)
-
-        new._plot_resume(dataset, **kwargs)
 
         return ax
 


### PR DESCRIPTION
## Summary

- remove the dead `_plot_resume()` helper and its remaining internal call sites
- keep `_figure_setup()` as the active core figure/axes setup helper and update its comments/docstring to match reality
- remove dead fallback handling around `_figure_setup()` and refresh internal plotting responsibility comments

## Testing

- `conda activate scpy && pytest tests/test_plotting/test_plot1d_refactored.py tests/test_plotting/test_plot2d_refactored.py tests/test_plotting/test_plot1d_legacy.py tests/test_plotting/test_multiplot_stateless.py tests/test_plotting/test_lazy_init.py -q`
- `conda activate scpy && pre-commit run --all-files`
- `conda activate scpy && pytest tests/test_plotting -q` *(locally hits an unrelated import-time performance threshold failure in `tests/test_plotting/test_lazy_initialization.py`; not caused by this lifecycle cleanup diff)*
