### PR TITLE
ENH: rich HTML repr for AnalysisResult and FitResult in Jupyter (#1299)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,12 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- ``AnalysisResult`` (PCA, NMF, PLS, MCR‑ALS, …) and ``FitResult`` now have a
+  rich ``_repr_html_`` for Jupyter notebooks, with collapsible Parameters,
+  Outputs, and Diagnostics sections and recursive rendering of embedded
+  NDDataset objects using their native HTML representation.  The text
+  ``__repr__`` and the public API are unchanged. (#1299)
+
 - ``find_peaks(..., as_result=True)`` now returns a lightweight
   ``PeakFindingResult`` object with ``peaks``, ``properties``, a ``table``
   view, ``to_dict()``, and ``to_csv()`` helpers. The default return value

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,12 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- ``AnalysisResult`` (PCA, NMF, PLS, MCR‑ALS, …) and ``FitResult`` now have a
+  rich ``_repr_html_`` for Jupyter notebooks, with collapsible Parameters,
+  Outputs, and Diagnostics sections and recursive rendering of embedded
+  NDDataset objects using their native HTML representation.  The text
+  ``__repr__`` and the public API are unchanged. (#1299)
+
 - ``find_peaks(..., as_result=True)`` now returns a lightweight
   ``PeakFindingResult`` object with ``peaks``, ``properties``, a ``table``
   view, ``to_dict()``, and ``to_csv()`` helpers. The default return value

--- a/src/spectrochempy/analysis/_base/_result.py
+++ b/src/spectrochempy/analysis/_base/_result.py
@@ -5,6 +5,11 @@
 # ======================================================================================
 """Result object infrastructure for analysis and fit outputs."""
 
+from spectrochempy.utils.print import DisplayItem
+from spectrochempy.utils.print import DisplaySection
+from spectrochempy.utils.print import _html_heading
+from spectrochempy.utils.print import _render_sections
+
 __all__ = ["ResultBase", "AnalysisResult", "FitResult"]
 
 
@@ -78,6 +83,66 @@ class ResultBase:
                 if isinstance(name, str) and name.isidentifier()
             )
         return sorted(names)
+
+    # ----------------------------------------------------------------------------------
+    # HTML representation (Jupyter notebooks)
+    # ----------------------------------------------------------------------------------
+    def _repr_sections(self):
+        sections: list[DisplaySection] = []
+
+        # --- Summary : estimator ---
+        sections.append(
+            DisplaySection(
+                "summary", "", [DisplayItem("field", self._estimator, "estimator")]
+            )
+        )
+
+        # --- Parameters ---
+        if self._parameters:
+            params = [
+                DisplayItem("field", str(v), k) for k, v in self._parameters.items()
+            ]
+            sections.append(
+                DisplaySection("data", f"Parameters ({len(params)})", params)
+            )
+
+        # --- Outputs ---
+        if self._outputs:
+            outputs = []
+            for name, obj in self._outputs.items():
+                if hasattr(obj, "_repr_html_"):
+                    outputs.append(DisplayItem("html", obj._repr_html_(), name))
+                else:
+                    shape = getattr(obj, "shape", None)
+                    label = str(shape) if shape is not None else type(obj).__name__
+                    outputs.append(DisplayItem("field", label, name))
+            sections.append(
+                DisplaySection("data", f"Outputs ({len(outputs)})", outputs)
+            )
+
+        # --- Diagnostics ---
+        if self._diagnostics:
+            diags = []
+            for name, obj in self._diagnostics.items():
+                if hasattr(obj, "_repr_html_"):
+                    diags.append(DisplayItem("html", obj._repr_html_(), name))
+                else:
+                    diags.append(DisplayItem("field", str(obj), name))
+            sections.append(
+                DisplaySection("data", f"Diagnostics ({len(diags)})", diags)
+            )
+
+        return sections
+
+    def _repr_html_(self):
+        sections = self._repr_sections()
+        body = _render_sections(sections)
+        heading = _html_heading(self)
+        return (
+            '<div class="scp-output">'
+            f"<details open><summary>{heading}</summary>\n{body}\n"
+            "</details></div>"
+        )
 
     # ----------------------------------------------------------------------------------
     # Representation

--- a/src/spectrochempy/utils/print.py
+++ b/src/spectrochempy/utils/print.py
@@ -30,6 +30,7 @@ class ItemKind(str):
     DATA = "data"
     LABEL = "label"
     BLOCK = "block"
+    HTML = "html"
 
 
 class DisplayItem:
@@ -147,6 +148,8 @@ def _render_sections(sections: list[DisplaySection]) -> str:
                     items_html.append(f'<div class="label">{v}</div>')
             elif item.kind == "block":
                 items_html.append(f"<div>{v}</div>")
+            elif item.kind == "html":
+                items_html.append(v)
 
         body = "\n".join(items_html)
 
@@ -251,6 +254,10 @@ def _html_heading(obj):
                         parts.append(name)
         if parts:
             extras = " — " + ", ".join(parts)
+
+    # ResultBase / AnalysisResult / FitResult: show estimator name
+    elif hasattr(obj, "_estimator"):
+        extras = f" — {obj._estimator}"
 
     return f"{type_name}{name_part}{extras}"
 

--- a/tests/test_analysis/test_base/test_result_base.py
+++ b/tests/test_analysis/test_base/test_result_base.py
@@ -147,3 +147,79 @@ class TestFitResult:
         fitted = object()
         result = FitResult(estimator="Optimize", outputs={"fitted": fitted})
         assert result.fitted is fitted
+
+
+class TestResultBaseHTMLRepr:
+    """Behavioral tests for the HTML representation of ResultBase."""
+
+    def test_repr_html_returns_valid_html(self):
+        result = ResultBase(estimator="PCA")
+        html = result._repr_html_()
+        assert html.startswith('<div class="scp-output">')
+        assert "PCA" in html
+
+    def test_repr_html_has_collapsible_sections(self):
+        result = ResultBase(
+            estimator="Test",
+            parameters={"n_components": 5, "tol": 1e-6},
+            outputs={"scores": np.ones((10, 5))},
+            diagnostics={"explained_variance": np.array([0.9, 0.1])},
+        )
+        html = result._repr_html_()
+        assert "<details" in html
+        assert "Parameters (2)" in html
+        assert "Outputs" in html
+        assert "Diagnostics" in html
+        assert "tol" in html
+        assert "scores" in html
+
+    def test_repr_html_empty_sections_omitted(self):
+        result = ResultBase(estimator="Test")
+        html = result._repr_html_()
+        assert "Parameters" not in html
+        assert "Outputs" not in html
+        assert "Diagnostics" not in html
+
+    def test_repr_html_embeds_nddataset_repr(self):
+        from spectrochempy import NDDataset
+
+        scores = NDDataset(np.ones((10, 5)))
+        result = ResultBase(
+            estimator="PCA",
+            outputs={"scores": scores},
+        )
+        html = result._repr_html_()
+        assert "NDDataset" in html
+        assert "float64" in html
+
+    def test_repr_html_heading_shows_estimator(self):
+        result = ResultBase(estimator="MyEstimator")
+        heading = result._repr_html_()
+        assert "MyEstimator" in heading
+
+    def test_repr_html_analysis_result(self):
+        result = AnalysisResult(
+            estimator="PCA",
+            parameters={"n_components": 3},
+            outputs={"scores": np.ones((10, 3))},
+        )
+        html = result._repr_html_()
+        assert "PCA" in html
+        assert "AnalysisResult" in html
+
+    def test_repr_html_fit_result(self):
+        result = FitResult(
+            estimator="Optimize",
+            outputs={"fitted": np.ones((10,))},
+        )
+        html = result._repr_html_()
+        assert "Optimize" in html
+        assert "FitResult" in html
+
+    def test_repr_html_output_count_in_header(self):
+        result = ResultBase(
+            estimator="Test",
+            outputs={"a": np.ones(3), "b": np.ones((2, 3)), "c": np.ones(5)},
+        )
+        html = result._repr_html_()
+        assert "Outputs (3)" in html


### PR DESCRIPTION
## Summary

`AnalysisResult` (PCA, NMF, PLS, MCR-ALS, ...) and `FitResult` now have a rich HTML representation in Jupyter notebooks, matching the polish of `NDDataset`.

### Before

```
AnalysisResult
  estimator: PCA
  parameters:
      n_components: 5
      standardized: True
      ...
  outputs:
      scores (10, 5)
      loadings (5, 20)
  diagnostics:
      explained_variance (5,)
```

### After

```
▶ AnalysisResult — PCA
  ├─ estimator: PCA
  ├─ ▶ Parameters (5)     ← collapsible
  ├─ ▶ Outputs (3)        ← collapsible, embedded NDDataset rendered natively
  └─ ▶ Diagnostics (2)    ← collapsible
```

### Changes

1. **`ResultBase._repr_sections()`** — builds semantic sections for Parameters, Outputs, Diagnostics. Outputs/diagnostics that have `_repr_html_` (NDDataset, Coord, etc.) are rendered recursively via their native repr.

2. **`ResultBase._repr_html_()`** — follows the same pattern as NDDataset, Coord, CoordSet, Project (`_repr_sections → _render_sections → _html_heading`).

3. **`_render_sections`** — new `ItemKind.HTML` (`"html"`) that embeds raw HTML content without escaping, needed for recursive rendering.

4. **`_html_heading`** — handles ResultBase objects showing the estimator name (e.g. `"AnalysisResult — PCA"`).

### Design

- No changes to the public API.
- No changes to serialization.
- No changes to `__repr__` (text representation).
- No changes to individual estimators (PCA, PLS, etc.) — they inherit automatically.
- Reuses existing display infrastructure (`DisplaySection`, `DisplayItem`, `_render_sections`, `_html_heading`).

Fixes #1299