### PR TITLE
DOC: add uv as recommended installation method across all platforms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,17 @@ Full developer guide: [`docs/sources/devguide/`](docs/sources/devguide/)
 
 ## Quick start
 
+### Using uv (Recommended)
+
+```bash
+git clone https://github.com/your-user-name/spectrochempy.git
+cd spectrochempy
+uv venv --python 3.13 && source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+### Using pip
+
 ```bash
 git clone https://github.com/your-user-name/spectrochempy.git
 cd spectrochempy

--- a/docs/sources/devguide/contributing.rst
+++ b/docs/sources/devguide/contributing.rst
@@ -54,14 +54,25 @@ Setting Up Your Development Environment
 
    .. tabs::
 
-    .. tab:: MacOS/Linux
+    .. tab:: Using uv (Recommended)
+
+       uv is the recommended tool for development. It matches the project's own CI tooling.
+
+       .. sourcecode:: bash
+
+          uv venv --python 3.13
+          source .venv/bin/activate  # Linux/macOS
+          # or
+          .venv\Scripts\activate     # Windows
+
+    .. tab:: MacOS/Linux (venv)
 
        .. sourcecode:: bash
 
           python3 -m venv .venv
           source .venv/bin/activate
 
-    .. tab:: Windows
+    .. tab:: Windows (venv)
 
        .. sourcecode:: bash
 
@@ -70,12 +81,24 @@ Setting Up Your Development Environment
 
 4. Install SpectroChemPy in development mode:
 
-   .. sourcecode:: bash
+   .. tabs::
 
-       python -m pip install --upgrade pip
-       python -m pip install -e ".[dev]"  # Installs development and test dependencies
-       # or
-       python -m pip install -e ".[dev, docs]"  # Installs development, test and documentation dependencies
+    .. tab:: Using uv (Recommended)
+
+       .. sourcecode:: bash
+
+          uv pip install -e ".[dev]"  # Installs development and test dependencies
+          # or
+          uv pip install -e ".[dev, docs]"  # Installs development, test and documentation dependencies
+
+    .. tab:: Using pip
+
+       .. sourcecode:: bash
+
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"  # Installs development and test dependencies
+          # or
+          python -m pip install -e ".[dev, docs]"  # Installs development, test and documentation dependencies
 
 Making Changes
 --------------

--- a/docs/sources/gettingstarted/install/index.rst
+++ b/docs/sources/gettingstarted/install/index.rst
@@ -13,33 +13,85 @@ Prerequisites
 `SpectroChemPy` requires Python 3.11 or higher (tested up to 3.14). Python is a widely-adopted
 scientific programming language, particularly suited for data analysis and scientific computing.
 
+Choosing an Installation Method
+-------------------------------
+
+The best installation method depends on your workflow and experience level:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Situation
+     - Recommended method
+   * - New to Python
+     - ``uv`` — simple, fast, single-command setup
+   * - Existing conda environment
+     - ``mamba`` / ``conda`` (Miniforge) — integrates with existing environments
+   * - Scientific workflow (Jupyter, Spyder)
+     - ``mamba`` / ``conda`` (Miniforge) — full scientific distribution
+   * - HPC / CI / containers
+     - ``uv`` — fast, reproducible, minimal footprint
+   * - Installing from source / contributing
+     - ``uv`` — matches the project's own development tooling
+   * - Any environment / maximum compatibility
+     - ``pip`` — universal fallback
+
+.. note::
+
+   **uv** is a modern, fast Python package and project manager. It is the recommended
+   choice for most users. The SpectroChemPy development team uses ``uv`` daily.
+
+   **conda** / **mamba** (via `Miniforge <https://github.com/conda-forge/miniforge>`_)
+   is the recommended choice if you already rely on conda-based scientific environments.
+
+   **pip** works everywhere and is documented as a universal fallback.
+
 Installing Python
 -----------------
 
-Conda Package Managers (Recommended)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``uv`` (Recommended)
+~~~~~~~~~~~~~~~~~~~~~
 
-We recommend using one of these package managers for installing Python and managing dependencies:
+`uv <https://docs.astral.sh/uv/>`_ manages Python installations automatically.
+Install uv, then let it download and manage the required Python version:
 
-* `Anaconda <https://www.anaconda.com/distribution/>`_ - Full scientific distribution (~3GB)
-* `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ - Minimal distribution (~400MB)
-* `Mamba <https://mamba.readthedocs.io/en/latest/installation.html>`_ - Fast alternative to conda
-* `Micromamba <https://mamba.readthedocs.io/en/latest/installation.html#micromamba>`_ - Minimal mamba
+.. code-block:: bash
 
-Installation Steps
-~~~~~~~~~~~~~~~~~~
+   # Install uv (macOS/Linux)
+   curl -LsSf https://astral.sh/uv/install.sh | sh
 
-1. Download your chosen package manager
-2. Run the installer for your platform
-3. Open a terminal/command prompt
-4. Verify the installation:
+   # Install uv (Windows)
+   # powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+   # Install Python
+   uv python install 3.13
+
+See `uv's installation guide <https://docs.astral.sh/uv/getting-started/installation/>`_
+for alternatives (``pipx``, ``brew``, ``winget``, etc.).
+
+``Miniforge`` (conda / mamba)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Miniforge provides Python along with the ``conda`` and ``mamba`` package managers:
+
+* Download `Miniforge <https://github.com/conda-forge/miniforge>`_
+* Run the installer for your platform
+* Verify the installation:
 
 .. code-block:: bash
 
    conda --version  # or mamba --version
 
-Alternative Installation Methods
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For users who prefer a full distribution:
+
+* `Anaconda <https://www.anaconda.com/distribution/>`_ - Full scientific distribution (~3GB)
+* `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ - Minimal distribution (~400MB)
+
+System package manager
+~~~~~~~~~~~~~~~~~~~~~~
+
+If you prefer a standalone Python installation, use your platform's method:
 
 .. tabs::
 
@@ -49,13 +101,8 @@ Alternative Installation Methods
 
       .. code-block:: bash
 
-         # Install Homebrew
          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-         # Install Python
          brew install python
-
-         # Verify installation
          python3 --version
 
       **Using Official Installer:**
@@ -96,41 +143,60 @@ Alternative Installation Methods
          sudo dnf install python3.13
 
 Installing SpectroChemPy
-------------------------
+-----------------------
 
 Create Environment
 ~~~~~~~~~~~~~~~~~~
 
 First, create and activate a dedicated environment:
 
-.. code-block:: bash
+.. tabs::
 
-   # Using conda/mamba
-   mamba create -n scpy python=3.13
-   mamba activate scpy
+   .. tab:: Using uv (Recommended)
 
-   # OR using venv (if not using conda/mamba)
-   python -m venv scpy
-   source scpy/bin/activate  # On Windows: scpy\Scripts\activate
+      .. code-block:: bash
+
+         uv venv scpy --python 3.13
+         source scpy/bin/activate  # On Windows: scpy\Scripts\activate
+
+   .. tab:: Using conda / mamba
+
+      .. code-block:: bash
+
+         mamba create -n scpy python=3.13
+         mamba activate scpy
+
+   .. tab:: Using pip / venv
+
+      .. code-block:: bash
+
+         python -m venv scpy
+         source scpy/bin/activate  # On Windows: scpy\Scripts\activate
 
 Install Package
 ~~~~~~~~~~~~~~~
 
 .. tabs::
 
-   .. tab:: Using Mamba (Recommended)
+   .. tab:: Using uv (Recommended)
+
+      .. code-block:: bash
+
+         uv pip install spectrochempy
+
+   .. tab:: Using mamba
 
       .. code-block:: bash
 
          mamba install -c spectrocat spectrochempy
 
-   .. tab:: Using Conda
+   .. tab:: Using conda
 
       .. code-block:: bash
 
          conda install -c spectrocat spectrochempy
 
-   .. tab:: Using Pip
+   .. tab:: Using pip
 
       .. code-block:: bash
 

--- a/docs/sources/gettingstarted/install/install_adds.rst
+++ b/docs/sources/gettingstarted/install/install_adds.rst
@@ -21,7 +21,13 @@ Installation options:
 
 .. tabs::
 
-   .. tab:: Using mamba (recommended)
+   .. tab:: Using uv (Recommended)
+
+      .. code-block:: bash
+
+         uv pip install spectrochempy_data
+
+   .. tab:: Using mamba
 
       .. code-block:: bash
 
@@ -45,7 +51,16 @@ for specific domains. Install them as needed:
 
 .. tabs::
 
-    .. tab:: Using pip (recommended)
+    .. tab:: Using uv (Recommended)
+
+       .. code-block:: bash
+
+          uv pip install "spectrochempy[iris]"      # 2D-IRIS analysis
+          uv pip install "spectrochempy[nmr]"       # Bruker TopSpin reader & NMR processing
+          uv pip install "spectrochempy[tensor]"    # TensorLy-backed tensor decompositions
+          uv pip install spectrochempy-carroucell   # Carroucell experiment reader
+
+    .. tab:: Using pip
 
        .. code-block:: bash
 
@@ -54,7 +69,7 @@ for specific domains. Install them as needed:
           pip install spectrochempy[tensor]    # TensorLy-backed tensor decompositions
           pip install spectrochempy-carroucell  # Carroucell experiment reader
 
-    .. tab:: Using mamba (recommended)
+    .. tab:: Using mamba
 
        .. code-block:: bash
 
@@ -107,7 +122,13 @@ it can be installed separately:
 
 .. tabs::
 
-   .. tab:: Using mamba (recommended)
+   .. tab:: Using uv (Recommended)
+
+      .. code-block:: bash
+
+         uv pip install cantera
+
+   .. tab:: Using mamba
 
       .. code-block:: bash
 
@@ -128,7 +149,13 @@ For interactive matplotlib plots:
 
 .. tabs::
 
-   .. tab:: Using mamba (recommended)
+   .. tab:: Using uv (Recommended)
+
+      .. code-block:: bash
+
+         uv pip install "pyqt5>=5.15.0"
+
+   .. tab:: Using mamba
 
       .. code-block:: bash
 

--- a/docs/sources/gettingstarted/install/install_mac_linux.rst
+++ b/docs/sources/gettingstarted/install/install_mac_linux.rst
@@ -24,18 +24,37 @@ Environment Setup
 
 .. tabs::
 
-    .. tab:: Using conda/mamba (recommended)
+    .. tab:: Using uv (Recommended)
 
-        We strongly recommend using mamba as it's significantly faster at resolving dependencies.
+        `uv <https://docs.astral.sh/uv/>`_ is the recommended tool for most users.
+        Install uv if you do not have it yet:
 
-        1. Install Mambaforge
+        .. code-block:: bash
 
-        Download and install `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+
+        Then create a virtual environment:
+
+        .. code-block:: bash
+
+            # Create environment with Python 3.13
+            uv venv scpy-env --python 3.13
+
+            # Activate it
+            source scpy-env/bin/activate
+
+    .. tab:: Using conda / mamba
+
+        Mamba offers faster dependency resolution than conda.
+
+        1. Install Miniforge
+
+        Download and install `Miniforge <https://github.com/conda-forge/miniforge>`_
 
 
         2. Add required channels:
 
-        .. code-block:: bat
+        .. code-block:: bash
 
             mamba config --add channels conda-forge
             mamba config --add channels spectrocat
@@ -69,7 +88,22 @@ Install SpectroChemPy
 
 .. tabs::
 
-    .. tab:: Using conda/mamba
+    .. tab:: Using uv (Recommended)
+
+        .. code-block:: bash
+
+            uv pip install spectrochempy
+
+            # or if you want to install interactive version (including jupyter)
+            uv pip install "spectrochempy[interactive]"
+
+        Development version:
+
+        .. code-block:: bash
+
+            uv pip install spectrochempy --pre
+
+    .. tab:: Using conda / mamba
 
         Stable version
 

--- a/docs/sources/gettingstarted/install/install_sources.rst
+++ b/docs/sources/gettingstarted/install/install_sources.rst
@@ -40,12 +40,25 @@ Installation Methods
 
 .. tabs::
 
-    .. tab:: mamba (recommended)
+    .. tab:: uv (Recommended)
 
         .. code-block:: bash
 
-            # Install Mambaforge
-            # Get it from: https://github.com/conda-forge/miniforge#mambaforge
+            # Create environment
+            uv venv --python 3.13
+            source .venv/bin/activate  # Linux/macOS
+            # or
+            .venv\Scripts\activate     # Windows
+
+            # Install package in editable mode
+            uv pip install -e ".[dev]"
+
+    .. tab:: mamba
+
+        .. code-block:: bash
+
+            # Install Miniforge
+            # Get it from: https://github.com/conda-forge/miniforge
 
             # Create environment
             mamba env create -n scpy -f environments/environment.yml

--- a/docs/sources/gettingstarted/install/install_win.rst
+++ b/docs/sources/gettingstarted/install/install_win.rst
@@ -24,16 +24,37 @@ Environment Setup
 
 .. tabs::
 
-   .. tab:: Mamba (Recommended)
+   .. tab:: Using uv (Recommended)
 
-      1. Install Mambaforge:
+      1. Install uv:
 
-         * Download `Mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_
+         .. code-block:: powershell
+
+            powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+         Restart your terminal after installation.
+
+      2. Create environment:
+
+         .. code-block:: bat
+
+            uv venv scpy --python 3.13
+            scpy\Scripts\activate
+
+   .. tab:: Using conda / mamba
+
+      1. Install Miniforge:
+
+         * Download `Miniforge <https://github.com/conda-forge/miniforge>`_
          * Run the installer
          * Open cmd prompt
 
+      2. Add required channels:
 
+         .. code-block:: bat
 
+            mamba config --add channels conda-forge
+            mamba config --add channels spectrocat
 
       3. Create environment:
 
@@ -59,11 +80,26 @@ Environment Setup
             python -m pip install --upgrade pip
 
 Installing SpectroChemPy
-------------------------
+-----------------------
 
 .. tabs::
 
-   .. tab:: Using Mamba (Recommended)
+   .. tab:: Using uv (Recommended)
+
+      .. code-block:: bat
+
+         uv pip install spectrochempy
+
+         :: or with interactive extras
+         uv pip install "spectrochempy[interactive]"
+
+      Development version:
+
+      .. code-block:: bat
+
+         uv pip install spectrochempy --pre
+
+   .. tab:: Using conda / mamba
 
       .. code-block:: bat
 
@@ -75,14 +111,13 @@ Installing SpectroChemPy
 
          mamba install -c spectrocat/label/dev spectrochempy
 
-   .. tab:: Using Pip
+   .. tab:: Using pip
 
       .. code-block:: bat
 
-         # Install SpectroChemPy
          python -m pip install spectrochempy
 
-         # or if you want to install interactive version (including jupyter)
+         :: or if you want to install interactive version (including jupyter)
          python -m pip install "spectrochempy[interactive]"
 
 Verifying Installation
@@ -112,9 +147,9 @@ Create a batch file (`.bat`) with:
 
     @REM launch cmd in scpy environment
     @CALL CD C:\<yourWorkingFolder>
-    @CALL CMD /K C:\<yourMambaForgeFolder>\Scripts\activate.bat scpy
+    @CALL CMD /K C:\<yourMiniforgeFolder>\Scripts\activate.bat scpy
 
-Save as `activate-scpy.bat` and create a shortcut named "Mamba prompt (scpy)".
+Save as `activate-scpy.bat` and create a shortcut named "Miniforge prompt (scpy)".
 
 Next Steps
 ----------

--- a/docs/sources/gettingstarted/quickstart.py
+++ b/docs/sources/gettingstarted/quickstart.py
@@ -55,7 +55,12 @@
 # > * Basic knowledge of Python
 # > * Jupyter notebook environment
 #
-# You can install SpectroChemPy using either pip or mamba:
+# You can install SpectroChemPy using uv, pip, or mamba:
+#
+# **Using uv (recommended):**
+# ```bash
+# uv pip install spectrochempy
+# ```
 #
 # **Using pip:**
 # ```bash

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -256,3 +256,11 @@ Developer
   docs for documentation branches).  Added ``timeout-minutes: 360`` to
   both workflows and ``continue-on-error: true`` on archived-version
   steps so a single failing old-tag build does not block the rest.
+
+- DOC: Refreshed the installation guide across all platforms:
+  added ``uv`` as the recommended installation method, created a
+  "Choosing an installation method" decision table, replaced
+  deprecated Mambaforge references with Miniforge, and updated
+  contributor setup instructions to match the project's own
+  ``uv``-based development toolchain.  Conda/mamba and pip remain
+  documented as alternatives.  (#1366)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -223,3 +223,11 @@ Developer
   docs for documentation branches).  Added ``timeout-minutes: 360`` to
   both workflows and ``continue-on-error: true`` on archived-version
   steps so a single failing old-tag build does not block the rest.
+
+- DOC: Refreshed the installation guide across all platforms:
+  added ``uv`` as the recommended installation method, created a
+  "Choosing an installation method" decision table, replaced
+  deprecated Mambaforge references with Miniforge, and updated
+  contributor setup instructions to match the project's own
+  ``uv``-based development toolchain.  Conda/mamba and pip remain
+  documented as alternatives.  (#1366)


### PR DESCRIPTION
## Summary

Refresh the installation guide to reflect modern Python tooling.

### Changes

- **uv** added as the recommended installation method across all platforms (macOS, Linux, Windows)
- New "Choosing an installation method" decision table to guide users by use case
- Deprecated **Mambaforge** references replaced with **Miniforge** (conda-forge's current distribution)
- **conda/mamba** (Miniforge) and **pip** remain documented as alternatives
- Contributor setup instructions updated to match the project's own uv-based development toolchain
- All optional dependency sections (data, plugins, cantera, PyQt) updated with uv commands

### Review notes

Documentation-only changes. No SpectroChemPy source code was modified.