### PR TITLE
FIX: avoid traitlets dtype warning by coercing MaskedArray to plain ndarray in transformers

### DIFF
--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -258,6 +258,10 @@ class BasePreprocessor:
         items = ", ".join(f"{k}={v!r}" for k, v in params.items())
         return f"{cls}({items})"
 
+    def _set_data(self, new, data):
+        r"""Assign transformed data, coercing MaskedArray → plain ndarray."""
+        new._data = np.asarray(data)
+
     def _fit(self, dataset):
         raise NotImplementedError("Subclasses must implement _fit().")
 
@@ -304,13 +308,13 @@ class CenterTransformer(BasePreprocessor):
 
     def _transform(self, dataset):
         new = dataset.copy()
-        new._data = dataset.masked_data - self.mean_
+        self._set_data(new, dataset.masked_data - self.mean_)
         new.history = f"CenterTransformer applied on dimension {self._dim_name}"
         return new
 
     def _inverse_transform(self, dataset):
         new = dataset.copy()
-        new._data = dataset.masked_data + self.mean_
+        self._set_data(new, dataset.masked_data + self.mean_)
         new.history = f"CenterTransformer inverse applied on dimension {self._dim_name}"
         return new
 
@@ -357,7 +361,7 @@ class AutoscaleTransformer(BasePreprocessor):
         new = dataset.copy()
         data = dataset.masked_data
         std_safe = np.where(self.std_ == 0, 1, self.std_)
-        new._data = (data - self.mean_) / std_safe
+        self._set_data(new, (data - self.mean_) / std_safe)
         new.history = f"AutoscaleTransformer applied on dimension {self._dim_name}"
         return new
 
@@ -365,7 +369,7 @@ class AutoscaleTransformer(BasePreprocessor):
         new = dataset.copy()
         data = dataset.masked_data
         std_safe = np.where(self.std_ == 0, 1, self.std_)
-        new._data = data * std_safe + self.mean_
+        self._set_data(new, data * std_safe + self.mean_)
         new.history = (
             f"AutoscaleTransformer inverse applied on dimension {self._dim_name}"
         )
@@ -490,9 +494,9 @@ class NormalizeTransformer(BasePreprocessor):
         data = dataset.masked_data
 
         if self.method in ("max", "sum", "vector"):
-            new._data = data / self.norm_
+            self._set_data(new, data / self.norm_)
         elif self.method == "minmax":
-            new._data = (data - self.dmin_) / self.range_
+            self._set_data(new, (data - self.dmin_) / self.range_)
 
         new.history = (
             f"NormalizeTransformer ({self.method}) applied on dimension "
@@ -505,9 +509,9 @@ class NormalizeTransformer(BasePreprocessor):
         data = dataset.masked_data
 
         if self.method in ("max", "sum", "vector"):
-            new._data = data * self.norm_
+            self._set_data(new, data * self.norm_)
         elif self.method == "minmax":
-            new._data = data * self.range_ + self.dmin_
+            self._set_data(new, data * self.range_ + self.dmin_)
 
         new.history = (
             f"NormalizeTransformer ({self.method}) inverse applied on dimension "
@@ -634,7 +638,7 @@ class MSCTransformer(BasePreprocessor):
         a = (sum_x - b * sum_ref) / n
 
         b_safe = np.where(b == 0, 1, b)
-        new._data = (data - a) / b_safe
+        self._set_data(new, (data - a) / b_safe)
         new.history = f"MSCTransformer applied on dimension {self._dim_name}"
         return new
 
@@ -642,7 +646,7 @@ class MSCTransformer(BasePreprocessor):
         new = dataset.copy()
         data = dataset.masked_data
 
-        new._data = data * self.b_ + self.a_
+        self._set_data(new, data * self.b_ + self.a_)
         new.history = f"MSCTransformer inverse applied on dimension {self._dim_name}"
         return new
 
@@ -693,7 +697,7 @@ class ParetoScaleTransformer(BasePreprocessor):
         data = dataset.masked_data
 
         std_safe = np.where(self.std_ == 0, 1, self.std_)
-        new._data = (data - self.mean_) / np.sqrt(std_safe)
+        self._set_data(new, (data - self.mean_) / np.sqrt(std_safe))
         new.history = f"ParetoScaleTransformer applied on dimension {self._dim_name}"
         return new
 
@@ -702,7 +706,7 @@ class ParetoScaleTransformer(BasePreprocessor):
         data = dataset.masked_data
 
         std_safe = np.where(self.std_ == 0, 1, self.std_)
-        new._data = data * np.sqrt(std_safe) + self.mean_
+        self._set_data(new, data * np.sqrt(std_safe) + self.mean_)
         new.history = (
             f"ParetoScaleTransformer inverse applied on dimension " f"{self._dim_name}"
         )
@@ -758,7 +762,7 @@ class RangeScaleTransformer(BasePreprocessor):
         new = dataset.copy()
         data = dataset.masked_data
 
-        new._data = data / self.range_
+        self._set_data(new, data / self.range_)
         new.history = f"RangeScaleTransformer applied on dimension {self._dim_name}"
         return new
 
@@ -766,7 +770,7 @@ class RangeScaleTransformer(BasePreprocessor):
         new = dataset.copy()
         data = dataset.masked_data
 
-        new._data = data * self.range_
+        self._set_data(new, data * self.range_)
         new.history = (
             f"RangeScaleTransformer inverse applied on dimension " f"{self._dim_name}"
         )
@@ -821,7 +825,7 @@ class RobustScaleTransformer(BasePreprocessor):
         new = dataset.copy()
         data = dataset.masked_data
 
-        new._data = (data - self.median_) / self.mad_
+        self._set_data(new, (data - self.median_) / self.mad_)
         new.history = f"RobustScaleTransformer applied on dimension {self._dim_name}"
         return new
 
@@ -829,7 +833,7 @@ class RobustScaleTransformer(BasePreprocessor):
         new = dataset.copy()
         data = dataset.masked_data
 
-        new._data = data * self.mad_ + self.median_
+        self._set_data(new, data * self.mad_ + self.median_)
         new.history = (
             f"RobustScaleTransformer inverse applied on dimension " f"{self._dim_name}"
         )
@@ -882,12 +886,12 @@ class LogTransformer(BasePreprocessor):
         data = dataset.masked_data
 
         if self.method == "log1p":
-            new._data = np.log1p(data)
+            self._set_data(new, np.log1p(data))
             new.history = "LogTransformer (log1p) applied"
         elif self.method == "log":
             if np.any(data <= 0):
                 data = data + self.eps
-            new._data = np.log(data)
+            self._set_data(new, np.log(data))
             new.history = "LogTransformer (log) applied"
         else:
             raise SpectroChemPyError(
@@ -901,10 +905,10 @@ class LogTransformer(BasePreprocessor):
         data = dataset.masked_data
 
         if self.method == "log1p":
-            new._data = np.expm1(data)
+            self._set_data(new, np.expm1(data))
             new.history = "LogTransformer (log1p) inverse applied"
         elif self.method == "log":
-            new._data = np.exp(data)
+            self._set_data(new, np.exp(data))
             new.history = "LogTransformer (log) inverse applied"
         else:
             raise SpectroChemPyError(


### PR DESCRIPTION
## Summary

Fixes a `UserWarning` introduced in #1341–#1344 where assigning a `numpy.ma.MaskedArray` result to `NDDataset._data` triggered traitlets' dtype-coercion warning.

## Problem

All transformer `_transform` and `_inverse_transform` methods do:
```python
new = dataset.copy()
new._data = dataset.masked_data - self.mean_
```

`dataset.masked_data` is a `MaskedArray`. Any arithmetic on it (subtraction, division, `np.log1p`, etc.) returns another `MaskedArray`. When this `MaskedArray` is assigned to the `_data` trait (which expects a plain `ndarray`), `spectrochempy.extern.traittypes.Array.validate` calls `np.asarray(value, dtype=None)`. Because the input is a `MaskedArray` (not a plain `ndarray`), `np.asarray` creates a new array object, and traitlets warns:

```
Given trait value dtype "float64" does not match required type "float64".
A coerced copy has been created.
```

## Fix

Added a small helper `_set_data(new, data)` on `BasePreprocessor` that wraps the assignment with `np.asarray(...)` **explicitly**. This converts `MaskedArray` → plain `ndarray` before traitlets sees it, avoiding the warning.

All 18 `_transform` / `_inverse_transform` assignments across the 9 transformer classes now use this helper.

## Verification

- 102 tests in `test_preprocessing.py` pass.
- All 9 procedural functions (`center`, `autoscale`, `snv`, `msc`, `normalize`, `pareto_scale`, `range_scale`, `robust_scale`, `log_transform`) now run silently with `warnings.filterwarnings('error')`.
