### PR TITLE
FIX: WiRE reader spurious 'm' auxiliary coordinate (#1332)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -89,6 +89,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- WiRE (``.wdf``) reader no longer attaches YLST data as a confusing auxiliary ``m``
+  coordinate in ``coordset``. The YLST data is now stored on ``dataset.meta`` (as
+  ``ylst_data``, ``ylst_title``, ``ylst_units``) where it belongs as per-spectrum
+  metadata. (#1332)
+
 - ``MCRALS`` correctness fixes: empty ``closureConc`` no longer runs a
   wasteful closure block (PR1 B4); single-component closure targets
   (``closureConc=[0]``, ``closureConc="all"``) are now honoured instead of

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -81,6 +81,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- WiRE (``.wdf``) reader no longer attaches YLST data as a confusing auxiliary ``m``
+  coordinate in ``coordset``. The YLST data is now stored on ``dataset.meta`` (as
+  ``ylst_data``, ``ylst_title``, ``ylst_units``) where it belongs as per-spectrum
+  metadata. (#1332)
+
 - ``MCRALS`` correctness fixes: empty ``closureConc`` no longer runs a
   wasteful closure block (PR1 B4); single-component closure targets
   (``closureConc=[0]``, ``closureConc="all"``) are now honoured instead of

--- a/src/spectrochempy/core/readers/read_wire.py
+++ b/src/spectrochempy/core/readers/read_wire.py
@@ -181,12 +181,17 @@ class _wdfReader:
         dataset.data = data
         dataset.title = "count"
 
+        # Store YLST metadata (per-spectrum metadata, not a coordinate axis)
+        dataset.meta.ylst_data = coord_meta.data
+        dataset.meta.ylst_title = coord_meta.title
+        dataset.meta.ylst_units = coord_meta.units
+
         # Fill the dataset with the coordinates
         odim = list(other_dimensions.values())
         if self._meta.measurement_type == MeasurementType.Single:
-            dataset.set_coordset(x=coord_x, y=odim[0], m=coord_meta)
+            dataset.set_coordset(x=coord_x, y=odim[0])
         elif self._meta.measurement_type == MeasurementType.Series:
-            dataset.set_coordset(x=coord_x, y=odim[::-1], m=coord_meta)
+            dataset.set_coordset(x=coord_x, y=odim[::-1])
         elif self._meta.measurement_type == MeasurementType.Mapping:
             if self._meta.map_area_type == MapAreaType.Unspecified:
                 self._meta.map_area_type = MapAreaType.ColumnMajor
@@ -202,7 +207,7 @@ class _wdfReader:
                 dist = dist - dist[0]
                 distance = Coord(dist, units=X.units, title="distance")
                 coord_y = CoordSet(distance, Time, Y, X)
-                dataset.set_coordset(x=coord_x, y=coord_y, m=coord_meta)
+                dataset.set_coordset(x=coord_x, y=coord_y)
 
             # xy column major scan
             elif self._meta.map_area_type == MapAreaType.ColumnMajor:
@@ -211,7 +216,7 @@ class _wdfReader:
                 if np.all(np.array(map_shape) > 1):
                     X.data = X.data.reshape(map_shape[::-1])[0]
                     Y.data = Y.data.reshape(map_shape[::-1])[:, 0]
-                dataset.set_coordset(x=coord_x, y=X, m=coord_meta, z=Y)
+                dataset.set_coordset(x=coord_x, y=X, z=Y)
 
             # not implemented yet
             else:

--- a/tests/test_core/test_readers/test_read_wire.py
+++ b/tests/test_core/test_readers/test_read_wire.py
@@ -14,21 +14,38 @@ def _skip_if_no_testdata():
         pytest.skip("test data not available (set SCP_TEST_DATA_DOWNLOAD=1)")
 
 
+def _check_no_aux_m_coord(dataset, expected_ndim):
+    """Verify the dataset has no spurious 'm' auxiliary coordinate."""
+    assert (
+        dataset.ndim == expected_ndim
+    ), f"expected {expected_ndim}D, got {dataset.ndim}D"
+    assert (
+        "m" not in dataset.coordset.names
+    ), f"unexpected 'm' coordinate in {dataset.coordset.names}"
+    assert hasattr(dataset.meta, "ylst_data"), "YLST metadata missing"
+    assert hasattr(dataset.meta, "ylst_title"), "YLST title missing"
+    assert hasattr(dataset.meta, "ylst_units"), "YLST units missing"
+
+
 def test_read_wire():
     # First read a single spectrum (measurement type : single)
     dataset = scp.read_wire("ramandata/wire/sp.wdf")
+    _check_no_aux_m_coord(dataset, expected_ndim=2)
     _ = dataset.plot()
 
     # Now read a series of spectra (measurement type : series) from a Z-depth scan.
     dataset = scp.read_wire("ramandata/wire/depth.wdf")
+    _check_no_aux_m_coord(dataset, expected_ndim=2)
     _ = dataset.plot_image()
 
     # extract a line scan data from a StreamLine HR measurement
     dataset = scp.read_wire("ramandata/wire/line.wdf")
+    _check_no_aux_m_coord(dataset, expected_ndim=2)
     _ = dataset.plot_image()
 
     # finally extract grid scan data from a StreamLine HR measurement
     dataset = scp.read_wire("ramandata/wire/mapping.wdf")
+    _check_no_aux_m_coord(dataset, expected_ndim=3)
     _ = dataset.sum(dim=2).plot_image()
 
     # show spectra if test run as a single pytest test


### PR DESCRIPTION
## Summary

The WiRE (`.wdf`) reader was attaching YLST block data (per-spectrum metadata) as an auxiliary coordinate named `m` in the dataset's `CoordSet`. This caused confusion because `coordset.names` showed `['m', 'x', 'y']` for a 2D dataset, making it look like an extra dimension.

## Fix

- YLST data is now stored on `dataset.meta` as `ylst_data`, `ylst_title`, `ylst_units` instead of as a coordinate `m`.
- Removed `m=coord_meta` from all four `set_coordset()` calls (Single, Series, XYLine mapping, ColumnMajor mapping).
- Added test helper `_check_no_aux_m_coord` to verify no spurious `m` coordinate appears and YLST metadata is present.

## Out of scope

- No changes to the CoordSet or Coord classes themselves.
- No changes to how other readers handle coordinates.

Fixes #1332