### PR TITLE
FIX: resolve merge-base error in pr-compliance changelog check

### DIFF
--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -2,7 +2,7 @@ name: PR Compliance
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -48,9 +48,8 @@ jobs:
       - name: Check changelog updated
         if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
         run: |
-          BASE="origin/${{ github.base_ref }}"
-          git fetch origin ${{ github.base_ref }} --depth=1
-          CHANGED=$(git diff --name-only "$BASE"...HEAD)
+          # fetch-depth:0 in checkout already has full history; no shallow fetch needed
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}..HEAD)
           if echo "$CHANGED" | grep -q "docs/sources/whatsnew/changelog.rst"; then
             echo "Changelog updated."
           else


### PR DESCRIPTION
Fixes a CI failure introduced in #1341.

**Problem:** The  job in  used .github/PULL_REQUEST_TEMPLATE.md
.github/workflows/build_docs.yml
.github/workflows/pr-compliance.yml
.github/workflows/scripts/check_commit_prefix.py
.github/workflows/test_package.yml
.pre-commit-config.yaml
AGENTS.md
CONTRIBUTING.md
README.md
docs/sources/devguide/contributing_plotting.rst
docs/sources/devguide/index.rst
docs/sources/devguide/plotting_architecture.rst
docs/sources/index.rst.tmpl
docs/sources/reference/bibliography.bib
docs/sources/reference/index.rst
docs/sources/reference/papers.rst
docs/sources/reference/plugins.rst
docs/sources/userguide/analysis/fitting.py
docs/sources/userguide/importexport/import.py
docs/sources/userguide/objects/dataset/dataset.py
docs/sources/userguide/objects/project/project.py
docs/sources/userguide/plotting/customization.py
docs/sources/userguide/plotting/index.rst
docs/sources/userguide/plotting/overview.py
docs/sources/userguide/plotting/plot_types.py
docs/sources/userguide/plugins/carroucell.rst
docs/sources/userguide/plugins/examples.rst
docs/sources/userguide/plugins/hypercomplex.rst
docs/sources/userguide/plugins/index.rst
docs/sources/userguide/plugins/iris.rst
docs/sources/userguide/plugins/nmr.rst
docs/sources/userguide/plugins/official_plugins.rst
docs/sources/userguide/plugins/perkinelmer.rst
docs/sources/userguide/plugins/tensor.rst
docs/sources/userguide/processing/apodization.py
docs/sources/userguide/processing/fourier.py
docs/sources/userguide/processing/math_operations.py
docs/sources/userguide/processing/td_baseline.py
docs/sources/userguide/processing/transformations.py
docs/sources/whatsnew/changelog.rst
docs/sources/whatsnew/latest.rst
maintainers/README.md
maintainers/api-conventions.md
maintainers/architecture/INDEX.md
maintainers/architecture/README.md
maintainers/architecture/array-class-responsibility.md
maintainers/architecture/coordset-storage-architecture.md
maintainers/architecture/display-architecture.md
maintainers/architecture/mathematical-semantics-and-metadata-propagation.md
maintainers/architecture/metadata-and-support-model.md
maintainers/architecture/portable-persistence-model.md
maintainers/architecture/reader-normalization-architecture.md
maintainers/architecture/result-object-contract-rfc.md
maintainers/architecture/result-object-migration-roadmap.md
maintainers/architecture/tensor-plugin-migration.md
maintainers/rfcs/INDEX.md
maintainers/rfcs/analysis-fit-result-architecture.md
maintainers/rfcs/coord-labels-portable-semantics.md
maintainers/rfcs/coordinate-and-coordset-semantics.md
maintainers/rfcs/coordinate-arithmetic-semantics.md
maintainers/rfcs/csdm-position-statement.md
maintainers/rfcs/dimensional-semantics-contract.md
maintainers/rfcs/display-representation-model-rfc.md
maintainers/rfcs/label-semantics-contract.md
maintainers/rfcs/metadata-contract.md
maintainers/rfcs/metadata-taxonomy-contract.md
maintainers/rfcs/modeldata-semantic-contract.md
maintainers/rfcs/namespace-api-convention.md
maintainers/rfcs/nddataset-xarray-mapping-specification.md
maintainers/rfcs/portable-metadata-subset-contract.md
maintainers/rfcs/project-copy-semantics-rfc.md
maintainers/rfcs/project-invariants-rfc.md
maintainers/rfcs/provenance-and-history-contract.md
maintainers/rfcs/reader-metadata-normalization-contract.md
maintainers/rfcs/roi-semantic-contract.md
maintainers/rfcs/scientific-object-model-and-persistence-boundaries.md
maintainers/rfcs/trusted-and-portable-persistence.md
maintainers/rfcs/xarray-backed-netcdf-persistence.md
maintainers/roadmap/INDEX.md
maintainers/roadmap/completed-campaigns.md
maintainers/roadmap/current-roadmap.md
maintainers/roadmap/vendor-io-migration.md
plugins/spectrochempy-carroucell/README.md
plugins/spectrochempy-carroucell/src/spectrochempy_carroucell/read_carroucell.py
plugins/spectrochempy-nmr/README.md
plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
plugins/spectrochempy-nmr/examples/processing/nmr/plot_read_nmr_topspin.py
plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
plugins/spectrochempy-perkinelmer/examples/plot_read_perkinelmer.py
plugins/spectrochempy-perkinelmer/src/spectrochempy_perkinelmer/read_perkinelmer.py
pyproject.toml
src/spectrochempy/analysis/crossdecomposition/pls.py
src/spectrochempy/analysis/curvefitting/_models.py
src/spectrochempy/analysis/decomposition/mcrals.py
src/spectrochempy/application/envsetup.py
src/spectrochempy/core/dataset/arraymixins/ndmath.py
src/spectrochempy/core/dataset/nddataset.py
src/spectrochempy/core/project/project.py
src/spectrochempy/core/readers/importer.py
src/spectrochempy/core/readers/read_csv.py
src/spectrochempy/core/readers/read_jcamp.py
src/spectrochempy/core/readers/read_labspec.py
src/spectrochempy/core/readers/read_matlab.py
src/spectrochempy/core/readers/read_omnic.py
src/spectrochempy/core/readers/read_opus.py
src/spectrochempy/core/readers/read_quadera.py
src/spectrochempy/core/readers/read_soc.py
src/spectrochempy/core/readers/read_spc.py
src/spectrochempy/core/readers/read_wire.py
src/spectrochempy/core/readers/read_zip.py
src/spectrochempy/core/writers/exporter.py
src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
src/spectrochempy/examples/analysis/c_curvefitting/plot_lineshapes.py
src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
src/spectrochempy/examples/core/d_plotting/plot_plotting.py
src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
src/spectrochempy/lazyimport/api_methods.py
src/spectrochempy/lazyimport/dataset_methods.py
src/spectrochempy/plotting/__init__.pyi
src/spectrochempy/plotting/_kwargs.py
src/spectrochempy/plotting/_methods.py
src/spectrochempy/plotting/_style.py
src/spectrochempy/plotting/backends/matplotlib_backend.py
src/spectrochempy/plotting/multiplot.py
src/spectrochempy/plotting/plot1d.py
src/spectrochempy/plotting/plot2d.py
src/spectrochempy/processing/alignement/align.py
src/spectrochempy/processing/fft/apodization.py
src/spectrochempy/processing/fft/shift.py
src/spectrochempy/processing/filter/denoise.py
src/spectrochempy/processing/transformation/__init__.pyi
src/spectrochempy/processing/transformation/concatenate.py
src/spectrochempy/processing/transformation/npy.py
src/spectrochempy/processing/transformation/preprocessing.py
src/spectrochempy/processing/transformation/preprocessing_transformers.py
src/spectrochempy/utils/decorators.py
src/spectrochempy/utils/objects.py
tests/test_analysis/test_curvefitting/test_models.py
tests/test_analysis/test_decomposition/test_mcrals.py
tests/test_application/test_envsetup.py
tests/test_core/test_dataset/test_workflow_api_ergonomics_baseline.py
tests/test_plotting/test_contract_plot1d.py
tests/test_plotting/test_contract_plot2d.py
tests/test_plotting/test_multiplot_refactored.py
tests/test_plotting/test_multiplot_stateless.py
tests/test_plotting/test_plot1d_legacy.py
tests/test_plotting/test_stateless_plotting.py
tests/test_processing/test_fft/test_apodization_core.py
tests/test_processing/test_fft/test_shift_core.py
tests/test_processing/test_filter/test_filter_shape.py
tests/test_processing/test_transformation/test_concatenate.py
tests/test_processing/test_transformation/test_npy.py
tests/test_processing/test_transformation/test_preprocessing.py
tests/test_utils/test_objects.py (triple-dot syntax) which requires a merge base. When GitHub Actions checks out a PR with `fetch-depth: 0`, the shallow fetch of `origin/master` with `--depth=1` does not always provide enough history to compute the merge base, causing:



**Fix:** Replace triple-dot with double-dot syntax () and remove the unnecessary , since  with  already provides full history.