### PR TITLE
DOC: add Plugin public API reference to sidebar menu

### DIFF
--- a/docs/sources/index.rst.tmpl
+++ b/docs/sources/index.rst.tmpl
@@ -110,8 +110,8 @@ SpectroChemPy: Advanced Spectroscopic Data Analysis
 
     {% if include_api -%}
     reference/index
-    {% endif -%}
     reference/plugins
+    {% endif -%}
     reference/glossary
     reference/bibliography
     reference/papers

--- a/docs/sources/index.rst.tmpl
+++ b/docs/sources/index.rst.tmpl
@@ -111,6 +111,7 @@ SpectroChemPy: Advanced Spectroscopic Data Analysis
     {% if include_api -%}
     reference/index
     {% endif -%}
+    reference/plugins
     reference/glossary
     reference/bibliography
     reference/papers

--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -792,14 +792,3 @@ File
 
     pathclean
 
-*******************
-Official plugins
-*******************
-
-Plugin-owned public API pages are documented separately from the User Guide on
-the dedicated reference page below.
-
-.. toctree::
-   :maxdepth: 1
-
-   plugins

--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -791,4 +791,3 @@ File
     :toctree: generated/
 
     pathclean
-


### PR DESCRIPTION
The Plugin public API reference page existed at `reference/plugins.rst` but was hidden from the sidebar because it was only linked as a sub-toctree of `reference/index` in the content area, while the Reference sidebar section had `:maxdepth: 1`.

**Changes:**
- Added `reference/plugins` as a direct sibling entry in the Reference toctree (`index.rst.tmpl`)
- Removed the now-redundant `plugins` sub-toctree from `reference/index.rst`

The sidebar now shows `Plugin public API reference` at the same level as `Public API reference`, `Glossary`, `Bibliography`, and `Papers` under the Reference section.