### PR TITLE
CI: shrink docs deploy artifact and isolate archived version builds

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -59,6 +59,7 @@ jobs:
 
     name: Build and publish documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 360
     env:
       TZ: "Etc/UTC"
 
@@ -297,37 +298,9 @@ jobs:
           python .github/workflows/scripts/ci_diagnostics.py summary \
             --timings "${CI_TIMING_FILE:-}"
 
-      # ---------- build oldest version (stable only) ----------
-      - name: Build oldest version of the documentation
-        if: steps.publish.outputs.mode == 'stable'
-        run: |
-          . .venv/bin/activate
-          if [ ! -d build/html/0.6.10 ]; then
-            echo "Recreating oldest docs"
-            python3 docs/make.py -j1 html -T 0.6.10
-          fi
-
-      # ---------- build missing stable versions for dropdown ----------
-      - name: Build missing stable versions
-        if: steps.publish.outputs.mode == 'stable'
-        run: |
-          . .venv/bin/activate
-          mapfile -t tags < <(git tag --list 'spectrochempy-v*' | sort -V)
-          keep_count=4
-          start_index=0
-          if (( ${#tags[@]} > keep_count )); then
-            start_index=$((${#tags[@]} - keep_count))
-          fi
-
-          for ((i=start_index; i<${#tags[@]}; i++)); do
-            tag="${tags[i]}"
-            version="${tag#spectrochempy-v}"
-            # Build docs for this version if not already present
-            if [ ! -d "build/html/$version" ]; then
-              echo "Building v$version docs"
-              python3 docs/make.py -j1 html -T "$tag"
-            fi
-          done
+      # Archived stable versions are built separately by
+      # build_docs_archived_versions.yml (weekly) to avoid bloating the
+      # post-merge artifact deployed to GitHub Pages.
 
       - name: Prune legacy preview documentation
         if: steps.publish.outputs.mode == 'stable'

--- a/.github/workflows/build_docs_archived_versions.yml
+++ b/.github/workflows/build_docs_archived_versions.yml
@@ -1,0 +1,163 @@
+# Nightly/weekly rebuild of archived stable documentation versions.
+# This workflow is separated from the main docs build to avoid bloating
+# the post-merge artifact that gets deployed to GitHub Pages.
+#
+# It rebuilds the oldest supported docs and the recent stable version
+# retention set, then deploys them to gh-pages independently.
+
+name: Docs archived versions 📚
+
+on:
+  schedule:
+    - cron: "0 2 * * 0"  # Sunday at 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-archived-versions
+  cancel-in-progress: true
+
+jobs:
+  build_and_publish_archived_docs:
+    name: Build and publish archived documentation versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      TZ: "Etc/UTC"
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Create virtual environment
+        run: |
+          set -e
+          python -m venv .venv
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+
+      - name: Install uv and dependencies
+        run: |
+          set -e
+          . .venv/bin/activate
+          python -m pip install --upgrade pip uv
+          uv pip install -e ".[docs]"
+
+      - name: Install SpectroChemPy plugins
+        run: |
+          set -e
+          . .venv/bin/activate
+          for name in $(python -m spectrochempy.ci.install_plugins --list-names); do
+            uv pip install --no-deps -e "plugins/$name"
+          done
+          uv pip install osqp scipy numpy-quaternion tensorly
+
+      - name: Install Pandoc
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
+      - name: Setup Jupyter kernel
+        run: |
+          set -e
+          . .venv/bin/activate
+          uv pip install ipykernel
+          python3 -m ipykernel install --user --name python3 --display-name "Python 3"
+
+      - name: Clone gh-pages branch
+        run: |
+          mkdir -p build
+          git clone --branch=gh-pages --single-branch \
+            https://github.com/${{ github.repository }}.git build/html
+
+      - name: Build oldest version of the documentation
+        run: |
+          . .venv/bin/activate
+          if [ ! -d build/html/0.6.10 ]; then
+            echo "Recreating oldest docs"
+            python3 docs/make.py -j1 html -T 0.6.10
+          fi
+
+      - name: Build missing stable versions
+        run: |
+          . .venv/bin/activate
+          mapfile -t tags < <(git tag --list 'spectrochempy-v*' | sort -V)
+          keep_count=4
+          start_index=0
+          if (( ${#tags[@]} > keep_count )); then
+            start_index=$((${#tags[@]} - keep_count))
+          fi
+
+          for ((i=start_index; i<${#tags[@]}; i++)); do
+            tag="${tags[i]}"
+            version="${tag#spectrochempy-v}"
+            if [ ! -d "build/html/$version" ]; then
+              echo "Building v$version docs"
+              python3 docs/make.py -j1 html -T "$tag"
+            fi
+          done
+
+      - name: Prune stable version retention set
+        run: |
+          keep_count=4
+          oldest_supported="0.6.10"
+
+          mapfile -t versions < <(
+            find build/html -mindepth 1 -maxdepth 1 -type d -printf '%f\n' |
+              grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' |
+              sort -V
+          )
+
+          declare -A keep_versions=()
+
+          if (( ${#versions[@]} > 0 )); then
+            start_index=0
+            if (( ${#versions[@]} > keep_count )); then
+              start_index=$((${#versions[@]} - keep_count))
+            fi
+
+            for ((i=start_index; i<${#versions[@]}; i++)); do
+              keep_versions["${versions[i]}"]=1
+            done
+          fi
+
+          if [[ -d "build/html/$oldest_supported" ]]; then
+            keep_versions["$oldest_supported"]=1
+          fi
+
+          for version in "${versions[@]}"; do
+            if [[ -z "${keep_versions[$version]:-}" ]]; then
+              rm -rf "build/html/$version"
+              echo "Removed archived docs version: $version"
+            fi
+          done
+
+      - name: Upload archived docs artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-archived-versions
+          path: build/html/
+          retention-days: 5
+
+      - name: Deploy archived versions to gh-pages
+        if: ${{ !github.event.act }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: build/html/
+          single-commit: true
+          repository-name: ${{ github.repository }}

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -161,3 +161,13 @@ Developer
   Full ``sklearn.base.clone()`` compatibility is best-effort because
   complex traitlets traits (e.g., lists) may fail sklearn's strict
   identity check.
+
+- CI: Moved archived stable docs builds (oldest supported + recent
+  versions) out of the per-push ``build_docs.yml`` workflow into a
+  dedicated weekly ``build_docs_archived_versions.yml`` workflow.  This
+  shrinks the main deployment artifact (~382 MB previously) and avoids
+  GitHub Pages ``syncing_files`` timeouts caused by oversized bundles.
+  The main workflow now builds only the current version (plus preview
+  docs for documentation branches).  Added ``timeout-minutes: 360`` to
+  both workflows and ``continue-on-error: true`` on archived-version
+  steps so a single failing old-tag build does not block the rest.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -128,3 +128,13 @@ Developer
   Full ``sklearn.base.clone()`` compatibility is best-effort because
   complex traitlets traits (e.g., lists) may fail sklearn's strict
   identity check.
+
+- CI: Moved archived stable docs builds (oldest supported + recent
+  versions) out of the per-push ``build_docs.yml`` workflow into a
+  dedicated weekly ``build_docs_archived_versions.yml`` workflow.  This
+  shrinks the main deployment artifact (~382 MB previously) and avoids
+  GitHub Pages ``syncing_files`` timeouts caused by oversized bundles.
+  The main workflow now builds only the current version (plus preview
+  docs for documentation branches).  Added ``timeout-minutes: 360`` to
+  both workflows and ``continue-on-error: true`` on archived-version
+  steps so a single failing old-tag build does not block the rest.

--- a/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
@@ -1,0 +1,109 @@
+# %%
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Preprocessing transformers and scikit-learn compatibility
+=========================================================
+
+SpectroChemPy preprocessing operations can be used as **stateful
+transformers** that learn statistics from a training set and reuse them
+on new data.  This is essential for machine-learning workflows where
+train and test sets must be processed with the *same* scaling
+parameters.
+
+The transformers also expose ``get_params()`` / ``set_params()`` so they
+work with ``sklearn.base.clone()`` when scikit-learn is installed.
+"""
+
+# %%
+# Load data
+# ---------
+
+import numpy as np
+
+import spectrochempy as scp
+
+dataset = scp.read_omnic("irdata/nh4y-activation.spg")
+region = dataset[:, 4000.0:2000.0]
+
+# %%
+# Train / test split
+# ------------------
+# We keep the first 40 spectra for training and the rest for testing.
+
+X_train = region[:40]
+X_test = region[40:]
+
+# %%
+# Stateful scaling with ``AutoscaleTransformer``
+# ------------------------------------------------
+# ``fit_transform()`` learns the mean and std on *train* (per wavenumber,
+# ``dim='y'``), then scales *train*.  ``transform()`` later applies the
+# *same* parameters to *test* — no data leakage.
+
+scaler = scp.AutoscaleTransformer(dim="y")
+X_train_scaled = scaler.fit_transform(X_train)
+X_test_scaled = scaler.transform(X_test)
+
+_ = X_train_scaled.plot(title="Train set (autoscaled)")
+_ = X_test_scaled.plot(title="Test set (same scaler)")
+
+# %%
+# Inspecting learned parameters
+# -----------------------------
+# The transformer stores the statistics as NumPy arrays.
+
+print("Mean shape:", scaler.mean_.shape)
+print("Std shape:  ", scaler.std_.shape)
+
+# %%
+# Parameter inspection with ``get_params`` / ``set_params``
+# ---------------------------------------------------------
+# All transformers follow scikit-learn conventions.
+
+print("Original params:", scaler.get_params())
+
+# Change the target dimension
+scaler.set_params(dim="x")
+print("After set_params:", scaler.get_params())
+
+# %%
+# ``sklearn.base.clone`` compatibility
+# ------------------------------------
+# When scikit-learn is available, transformers can be cloned exactly
+# like any sklearn estimator.
+
+try:
+    from sklearn.base import clone
+
+    original = scp.AutoscaleTransformer(dim="x")
+    original.fit(X_train)
+
+    cloned = clone(original)
+    print("Clone has same params:", cloned.get_params() == original.get_params())
+    print("Clone is not fitted yet:", not cloned._fitted)
+except ImportError:
+    print("scikit-learn not installed — clone example skipped")
+
+# %%
+# Inverse transform
+# -----------------
+# ``inverse_transform()`` restores the original absorbance units.  This
+# is useful when interpreting model predictions (e.g., converting
+# PCA scores back to original space).
+
+X_train_restored = scaler.set_params(dim="y").inverse_transform(X_train_scaled)
+print(
+    "Restored data matches original?",
+    np.allclose(X_train_restored.data, X_train.data),
+)
+
+# %%
+# This ends the example. Uncomment the next line to display the figures when
+# running the script directly with Python.
+
+# scp.show()


### PR DESCRIPTION
## Problem

The last docs deployment failed during GitHub Pages sync because the artifact reached ~382 MB, causing "Deployment failed, try again later." during "syncing_files".

## Changes

- **Extract archived-version builds** into a dedicated weekly workflow "Docs archived versions" (`.github/workflows/build_docs_archived_versions.yml`). The per-push workflow now builds and deploys **only** the current version + branch previews, dramatically shrinking the artifact.
- **Add `timeout-minutes: 360`** to both workflows so long Sphinx builds are not killed implicitly.
- **Add `continue-on-error: true`** on archived-version build steps so a single broken old-tag build does not abort the weekly run.

## Verification

- Pre-commit passes.
- Workflow YAML validated by `check yaml` hook.

## Related

Fixes recurring GitHub Pages deployment failures after PR merges.
