### PR TITLE
FIX: clarify and honor plotting show contract

### DIFF
--- a/docs/sources/userguide/plotting/index.rst
+++ b/docs/sources/userguide/plotting/index.rst
@@ -67,7 +67,10 @@ For day-to-day use, the plotting contract is:
   ``marker`` input can mean different things for lines, scatter plots, contour
   plots, and image-like plots.
 - ``ax``, ``clear``, and ``show`` control figure lifecycle for ordinary dataset
-  plots. Composite plotters can have narrower or specialized lifecycle rules.
+  plots. Here ``show`` means "perform SpectroChemPy's explicit display step
+  after plotting", not "guarantee figure visibility". In notebook environments,
+  figures can still render inline without that explicit call. Composite
+  plotters can have narrower or specialized lifecycle rules.
 - ``plot_multiple()`` overlays several datasets on one axes, while
   ``multiplot()`` creates a grid of axes.
 

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -2187,6 +2187,11 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         **kwargs
             Additional arguments passed to the plotting function.
 
+            Common lifecycle kwargs include ``ax``, ``clear``, and ``show``.
+            Here, ``show`` controls whether SpectroChemPy performs its
+            explicit display step after plotting. In notebook environments,
+            figures may still render inline without that explicit call.
+
             For ``method="stack"``, ``palette`` controls categorical or continuous
             color selection. It accepts ``None``, a colormap name, or an explicit
             list of colors.

--- a/src/spectrochempy/plotting/backends/matplotlib_backend.py
+++ b/src/spectrochempy/plotting/backends/matplotlib_backend.py
@@ -83,6 +83,9 @@ def plot_dataset_impl(
         If None, method is chosen based on data dimensionality.
     **kwargs
         Additional arguments passed to the plotting function.
+        ``show`` controls whether SpectroChemPy performs its explicit display
+        step after plotting. In notebook environments, figures may still
+        render inline without that explicit call.
 
     Returns
     -------

--- a/src/spectrochempy/plotting/multiplot.py
+++ b/src/spectrochempy/plotting/multiplot.py
@@ -288,6 +288,10 @@ def multiplot(
         Title of the figure to display on top.
     suptitle_color : color
         Color of the subtitles
+    show : bool, optional, default: True
+        Whether SpectroChemPy should perform its explicit display step after
+        plotting. In notebook environments, figures may still render inline
+        without this explicit call.
 
     Returns
     -------
@@ -307,8 +311,10 @@ def multiplot(
 
     from spectrochempy.application.preferences import preferences as prefs
     from spectrochempy.utils.mplutils import get_figure
+    from spectrochempy.utils.mplutils import show as mpl_show
 
     kwargs = normalize_plot_kwargs(kwargs)
+    user_show = kwargs.pop("show", True)
 
     # Resolve plotting style(s) locally (do not mutate global rcParams)
     style = normalize_style_argument(kwargs.pop("style", None), default=["scpy"])
@@ -648,6 +654,9 @@ def multiplot(
             fig.canvas.mpl_connect("axes_leave_event", _onenter)
             fig.canvas.mpl_connect("figure_enter_event", _onenter)
             fig.canvas.mpl_connect("figure_leave_event", _onenter)
+
+        if user_show:
+            mpl_show()
 
         # Return based on contract
         if return_dict:

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -112,6 +112,10 @@ def plot_1D(dataset, method=None, **kwargs):
     show_complex : bool, optional, default: False
         Show both real and imaginary component for complex data.
         By default only the real component is displayed.
+    show : bool, optional, default: True
+        Whether SpectroChemPy should perform its explicit display step after
+        plotting. In notebook environments, figures may still render inline
+        without this explicit call.
     show_mask: bool, optional
         Should we display the mask using colored area.
     show_z : bool, optional, default: True
@@ -1118,6 +1122,7 @@ def plot_multiple(
     lazy_ensure_mpl_config()
 
     from spectrochempy.utils.mplutils import get_figure
+    from spectrochempy.utils.mplutils import show as mpl_show
 
     fig = get_figure(
         preferences=kwargs.get("preferences"),
@@ -1164,5 +1169,8 @@ def plot_multiple(
             frameon=True,
             fontsize="small",
         )
+
+    if user_show:
+        mpl_show()
 
     return ax

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -340,6 +340,10 @@ def plot_lines(dataset, **kwargs):
     show_complex : bool, optional, default: False
         Show both real and imaginary component for complex data.
         By default only the real component is displayed.
+    show : bool, optional, default: True
+        Whether SpectroChemPy should perform its explicit display step after
+        plotting. In notebook environments, figures may still render inline
+        without this explicit call.
     show_mask: bool, optional
         Should we display the mask using colored area.
     show_z : bool, optional, default: True

--- a/tests/test_plotting/test_multiplot_refactored.py
+++ b/tests/test_plotting/test_multiplot_refactored.py
@@ -168,3 +168,29 @@ class TestMultiplot:
         # The key validation: if we got here without transform errors,
         # the bug fix worked
         assert True  # If this assertion passes, the bug is fixed
+
+    def test_multiplot_show_true_calls_display_helper(
+        self,
+        sample_1d_dataset,
+        mocker,
+        clean_figures,
+    ):
+        """multiplot(show=True) should own one final explicit display step."""
+        display = mocker.patch("spectrochempy.utils.mplutils.show")
+
+        _ = multiplot([sample_1d_dataset, sample_1d_dataset], show=True)
+
+        display.assert_called_once()
+
+    def test_multiplot_show_false_skips_display_helper(
+        self,
+        sample_1d_dataset,
+        mocker,
+        clean_figures,
+    ):
+        """multiplot(show=False) should suppress the explicit display step."""
+        display = mocker.patch("spectrochempy.utils.mplutils.show")
+
+        _ = multiplot([sample_1d_dataset, sample_1d_dataset], show=False)
+
+        display.assert_not_called()

--- a/tests/test_plotting/test_plot1d_legacy.py
+++ b/tests/test_plotting/test_plot1d_legacy.py
@@ -202,3 +202,39 @@ def test_plot_multiple_single_dataset_forwards_method():
         assert line.get_linestyle() == "None"
 
     plt.close("all")
+
+
+def test_plot_multiple_show_true_calls_display_helper(mocker):
+    """plot_multiple(show=True) should own one final explicit display step."""
+    import matplotlib.pyplot as plt
+    from spectrochempy import NDDataset
+    from spectrochempy.plotting.plot1d import plot_multiple
+
+    display = mocker.patch("spectrochempy.utils.mplutils.show")
+    datasets = [
+        NDDataset([1, 2, 3], name="A"),
+        NDDataset([2, 3, 4], name="B"),
+    ]
+
+    _ = plot_multiple(datasets, method="scatter", show=True)
+
+    display.assert_called_once()
+    plt.close("all")
+
+
+def test_plot_multiple_show_false_skips_display_helper(mocker):
+    """plot_multiple(show=False) should suppress the explicit display step."""
+    import matplotlib.pyplot as plt
+    from spectrochempy import NDDataset
+    from spectrochempy.plotting.plot1d import plot_multiple
+
+    display = mocker.patch("spectrochempy.utils.mplutils.show")
+    datasets = [
+        NDDataset([1, 2, 3], name="A"),
+        NDDataset([2, 3, 4], name="B"),
+    ]
+
+    _ = plot_multiple(datasets, method="scatter", show=False)
+
+    display.assert_not_called()
+    plt.close("all")


### PR DESCRIPTION
## Summary

This PR makes the plotting `show` contract consistent across overlay/grid helpers and clarifies its public meaning in the plotting API.

## Problem

The current plotting API exposes `show`, but not consistently:

- the main dataset plotting path uses `show` to decide whether SpectroChemPy performs its explicit display step after plotting;
- `plot_multiple()` captured `show`, forced it to `False` during the overlay loop, restored it, and then never applied it at the end;
- `multiplot()` was used publicly with `show=...`, but did not own a final explicit display step either;
- public entry-point documentation did not explain that `show=False` does not necessarily suppress notebook inline rendering.

## Changes

- make `plot_multiple()` own one final explicit display step when `show=True`;
- make `multiplot()` own one final explicit display step when `show=True`;
- document the real `show` semantics on the main public plotting entry points;
- clarify the user plotting guide so `show` means "perform SpectroChemPy's explicit display step" rather than "guarantee figure visibility".

## Notes

This PR does **not** rename the parameter or change its default value.
It only makes behavior consistent first and documents the current contract more honestly.

## Validation

Ran:

```bash
PYTHONPATH=src conda run -n scpy-core python -m pytest \
  tests/test_plotting/test_plot1d_legacy.py \
  tests/test_plotting/test_multiplot_refactored.py
```

Result:

- `17 passed`
