### PR TITLE
ENH: Add structured peak finding result helper

### DIFF
--- a/docs/sources/userguide/analysis/peak_finding.py
+++ b/docs/sources/userguide/analysis/peak_finding.py
@@ -361,6 +361,15 @@ _ = ax.legend(fontsize=6)
 # of the detected peaks in the
 # `properties` dictionary.
 #
+# If a tabular representation is needed for reporting or export, use
+# `as_result=True`. This keeps the default tuple return unchanged, but returns a
+# lightweight result object with dictionary rows and CSV export helpers.
+
+# %%
+result = s.find_peaks(height=(0.15, 0.22), prominence=0, as_result=True)
+result.to_dict()
+
+# %% [markdown]
 # #### Prominence
 #
 # The prominence of a peak can be defined as the vertical distance from the peak’s

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,12 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- ``find_peaks(..., as_result=True)`` now returns a lightweight
+  ``PeakFindingResult`` object with ``peaks``, ``properties``, ``to_dict()``,
+  and ``to_csv()`` helpers. The default return value remains the historical
+  ``(peaks, properties)`` tuple, and the new helpers do not add a pandas
+  dependency.
+
 - ``Optimize.validate_script(script=None)`` — new public method that validates a
   curve-fitting script before launching the optimisation.  Returns a list of
   ``ScriptError`` objects with the line number, offending line, and a

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,12 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- ``find_peaks(..., as_result=True)`` now returns a lightweight
+  ``PeakFindingResult`` object with ``peaks``, ``properties``, ``to_dict()``,
+  and ``to_csv()`` helpers. The default return value remains the historical
+  ``(peaks, properties)`` tuple, and the new helpers do not add a pandas
+  dependency.
+
 - ``Optimize.validate_script(script=None)`` — new public method that validates a
   curve-fitting script before launching the optimisation.  Returns a list of
   ``ScriptError`` objects with the line number, offending line, and a

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -15,15 +15,19 @@ specific to spectroscopic analysis, including:
 - Peak interpolation for improved accuracy
 """
 
-__all__ = ["find_peaks"]
+__all__ = ["PeakFindingResult", "find_peaks"]
 
 __dataset_methods__ = ["find_peaks"]
+
+import csv
+from pathlib import Path
 
 import numpy as np
 import scipy
 
 from spectrochempy.application.application import error_
 from spectrochempy.application.application import warning_
+from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.units import DimensionalityError
 from spectrochempy.core.units import Quantity
 
@@ -32,6 +36,145 @@ from spectrochempy.core.units import Quantity
 # argrelmin(data[, axis, order, mode]) 	Calculate the relative minima of data.
 # argrelmax(data[, axis, order, mode]) 	Calculate the relative maxima of data.
 # argrelextrema(data, comparator[, axis, ...]) 	Calculate the relative extrema of data.
+
+
+def _as_scalar(value):
+    """Return a plain scalar when *value* is a one-item numpy-like object."""
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (ValueError, TypeError):
+            pass
+    return value
+
+
+def _sequence_item(values, index):
+    """Return item *index* from numpy arrays, quantities, or Python sequences."""
+    try:
+        return _as_scalar(values[index])
+    except (TypeError, IndexError):
+        return _as_scalar(values)
+
+
+def _stringify_csv_value(value):
+    """Serialize peak table values without adding optional dependencies."""
+    value = _as_scalar(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    return str(value)
+
+
+class PeakFindingResult:
+    """
+    Structured result returned by :func:`find_peaks`.
+
+    Parameters
+    ----------
+    peaks : NDDataset or None
+        Dataset containing identified peak positions and heights.
+    properties : dict or None
+        Peak properties returned by :func:`scipy.signal.find_peaks`.
+
+    Notes
+    -----
+    The object is intentionally dependency-light. It exposes Python-native
+    table helpers and does not require pandas.
+    """
+
+    __slots__ = ("peaks", "properties")
+
+    def __init__(self, peaks, properties=None):
+        self.peaks = peaks
+        self.properties = dict(properties or {})
+
+    def __len__(self):
+        return 0 if self.peaks is None else len(self.peaks)
+
+    def __iter__(self):
+        """Allow ``peaks, properties = result`` for easy migration."""
+        yield self.peaks
+        yield self.properties
+
+    def __repr__(self):
+        return f"PeakFindingResult(n_peaks={len(self)})"
+
+    def to_dict(self):
+        """
+        Return peak information as a list of dictionaries.
+
+        Each dictionary contains ``index``, ``position``, ``height``, and any
+        per-peak properties whose length matches the number of detected peaks.
+        Values keep their native units when they are unit-bearing quantities.
+        """
+        if self.peaks is None:
+            return []
+
+        n_peaks = len(self)
+        positions = self._positions()
+        heights = np.ravel(self.peaks.data)
+        if self.peaks.units is not None:
+            heights = heights * self.peaks.units
+        rows = []
+
+        per_peak_properties = {}
+        for key, values in self.properties.items():
+            try:
+                if len(values) == n_peaks:
+                    per_peak_properties[key] = values
+            except TypeError:
+                continue
+
+        for index in range(n_peaks):
+            row = {
+                "index": index,
+                "position": _sequence_item(positions, index),
+                "height": _sequence_item(heights, index),
+            }
+            for key, values in per_peak_properties.items():
+                row[key] = _sequence_item(values, index)
+            rows.append(row)
+
+        return rows
+
+    def to_csv(self, path, *, delimiter=","):
+        """
+        Write peak information to a CSV file.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Destination path.
+        delimiter : str, default=','
+            CSV delimiter.
+
+        Returns
+        -------
+        pathlib.Path
+            The written path.
+        """
+        path = Path(path)
+        rows = self.to_dict()
+        fieldnames = ["index", "position", "height"]
+        for row in rows:
+            for key in row:
+                if key not in fieldnames:
+                    fieldnames.append(key)
+
+        with path.open("w", newline="", encoding="utf-8") as fid:
+            writer = csv.DictWriter(fid, fieldnames=fieldnames, delimiter=delimiter)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(
+                    {key: _stringify_csv_value(row.get(key, "")) for key in fieldnames}
+                )
+
+        return path
+
+    def _positions(self):
+        if self.peaks.coordset is None:
+            return np.arange(len(self.peaks))
+        coord = self.peaks.coordset[self.peaks.dims[-1]]
+        return coord.values
 
 
 def _as_peakfinding_quantity(value):
@@ -127,6 +270,7 @@ def find_peaks(
     rel_height=0.5,
     plateau_size=None,
     use_coord=True,
+    as_result=False,
 ):
     """
     Find and analyze peaks in spectroscopic data with advanced filtering options.
@@ -168,14 +312,21 @@ def find_peaks(
         Required size of peak plateau (flat top).
     use_coord : bool, default: True
         Whether to use coordinate system units instead of array indices.
+    as_result : bool, default: False
+        If True, return a :class:`PeakFindingResult` object. If False, preserve
+        the historical ``(peaks, properties)`` tuple return.
 
     Returns
     -------
-    peaks : NDDataset
-        Dataset containing identified peaks with interpolated positions and heights.
-    properties : dict
+    peaks : NDDataset or None
+        Dataset containing identified peaks with interpolated positions and
+        heights. Returned when ``as_result=False``.
+    properties : dict or None
         Peak properties including heights, widths, prominences, and more.
-        All values use appropriate units when use_coord=True.
+        All values use appropriate units when use_coord=True. Returned when
+        ``as_result=False``.
+    result : PeakFindingResult
+        Structured peak finding result. Returned when ``as_result=True``.
 
     Notes
     -----
@@ -196,6 +347,12 @@ def find_peaks(
     Physical-unit spacing constraints are accepted when coordinates carry units:
     >>> peaks, props = ds.find_peaks(distance="1 cm^-1", width=0.2)
     >>> len(peaks)
+    2
+
+    Return a structured result when a tabular/export representation is useful:
+    >>> result = ds.find_peaks(height=0.5, as_result=True)
+    >>> rows = result.to_dict()
+    >>> len(rows)
     2
 
     """
@@ -278,6 +435,8 @@ def find_peaks(
     # Check if any peaks were found
     if len(peaks) == 0:
         error_("No peaks found")
+        if as_result:
+            return PeakFindingResult(None, None)
         return None, None
 
     # Ensure properties is a dictionary even if empty
@@ -316,8 +475,6 @@ def find_peaks(
             else:
                 out.coordset(out.dims[-1])[i] = x_at_max
     if x_pos and not use_coord:
-        from spectrochempy.core.dataset.coord import Coord
-
         out.coordset = Coord(x_pos)
 
     # transform back index to coord
@@ -361,5 +518,8 @@ def find_peaks(
 
     out.name = "peaks of " + X.name
     out.history = f"find_peaks(): {len(peaks)} peak(s) found"
+
+    if as_result:
+        return PeakFindingResult(out, properties)
 
     return out, properties

--- a/tests/test_analysis/test_peakfinding/test_peakfinding.py
+++ b/tests/test_analysis/test_peakfinding/test_peakfinding.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import pytest
 
+from spectrochempy.analysis.peakfinding.peakfinding import PeakFindingResult
 from spectrochempy.analysis.peakfinding.peakfinding import find_peaks
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
@@ -111,6 +112,21 @@ def test_no_peaks_case():
     assert properties is None
 
 
+def test_no_peaks_result_case():
+    """Structured result preserves the no-peak outcome without raising."""
+    x = np.linspace(0, 10, 100)
+    y = np.zeros_like(x)
+    dataset = NDDataset(y, coordset=[Coord(x, title="x")])
+
+    result = find_peaks(dataset, height=0.1, as_result=True)
+
+    assert isinstance(result, PeakFindingResult)
+    assert len(result) == 0
+    assert result.peaks is None
+    assert result.properties == {}
+    assert result.to_dict() == []
+
+
 def test_three_point_peak():
     """Test detection of three-point peaks with explicit properties request."""
     x = np.linspace(0, 10, 100)
@@ -148,6 +164,61 @@ def test_minimal_peak_properties():
     # Properties should be empty but not None
     assert isinstance(properties, dict)
     assert len(properties) == 0
+
+
+def test_as_result_keeps_peak_data_and_allows_unpacking(simple_peaks_dataset):
+    """Opt-in structured result keeps the historical tuple data available."""
+    result = find_peaks(simple_peaks_dataset, height=0.5, as_result=True)
+
+    assert isinstance(result, PeakFindingResult)
+    assert len(result) == 3
+
+    peaks, properties = result
+    assert peaks is result.peaks
+    assert properties is result.properties
+    assert np.allclose(peaks.x.values, [2, 5, 8] * ur("cm^-1"), atol=0.1)
+    assert "peak_heights" in properties
+
+
+def test_peak_finding_result_to_dict(simple_peaks_dataset):
+    """Structured result exposes dependency-light row dictionaries."""
+    result = find_peaks(simple_peaks_dataset, height=0.5, width=0.1, as_result=True)
+
+    rows = result.to_dict()
+
+    assert len(rows) == 3
+    assert rows[0]["index"] == 0
+    assert rows[0]["position"].units == ur("cm^-1")
+    assert rows[0]["height"].units == ur.absorbance
+    assert "peak_heights" in rows[0]
+    assert "widths" in rows[0]
+
+
+def test_peak_finding_result_to_dict_single_peak(simple_peaks_dataset):
+    """Single-peak coordinate values can be scalar quantities."""
+    result = find_peaks(
+        simple_peaks_dataset, height=(1.8, 2.2), prominence=0, as_result=True
+    )
+
+    rows = result.to_dict()
+
+    assert len(rows) == 1
+    assert rows[0]["position"].units == ur("cm^-1")
+    assert rows[0]["height"].units == ur.absorbance
+
+
+def test_peak_finding_result_to_csv(simple_peaks_dataset, tmp_path):
+    """Structured result can be exported without pandas."""
+    result = find_peaks(simple_peaks_dataset, height=0.5, width=0.1, as_result=True)
+    path = tmp_path / "peaks.csv"
+
+    written = result.to_csv(path)
+
+    assert written == path
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("index,position,height")
+    assert "peak_heights" in text
+    assert "widths" in text
 
 
 def test_single_points_peak():


### PR DESCRIPTION
## Summary

Adds an opt-in structured result helper for peak finding:

- `find_peaks(..., as_result=True)` now returns `PeakFindingResult`
- the historical `(peaks, properties)` return remains the default
- `PeakFindingResult` exposes `peaks`, `properties`, `to_dict()`, and `to_csv()`
- the helper is dependency-light and does not add pandas

## Motivation

This is a small foundation step for the peak-analysis roadmap. It makes detected
peaks easier to report and export while preserving existing user code that
unpacks `peaks, properties = find_peaks(...)`.

## Validation

```bash
HOME=/tmp/spectrochempy-test-home MPLCONFIGDIR=/tmp/spectrochempy-mplconfig \
  /home/christian/miniforge3/bin/conda run -n scpy-core python -m pytest \
  tests/test_analysis/test_peakfinding/test_peakfinding.py
```

Result: `25 passed`.

```bash
/home/christian/miniforge3/bin/conda run -n scpy-core python -m ruff check \
  src/spectrochempy/analysis/peakfinding/peakfinding.py \
  tests/test_analysis/test_peakfinding/test_peakfinding.py \
  docs/sources/userguide/analysis/peak_finding.py
```

Result: `All checks passed`.
