### PR TITLE
ENH: add fit degrees of freedom and adjusted diagnostics to FitResult

### DIFF
--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -221,7 +221,10 @@ components = fit_result.components
 
 {
     "r_squared": fit_result.diagnostics["r_squared"],
+    "adjusted_r_squared": fit_result.diagnostics["adjusted_r_squared"],
     "rmse": fit_result.diagnostics["rmse"],
+    "degrees_of_freedom": fit_result.diagnostics["degrees_of_freedom"],
+    "reduced_chi_square": fit_result.diagnostics["reduced_chi_square"],
     "success": fit_result.diagnostics["success"],
 }
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -44,9 +44,11 @@ New Features
 - ``FitResult`` from ``Optimize.result`` now exposes a residual dataset as
   ``result.outputs["residuals"]`` / ``result.residuals`` and basic fit-quality
   diagnostics under ``result.diagnostics``: ``rss`` / ``sse``, ``rmse``,
-  ``r_squared``, plus normalized solver ``success``, ``status``, and
-  ``message`` fields. Existing ``result.fitted`` and ``result.components``
-  behavior is preserved.
+  ``r_squared``, ``n_observations``, ``n_varying_parameters``,
+  ``degrees_of_freedom``, ``reduced_chi_square``, and
+  ``adjusted_r_squared``, plus normalized solver ``success``, ``status``,
+  and ``message`` fields. Existing ``result.fitted`` and
+  ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:
   ``scp.polynomial(...)``, ``scp.gaussian(...)``,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -40,9 +40,11 @@ New Features
 - ``FitResult`` from ``Optimize.result`` now exposes a residual dataset as
   ``result.outputs["residuals"]`` / ``result.residuals`` and basic fit-quality
   diagnostics under ``result.diagnostics``: ``rss`` / ``sse``, ``rmse``,
-  ``r_squared``, plus normalized solver ``success``, ``status``, and
-  ``message`` fields. Existing ``result.fitted`` and ``result.components``
-  behavior is preserved.
+  ``r_squared``, ``n_observations``, ``n_varying_parameters``,
+  ``degrees_of_freedom``, ``reduced_chi_square``, and
+  ``adjusted_r_squared``, plus normalized solver ``success``, ``status``,
+  and ``message`` fields. Existing ``result.fitted`` and
+  ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:
   ``scp.polynomial(...)``, ``scp.gaussian(...)``,

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -67,23 +67,44 @@ def _scalar_from_masked(value, *, default=np.nan):
     return float(value)
 
 
-def _compute_fit_diagnostics(observed, fitted, solver_meta=None):
+def _count_varying_parameters(fp):
+    """Count free parameters using the same rule as the optimizer internals."""
+    if fp is None:
+        return 0
+
+    n_varying = 0
+    for key in sorted(fp.keys()):
+        if fp.fixed[key]:
+            continue
+        key_prefix = key.split("_")[0]
+        if key_prefix in fp.expvars:
+            n_varying += fp.expnumber
+        else:
+            n_varying += 1
+    return int(n_varying)
+
+
+def _compute_fit_diagnostics(observed, fitted, solver_meta=None, fit_parameters=None):
     """Compute residual output and basic fit-quality diagnostics."""
     if getattr(observed, "size", None) == 0 or getattr(fitted, "size", None) == 0:
         residuals = observed.copy()
     else:
         residuals = observed - fitted
 
-    residual_data = np.ma.asarray(residuals.real.masked_data)
-    observed_data = np.ma.asarray(observed.real.masked_data)
+    residual_data = np.ma.masked_invalid(np.ma.asarray(residuals.real.masked_data))
+    observed_data = np.ma.masked_invalid(np.ma.asarray(observed.real.masked_data))
 
     count = int(residual_data.count())
+    n_varying_parameters = _count_varying_parameters(fit_parameters)
+    degrees_of_freedom = count - n_varying_parameters
+
     sse = _scalar_from_masked(np.ma.sum(np.ma.abs(residual_data) ** 2), default=0.0)
     rss = sse
 
     if count == 0:
         rmse = float("nan")
         r_squared = float("nan")
+        adjusted_r_squared = float("nan")
     else:
         rmse = float(np.sqrt(sse / count))
         observed_mean = np.ma.mean(observed_data)
@@ -96,11 +117,28 @@ def _compute_fit_diagnostics(observed, fitted, solver_meta=None):
         else:
             r_squared = float(1.0 - (sse / tss))
 
+        if degrees_of_freedom > 0 and count > 1 and np.isfinite(r_squared):
+            adjusted_r_squared = float(
+                1.0 - ((1.0 - r_squared) * (count - 1) / degrees_of_freedom),
+            )
+        else:
+            adjusted_r_squared = float("nan")
+
+    if degrees_of_freedom > 0:
+        reduced_chi_square = float(rss / degrees_of_freedom)
+    else:
+        reduced_chi_square = float("nan")
+
     diagnostics = {
+        "n_observations": count,
+        "n_varying_parameters": n_varying_parameters,
+        "degrees_of_freedom": int(degrees_of_freedom),
         "sse": sse,
         "rss": rss,
         "rmse": rmse,
         "r_squared": r_squared,
+        "reduced_chi_square": reduced_chi_square,
+        "adjusted_r_squared": adjusted_r_squared,
     }
     diagnostics.update(dict(solver_meta or {}))
     return residuals, diagnostics
@@ -1246,6 +1284,7 @@ class Optimize(DecompositionAnalysis):
             self._X,
             fitted,
             getattr(self, "_fit_meta", {}),
+            self.fp,
         )
 
         return FitResult(

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -15,6 +15,7 @@ import spectrochempy as scp
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis._base._result import ResultBase
+from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.analysis.curvefitting.optimize import _compute_fit_diagnostics
 from tests.test_analysis.result_test_helpers import assert_fit_returns_self
 from tests.test_analysis.result_test_helpers import assert_result_basics
@@ -172,10 +173,15 @@ class TestOptimizeResult:
             "cost",
             "niter",
             "ncalls",
+            "n_observations",
+            "n_varying_parameters",
+            "degrees_of_freedom",
             "rss",
             "sse",
             "rmse",
             "r_squared",
+            "reduced_chi_square",
+            "adjusted_r_squared",
             "success",
             "status",
             "message",
@@ -192,10 +198,15 @@ class TestOptimizeResult:
         assert isinstance(diag["cost"], float) or diag["cost"] is None
         assert isinstance(diag["niter"], int)
         assert isinstance(diag["ncalls"], int)
+        assert isinstance(diag["n_observations"], int)
+        assert isinstance(diag["n_varying_parameters"], int)
+        assert isinstance(diag["degrees_of_freedom"], int)
         assert isinstance(diag["rss"], float)
         assert isinstance(diag["sse"], float)
         assert isinstance(diag["rmse"], float)
         assert isinstance(diag["r_squared"], float)
+        assert isinstance(diag["reduced_chi_square"], float)
+        assert isinstance(diag["adjusted_r_squared"], float)
         assert isinstance(diag["success"], bool)
         assert isinstance(diag["message"], str)
 
@@ -213,11 +224,22 @@ class TestOptimizeResult:
         # at least one iteration and function call should have occurred
         assert diag["niter"] >= 0
         assert diag["ncalls"] >= 0
+        assert diag["n_observations"] == synthetic_two_peak_dataset.size
+        assert diag["n_varying_parameters"] == 9
+        assert diag["degrees_of_freedom"] == (
+            diag["n_observations"] - diag["n_varying_parameters"]
+        )
         assert diag["rss"] == pytest.approx(diag["sse"])
         assert np.isfinite(diag["rmse"])
         assert diag["rmse"] >= 0.0
         assert np.isfinite(diag["r_squared"])
         assert diag["r_squared"] > 0.99
+        assert np.isfinite(diag["reduced_chi_square"])
+        assert diag["reduced_chi_square"] == pytest.approx(
+            diag["rss"] / diag["degrees_of_freedom"]
+        )
+        assert np.isfinite(diag["adjusted_r_squared"])
+        assert diag["adjusted_r_squared"] <= diag["r_squared"]
         assert isinstance(diag["status"], int | type(None))
 
     def test_rss_matches_residual_sum_of_squares(
@@ -246,18 +268,54 @@ class TestOptimizeResult:
         diag = opt.result.diagnostics
 
         assert np.isnan(diag["r_squared"])
+        assert np.isnan(diag["adjusted_r_squared"])
         assert diag["rmse"] >= 0.0 or np.isnan(diag["rmse"])
         assert diag["rss"] == pytest.approx(diag["sse"])
+        assert diag["degrees_of_freedom"] == (
+            diag["n_observations"] - diag["n_varying_parameters"]
+        )
+
+    def test_fixed_parameters_are_not_counted_as_varying(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        assert opt.result.diagnostics["n_varying_parameters"] == 9
 
     def test_empty_diagnostics_are_stable(self):
         empty = scp.NDDataset(np.array([], dtype=np.float64))
-        residuals, diagnostics = _compute_fit_diagnostics(empty, empty, {})
+        residuals, diagnostics = _compute_fit_diagnostics(empty, empty, {}, None)
 
         assert residuals.size == 0
+        assert diagnostics["n_observations"] == 0
+        assert diagnostics["n_varying_parameters"] == 0
+        assert diagnostics["degrees_of_freedom"] == 0
         assert diagnostics["rss"] == pytest.approx(0.0)
         assert diagnostics["sse"] == pytest.approx(0.0)
         assert np.isnan(diagnostics["rmse"])
         assert np.isnan(diagnostics["r_squared"])
+        assert np.isnan(diagnostics["reduced_chi_square"])
+        assert np.isnan(diagnostics["adjusted_r_squared"])
+
+    def test_non_positive_degrees_of_freedom_are_stable(self):
+        observed = scp.NDDataset(np.array([1.0, 2.0, 3.0], dtype=np.float64))
+        fitted = observed.copy()
+        fit_parameters = FitParameters()
+        fit_parameters["a"] = (1.0, None, None, False)
+        fit_parameters["b"] = (1.0, None, None, False)
+        fit_parameters["c"] = (1.0, None, None, False)
+
+        _, diagnostics = _compute_fit_diagnostics(observed, fitted, {}, fit_parameters)
+
+        assert diagnostics["n_observations"] == 3
+        assert diagnostics["n_varying_parameters"] == 3
+        assert diagnostics["degrees_of_freedom"] == 0
+        assert np.isnan(diagnostics["reduced_chi_square"])
+        assert np.isnan(diagnostics["adjusted_r_squared"])
 
     def test_dry_fit_exposes_conservative_solver_status(
         self, synthetic_two_peak_dataset, optimize_script
@@ -273,6 +331,10 @@ class TestOptimizeResult:
         assert diag["success"] is False
         assert diag["status"] is None
         assert diag["message"] == ""
+        assert diag["n_varying_parameters"] == 9
+        assert diag["degrees_of_freedom"] == (
+            diag["n_observations"] - diag["n_varying_parameters"]
+        )
 
     # ----------------------------------------------------------------------------------
     # Representation


### PR DESCRIPTION
## Summary

This PR implements the second small FitResult enrichment step for the Peak Analysis / fitting workflow.

Changes included here:

- add parameter-counting diagnostics to `Optimize.result` / `FitResult.diagnostics`:
  - `n_observations`
  - `n_varying_parameters`
  - `degrees_of_freedom`
- add derived fit diagnostics:
  - `reduced_chi_square`
  - `adjusted_r_squared`
- preserve the PR1 diagnostics and residual output
- keep parameter counting aligned with the current internal optimizer parameter vector:
  - fixed parameters are not counted
  - reference parameters are not counted
  - experiment-dependent free parameters are counted per internal degree of freedom
- add focused tests for:
  - parameter counting
  - degrees of freedom
  - reduced chi-square
  - adjusted `R²`
  - non-positive-DOF behavior
  - dry-fit stability
- update the peak-analysis workflow guide
- update the changelog
- append the implementation note to the maintainer audit

## Intentionally out of scope

This PR does not implement:

- Jacobian retention
- covariance
- confidence intervals
- parameter uncertainties
- correlation matrix
- AIC / BIC
- `result.solution`
- `EstimationResult`
- lmfit integration
- any automatic peak-fitting API
- any Optimize script syntax refactor

## Related context

- FitResult enrichment campaign
- maintainer audit: `spectrochempy_maintainer/notes/audits/fitresult-enrichment-audit-2026-07.md`
- PR1 introduced residuals, RSS/SSE, RMSE, R², and solver status/message diagnostics