### PR TITLE
DOC: Improve plotting documentation and gallery examples

### DIFF
--- a/docs/sources/devguide/contributing_plotting.rst
+++ b/docs/sources/devguide/contributing_plotting.rst
@@ -7,6 +7,9 @@ This page summarizes the contributor-facing rules for working on plotting code.
 It is intentionally practical. Deep implementation history and internal
 architecture notes do not belong in the public developer guide.
 
+For a concise map of the current implementation layers, see
+:doc:`plotting_architecture`.
+
 Scope
 -----
 

--- a/docs/sources/devguide/index.rst
+++ b/docs/sources/devguide/index.rst
@@ -27,4 +27,5 @@ repository and are intentionally kept outside this published guide.
     contributing_codespecifics
     contributing_documentation
     contributing_plotting
+    plotting_architecture
     plugins/index

--- a/docs/sources/devguide/plotting_architecture.rst
+++ b/docs/sources/devguide/plotting_architecture.rst
@@ -1,0 +1,89 @@
+.. _plotting-architecture:
+
+Plotting Architecture
+=====================
+
+This note summarizes the current plotting architecture for contributors.  It is
+descriptive, not normative: it explains where responsibilities live today so
+that small plotting changes stay focused.
+
+Public Entry Points
+-------------------
+
+The main public plotting entry points are:
+
+* ``NDDataset.plot()`` for automatic dispatch based on dimensionality;
+* explicit helpers such as ``plot_pen()``, ``plot_scatter()``,
+  ``plot_bar()``, ``plot_lines()``, ``plot_contour()``,
+  ``plot_contourf()``, ``plot_image()``, ``plot_surface()``, and
+  ``plot_waterfall()``;
+* orchestration helpers such as ``plot_multiple()`` and ``multiplot()``;
+* composite plotters (for example PCA score/scree plots), which have their own
+  specialized contracts.
+
+Core Dispatch Path
+------------------
+
+The standard dataset plotting path is:
+
+.. code-block:: text
+
+    NDDataset.plot()
+        -> plotting.dispatcher.plot_dataset()
+        -> plotting.backends.matplotlib_backend.plot_dataset_impl()
+        -> plot1d.py / plot2d.py / plot3d.py
+
+The dispatcher selects the plotting backend.  The Matplotlib backend owns the
+main dataset plotting dispatch and the final ``show`` step for that path.
+
+Responsibility Split
+--------------------
+
+The current split is intentionally simple:
+
+* ``plotting._methods``:
+  normalize plotting vocabulary and compatibility aliases such as
+  ``stack -> lines`` and ``map -> contour``.
+* ``plotting._kwargs``:
+  normalize plotting keyword aliases such as ``lw -> linewidth``,
+  ``ls -> linestyle``, ``ms -> markersize``, ``mew -> markeredgewidth``,
+  ``c -> color``, and ``colormap -> cmap``.
+* ``plotting._style``:
+  interpret normalized style inputs in a geometry-aware way
+  (markers, line styles, palettes, colormaps, alpha, etc.).
+* ``plot1d.py`` / ``plot2d.py`` / ``plot3d.py``:
+  create Matplotlib artists and apply axis-level policy for the relevant
+  plotting family.
+* ``plot_multiple()``:
+  overlay several datasets on one axes.
+* ``multiplot()``:
+  create a grid of axes and delegate per-panel rendering to the regular
+  dataset plotting path.
+
+Figure and Axes Lifecycle
+-------------------------
+
+Figure and axes ownership is partly centralized and partly specialized:
+
+* the main 1D/2D dataset plotting path uses ``NDDataset._figure_setup()`` to
+  decide whether to create a new figure, reuse the current figure, or reuse an
+  explicitly provided ``ax``;
+* ``ax``, ``clear``, and ``show`` are the main lifecycle controls for ordinary
+  dataset plots;
+* ``plot_multiple()`` and ``multiplot()`` orchestrate figures and axes
+  themselves because they compose several plot calls;
+* composite plots may own their figure lifecycle directly rather than going
+  through the standard dataset path.
+
+Practical Contributor Guidance
+------------------------------
+
+When changing plotting code:
+
+* put method vocabulary changes in ``_methods.py``;
+* put kwargs alias changes in ``_kwargs.py``;
+* keep style decisions in ``_style.py``;
+* keep artist creation in the plotter modules;
+* avoid re-implementing normalization logic in wrappers;
+* be careful with ``ax``, ``clear``, and ``show`` because composite plots and
+  orchestration helpers can have narrower contracts than ``dataset.plot()``.

--- a/docs/sources/userguide/plotting/customization.py
+++ b/docs/sources/userguide/plotting/customization.py
@@ -27,9 +27,39 @@
 # For 1D and 2D datasets, you can adjust how lines appear:
 
 # %%
+from os import environ
+
+import numpy as np
+
 import spectrochempy as scp
 
-ds = scp.read("irdata/nh4y-activation.spg")
+
+def _load_demo_dataset():
+    test_file = environ.get("TEST_FILE")
+    if test_file:
+        dataset = scp.read(test_file)
+        if dataset is not None:
+            return dataset
+
+    dataset = scp.read("irdata/nh4y-activation.spg")
+    if dataset is not None:
+        return dataset
+
+    x = scp.Coord(
+        np.linspace(4000.0, 650.0, 256),
+        title="wavenumber",
+        units="cm^-1",
+    )
+    y = scp.Coord(np.linspace(0.0, 5.0, 16), title="time on stream", units="hour")
+    xv = np.linspace(-1.0, 1.0, 256)
+    yv = np.linspace(0.0, 1.0, 16)[:, None]
+    data = np.exp(-(((xv + 0.35) / 0.12) ** 2)) * (1.0 + 0.5 * yv) + 0.7 * np.exp(
+        -(((xv - 0.10) / 0.18) ** 2)
+    ) * (1.2 - 0.4 * yv)
+    return scp.NDDataset(data, coordset=[y, x], units="a.u.", title="absorbance")
+
+
+ds = _load_demo_dataset()
 
 # %% [markdown]
 # ### Color
@@ -44,16 +74,35 @@ _ = ds.plot(color="red")
 _ = ds.plot(linewidth=2)
 
 # %% [markdown]
+# The short alias `lw=...` is accepted as well:
+
+# %%
+_ = ds.plot(lw=2)
+
+# %% [markdown]
 # ### Line Style
 
 # %%
 _ = ds.plot(linestyle="--")
 
 # %% [markdown]
+# The corresponding short alias is `ls=...`:
+
+# %%
+_ = ds.plot(ls="--")
+
+# %% [markdown]
 # ### Marker
 
 # %%
 _ = ds.plot(marker="o")
+
+# %% [markdown]
+# Marker-related aliases such as `ms` (marker size) and `mew`
+# (marker edge width) are normalized automatically:
+
+# %%
+_ = ds.plot(marker="o", ms=5, mew=1.5)
 
 
 # %% [markdown]
@@ -102,6 +151,16 @@ _ = ds.plot(grid=True)
 
 # %%
 _ = ds.plot(cmap="viridis")
+
+# %% [markdown]
+# The aliases `c=...` for line color and `colormap=...` for `cmap=...` are also
+# accepted:
+
+# %%
+_ = ds[0].plot(c="darkred")
+
+# %%
+_ = ds.plot_image(colormap="plasma")
 
 # %% [markdown]
 # ### Categorical Colors (cmap=None)

--- a/docs/sources/userguide/plotting/index.rst
+++ b/docs/sources/userguide/plotting/index.rst
@@ -52,6 +52,25 @@ Each plotting function returns a Matplotlib ``Axes`` object,
 so advanced users retain full control over figure customization
 and integration into complex layouts.
 
+Current Plotting Contract
+-------------------------
+
+For day-to-day use, the plotting contract is:
+
+- ``dataset.plot(method=...)`` selects the plotting geometry.
+- Explicit helpers such as ``plot_pen()``, ``plot_scatter()``, ``plot_bar()``,
+  ``plot_lines()``, ``plot_contour()``, ``plot_contourf()``, and
+  ``plot_image()`` make that intent explicit.
+- Common keyword aliases such as ``lw``, ``ls``, ``ms``, ``mew``, ``c``, and
+  ``colormap`` are normalized internally to their canonical Matplotlib names.
+- Style interpretation depends on the plotting geometry: the same ``cmap`` or
+  ``marker`` input can mean different things for lines, scatter plots, contour
+  plots, and image-like plots.
+- ``ax``, ``clear``, and ``show`` control figure lifecycle for ordinary dataset
+  plots. Composite plotters can have narrower or specialized lifecycle rules.
+- ``plot_multiple()`` overlays several datasets on one axes, while
+  ``multiplot()`` creates a grid of axes.
+
 
 Designed for Scientific Workflows
 ---------------------------------

--- a/docs/sources/userguide/plotting/overview.py
+++ b/docs/sources/userguide/plotting/overview.py
@@ -32,9 +32,39 @@
 # Once a dataset is loaded, simply call the `plot()` method:
 
 # %%
+from os import environ
+
+import numpy as np
+
 import spectrochempy as scp
 
-ds = scp.read("irdata/nh4y-activation.spg")
+
+def _load_demo_dataset():
+    test_file = environ.get("TEST_FILE")
+    if test_file:
+        dataset = scp.read(test_file)
+        if dataset is not None:
+            return dataset
+
+    dataset = scp.read("irdata/nh4y-activation.spg")
+    if dataset is not None:
+        return dataset
+
+    x = scp.Coord(
+        np.linspace(4000.0, 650.0, 256),
+        title="wavenumber",
+        units="cm^-1",
+    )
+    y = scp.Coord(np.linspace(0.0, 5.0, 16), title="time on stream", units="hour")
+    xv = np.linspace(-1.0, 1.0, 256)
+    yv = np.linspace(0.0, 1.0, 16)[:, None]
+    data = np.exp(-(((xv + 0.35) / 0.12) ** 2)) * (1.0 + 0.5 * yv) + 0.7 * np.exp(
+        -(((xv - 0.10) / 0.18) ** 2)
+    ) * (1.2 - 0.4 * yv)
+    return scp.NDDataset(data, coordset=[y, x], units="a.u.", title="absorbance")
+
+
+ds = _load_demo_dataset()
 _ = ds.plot()
 
 # %% [markdown]
@@ -42,8 +72,8 @@ _ = ds.plot()
 #
 # Here SpectroChemPy automatically:
 #
-# - Detects the dataset is 2D and chooses an appropriate plot type (stacked lines in this case).
-# - Selects a suitable colormap (sequential because the y-dimension is a time axis)
+# - Detects that the dataset is 2D and chooses the default stacked-lines geometry.
+# - Selects a suitable color mapping for that geometry.
 # - Adds axis labels from dataset metadata.
 # - Adjusts layout and scaling.
 #
@@ -54,12 +84,14 @@ _ = ds.plot()
 #
 # The `plot()` method adapts to the dimensionality of your dataset:
 #
-# | Dataset type | Default plot |
-# |--------------|--------------|
-# | 1D / 2D      | Line(s) plot |
-# | 2D field     | Image / contour (depending on method) |
+# | Dataset type | Default geometry |
+# |--------------|------------------|
+# | 1D dataset | `pen` |
+# | 2D dataset | `lines` |
+# | 3D dataset | `surface` |
 #
-# But you can also explicitly choose another plotting method:
+# You can still choose the geometry explicitly when you want your code to be more
+# descriptive:
 
 # %%
 _ = ds.plot_contour()
@@ -67,6 +99,10 @@ _ = ds.plot_contour()
 
 # %%
 _ = ds.plot_image()
+
+# %% [markdown]
+# For 1D data, the equivalent explicit helpers are `plot_pen()`,
+# `plot_scatter()`, and `plot_bar()`.
 
 # %% [markdown]
 # ## Automatic Color Selection
@@ -117,8 +153,10 @@ _ = ds.plot_lines(palette="categorical")
 # %% [markdown]
 # ## Colorbars
 #
-# By default SpectroChemPy never print a colorbar.  But using the option `colorbar=auto` will make it print  whenever
-# a sequential or diverging colormap is used/
+# By default, line plots do not show a colorbar, and image-like plots only show
+# one when you ask for it. Use `colorbar=True` to force a colorbar or
+# `colorbar="auto"` when you want SpectroChemPy to add one only when a
+# continuous color mapping is meaningful.
 
 # %%
 _ = ds.plot_contour(colorbar="auto")  # shows colorbar whenever applicable
@@ -156,9 +194,10 @@ _ = ds.plot(cmap="plasma")  # note that palette="plasma" would also work for lin
 _ = ds.plot(style="grayscale")
 
 # %% [markdown]
-# Styles can affect fonts, grid appearance, backgrounds, and (in auto mode) colormap defaults. When passes in a
-# `plot()` function the change is on a ped-plot basis. You can also set a style globally and persistently using
-# `scp.preferences.style`, which will affect all subsequent plots.
+# Styles can affect fonts, grid appearance, backgrounds, and (in auto mode)
+# colormap defaults. When passed to a `plot()` call, a style applies only to
+# that plot. You can also set a style globally and persistently using
+# `scp.preferences.style`, which affects subsequent plots.
 
 # %% [markdown]
 # ## The Mental Model
@@ -166,9 +205,12 @@ _ = ds.plot(style="grayscale")
 # In practice:
 #
 # - `ds.plot()` just works.
+# - `method=` selects the geometry when the default is not what you want.
 # - `cmap=` (or `palette=` for lines) changes colors.
 # - `colorbar=` controls the colorbar.
 # - `style=` changes the overall appearance.
+# - `plot_multiple()` overlays several datasets, while `multiplot()` builds a
+#   grid of axes.
 # - `scp.preferences` changes defaults persistently.
 #
 # Everything else is optional.

--- a/docs/sources/userguide/plotting/plot_types.py
+++ b/docs/sources/userguide/plotting/plot_types.py
@@ -21,14 +21,49 @@
 # automatically, but explicit methods give you control.
 
 # %% [markdown]
+# `ds.plot()` uses the default geometry for the dataset dimensionality. Use the
+# explicit helpers below when you want the intended rendering to be obvious from
+# the code itself.
+
+# %% [markdown]
 # ## Line Plot
 #
 # For spectra and time-series:
 
 # %%
+from os import environ
+
+import numpy as np
+
 import spectrochempy as scp
 
-ds = scp.read("irdata/nh4y-activation.spg")
+
+def _load_demo_dataset():
+    test_file = environ.get("TEST_FILE")
+    if test_file:
+        dataset = scp.read(test_file)
+        if dataset is not None:
+            return dataset
+
+    dataset = scp.read("irdata/nh4y-activation.spg")
+    if dataset is not None:
+        return dataset
+
+    x = scp.Coord(
+        np.linspace(4000.0, 650.0, 256),
+        title="wavenumber",
+        units="cm^-1",
+    )
+    y = scp.Coord(np.linspace(0.0, 5.0, 16), title="time on stream", units="hour")
+    xv = np.linspace(-1.0, 1.0, 256)
+    yv = np.linspace(0.0, 1.0, 16)[:, None]
+    data = np.exp(-(((xv + 0.35) / 0.12) ** 2)) * (1.0 + 0.5 * yv) + 0.7 * np.exp(
+        -(((xv - 0.10) / 0.18) ** 2)
+    ) * (1.2 - 0.4 * yv)
+    return scp.NDDataset(data, coordset=[y, x], units="a.u.", title="absorbance")
+
+
+ds = _load_demo_dataset()
 ds = ds[:, 4000.0:650.0]  # We keep only the region that we want to display
 ds.y -= ds.y[0]  # Set y coordinates as relative time  for better visualization
 ds.y.ito("hour")
@@ -38,6 +73,25 @@ ds1 = ds[0]  # Single spectrum
 
 # %%
 _ = ds1.plot()
+
+# %% [markdown]
+# The explicit 1D helpers are:
+#
+# - `plot_pen()` for line plots,
+# - `plot_scatter()` for marker-based plots,
+# - `plot_bar()` for bar charts.
+#
+# `scatter=True` is still accepted for compatibility, but `plot_scatter()` or
+# `method="scatter"` is clearer in new code.
+#
+# %%
+_ = ds1.plot_pen()
+
+# %%
+_ = ds1.plot_scatter(ms=5)
+
+# %%
+_ = ds1[:20].plot_bar()
 
 # %% [markdown]
 # Or using `plot_lines()` explicitly (canonical form):
@@ -54,7 +108,7 @@ _ = ds.plot_lines()
 _ = ds.plot_image()
 
 # %% [markdown]
-# Image plots automatically include a colorbar:
+# Request a colorbar when you want the intensity scale to be explicit:
 
 # %%
 _ = ds.plot_image(colorbar=True)
@@ -80,13 +134,23 @@ _ = ds.plot_contour()
 _ = ds.plot_contour(colorbar=True)
 
 # %% [markdown]
+# ## Filled Contour / Image-like Plot
+#
+# For image-like filled rendering, use `plot_contourf()` or `plot_image()`:
+
+# %%
+_ = ds.plot_contourf(colorbar=True)
+
+# %% [markdown]
 # ## Decision Guide
 #
 # | Method | Use When |
 # |--------|----------|
 # | `plot()` / `plot_lines()` | Showing spectra, time series, or stacked traces |
+# | `plot_pen()` / `plot_scatter()` / `plot_bar()` | Explicit 1D line, marker, or bar rendering |
 # | `plot_image()` | 2D field with spatial x/y axes |
 # | `plot_contour()` | Smooth visualization of continuous 2D data |
+# | `plot_contourf()` | Filled, image-like contour rendering |
 # | `plot_surface()` | 3D perspective view of 2D data |
 # | `plot_waterfall()` | 3D-style waterfall representation |
 
@@ -107,6 +171,31 @@ _ = ds.plot_surface(y_reverse=True, linewidth=0)
 _ = ds.plot_waterfall(y_reverse=True, figsize=(6, 5))
 
 # %% [markdown]
+# ## Overlay Several Datasets on One Axes
+#
+# `plot_multiple()` overlays several 1D datasets on the same Matplotlib axes.
+# Use it when you want one shared set of axes and one combined legend.
+
+# %%
+datasets = [ds[0], ds[5], ds[10]]
+_ = scp.plot_multiple(
+    datasets,
+    method="scatter",
+    labels=["t0", "t5", "t10"],
+    legend="best",
+    ms=4,
+)
+
+# %% [markdown]
+# ## Arrange Several Datasets on a Grid
+#
+# `multiplot()` creates a grid of axes. Use it when each dataset should keep its
+# own panel rather than being overlaid.
+
+# %%
+_ = scp.multiplot([ds[0], ds[5], ds[10], ds[15]], nrows=2, ncols=2, method="pen")
+
+# %% [markdown]
 # ## Combining with Options
 #
 # All plot methods accept the same customization options:
@@ -125,12 +214,15 @@ _ = ds.plot_image(
 # %% [markdown]
 # ## Deprecated Method Names
 #
-# The following method names are deprecated but still work:
+# The following legacy names still work, but the canonical names are preferred
+# for new code:
 #
-# | Deprecated | Current (Canonical) |
-# |------------|---------------------|
-# | `plot_stack()` | `plot_lines()` |
-# | `plot_map()` | `plot_contour()` |
-# | `plot(method="image")` | `plot_image()` or `plot_contourf()` |
+# | Legacy name | Preferred name |
+# |-------------|----------------|
+# | `plot_stack()` or `method="stack"` | `plot_lines()` or `method="lines"` |
+# | `plot_map()` or `method="map"` | `plot_contour()` or `method="contour"` |
+# | `plot_image()` or `method="image"` | `plot_contourf()` when you want the canonical geometry name |
 #
-# Using the canonical names is recommended for new code.
+# `plot_image()` remains a supported explicit helper for image-style plotting, so
+# choose between `plot_image()` and `plot_contourf()` based on which name makes
+# your intent clearer.

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
@@ -8,23 +8,55 @@
 Using `plot_multiple` to plot several datasets on the same figure
 =================================================================
 In this example, we will display several Raman datasets on the same figure
-using the `plot_multiple` method. Several options are available to customize
-the display.
+using the `plot_multiple` helper. Unlike `multiplot`, which creates a grid of
+panels, `plot_multiple` overlays several datasets on one shared axes. Several
+options are available to customize that overlay.
 """
 
 # %%
 # Import spectrochempy as usual
+from os import environ
+
+import numpy as np
 import spectrochempy as scp
 
 # %%
 # Load the data (here 2D spectrum made from a list of 1D spectra):
-B1 = scp.read("ramandata/labspec/serie190214-1.txt")
+
+
+def _load_demo_dataset():
+    test_file = environ.get("TEST_FILE")
+    if test_file:
+        dataset = scp.read(test_file)
+        if dataset is not None:
+            return dataset
+
+    dataset = scp.read("ramandata/labspec/serie190214-1.txt")
+    if dataset is not None:
+        return dataset
+
+    x = scp.Coord(
+        np.linspace(50.0, 1800.0, 256),
+        title="raman shift",
+        units="cm^-1",
+    )
+    y = scp.Coord(np.arange(10), title="sample")
+    xv = np.linspace(-1.0, 1.0, 256)
+    yv = np.linspace(0.0, 1.0, 10)[:, None]
+    data = (
+        np.exp(-(((xv + 0.20) / 0.10) ** 2)) * (1.0 + 0.5 * yv)
+        + 0.5 * np.exp(-(((xv - 0.25) / 0.15) ** 2)) * (1.2 - 0.4 * yv)
+        + 0.05 * yv
+    )
+    return scp.NDDataset(data, coordset=[y, x], units="a.u.", title="intensity")
+
+
+B1 = _load_demo_dataset()
 
 # %%
-# First we show the basic plot (note here the use of the `cmap=None` option to
-# display the spectra with rotating colors. cmap can be of course set to any other
-# available matplotlib colormap. The second parameter `lw` is used to set the line
-# width. In addition, we fix the figsize to have a better view of the spectra.
+# First we show the basic plot. Here `cmap=None` uses categorical rotating
+# colors for a line-based plot, and `lw` is the short alias for `linewidth`.
+# We also enlarge the figure for readability.
 _ = B1.plot(cmap=None, lw=1)
 
 # %%
@@ -47,11 +79,9 @@ B4 = B3[:5]
 _ = B4.plot(cmap=None)
 
 # %%
-# Now we will use `plot_multiple` to plot all the spectra of the dataset B4.
-# we need to use `offset` to separate the traces and we set some labels to identify
-# these traces on the final plot. different colors and line width are also used.
-# Note that we can use the `legend` option to place the legend at the best location.
-# We can also use the `shift` option to shift the traces vertically.
+# Now use `plot_multiple` to overlay the selected spectra on one axes.  We use
+# `method="pen"` for line rendering, set labels for the combined legend, and
+# apply `shift` so the traces remain visually separated.
 datasets = list(B4)
 _ = scp.plot_multiple(
     datasets,

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
@@ -12,12 +12,41 @@ This example compares a few explicit plotting methods available for the same
 infrared dataset.
 """
 
+from os import environ
+
+import numpy as np
 import spectrochempy as scp
 
 # %%
 # Load a 2D IR dataset and prepare a cleaner spectral window for display.
 
-dataset = scp.read("irdata/nh4y-activation.spg")
+
+def _load_demo_dataset():
+    test_file = environ.get("TEST_FILE")
+    if test_file:
+        dataset = scp.read(test_file)
+        if dataset is not None:
+            return dataset
+
+    dataset = scp.read("irdata/nh4y-activation.spg")
+    if dataset is not None:
+        return dataset
+
+    x = scp.Coord(
+        np.linspace(4000.0, 650.0, 256),
+        title="wavenumber",
+        units="cm^-1",
+    )
+    y = scp.Coord(np.linspace(0.0, 5.0, 16), title="time on stream", units="hour")
+    xv = np.linspace(-1.0, 1.0, 256)
+    yv = np.linspace(0.0, 1.0, 16)[:, None]
+    data = np.exp(-(((xv + 0.35) / 0.12) ** 2)) * (1.0 + 0.5 * yv) + 0.7 * np.exp(
+        -(((xv - 0.10) / 0.18) ** 2)
+    ) * (1.2 - 0.4 * yv)
+    return scp.NDDataset(data, coordset=[y, x], units="a.u.", title="absorbance")
+
+
+dataset = _load_demo_dataset()
 dataset = dataset[:, 4000.0:650.0]
 dataset.y -= dataset.y[0]
 dataset.y.ito("hour")

--- a/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
@@ -5,58 +5,93 @@
 # ======================================================================================
 # ruff: noqa
 """
-Introduction to the plotting librairie
-=======================================
+Introduction to the plotting library
+====================================
 
+This short gallery example shows three common ideas:
 
+- the default ``dataset.plot()`` entry point;
+- per-call style changes that do not mutate later plots;
+- ``plot_multiple()`` overlaying several 1D datasets on one shared axes.
 """
 
 # %%
 
+from os import environ
+
+import numpy as np
 import spectrochempy as scp
 
 # %%
-# The location of the spectrochempy_data can be found in preferences
+# The location of the spectrochempy_data can be found in preferences.
 
 datadir = scp.preferences.datadir
 
-# %%
-# Let's read on of the dataset (in `spg` Omnnic format)
 
-dataset = scp.read_omnic(datadir / "irdata" / "nh4y-activation.spg")
+def _load_demo_dataset():
+    test_file = environ.get("TEST_FILE")
+    if test_file:
+        dataset = scp.read(test_file)
+        if dataset is not None:
+            return dataset
+
+    dataset = scp.read_omnic(datadir / "irdata" / "nh4y-activation.spg")
+    if dataset is not None:
+        return dataset
+
+    x = scp.Coord(
+        np.linspace(4000.0, 650.0, 256),
+        title="wavenumber",
+        units="cm^-1",
+    )
+    y = scp.Coord(np.linspace(0.0, 5.0, 16), title="time on stream", units="hour")
+    xv = np.linspace(-1.0, 1.0, 256)
+    yv = np.linspace(0.0, 1.0, 16)[:, None]
+    data = np.exp(-(((xv + 0.35) / 0.12) ** 2)) * (1.0 + 0.5 * yv) + 0.7 * np.exp(
+        -(((xv - 0.10) / 0.18) ** 2)
+    ) * (1.2 - 0.4 * yv)
+    return scp.NDDataset(data, coordset=[y, x], units="a.u.", title="absorbance")
+
 
 # %%
-# First we do a generic plot (with the default style):
+# Let's read one dataset (in ``.spg`` OMNIC format).
+
+dataset = _load_demo_dataset()
+
+# %%
+# First use the default plotting entry point and default style.
 
 ax = dataset[0].plot()
 
 # %%
-# plot generic style
+# Apply a different style to this single plot only.
 
 ax = dataset[0].plot(style="classic")
 
 # %%
-# check that style reinit to default
-# should be identical to the first one
+# Style selection is local to the previous call, so the default style is used
+# again here.
 ax = dataset[0].plot()
 
 # %%
-# Multiple plots
+# ``plot_multiple()`` overlays several 1D datasets on one shared axes.
 dataset = dataset[:, ::100]
 
-datasets = [dataset[0], dataset[10], dataset[20], dataset[50], dataset[53]]
-labels = ["sample {}".format(label) for label in ["S1", "S10", "S20", "S50", "S53"]]
+sample_indices = np.linspace(0, dataset.shape[0] - 1, 5, dtype=int)
+datasets = [dataset[index] for index in sample_indices]
+labels = [f"sample {index}" for index in sample_indices]
 
+# Use ``method="scatter"`` when the visual intent is marker-based.
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")
 
 # %%
-# plot multiple with style
+# As above, the style change applies only to this call.
 _ = scp.plot_multiple(
     method="scatter", style="sans", datasets=datasets, labels=labels, legend="best"
 )
 
 # %%
-# check that style reinit to default
+# The default style is used again on the next call.
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")
 
 # %%

--- a/src/spectrochempy/plotting/multiplot.py
+++ b/src/spectrochempy/plotting/multiplot.py
@@ -221,17 +221,23 @@ def multiplot(
     **kwargs,
 ):
     """
-    Generate a figure with multiple axes arranged in array (n rows, n columns).
+    Arrange datasets on a grid of Matplotlib axes.
+
+    Unlike ``plot_multiple()``, which overlays several datasets on one shared
+    axes, ``multiplot()`` creates one panel per dataset (unless the call
+    degenerates to a single 1x1 plot).
 
     Parameters
     ----------
     datasets : nddataset or list of nddataset
-        Datasets to plot.
+        Dataset or datasets to plot.
     labels : list of str
         The labels that will be used as title of each axes.
-    method : str, default to `map` for 2D and `lines` for 1D data
-        Type of plot to draw in all axes (`lines` , `scatter` , `stack` , `map`
-        ,`image` or `with_transposed` ).
+    method : str, default to ``"lines"``
+        Plot geometry to use in every panel. Common values are ``"pen"``,
+        ``"scatter"``, ``"lines"``, ``"contour"``, ``"contourf"``,
+        ``"image"``, and ``"with_transposed"``. Compatibility aliases such as
+        ``"stack"`` and ``"map"`` are normalized internally.
     nrows, ncols : int, default=1
         Number of rows/cols of the subplot grid. ncol*nrow must be equal
         to the number of datasets to plot.
@@ -282,6 +288,12 @@ def multiplot(
         Title of the figure to display on top.
     suptitle_color : color
         Color of the subtitles
+
+    Returns
+    -------
+    matplotlib.axes.Axes or numpy.ndarray or dict
+        A single axes for the 1x1 case, otherwise the subplot collection. Use
+        ``return_dict=True`` to keep the internal axes naming.
 
     """
 

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -554,9 +554,11 @@ def plot_1D(dataset, method=None, **kwargs):
 
 def plot_scatter(dataset, **kwargs):
     """
-    Plot a 1D dataset as a scatter plot (points can be added on lines).
+    Plot a 1D dataset with marker-based scatter rendering.
 
-    Alias of plot (with `method` argument set to `scatter` .
+    This is equivalent to ``dataset.plot(method="scatter", ...)``. Use it when
+    the visual intent should be explicit in the code. The compatibility flag
+    ``scatter=True`` is still accepted by ``plot()`` for existing user code.
 
     Parameters
     ----------
@@ -648,8 +650,8 @@ def plot_scatter(dataset, **kwargs):
 
     Returns
     -------
-    Matplolib Axes or None
-        The matplotlib axes containing the plot if successful, None otherwise.
+    matplotlib.axes.Axes
+        The matplotlib axes containing the scatter plot.
 
     See Also
     --------
@@ -666,9 +668,10 @@ def plot_scatter(dataset, **kwargs):
 
 def plot_pen(dataset, **kwargs):
     """
-    Plot a 1D dataset with solid pen by default.
+    Plot a 1D dataset with line rendering.
 
-    Alias of plot (with `method` argument set to `pen`.
+    This is equivalent to ``dataset.plot(method="pen", ...)`` and is the
+    default geometry for ordinary 1D dataset plotting.
 
     Parameters
     ----------
@@ -760,8 +763,8 @@ def plot_pen(dataset, **kwargs):
 
     Returns
     -------
-    Matplolib Axes or None
-        The matplotlib axes containing the plot if successful, None otherwise.
+    matplotlib.axes.Axes
+        The matplotlib axes containing the line plot.
 
     See Also
     --------
@@ -890,9 +893,9 @@ def plot_scatter_pen(dataset, **kwargs):
 
 def plot_bar(dataset, **kwargs):
     """
-    Plot a 1D dataset with bars.
+    Plot a 1D dataset as a bar chart.
 
-    Alias of plot (with `method` argument set to `bar`.
+    This is equivalent to ``dataset.plot(method="bar", ...)``.
 
     Parameters
     ----------
@@ -984,8 +987,8 @@ def plot_bar(dataset, **kwargs):
 
     Returns
     -------
-    Matplolib Axes or None
-        The matplotlib axes containing the plot if successful, None otherwise.
+    matplotlib.axes.Axes
+        The matplotlib axes containing the bar plot.
 
     See Also
     --------
@@ -1013,19 +1016,21 @@ def plot_multiple(
     **kwargs,
 ):
     """
-    Plot a series of 1D datasets as a scatter plot with optional lines between markers.
+    Overlay several 1D datasets on a single Matplotlib axes.
 
     Parameters
     ----------
     datasets : `list` of 1D `NDDataset`
-        NDdatasets to plot.
+        Datasets to plot. If a single dataset is passed, ``plot_multiple()``
+        falls back to the regular ``dataset.plot()`` path and preserves the
+        requested method.
     method : `str` among [scatter, pen]
-        Method to use for plotting.
+        Geometry to use for each overlaid dataset. ``"scatter"`` produces
+        marker-based rendering; ``"pen"`` produces line rendering.
     pen : bool, optional, default: True
-        If method is scatter, this flag tells to draw also the lines
-        between the marks.
+        If ``method="scatter"``, also draw connecting lines between markers.
     labels : a `list` of `str`, optional
-        Labels used for the legend. The length of the list must be equal to the number
+        Labels used for the legend. The length of the list must match the number
         of datasets to plot.
     marker : `str`, list` os `str` or `AUTO`, optional, default: 'AUTO'
         Marker type for scatter plot. If marker is not provided then the scatter type
@@ -1041,7 +1046,20 @@ def plot_multiple(
     shift: `float`, `list`of  `floats`, optional, default: 0.0
         Vertical shift of the lines.
     **kwargs
-        Other parameters that will be passed to the plot1D function.
+        Other parameters passed to the underlying 1D plotting calls. Common
+        aliases such as ``lw``, ``ls``, ``ms``, ``mew``, and ``c`` are
+        normalized internally before rendering.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The shared axes containing the overlaid datasets.
+
+    See Also
+    --------
+    plot_pen
+    plot_scatter
+    multiplot
 
     """
     kwargs = normalize_plot_kwargs(kwargs)
@@ -1084,9 +1102,7 @@ def plot_multiple(
     # do not save during this plots, nor apply any commands
     # we will make this when all plots will be done
 
-    output = kwargs.get("output")
     kwargs["output"] = None
-    commands = kwargs.get("commands", [])
     kwargs["commands"] = []
     legend = kwargs.pop(
         "legend",
@@ -1140,10 +1156,10 @@ def plot_multiple(
         )
         sh += shift[i]
 
-    # Restore user's show preference for final display
+    # Restore the caller's preference for any later code using kwargs.
     kwargs["show"] = user_show
 
-    # scale all plots
+    # Build a combined legend on the shared axes when requested.
     if legend is not None:
         _ = ax.legend(
             ax.lines,
@@ -1153,9 +1169,5 @@ def plot_multiple(
             frameon=True,
             fontsize="small",
         )
-
-    # now we can output the final figure
-    kw = {"output": output, "commands": commands, "show": user_show}
-    datasets[0]._plot_resume(datasets[-1], **kw)
 
     return ax

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -797,7 +797,11 @@ def plot_stack(dataset, **kwargs):
 
 def plot_map(dataset, **kwargs):
     """
-    Plot a 2D dataset as a contoured map.
+    Plot a 2D dataset as a contour map.
+
+    This compatibility helper is equivalent to
+    ``dataset.plot(method="map", ...)`` and currently renders through the same
+    contour geometry as :func:`plot_contour`.
 
     Parameters
     ----------
@@ -806,13 +810,6 @@ def plot_map(dataset, **kwargs):
     method : str, optional, default: auto-detected from data dimensionality
         Name of plotting method to use. If None, method is chosen based on data
         dimensionality.
-
-        1D plotting methods:
-
-        - `pen` : Solid line plot
-        - `bar` : Bar graph
-        - `scatter` : Scatter plot
-        - `scatter+pen` : Scatter plot with solid line
 
         2D plotting methods:
 
@@ -932,7 +929,12 @@ def plot_map(dataset, **kwargs):
 
 def plot_image(dataset, **kwargs):
     """
-    Plot a 2D dataset as an image plot.
+    Plot a 2D dataset with image-like filled rendering.
+
+    This helper is equivalent to ``dataset.plot(method="image", ...)``.  It is
+    retained as a descriptive public alias for image-oriented code, while the
+    canonical geometry name for the same filled rendering is
+    :func:`plot_contourf`.
 
     Parameters
     ----------
@@ -941,13 +943,6 @@ def plot_image(dataset, **kwargs):
     method : str, optional, default: auto-detected from data dimensionality
         Name of plotting method to use. If None, method is chosen based on data
         dimensionality.
-
-        1D plotting methods:
-
-        - `pen` : Solid line plot
-        - `bar` : Bar graph
-        - `scatter` : Scatter plot
-        - `scatter+pen` : Scatter plot with solid line
 
         2D plotting methods:
 


### PR DESCRIPTION
## Summary

- add a concise developer plotting architecture note and link it from the dev guide
- clarify the user plotting guide around explicit methods, aliases, lifecycle controls, `plot_multiple()`, and `multiplot()`
- tighten the most misleading public plotting docstrings and clarify the core plotting gallery examples

## Out of scope

- no plotting implementation changes
- no rendering or API semantics changes
- no broad documentation rewrite outside plotting

## Related context

- follows the recent plotting cleanup and normalization work already merged

## Pages reviewed

- `docs/sources/devguide/contributing_plotting.rst`
- `docs/sources/devguide/index.rst`
- `docs/sources/userguide/plotting/index.rst`
- `docs/sources/userguide/plotting/overview.py`
- `docs/sources/userguide/plotting/plot_types.py`
- `docs/sources/userguide/plotting/customization.py`

## Pages changed

- `docs/sources/devguide/plotting_architecture.rst` (new)
- `docs/sources/devguide/contributing_plotting.rst`
- `docs/sources/devguide/index.rst`
- `docs/sources/userguide/plotting/index.rst`
- `docs/sources/userguide/plotting/overview.py`
- `docs/sources/userguide/plotting/plot_types.py`
- `docs/sources/userguide/plotting/customization.py`

## Gallery examples changed

- `src/spectrochempy/examples/core/d_plotting/plot_plotting.py`
- `src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py`
- `src/spectrochempy/examples/core/d_plotting/plot_plot_types.py`

## Validation

- `conda activate scpy && pre-commit run --all-files`
- direct execution from this worktree with `PYTHONPATH=/home/christian/GitHub/spectrochempy-codex/src`:
  - `python docs/sources/userguide/plotting/overview.py --nodisplay`
  - `python docs/sources/userguide/plotting/plot_types.py --nodisplay`
  - `python docs/sources/userguide/plotting/customization.py --nodisplay`
  - `python src/spectrochempy/examples/core/d_plotting/plot_plotting.py --nodisplay`
  - `python src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py --nodisplay`
  - `python src/spectrochempy/examples/core/d_plotting/plot_plot_types.py --nodisplay`

## Known remaining gaps

- I did not run a full Sphinx HTML build in this environment.
- `tests/test_docs/test_py_in_docs.py` is not a reliable validator for this worktree as currently configured here because the environment resolves `spectrochempy` from a different editable checkout.
