### PR TITLE
DOC: add preprocessing ops to API reference index

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -306,6 +306,20 @@ Joining or splitting datasets
     stack
 
 
+Chemometric preprocessing
+=========================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    normalize
+    center
+    autoscale
+    snv
+    msc
+
+
 Indexing
 ========
 


### PR DESCRIPTION
Follow-up to #1337.

The preprocessing operations (normalize, center, autoscale, snv, msc) were merged but were missing from the public API reference index (`docs/sources/reference/index.rst`). This PR adds them to the autosummary so they appear in the generated documentation.

No code changes — documentation only.