### PR TITLE
ENH: Add PeakTable for peak finding results

### DIFF
--- a/docs/sources/userguide/analysis/peak_finding.py
+++ b/docs/sources/userguide/analysis/peak_finding.py
@@ -363,11 +363,12 @@ _ = ax.legend(fontsize=6)
 #
 # If a tabular representation is needed for reporting or export, use
 # `as_result=True`. This keeps the default tuple return unchanged, but returns a
-# lightweight result object with dictionary rows and CSV export helpers.
+# lightweight result object with a `table` view, dictionary rows and CSV export
+# helpers.
 
 # %%
 result = s.find_peaks(height=(0.15, 0.22), prominence=0, as_result=True)
-result.to_dict()
+result.table.to_dict()
 
 # %% [markdown]
 # #### Prominence

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -20,10 +20,10 @@ New Features
 .. Add here new public features (do not delete this comment)
 
 - ``find_peaks(..., as_result=True)`` now returns a lightweight
-  ``PeakFindingResult`` object with ``peaks``, ``properties``, ``to_dict()``,
-  and ``to_csv()`` helpers. The default return value remains the historical
-  ``(peaks, properties)`` tuple, and the new helpers do not add a pandas
-  dependency.
+  ``PeakFindingResult`` object with ``peaks``, ``properties``, a ``table``
+  view, ``to_dict()``, and ``to_csv()`` helpers. The default return value
+  remains the historical ``(peaks, properties)`` tuple, and the new helpers do
+  not add a pandas dependency.
 
 - ``Optimize.validate_script(script=None)`` — new public method that validates a
   curve-fitting script before launching the optimisation.  Returns a list of

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -16,10 +16,10 @@ New Features
 ~~~~~~~~~~~~
 
 - ``find_peaks(..., as_result=True)`` now returns a lightweight
-  ``PeakFindingResult`` object with ``peaks``, ``properties``, ``to_dict()``,
-  and ``to_csv()`` helpers. The default return value remains the historical
-  ``(peaks, properties)`` tuple, and the new helpers do not add a pandas
-  dependency.
+  ``PeakFindingResult`` object with ``peaks``, ``properties``, a ``table``
+  view, ``to_dict()``, and ``to_csv()`` helpers. The default return value
+  remains the historical ``(peaks, properties)`` tuple, and the new helpers do
+  not add a pandas dependency.
 
 - ``Optimize.validate_script(script=None)`` — new public method that validates a
   curve-fitting script before launching the optimisation.  Returns a list of

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -15,7 +15,7 @@ specific to spectroscopic analysis, including:
 - Peak interpolation for improved accuracy
 """
 
-__all__ = ["PeakFindingResult", "find_peaks"]
+__all__ = ["PeakFindingResult", "PeakTable", "find_peaks"]
 
 __dataset_methods__ = ["find_peaks"]
 
@@ -64,6 +64,153 @@ def _stringify_csv_value(value):
     return str(value)
 
 
+_BASE_PEAK_COLUMNS = ("index", "position", "height")
+_PROPERTY_COLUMN_NAMES = {
+    "peak_heights": "peak_height",
+    "prominences": "prominence",
+    "widths": "width",
+    "width_heights": "width_height",
+    "left_bases": "left_base",
+    "right_bases": "right_base",
+    "left_ips": "left_ip",
+    "right_ips": "right_ip",
+    "plateau_sizes": "plateau_size",
+    "left_edges": "left_edge",
+    "right_edges": "right_edge",
+}
+
+
+def _peak_rows(peaks, properties, *, raw_property_names=False):
+    """Build row dictionaries from peak positions, heights, and properties."""
+    if peaks is None:
+        return []
+
+    n_peaks = len(peaks)
+    positions = _peak_positions(peaks)
+    heights = np.ravel(peaks.data)
+    if peaks.units is not None:
+        heights = heights * peaks.units
+    rows = []
+
+    per_peak_properties = {}
+    for key, values in properties.items():
+        try:
+            if len(values) == n_peaks:
+                per_peak_properties[key] = values
+        except TypeError:
+            continue
+
+    for index in range(n_peaks):
+        row = {
+            "index": index,
+            "position": _sequence_item(positions, index),
+            "height": _sequence_item(heights, index),
+        }
+        for key, values in per_peak_properties.items():
+            column = key if raw_property_names else _PROPERTY_COLUMN_NAMES.get(key, key)
+            row[column] = _sequence_item(values, index)
+        rows.append(row)
+
+    return rows
+
+
+def _peak_positions(peaks):
+    """Return peak positions from coordinates or point indexes."""
+    if peaks.coordset is None:
+        return np.arange(len(peaks))
+    coord = peaks.coordset[peaks.dims[-1]]
+    return coord.values
+
+
+def _fieldnames(rows, *, columns=_BASE_PEAK_COLUMNS):
+    """Return stable field names from base columns plus row-specific columns."""
+    fieldnames = list(columns)
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    return fieldnames
+
+
+class PeakTable:
+    """
+    Dependency-light tabular view of detected peaks.
+
+    Parameters
+    ----------
+    peaks : NDDataset or None
+        Dataset containing identified peak positions and heights.
+    properties : dict or None
+        Peak properties returned by :func:`scipy.signal.find_peaks`.
+
+    Notes
+    -----
+    ``PeakTable`` uses user-facing singular column names such as
+    ``peak_height``, ``prominence`` and ``width``. The raw SciPy property
+    dictionary remains available on :class:`PeakFindingResult`.
+    """
+
+    __slots__ = ("peaks", "properties")
+
+    def __init__(self, peaks, properties=None):
+        self.peaks = peaks
+        self.properties = dict(properties or {})
+
+    def __len__(self):
+        return 0 if self.peaks is None else len(self.peaks)
+
+    def __iter__(self):
+        return iter(self.to_dict())
+
+    def __repr__(self):
+        return f"PeakTable(n_peaks={len(self)})"
+
+    @property
+    def columns(self):
+        """Return stable base columns plus currently available optional columns."""
+        return tuple(_fieldnames(self.to_dict()))
+
+    def to_dict(self):
+        """
+        Return peak information as a list of dictionaries.
+
+        Each dictionary contains ``index``, ``position``, ``height`` and any
+        available per-peak properties. Values keep their native units when they
+        are unit-bearing quantities.
+        """
+        return _peak_rows(self.peaks, self.properties)
+
+    def to_csv(self, path, *, delimiter=","):
+        """
+        Write peak information to a CSV file.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Destination path.
+        delimiter : str, default=','
+            CSV delimiter.
+
+        Returns
+        -------
+        pathlib.Path
+            The written path.
+        """
+        path = Path(path)
+        rows = self.to_dict()
+        fieldnames = _fieldnames(rows)
+
+        with path.open("w", newline="", encoding="utf-8") as fid:
+            writer = csv.DictWriter(fid, fieldnames=fieldnames, delimiter=delimiter)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(
+                    {key: _stringify_csv_value(row.get(key, "")) for key in fieldnames}
+                )
+
+        return path
+
+
 class PeakFindingResult:
     """
     Structured result returned by :func:`find_peaks`.
@@ -98,6 +245,11 @@ class PeakFindingResult:
     def __repr__(self):
         return f"PeakFindingResult(n_peaks={len(self)})"
 
+    @property
+    def table(self):
+        """Return a dependency-light tabular view of the detected peaks."""
+        return PeakTable(self.peaks, self.properties)
+
     def to_dict(self):
         """
         Return peak information as a list of dictionaries.
@@ -106,35 +258,7 @@ class PeakFindingResult:
         per-peak properties whose length matches the number of detected peaks.
         Values keep their native units when they are unit-bearing quantities.
         """
-        if self.peaks is None:
-            return []
-
-        n_peaks = len(self)
-        positions = self._positions()
-        heights = np.ravel(self.peaks.data)
-        if self.peaks.units is not None:
-            heights = heights * self.peaks.units
-        rows = []
-
-        per_peak_properties = {}
-        for key, values in self.properties.items():
-            try:
-                if len(values) == n_peaks:
-                    per_peak_properties[key] = values
-            except TypeError:
-                continue
-
-        for index in range(n_peaks):
-            row = {
-                "index": index,
-                "position": _sequence_item(positions, index),
-                "height": _sequence_item(heights, index),
-            }
-            for key, values in per_peak_properties.items():
-                row[key] = _sequence_item(values, index)
-            rows.append(row)
-
-        return rows
+        return _peak_rows(self.peaks, self.properties, raw_property_names=True)
 
     def to_csv(self, path, *, delimiter=","):
         """
@@ -154,11 +278,7 @@ class PeakFindingResult:
         """
         path = Path(path)
         rows = self.to_dict()
-        fieldnames = ["index", "position", "height"]
-        for row in rows:
-            for key in row:
-                if key not in fieldnames:
-                    fieldnames.append(key)
+        fieldnames = _fieldnames(rows)
 
         with path.open("w", newline="", encoding="utf-8") as fid:
             writer = csv.DictWriter(fid, fieldnames=fieldnames, delimiter=delimiter)
@@ -169,12 +289,6 @@ class PeakFindingResult:
                 )
 
         return path
-
-    def _positions(self):
-        if self.peaks.coordset is None:
-            return np.arange(len(self.peaks))
-        coord = self.peaks.coordset[self.peaks.dims[-1]]
-        return coord.values
 
 
 def _as_peakfinding_quantity(value):

--- a/tests/test_analysis/test_peakfinding/test_peakfinding.py
+++ b/tests/test_analysis/test_peakfinding/test_peakfinding.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from spectrochempy.analysis.peakfinding.peakfinding import PeakFindingResult
+from spectrochempy.analysis.peakfinding.peakfinding import PeakTable
 from spectrochempy.analysis.peakfinding.peakfinding import find_peaks
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
@@ -125,6 +126,10 @@ def test_no_peaks_result_case():
     assert result.peaks is None
     assert result.properties == {}
     assert result.to_dict() == []
+    assert isinstance(result.table, PeakTable)
+    assert len(result.table) == 0
+    assert result.table.columns == ("index", "position", "height")
+    assert result.table.to_dict() == []
 
 
 def test_three_point_peak():
@@ -194,6 +199,28 @@ def test_peak_finding_result_to_dict(simple_peaks_dataset):
     assert "widths" in rows[0]
 
 
+def test_peak_table_exposes_singular_column_names(simple_peaks_dataset):
+    """PeakTable provides user-facing singular names while properties stay raw."""
+    result = find_peaks(simple_peaks_dataset, height=0.5, width=0.1, as_result=True)
+
+    table = result.table
+    rows = table.to_dict()
+
+    assert isinstance(table, PeakTable)
+    assert repr(table) == "PeakTable(n_peaks=3)"
+    assert len(table) == 3
+    assert list(table) == rows
+    assert "peak_height" in table.columns
+    assert "width" in table.columns
+    assert "peak_heights" not in table.columns
+    assert "widths" not in table.columns
+    assert rows[0]["position"].units == ur("cm^-1")
+    assert rows[0]["height"].units == ur.absorbance
+    assert rows[0]["peak_height"].units == ur.absorbance
+    assert rows[0]["width"].units == ur("cm^-1")
+    assert "peak_heights" in result.properties
+
+
 def test_peak_finding_result_to_dict_single_peak(simple_peaks_dataset):
     """Single-peak coordinate values can be scalar quantities."""
     result = find_peaks(
@@ -219,6 +246,33 @@ def test_peak_finding_result_to_csv(simple_peaks_dataset, tmp_path):
     assert text.startswith("index,position,height")
     assert "peak_heights" in text
     assert "widths" in text
+
+
+def test_peak_table_to_csv(simple_peaks_dataset, tmp_path):
+    """PeakTable writes singular user-facing column names."""
+    result = find_peaks(simple_peaks_dataset, height=0.5, width=0.1, as_result=True)
+    path = tmp_path / "peak-table.csv"
+
+    written = result.table.to_csv(path)
+
+    assert written == path
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("index,position,height")
+    assert "peak_height" in text
+    assert "width" in text
+    assert "peak_heights" not in text
+    assert "widths" not in text
+
+
+def test_peak_table_no_peak_csv_header(tmp_path):
+    """Empty PeakTable writes a stable header-only CSV for batch workflows."""
+    table = PeakTable(None, None)
+    path = tmp_path / "empty-peak-table.csv"
+
+    written = table.to_csv(path)
+
+    assert written == path
+    assert path.read_text(encoding="utf-8") == "index,position,height\n"
 
 
 def test_single_points_peak():


### PR DESCRIPTION
## Summary

This PR adds a lightweight `PeakTable` domain object for structured peak finding output.

It builds on the opt-in `PeakFindingResult` API introduced in #1356:

- `result.table` now returns a dependency-free tabular view of detected peaks.
- `PeakTable.to_dict()` exposes user-facing singular column names such as `peak_height`, `prominence`, `width`, `left_base`, and `right_base`.
- `PeakTable.to_csv()` writes the table without adding pandas or Excel dependencies.
- `PeakFindingResult.to_dict()` and `PeakFindingResult.to_csv()` keep their existing raw SciPy-style property names for compatibility.
- Empty peak results now have a stable header-only table representation.

## Motivation

`PeakTable` gives peak finding a stable reporting/export layer before adding fitting-specific helpers such as script generation. This keeps detected peak representation independent from `Optimize` while making future reporting, batch analysis, assistant workflows, and autoscript generation easier to build.

## Validation

- `HOME=/tmp/spectrochempy-test-home MPLCONFIGDIR=/tmp/spectrochempy-mplconfig /home/christian/miniforge3/bin/conda run -n scpy-core python -m pytest tests/test_analysis/test_peakfinding/test_peakfinding.py`
- `/home/christian/miniforge3/bin/conda run -n scpy-core python -m ruff check src/spectrochempy/analysis/peakfinding/peakfinding.py tests/test_analysis/test_peakfinding/test_peakfinding.py docs/sources/userguide/analysis/peak_finding.py`
- `pre-commit run --all-files` run by maintainer before PR creation; `latest.rst` included as generated output.
