### PR TITLE
FIX: Keep notebook plotting inline by default

### DIFF
--- a/src/spectrochempy/application/envsetup.py
+++ b/src/spectrochempy/application/envsetup.py
@@ -3,7 +3,6 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
-import importlib.util
 import sys
 from os import environ
 
@@ -67,13 +66,11 @@ def setup_environment():
                 output = import_item("google.colab").output
                 output.enable_custom_widget_manager()
 
-            elif importlib.util.find_spec("ipympl") is not None:
-                IP.run_line_magic("matplotlib", "widget")
-
-            elif importlib.util.find_spec("PyQt6") is not None:
-                IP.run_line_magic("matplotlib", "qt")
-
             else:
+                # Keep notebook rendering inline by default.
+                # Interactive backends such as widget/qt should be an explicit
+                # user choice, otherwise merely having extra GUI packages
+                # installed can move figures out of the notebook.
                 IP.run_line_magic("matplotlib", "inline")
         except Exception:
             IP.run_line_magic("matplotlib", "inline")

--- a/src/spectrochempy/plotting/backends/matplotlib_backend.py
+++ b/src/spectrochempy/plotting/backends/matplotlib_backend.py
@@ -89,6 +89,16 @@ def plot_dataset_impl(
     Any
         The matplotlib axes.
     """
+    # Ensure environment is set up BEFORE importing matplotlib.
+    # In notebooks/nbsphinx, setup_environment() activates %matplotlib inline
+    # which switches the backend.  If we import matplotlib first with the
+    # default backend (Agg) and *then* switch, the existing figures are
+    # closed by plt.switch_backend() -> plt.close('all'), and we lose the
+    # plot.  See note in envsetup.py for details.
+    from spectrochempy.application.application import _get_environment
+
+    _get_environment()
+
     # Initialize matplotlib lazily
     lazy_ensure_mpl_config()
     kwargs = normalize_plot_kwargs(kwargs)

--- a/src/spectrochempy/plotting/multiplot.py
+++ b/src/spectrochempy/plotting/multiplot.py
@@ -297,6 +297,16 @@ def multiplot(
 
     """
 
+    # Ensure environment is set up BEFORE importing matplotlib.
+    # In notebooks/nbsphinx, setup_environment() activates %matplotlib inline
+    # which switches the backend.  If we import matplotlib first with the
+    # default backend (Agg) and *then* switch, the existing figures are
+    # closed by plt.switch_backend() -> plt.close('all'), and we lose the
+    # plot.
+    from spectrochempy.application.application import _get_environment
+
+    _get_environment()
+
     from spectrochempy.plotting.plot_setup import lazy_ensure_mpl_config
 
     lazy_ensure_mpl_config()

--- a/tests/test_application/test_envsetup.py
+++ b/tests/test_application/test_envsetup.py
@@ -1,0 +1,58 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+from spectrochempy.application import envsetup
+
+
+class _FakeIPython:
+    def __init__(self, repr_text="ipykernel"):
+        self.repr_text = repr_text
+        self.magics = []
+
+    def run_line_magic(self, name, value):
+        self.magics.append((name, value))
+
+    def __str__(self):
+        return self.repr_text
+
+
+def test_setup_environment_notebook_defaults_to_inline(monkeypatch):
+    ip = _FakeIPython()
+
+    monkeypatch.setattr(envsetup, "is_terminal", lambda: False)
+    monkeypatch.setattr(envsetup, "is_notebook", lambda: True)
+    monkeypatch.setattr(envsetup, "get_ipython", lambda: ip)
+    monkeypatch.setattr(envsetup, "setup_jupyter_css", lambda: None)
+    monkeypatch.setattr(envsetup.sys, "argv", ["python"])
+    monkeypatch.delenv("DOC_BUILDING", raising=False)
+
+    no_display, _, is_pytest = envsetup.setup_environment()
+
+    assert no_display is False
+    assert is_pytest is False
+    assert ip.magics == [("matplotlib", "inline")]
+
+
+def test_setup_environment_notebook_uses_inline_for_nbsphinx(monkeypatch):
+    ip = _FakeIPython()
+
+    monkeypatch.setattr(envsetup, "is_terminal", lambda: False)
+    monkeypatch.setattr(envsetup, "is_notebook", lambda: True)
+    monkeypatch.setattr(envsetup, "get_ipython", lambda: ip)
+    monkeypatch.setattr(envsetup, "setup_jupyter_css", lambda: None)
+    monkeypatch.setattr(
+        envsetup.sys,
+        "argv",
+        [
+            "ipykernel_launcher",
+            "--InlineBackend.rc={'figure.dpi': 96}",
+        ],
+    )
+    monkeypatch.delenv("DOC_BUILDING", raising=False)
+
+    envsetup.setup_environment()
+
+    assert ip.magics == [("matplotlib", "inline")]


### PR DESCRIPTION
## Summary

This PR fixes notebook plotting so figures remain inline by default, even when Qt or `ipympl` is installed in the environment.

## Root Cause

`setup_environment()` selected an interactive matplotlib backend automatically in notebooks when optional GUI packages were present:

- `ipympl` -> `widget`
- `PyQt6` -> `qt`

That made figures render outside the notebook in normal Jupyter usage. In parallel, plotting paths could import matplotlib before the notebook backend was configured, which could force a later backend switch and close existing figures.

## Changes

- keep notebook rendering on `%matplotlib inline` by default;
- keep interactive notebook backends as an explicit user choice instead of an automatic side effect of installed packages;
- ensure plotting initializes the SpectroChemPy environment before the first matplotlib import in dataset plotting and `plot_multiple()`;
- add a regression test for notebook backend selection.

## Impact

- notebooks behave predictably again;
- installing Qt no longer moves figures out of the notebook;
- lazy loading is preserved because environment setup is still deferred until plotting needs it.

## Validation

- `PYTHONPATH=src conda run -n scpy-core python -m pytest tests/test_application/test_envsetup.py tests/test_plotting/test_lazy_initialization.py`
- result: `13 passed`
