### PR TITLE
ENH: Add selection helpers to PeakTable

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -28,7 +28,8 @@ New Features
 - Peak analysis workflows are now easier to inspect and validate:
   ``find_peaks(..., as_result=True)`` returns a lightweight
   ``PeakFindingResult`` object with ``peaks``, ``properties``, a ``table``
-  view, ``to_dict()``, and ``to_csv()`` helpers, while
+  view, ``to_dict()``, ``to_csv()``, ``sort_by()``, ``head()``, ``top()``,
+  and ``column()`` helpers, while
   ``Optimize.validate_script(script=None)`` can validate a curve-fitting
   script before launching the optimisation and returns structured
   ``ScriptError`` diagnostics.  The default ``find_peaks()`` return value

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -24,7 +24,8 @@ New Features
 - Peak analysis workflows are now easier to inspect and validate:
   ``find_peaks(..., as_result=True)`` returns a lightweight
   ``PeakFindingResult`` object with ``peaks``, ``properties``, a ``table``
-  view, ``to_dict()``, and ``to_csv()`` helpers, while
+  view, ``to_dict()``, ``to_csv()``, ``sort_by()``, ``head()``, ``top()``,
+  and ``column()`` helpers, while
   ``Optimize.validate_script(script=None)`` can validate a curve-fitting
   script before launching the optimisation and returns structured
   ``ScriptError`` diagnostics.  The default ``find_peaks()`` return value

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -64,6 +64,16 @@ def _stringify_csv_value(value):
     return str(value)
 
 
+def _column_value(value, *, unit=None, as_float=False):
+    """Normalize a table value for sorting or export-oriented column access."""
+    value = _as_scalar(value)
+    if unit is not None and hasattr(value, "to"):
+        value = value.to(unit)
+    if as_float:
+        return float(getattr(value, "magnitude", value))
+    return value
+
+
 _BASE_PEAK_COLUMNS = ("index", "position", "height")
 _PROPERTY_COLUMN_NAMES = {
     "peak_heights": "peak_height",
@@ -150,13 +160,16 @@ class PeakTable:
     dictionary remains available on :class:`PeakFindingResult`.
     """
 
-    __slots__ = ("peaks", "properties")
+    __slots__ = ("peaks", "properties", "_rows")
 
-    def __init__(self, peaks, properties=None):
+    def __init__(self, peaks, properties=None, rows=None):
         self.peaks = peaks
         self.properties = dict(properties or {})
+        self._rows = None if rows is None else [dict(row) for row in rows]
 
     def __len__(self):
+        if self._rows is not None:
+            return len(self._rows)
         return 0 if self.peaks is None else len(self.peaks)
 
     def __iter__(self):
@@ -178,7 +191,79 @@ class PeakTable:
         available per-peak properties. Values keep their native units when they
         are unit-bearing quantities.
         """
+        if self._rows is not None:
+            return [dict(row) for row in self._rows]
         return _peak_rows(self.peaks, self.properties)
+
+    def head(self, n):
+        """
+        Return the first *n* rows as a new ``PeakTable``.
+
+        Parameters
+        ----------
+        n : int
+            Number of rows to keep.
+        """
+        return PeakTable(None, None, rows=self.to_dict()[:n])
+
+    def column(self, name, *, unit=None, as_float=False):
+        """
+        Return a column as a list of values.
+
+        Parameters
+        ----------
+        name : str
+            Column name.
+        unit : str or Quantity, optional
+            Target unit for unit-aware values.
+        as_float : bool, default=False
+            If True, return plain floats.
+        """
+        if name not in self.columns:
+            raise KeyError(f"Unknown peak-table column: {name!r}")
+        return [
+            _column_value(row[name], unit=unit, as_float=as_float)
+            for row in self.to_dict()
+        ]
+
+    def sort_by(self, name, *, reverse=False, unit=None):
+        """
+        Return a new ``PeakTable`` sorted by the given column.
+
+        Parameters
+        ----------
+        name : str
+            Column name used as sorting key.
+        reverse : bool, default=False
+            If True, sort in descending order.
+        unit : str or Quantity, optional
+            Target unit for unit-aware values before comparison.
+        """
+        if name not in self.columns:
+            raise KeyError(f"Unknown peak-table column: {name!r}")
+        rows = self.to_dict()
+        rows.sort(
+            key=lambda row: _column_value(row[name], unit=unit, as_float=True),
+            reverse=reverse,
+        )
+        return PeakTable(None, None, rows=rows)
+
+    def top(self, n, *, by, reverse=True, unit=None):
+        """
+        Return the top *n* rows according to a given column.
+
+        Parameters
+        ----------
+        n : int
+            Number of rows to keep.
+        by : str
+            Column name used as ranking key.
+        reverse : bool, default=True
+            If True, keep the largest values first.
+        unit : str or Quantity, optional
+            Target unit for unit-aware values before comparison.
+        """
+        return self.sort_by(by, reverse=reverse, unit=unit).head(n)
 
     def to_csv(self, path, *, delimiter=","):
         """

--- a/tests/test_analysis/test_peakfinding/test_peakfinding.py
+++ b/tests/test_analysis/test_peakfinding/test_peakfinding.py
@@ -221,6 +221,37 @@ def test_peak_table_exposes_singular_column_names(simple_peaks_dataset):
     assert "peak_heights" in result.properties
 
 
+def test_peak_table_sort_head_and_column_helpers(simple_peaks_dataset):
+    """PeakTable offers notebook-friendly selection helpers."""
+    result = find_peaks(simple_peaks_dataset, height=0.5, width=0.1, as_result=True)
+
+    selected = result.table.top(2, by="height").sort_by(
+        "position", reverse=True, unit="cm^-1"
+    )
+
+    assert isinstance(selected, PeakTable)
+    assert len(selected) == 2
+    positions = selected.column("position", unit="cm^-1", as_float=True)
+    heights = selected.column("height", as_float=True)
+
+    assert positions == sorted(positions, reverse=True)
+    assert heights[0] >= 0.0
+    assert heights[1] >= 0.0
+    assert all(isinstance(value, float) for value in positions)
+    assert all(isinstance(value, float) for value in heights)
+
+
+def test_peak_table_helper_unknown_column(simple_peaks_dataset):
+    """PeakTable helper methods fail clearly on unknown columns."""
+    result = find_peaks(simple_peaks_dataset, height=0.5, width=0.1, as_result=True)
+
+    with pytest.raises(KeyError, match="Unknown peak-table column"):
+        result.table.sort_by("missing")
+
+    with pytest.raises(KeyError, match="Unknown peak-table column"):
+        result.table.column("missing")
+
+
 def test_peak_finding_result_to_dict_single_peak(simple_peaks_dataset):
     """Single-peak coordinate values can be scalar quantities."""
     result = find_peaks(


### PR DESCRIPTION
## Summary
- add lightweight `PeakTable` helpers for row selection and column extraction: `sort_by()`, `head()`, `top()`, and `column()`
- keep the API dependency-light while making notebook workflows easier to write without ad hoc helper functions
- add focused tests for the new helpers and fold the capability into the existing peak-analysis changelog entry

## Out of scope
- no pandas dependency or dataframe-style API expansion
- no additional fitting automation in this PR
- no tutorial rewrite in this PR

## Validation
- `PYTHONPATH=src conda run -n scpy-core python -m pytest tests/test_analysis/test_peakfinding/test_peakfinding.py -k "peak_table"`
- `pre-commit run --all-files`