### PR TITLE
ENH: add get_params, set_params, and __repr__ to AnalysisConfigurable for sklearn compatibility

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -152,3 +152,12 @@ Developer
   duplication between the procedural and transformer APIs while
   preserving full backward compatibility, including `inplace` behaviour
   and history messages.
+
+- All analysis estimators (PCA, PLSRegression, Baseline, MCRALS, NMF,
+  etc.) now expose ``get_params()`` and ``set_params(**params)``
+  following scikit-learn conventions, plus a clear ``__repr__``.
+  This enables parameter inspection and grid exploration for any
+  ``AnalysisConfigurable`` subclass without adding new dependencies.
+  Full ``sklearn.base.clone()`` compatibility is best-effort because
+  complex traitlets traits (e.g., lists) may fail sklearn's strict
+  identity check.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -119,3 +119,12 @@ Developer
   duplication between the procedural and transformer APIs while
   preserving full backward compatibility, including `inplace` behaviour
   and history messages.
+
+- All analysis estimators (PCA, PLSRegression, Baseline, MCRALS, NMF,
+  etc.) now expose ``get_params()`` and ``set_params(**params)``
+  following scikit-learn conventions, plus a clear ``__repr__``.
+  This enables parameter inspection and grid exploration for any
+  ``AnalysisConfigurable`` subclass without adding new dependencies.
+  Full ``sklearn.base.clone()`` compatibility is best-effort because
+  complex traitlets traits (e.g., lists) may fail sklearn's strict
+  identity check.

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -21,6 +21,7 @@ from spectrochempy.utils.baseconfigurable import BaseConfigurable
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
 from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.exceptions import NotFittedError
+from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.traits import NDDatasetType
 
 
@@ -187,6 +188,63 @@ class AnalysisConfigurable(BaseConfigurable):
         if self._is_dataset or self._output_type == "NDDataset":
             return X
         return np.asarray(X)
+
+    def get_params(self, deep=True):
+        r"""
+        Get the configuration parameters of this estimator.
+
+        Parameters
+        ----------
+        deep : `bool`, optional, default:`True`
+            Ignored.  Present for compatibility with scikit-learn conventions.
+
+        Returns
+        -------
+        `dict`
+            Mapping of parameter name -> current value.
+
+        """
+        return dict(self.params())
+
+    def set_params(self, **params):
+        r"""
+        Set configuration parameters on this estimator.
+
+        Returns `self` so that calls can be chained.
+
+        Parameters
+        ----------
+        **params
+            Parameter names and values to update.
+
+        Returns
+        -------
+        self
+            The estimator instance.
+
+        Raises
+        ------
+        SpectroChemPyError
+            If a parameter name does not correspond to a configurable trait.
+
+        """
+        for key, value in params.items():
+            if not hasattr(self, key):
+                raise SpectroChemPyError(
+                    f"Invalid parameter '{key}' for {self.__class__.__name__}."
+                )
+            setattr(self, key, value)
+        return self
+
+    def __repr__(self):
+        cls = self.__class__.__name__
+        params = self.get_params()
+        # Show a concise subset for readability
+        display = {k: v for k, v in params.items() if not k.startswith("_")}
+        if not display:
+            return f"{cls}()"
+        items = ", ".join(f"{k}={v!r}" for k, v in display.items())
+        return f"{cls}({items})"
 
 
 # ======================================================================================

--- a/tests/test_analysis/test_base/test_sklearn_compat.py
+++ b/tests/test_analysis/test_base/test_sklearn_compat.py
@@ -1,0 +1,92 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+"""Tests for sklearn-compatible API on analysis estimators."""
+
+import numpy as np
+import pytest
+
+from spectrochempy import NDDataset
+from spectrochempy.analysis.decomposition.pca import PCA
+from spectrochempy.processing.baselineprocessing.baselineprocessing import Baseline
+from spectrochempy.utils.exceptions import SpectroChemPyError
+
+
+class TestAnalysisGetParams:
+    def test_pca_get_params(self):
+        pca = PCA(n_components=5)
+        params = pca.get_params()
+        assert isinstance(params, dict)
+        assert params["n_components"] == 5
+        assert "svd_solver" in params
+
+    def test_baseline_get_params(self):
+        bl = Baseline()
+        params = bl.get_params()
+        assert isinstance(params, dict)
+        assert "multivariate" in params
+
+    def test_params_reflect_current_values(self):
+        pca = PCA()
+        pca.n_components = 3
+        params = pca.get_params()
+        assert params["n_components"] == 3
+
+
+class TestAnalysisSetParams:
+    def test_pca_set_params(self):
+        pca = PCA()
+        result = pca.set_params(n_components=7)
+        assert result is pca
+        assert pca.n_components == 7
+
+    def test_set_params_chaining(self):
+        pca = PCA()
+        pca.set_params(n_components=2).fit(
+            NDDataset(np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]))
+        )
+        assert pca.n_components == 2
+
+    def test_set_params_invalid_raises(self):
+        pca = PCA()
+        with pytest.raises(SpectroChemPyError, match="Invalid parameter"):
+            pca.set_params(nonexistent_param=42)
+
+
+class TestAnalysisRepr:
+    def test_pca_repr(self):
+        pca = PCA(n_components=5)
+        r = repr(pca)
+        assert "PCA" in r
+        assert "n_components=5" in r
+
+    def test_baseline_repr(self):
+        bl = Baseline()
+        r = repr(bl)
+        assert "Baseline" in r
+
+
+class TestAnalysisSklearnClone:
+    def test_sklearn_clone_not_guaranteed_for_traitlets_classes(self):
+        """
+        sklearn.base.clone() may fail on AnalysisConfigurable subclasses
+        because traitlets modifies constructor arguments (e.g., empty
+        lists become internal traitlet structures).  get_params and
+        set_params work, but clone compatibility is best-effort only.
+        """
+        try:
+            from sklearn.base import clone
+        except ImportError:
+            pytest.skip("scikit-learn not installed")
+
+        pca = PCA(n_components=3)
+        # clone may raise RuntimeError; that is acceptable
+        try:
+            cloned = clone(pca)
+        except RuntimeError as exc:
+            assert "Cannot clone" in str(exc)
+            pytest.xfail("traitlets traits break sklearn clone identity check")


### PR DESCRIPTION
## Summary

This PR extends the lightweight scikit-learn compatibility layer (previously added to preprocessing transformers in #1345) to all `AnalysisConfigurable` subclasses — PCA, PLSRegression, Baseline, MCRALS, NMF, SVD, etc.

## New API surface

All analysis estimators now expose:

- **`get_params(deep=True)`** — returns a `dict` of current trait values tagged `config=True`.  Works by wrapping the existing `MetaConfigurable.params()` method (no new infrastructure).
- **`set_params(**params)`** — updates traits in-place and returns `self` for chaining.  Raises `SpectroChemPyError` with a clear message for invalid parameter names.
- **`__repr__`** — returns a readable string such as `PCA(n_components=5, svd_solver='auto', ...)`.

## Why this matters

- Parameter inspection and grid exploration become possible for any analysis estimator without a pipeline class.
- `sklearn.base.clone()` compatibility is **best-effort** : it works for simple traits (int, float, str, bool) but may fail on complex traitlets structures (e.g., `List` traits like `ranges=[]`) because sklearn clone performs a strict identity check that traitlets' internal conversions violate.

## No new dependencies

Scikit-learn is **not** added as a dependency.  The compatibility layer reuses existing `MetaConfigurable.params()`.

## Tests

9 new test cases covering:
- `get_params()` returns correct current values for PCA and Baseline.
- `set_params()` updates traits and returns self.
- `set_params()` supports chaining (`set_params(...).fit(...)`).
- Invalid parameter names raise `SpectroChemPyError`.
- `__repr__` contains class name and key parameters.
- `sklearn.base.clone()` failure on traitlets classes is handled gracefully (documented as expected limitation).

## Single point of change

Only `AnalysisConfigurable` in `src/spectrochempy/analysis/_base/_analysisbase.py` was modified.  All subclasses (PCA, PLS, Baseline, MCRALS, NMF, SVD, etc.) inherit the new methods automatically.
