### PR TITLE
FIX: honour the strict argument in npy.dot()

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -83,6 +83,12 @@ Bug Fixes
   ``ylst_data``, ``ylst_title``, ``ylst_units``) where it belongs as per-spectrum
   metadata. (#1332)
 
+- ``scp.dot()`` now honours its ``strict`` argument, forwarding it to
+  ``numpy.ma.dot`` so masked values are propagated (``strict=True``) or treated
+  as zero (``strict=False``) as documented. The signature default now matches
+  the documentation and NumPy (``strict=False``), which preserves the previous
+  behaviour for existing callers (``strict`` was silently ignored before).
+
 - ``MCRALS`` is now more robust in constrained and hard-model workflows:
   closure constraints are applied correctly for empty and single-component
   selections, zero-norm spectral normalization no longer produces

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -75,6 +75,12 @@ Bug Fixes
   ``ylst_data``, ``ylst_title``, ``ylst_units``) where it belongs as per-spectrum
   metadata. (#1332)
 
+- ``scp.dot()`` now honours its ``strict`` argument, forwarding it to
+  ``numpy.ma.dot`` so masked values are propagated (``strict=True``) or treated
+  as zero (``strict=False``) as documented. The signature default now matches
+  the documentation and NumPy (``strict=False``), which preserves the previous
+  behaviour for existing callers (``strict`` was silently ignored before).
+
 - ``MCRALS`` is now more robust in constrained and hard-model workflows:
   closure constraints are applied correctly for empty and single-component
   selections, zero-norm spectral normalization no longer produces

--- a/src/spectrochempy/processing/transformation/npy.py
+++ b/src/spectrochempy/processing/transformation/npy.py
@@ -12,7 +12,7 @@ from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.utils.objects import make_new_object
 
 
-def dot(a, b, strict=True, out=None):
+def dot(a, b, strict=False, out=None):
     """
     Return the dot product of two NDDatasets.
 
@@ -73,7 +73,7 @@ def dot(a, b, strict=True, out=None):
         # try to cast to NDDataset
         b = NDDataset(b)
 
-    data = np.ma.dot(a.masked_data, b.masked_data)
+    data = np.ma.dot(a.masked_data, b.masked_data, strict=strict)
     mask = data.mask
     data = data.data
 

--- a/src/spectrochempy/processing/transformation/npy.py
+++ b/src/spectrochempy/processing/transformation/npy.py
@@ -62,7 +62,11 @@ def dot(a, b, strict=False, out=None):
 
     if not isinstance(a, NDDataset) and not isinstance(b, NDDataset):
         # must be between numpy object or something non valid. Let numpy
-        # deal with this
+        # deal with this. Route masked-array inputs through numpy.ma.dot so
+        # the ``strict`` argument is honoured (plain np.dot would silently
+        # ignore it); otherwise fall back to the regular np.dot.
+        if isinstance(a, np.ma.MaskedArray) or isinstance(b, np.ma.MaskedArray):
+            return np.ma.dot(a, b, strict=strict)
         return np.dot(a, b)
 
     if not isinstance(a, NDDataset):

--- a/tests/test_processing/test_transformation/test_npy.py
+++ b/tests/test_processing/test_transformation/test_npy.py
@@ -8,6 +8,7 @@
 import numpy as np
 import pytest
 
+from spectrochempy import NDDataset
 from spectrochempy import diag
 from spectrochempy.processing.transformation.npy import dot
 
@@ -55,3 +56,46 @@ def test_npy(ds1):
     # isinstance typo regression: first arg numpy, second arg NDDataset
     x = dot(a.data.T, b)
     assert x.shape == (a.x.size, b.x.size)
+
+
+def test_dot_strict_mask_propagation():
+    # `strict` must be honoured and forwarded to numpy.ma.dot.
+    # With a masked entry in row 0 of `a`, strict propagation masks the whole
+    # corresponding row of the result; non-strict treats masked values as 0.
+    a = np.ma.array([[1.0, 2.0], [3.0, 4.0]], mask=[[0, 1], [0, 0]])
+    b = np.ma.array([[5.0, 6.0], [7.0, 8.0]], mask=[[0, 0], [0, 0]])
+    da = NDDataset(a)
+    db = NDDataset(b)
+
+    # numpy reference behaviour
+    ref_loose = np.ma.dot(a, b, strict=False)
+    ref_strict = np.ma.dot(a, b, strict=True)
+    assert not np.ma.getmaskarray(ref_loose).any()
+    assert np.array_equal(
+        np.ma.getmaskarray(ref_strict), [[True, True], [False, False]]
+    )
+
+    # strict=True must mask the whole result row impacted by the masked value
+    r_strict = dot(da, db, strict=True)
+    assert np.array_equal(
+        np.ma.getmaskarray(np.ma.array(r_strict.data, mask=r_strict.mask)),
+        [[True, True], [False, False]],
+    )
+
+    # strict=False keeps every entry unmasked and matches numpy
+    r_loose = dot(da, db, strict=False)
+    assert not np.ma.getmaskarray(np.ma.array(r_loose.data, mask=r_loose.mask)).any()
+    np.testing.assert_allclose(r_loose.data, ref_loose.data)
+
+    # strict actually changes the outcome, so the two must differ
+    assert not np.array_equal(
+        np.ma.getmaskarray(np.ma.array(r_strict.data, mask=r_strict.mask)),
+        np.ma.getmaskarray(np.ma.array(r_loose.data, mask=r_loose.mask)),
+    )
+
+    # default must preserve the historical (non-strict) behaviour
+    r_default = dot(da, db)
+    assert np.array_equal(
+        np.ma.getmaskarray(np.ma.array(r_default.data, mask=r_default.mask)),
+        np.ma.getmaskarray(np.ma.array(r_loose.data, mask=r_loose.mask)),
+    )

--- a/tests/test_processing/test_transformation/test_npy.py
+++ b/tests/test_processing/test_transformation/test_npy.py
@@ -99,3 +99,32 @@ def test_dot_strict_mask_propagation():
         np.ma.getmaskarray(np.ma.array(r_default.data, mask=r_default.mask)),
         np.ma.getmaskarray(np.ma.array(r_loose.data, mask=r_loose.mask)),
     )
+
+
+def test_dot_strict_direct_masked_arrays():
+    # When neither input is an NDDataset but both are numpy masked arrays,
+    # `strict` must still be forwarded to numpy.ma.dot rather than dropped by
+    # a plain np.dot. The result is a numpy masked array (no NDDataset wrapping).
+    a = np.ma.array([[1.0, 2.0], [3.0, 4.0]], mask=[[0, 1], [0, 0]])
+    b = np.ma.array([[5.0, 6.0], [7.0, 8.0]], mask=[[0, 0], [0, 0]])
+
+    ref_loose = np.ma.dot(a, b, strict=False)
+    ref_strict = np.ma.dot(a, b, strict=True)
+
+    r_strict = dot(a, b, strict=True)
+    assert isinstance(r_strict, np.ma.MaskedArray)
+    assert np.array_equal(np.ma.getmaskarray(r_strict), np.ma.getmaskarray(ref_strict))
+    assert np.array_equal(np.ma.getmaskarray(r_strict), [[True, True], [False, False]])
+
+    r_loose = dot(a, b, strict=False)
+    assert not np.ma.getmaskarray(r_loose).any()
+    np.testing.assert_allclose(r_loose.data, ref_loose.data)
+
+    # default keeps the historical non-strict behaviour
+    r_default = dot(a, b)
+    assert not np.ma.getmaskarray(np.ma.asarray(r_default)).any()
+
+    # a plain (non-masked) pair must still go through np.dot unchanged
+    r_plain = dot(a.data, b.data)
+    assert not isinstance(r_plain, np.ma.MaskedArray)
+    np.testing.assert_allclose(r_plain, np.dot(a.data, b.data))


### PR DESCRIPTION
`spectrochempy.dot()` (`processing/transformation/npy.py`) accepts a `strict` argument but never forwarded it to `numpy.ma.dot`, so mask propagation could not be controlled and `strict` was silently ignored. The signature also defaulted to `strict=True` while the docstring documents `Default is False`, and the actual runtime behaviour was always non-strict because the argument was dropped.

This forwards `strict` to `numpy.ma.dot(...)` and sets the default to `False`, matching both the docstring and NumPy. Since the argument was previously ignored (effective `strict=False`), keeping `False` as the default preserves the existing no-argument behaviour for all current callers, while `strict=True` now actually works.

Added `test_dot_strict_mask_propagation` covering: `strict=True` masks the whole impacted result row, `strict=False` matches NumPy and leaves entries unmasked, the two differ, and the default preserves the historical non-strict result. Full `test_npy.py` passes.