### PR TITLE
ENH: retain Optimize jacobian artifacts for future covariance work

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -472,6 +472,11 @@ components = f1.result.components
 # `f1.result` groups fitted outputs and diagnostics without removing the
 # existing direct estimator surface. Direct access such as `f1.components`,
 # `f1.predict()`, and plotting helpers remains supported.
+#
+# Raw solver artifacts stay on the estimator. Least-squares-backed methods keep
+# the retained Jacobian on `f1.jacobian`, while `simplex`, `basinhopping`, and
+# dry fits return `None`. This is preparatory infrastructure for future
+# uncertainty estimation and is intentionally not exposed through `FitResult`.
 
 # Show the result
 _ = ndOHcorr.plot()

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -47,8 +47,10 @@ New Features
   ``r_squared``, ``n_observations``, ``n_varying_parameters``,
   ``degrees_of_freedom``, ``reduced_chi_square``, and
   ``adjusted_r_squared``, plus normalized solver ``success``, ``status``,
-  and ``message`` fields. Existing ``result.fitted`` and
-  ``result.components`` behavior is preserved.
+  and ``message`` fields. ``Optimize`` also retains the raw least-squares
+  Jacobian on ``opt.jacobian`` when a backend naturally provides one, while
+  methods without a native Jacobian expose ``None``. Existing
+  ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:
   ``scp.polynomial(...)``, ``scp.gaussian(...)``,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -43,8 +43,10 @@ New Features
   ``r_squared``, ``n_observations``, ``n_varying_parameters``,
   ``degrees_of_freedom``, ``reduced_chi_square``, and
   ``adjusted_r_squared``, plus normalized solver ``success``, ``status``,
-  and ``message`` fields. Existing ``result.fitted`` and
-  ``result.components`` behavior is preserved.
+  and ``message`` fields. ``Optimize`` also retains the raw least-squares
+  Jacobian on ``opt.jacobian`` when a backend naturally provides one, while
+  methods without a native Jacobian expose ``None``. Existing
+  ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:
   ``scp.polynomial(...)``, ``scp.gaussian(...)``,

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -67,6 +67,15 @@ def _scalar_from_masked(value, *, default=np.nan):
     return float(value)
 
 
+def _freeze_jacobian_artifact(jacobian):
+    """Return an immutable ndarray snapshot of a solver-provided Jacobian."""
+    if jacobian is None:
+        return None
+    array = np.array(jacobian, copy=True)
+    array.flags.writeable = False
+    return array
+
+
 def _count_varying_parameters(fp):
     """Count free parameters using the same rule as the optimizer internals."""
     if fp is None:
@@ -208,6 +217,22 @@ def _normalize_solver_meta(method, result, warnmess=None):
         "success": False,
         "status": None,
         "message": message,
+    }
+
+
+def _extract_solver_artifacts(method, result):
+    """Retain backend artifacts needed for future uncertainty features."""
+    method_lower = method.lower()
+
+    if method_lower in ["lm", "trf"]:
+        return {
+            "jacobian": _freeze_jacobian_artifact(getattr(result, "jac", None)),
+            "jacobian_backend": method_lower,
+        }
+
+    return {
+        "jacobian": None,
+        "jacobian_backend": method_lower,
     }
 
 
@@ -649,8 +674,12 @@ class Optimize(DecompositionAnalysis):
             "status": None,
             "message": "",
         }
+        solver_artifacts = {
+            "jacobian": None,
+            "jacobian_backend": None,
+        }
         if not self.dry:
-            fp, fopt, solver_meta = _optimize(
+            fp, fopt, solver_meta, solver_artifacts = _optimize(
                 func,
                 fp,
                 args=(X,),
@@ -669,6 +698,7 @@ class Optimize(DecompositionAnalysis):
             "ncalls": ncalls,
             **solver_meta,
         }
+        self._solver_artifacts = solver_artifacts
 
         # replace the previous script with new fp parameters
         self.script = str(fp)
@@ -1256,6 +1286,25 @@ class Optimize(DecompositionAnalysis):
         """
         return super().fit(X, Y=None)
 
+    @property
+    def jacobian(self):
+        """
+        Return the retained raw solver Jacobian when the backend provides one.
+
+        Returns
+        -------
+        ndarray or None
+            Immutable Jacobian matrix for least-squares-backed methods.
+            Returns ``None`` for backends that do not naturally expose a
+            Jacobian, and for dry fits.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                "The fit method must be used before accessing the jacobian",
+            )
+
+        return getattr(self, "_solver_artifacts", {}).get("jacobian")
+
     # ----------------------------------------------------------------------------------
     # Result object
     # ----------------------------------------------------------------------------------
@@ -1393,6 +1442,7 @@ def _optimize(
         )
         res, fopt, warnmess = result.x, result.cost, result.message
         solver_meta = _normalize_solver_meta(method, result, warnmess)
+        solver_artifacts = _extract_solver_artifacts(method, result)
 
     elif method.lower() == "simplex":
         result = optimize.fmin(
@@ -1409,8 +1459,9 @@ def _optimize(
         )
         res, fopt, _, _, warnmess = result
         solver_meta = _normalize_solver_meta(method, None, warnmess)
+        solver_artifacts = _extract_solver_artifacts(method, None)
 
-    elif method.upper() == "basinhopping":
+    elif method.lower() == "basinhopping":
         result = optimize.basinhopping(
             internal_func,
             par,
@@ -1430,6 +1481,7 @@ def _optimize(
         #                                                full_output=True, disp=False, callback=callback)
         res, fopt, warnmess = result.x, result.fun, result.message
         solver_meta = _normalize_solver_meta(method, result, warnmess)
+        solver_artifacts = _extract_solver_artifacts(method, result)
 
     elif method == "XXXX":
         raise NotImplementedError(f"method: {method}")
@@ -1447,7 +1499,7 @@ def _optimize(
     if warnmess == 2:
         warning_("Maximum number of iterations reached.")
 
-    return fpe, fopt, solver_meta
+    return fpe, fopt, solver_meta, solver_artifacts
 
 
 # ======================================================================================

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -16,6 +16,7 @@ from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
+from spectrochempy.analysis.curvefitting import optimize as optimize_module
 from spectrochempy.analysis.curvefitting.optimize import _compute_fit_diagnostics
 from tests.test_analysis.result_test_helpers import assert_fit_returns_self
 from tests.test_analysis.result_test_helpers import assert_result_basics
@@ -335,6 +336,121 @@ class TestOptimizeResult:
         assert diag["degrees_of_freedom"] == (
             diag["n_observations"] - diag["n_varying_parameters"]
         )
+
+    # ----------------------------------------------------------------------------------
+    # Solver artifacts
+    # ----------------------------------------------------------------------------------
+    def test_jacobian_raises_before_fit(self, optimize_script):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        with pytest.raises(NotFittedError):
+            _ = opt.jacobian
+
+    def test_jacobian_available_for_least_squares_backend(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        jacobian = opt.jacobian
+
+        assert jacobian is not None
+        assert jacobian.flags.writeable is False
+        assert jacobian.shape == (
+            opt.result.diagnostics["n_observations"],
+            opt.result.diagnostics["n_varying_parameters"],
+        )
+
+    def test_jacobian_available_for_leastsq_alias(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.method = "leastsq"
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        jacobian = opt.jacobian
+
+        assert jacobian is not None
+        assert jacobian.flags.writeable is False
+        assert jacobian.shape == (
+            opt.result.diagnostics["n_observations"],
+            opt.result.diagnostics["n_varying_parameters"],
+        )
+
+    def test_jacobian_absent_for_simplex_backend(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.method = "simplex"
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        assert opt.jacobian is None
+
+    def test_jacobian_absent_for_basinhopping_backend(
+        self, synthetic_two_peak_dataset, optimize_script, monkeypatch
+    ):
+        class _FakeLocalResult:
+            success = True
+            status = 0
+            message = "ok"
+            jac = np.ones((synthetic_two_peak_dataset.size, 9))
+
+        class _FakeBasinhoppingResult:
+            x = np.zeros(9, dtype=np.float64)
+            fun = 0.0
+            message = "ok"
+            success = True
+            status = 0
+            lowest_optimization_result = _FakeLocalResult()
+
+        monkeypatch.setattr(
+            optimize_module.optimize,
+            "basinhopping",
+            lambda *args, **kwargs: _FakeBasinhoppingResult(),
+        )
+
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.method = "basinhopping"
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        assert opt.jacobian is None
+
+    def test_jacobian_absent_for_dry_fit(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.dry = True
+        opt.fit(synthetic_two_peak_dataset)
+
+        assert opt.jacobian is None
+
+    def test_fit_result_does_not_expose_jacobian(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        assert "jacobian" not in opt.result.outputs
+        assert "jacobian" not in opt.result.diagnostics
+        with pytest.raises(AttributeError):
+            _ = opt.result.jacobian
 
     # ----------------------------------------------------------------------------------
     # Representation


### PR DESCRIPTION
## Summary

This PR implements PR3 of the FitResult enrichment campaign: Jacobian retention.

It defines a conservative backend contract for raw solver Jacobians without
turning Jacobians into FitResult diagnostics yet.

## Changes

- retain solver Jacobians on `Optimize.jacobian` for least-squares-backed fits
- return `None` for backends without a stable natural Jacobian (`simplex`,
  `basinhopping`) and for dry fits
- keep Jacobians out of `FitResult` for now
- store retained solver artifacts separately from fit diagnostics
- add focused backend and dry-fit tests
- document the contract in the fitting guide and changelog
- append the PR3 implementation note to the maintainer audit

## Notes

This is an infrastructure PR for future covariance work.
It does **not** implement covariance, uncertainties, confidence intervals,
or other statistical interpretation yet.