### PR TITLE
DEV: clean repository spelling and add codespell to pre-commit

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 [codespell]
 # Skip generated, third-party, binary-like, or data-heavy files where
 # spell-check noise is expected to outweigh value.
-skip = .git,.pytest_cache,.ruff_cache,./LICENSE,./LICENSES/*,./maintainers/*,./docs/_static/license_CeCILL.html,./docs/_static/versions.json,./docs/_templates/layout.html,./docs/sources/reference/bibliography.bib,./docs/sources/reference/papers.rst,./docs/sources/whatsnew/latest.rst,./src/spectrochempy.egg-info/*,./src/spectrochempy/extern/*,./src/spectrochempy/data/databases/isotopes.csv,*.ipynb,*.mat,*.npy,*.npz,*.spg,*.wdf
+skip = .git,.pytest_cache,.ruff_cache,LICENSE,./LICENSE,LICENSES/*,./LICENSES/*,maintainers/*,./maintainers/*,docs/_static/license_CeCILL.html,./docs/_static/license_CeCILL.html,docs/_static/versions.json,./docs/_static/versions.json,docs/_templates/layout.html,./docs/_templates/layout.html,docs/sources/reference/bibliography.bib,./docs/sources/reference/bibliography.bib,docs/sources/reference/papers.rst,./docs/sources/reference/papers.rst,docs/sources/whatsnew/latest.rst,./docs/sources/whatsnew/latest.rst,src/spectrochempy.egg-info/*,./src/spectrochempy.egg-info/*,src/spectrochempy/extern/*,./src/spectrochempy/extern/*,src/spectrochempy/data/databases/isotopes.csv,./src/spectrochempy/data/databases/isotopes.csv,*.ipynb,*.mat,*.npy,*.npz,*.spg,*.wdf
 
 # Domain-specific short names that are intentional in SpectroChemPy and would
 # otherwise be reported as false positives.

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,8 @@
+[codespell]
+# Skip generated, third-party, binary-like, or data-heavy files where
+# spell-check noise is expected to outweigh value.
+skip = .git,.pytest_cache,.ruff_cache,./LICENSE,./LICENSES/*,./maintainers/*,./docs/_static/license_CeCILL.html,./docs/_static/versions.json,./docs/_templates/layout.html,./docs/sources/reference/bibliography.bib,./docs/sources/reference/papers.rst,./docs/sources/whatsnew/latest.rst,./src/spectrochempy.egg-info/*,./src/spectrochempy/extern/*,./src/spectrochempy/data/databases/isotopes.csv,*.ipynb,*.mat,*.npy,*.npz,*.spg,*.wdf
+
+# Domain-specific short names that are intentional in SpectroChemPy and would
+# otherwise be reported as false positives.
+ignore-words-list = ALS,COO,IST,SER,alignement,ans,iif,linez,nam,nd,ressources,sav,ser,som,te

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,12 @@ repos:
       - id: mixed-line-ending
       - id: check-yaml
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: [--config, .codespellrc]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,7 @@ pre-commit run --all-files
 Hooks currently include:
 
 * Ruff linting and formatting;
+* codespell repository spelling checks (configured by `.codespellrc`);
 * requirements regeneration;
 * lazy stub regeneration;
 * version and release-note updates.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ if not single_doc_or_dir:
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["../_templates", "_templates"]
-# for some reason, the templates are not taken into account without specifiying
+# for some reason, the templates are not taken into account without specifying
 # twe two locations (it looks like sphinx is looking for the templates relative to the source
 # directory instead of the conf.py dir.
 

--- a/docs/make.py
+++ b/docs/make.py
@@ -755,7 +755,7 @@ class BuildDocumentation:
         # Create the directories required for building the documentation
         self._make_dirs()
 
-        # Get previous versions and save them in a json file to b use by the versions.js scipt
+        # Get previous versions and save them in a json file to be used by the versions.js script
         previous_versions = self._get_previous_versions()
 
         # Eventually clean the build target directory

--- a/docs/sources/devguide/contributing_codebase.rst
+++ b/docs/sources/devguide/contributing_codebase.rst
@@ -34,7 +34,8 @@ Pre-commit
 ----------
 
 We encourage you to use `pre-commit hooks <https://pre-commit.com/>`__
-to automatically run ``ruff check`` and ``ruff format`` when you make a git commit.
+to automatically run checks such as ``ruff`` and ``codespell`` when you make a
+git commit.
 This can be done by installing ``pre-commit``:
 
     .. code-block:: bash

--- a/docs/sources/reference/glossary.rst
+++ b/docs/sources/reference/glossary.rst
@@ -47,7 +47,7 @@ Glossary
         and :cite:`maeder:2009` for more recent references.
 
     ICA
-        ``Independant Component Analysis``.
+        ``Independent Component Analysis``.
         ICA is a method for separating a multivariate signal into additive subcomponents.
 
     loading
@@ -107,7 +107,7 @@ Glossary
 
     PLS
         ``Partial Least Squares`` regression (or Projection on Latent Structures) is a statistical method to
-        estimate :math:`n \times l` dependant or predicted variables :math:`Y` from :math:`n \times m`
+        estimate :math:`n \times l` dependent or predicted variables :math:`Y` from :math:`n \times m`
         explanatory or observed variables :math:`X` by projecting both of them on new spaces spanned by
         :math:`k` latent variables according to the master equations :
 
@@ -145,7 +145,7 @@ Glossary
 
         where :math:`\mathbf{U}(n,k)` and :math:`\mathbf{V}^t(k,m)` are matrices regrouping so-called left
         and right singular vectors of size :math:`k \leq \min(n,m)`. The factorization is exact (null
-        error :math:`E`) whan :math:`k = \min(n,m)`. Among other properties, left and right singular
+        error :math:`E`) when :math:`k = \min(n,m)`. Among other properties, left and right singular
         vectors form two orthonormal basis of :math:`k`-dimensional spaces.
         Hence, for :math:`\mathbf{U}`:
 
@@ -153,7 +153,7 @@ Glossary
 
         :math:`\Sigma` is a diagonal :math:`k\times k` matrix which diagonal elements :math:`\sigma_i`
         are called the  *singular values* of the matrix :math:`X`. The number :math:`r` of non-negligible
-        (formally non-null) sigular values is called the :term:`rank` of :math:`X` and determines the
+        (formally non-null) singular values is called the :term:`rank` of :math:`X` and determines the
         number of linear independent lines or columns of :math:`X`.
 
         The singular values :math:`\sigma_i` are generally chosen in descending order, so that the first

--- a/docs/sources/userguide/analysis/pca.py
+++ b/docs/sources/userguide/analysis/pca.py
@@ -112,7 +112,7 @@ pca.n_components
 
 # %% [markdown]
 # As the main purpose of PCA is dimensionality reduction, we generally limit the PCA to a limited number of components.
-# This can be done by either reseting the number of components of an existing object:
+# This can be done by either resetting the number of components of an existing object:
 # %%
 pca.n_components = 8
 _ = pca.fit(X)

--- a/docs/sources/userguide/analysis/pls.py
+++ b/docs/sources/userguide/analysis/pls.py
@@ -34,7 +34,7 @@ import spectrochempy as scp
 # ## Introduction
 #
 # PLSRegression (standing for Partial Least Squares regression ) is a statistical method to estimate
-# $n \times l$ dependant or predicted variables $Y$ from $n \times m$ explanatory or observed
+# $n \times l$ dependent or predicted variables $Y$ from $n \times m$ explanatory or observed
 # variables $X$ by projecting both of them on new spaces spanned by $k$ latent variables,
 # according to the master equations :
 # $$ X = S_X L_X^T + E_X $$
@@ -69,7 +69,7 @@ for a in A:
 # In this tutorial, we are first interested in the dataset named `'m5spec'`, corresponding to the 80 spectra
 # on one of the instruments and `'propvals'` giving the property values of the 80 corn samples.
 #
-# Let's name the specta NDDataset `X` , add few informations about the x-scale and plot it, before and
+# Let's name the spectra NDDataset `X`, add a few pieces of information about the x-scale and plot it, before and
 # after detrend:
 
 # %%

--- a/docs/sources/userguide/importexport/import.py
+++ b/docs/sources/userguide/importexport/import.py
@@ -217,7 +217,7 @@ X
 #   string literals, `\\` represents a literal backslash, e.g.
 #   `r'C:\\users\\Brian'`.
 # - In python, the slash `/` is used as the path separator in all systems (Windows, Linux, OSX, ...).
-#   So it can be used in all cases. For exemple:
+#   So it can be used in all cases. For example:
 #
 #       X = scp.read('C:/users/Brian/s/Life/wodger.spg')
 #

--- a/docs/sources/userguide/importexport/importIR.rst
+++ b/docs/sources/userguide/importexport/importIR.rst
@@ -23,7 +23,7 @@ JCAMP-DX ``read_jcamp()`` Standard IR exchange format
 ======== ================ ==============================
 
 
-Detailled Tutorials
+Detailed Tutorials
 -------------------
 
 .. toctree::

--- a/docs/sources/userguide/importexport/importOPUS.py
+++ b/docs/sources/userguide/importexport/importOPUS.py
@@ -75,7 +75,7 @@ Z1
 # <div class='alert alert-info'>
 # <b>Note:</b><br/>
 #     By default all files in the given directory are merged as a single dataset if they are compatibles (*i.e.*, same shape, same type of experiment...).<br/>
-#     If they cannot be merged due to imcompatible shape or type, separate datasets are returned with dataset merged in different groups.
+#     If they cannot be merged due to incompatible shape or type, separate datasets are returned with dataset merged in different groups.
 
 # %% [markdown] {"editable": true, "slideshow": {"slide_type": ""}}
 # For instance in the following, two dataset will be returned:
@@ -94,7 +94,7 @@ LZ = scp.read_opus("irdata/OPUS")
 LZ
 
 # %% [markdown] {"editable": true, "slideshow": {"slide_type": ""}}
-# As previously two datasets are returned due to the imcompatible types and shapes of the experiments.
+# As previously two datasets are returned due to the incompatible types and shapes of the experiments.
 #
 # If one desire to load of files into separate datasets, then set the **merge** attribute to False.
 
@@ -144,7 +144,7 @@ ZSM
 # %% [markdown] {"editable": true, "slideshow": {"slide_type": ""}}
 # ### Reading OPUS file Metadata
 #
-# As just seen above, more informations can be obtained on the experiment and spectrometer parameters using the dataset metadata (**meta** attribute).
+# As just seen above, more information can be obtained on the experiment and spectrometer parameters using the dataset metadata (**meta** attribute).
 #
 # For instance, to get a display of all metadata:
 #
@@ -182,7 +182,7 @@ except ValueError:
     scp.error_("meta data dictionary is read only!")
 
 # %% [markdown] {"editable": true, "slideshow": {"slide_type": ""}}
-# To add a new value (or to modifify/delete an existing value), the `readonly` flag must be unset before the operation:
+# To add a new value (or to modify/delete an existing value), the `readonly` flag must be unset before the operation:
 
 # %% {"editable": true, "slideshow": {"slide_type": ""}}
 Z.meta.readonly = False

--- a/docs/sources/userguide/introduction/introduction.py
+++ b/docs/sources/userguide/introduction/introduction.py
@@ -122,7 +122,7 @@ nd
 #
 # * [Core objects](../objects/index.rst) : This is really the starting point for understanding how SpectroChemPy works. In fact, virtually all the functions offered by the API use one of these objects: `NDDataset` (the most important!) or `Project`.
 #
-# * [Import & export](../importexport/index.rst) : This part shows how to import spectroscopic data and transform it into an NDDataset, the object on which processsing and analysis procedures will then be applied.
+# * [Import & export](../importexport/index.rst) : This part shows how to import spectroscopic data and transform it into an NDDataset, the object on which processing and analysis procedures will then be applied.
 #
 # * [Processing](../processing/index.rst) : This section explains how to prepare datasets for future analysis. By processing, we mean methods which generally return the same dataset transformed by mathematical operations (for example, this may be a `sqrt` or `log` operation, or a `fft` operation or many others), or part of a dataset transformed by a slicing or concatenation operation.
 #

--- a/docs/sources/userguide/plotting/overview.py
+++ b/docs/sources/userguide/plotting/overview.py
@@ -107,7 +107,7 @@ _ = ds.plot_lines(palette="categorical")
 # ds_neg.plot_image(colorbar=True)
 
 # %% [markdown]
-# As expected,the default diverging colormap has been chosen . But this can be overriden using:
+# As expected,the default diverging colormap has been chosen . But this can be overridden using:
 #
 # ds_neg.plot_image(cmap_mode='sequential')   # forces sequential colormap even for data with negative values
 

--- a/docs/sources/userguide/processing/baseline.py
+++ b/docs/sources/userguide/processing/baseline.py
@@ -414,7 +414,7 @@ _ = ax.set_ylim([-0.3, 0.8])
 #
 # When the baseline to remove is a simple linear correction, one can use `basc` without
 # entering any parameter. This performs an automatic linear baseline correction.
-# This is close to detrend(oreder=1), exceot that the linear baseline is fitted on the
+# This is close to detrend(order=1), except that the linear baseline is fitted on the
 # the spectra limit to fit the baseline. This is useful when the spectra limits are
 # signal free.
 
@@ -423,7 +423,7 @@ Aa = A.basc()
 _ = Aa.plot()  # range are automatically set to the start and end of the spectra, model='polynomial', order='linear'
 
 # %% [markdown]
-# All parameters of `Baseline` can be used in basc. It is thus probably quite conveninent if one wants to write shorter code.
+# All parameters of `Baseline` can be used in basc. It is thus probably quite convenient if one wants to write shorter code.
 
 # %% [markdown]
 # ### Rubberband

--- a/docs/sources/userguide/processing/math_operations.py
+++ b/docs/sources/userguide/processing/math_operations.py
@@ -295,7 +295,7 @@ _ = out.plot(figsize=(6, 2.5))
 # ##### log
 # Natural logarithm, element-wise.
 #
-# This doesn't generate un error for negative numbrs, but the output is masked for those values
+# This doesn't generate an error for negative numbers, but the output is masked for those values
 
 # %%
 out = np.log(dataset)

--- a/docs/sources/whatsnew/v0.6.2.rst
+++ b/docs/sources/whatsnew/v0.6.2.rst
@@ -12,7 +12,7 @@ New features
 * `~spectrochempy.PLSRegression` (Partial Least Squares regression) method added.
 
 * `read` method now handle any url pointing
-  to a spectrochempy readeable file. An url to a compressed (zip) files are also accepted.
+  to a SpectroChemPy readable file. A URL to compressed (zip) files is also accepted.
 
   Example:
 

--- a/docs/sources/whatsnew/v0.6.4.rst
+++ b/docs/sources/whatsnew/v0.6.4.rst
@@ -27,8 +27,8 @@ Breaking changes
   to a number of significant digits (given by the parameter `sigdigits`).
   If the data are linear already, nothing is modified.
 * The rounding of the data is now done in the `~spectrochempy.Coord` class automatically to at least
-  2 decimals everytime the `data` are modified and during Coord initialisation,
-  unless the parameter `bounding` is set to `False` during intialisation.
+  2 decimals every time the `data` are modified and during Coord initialisation,
+  unless the parameter `bounding` is set to `False` during initialisation.
 * Issue #647. ActionMassKinetics has been optimized and refactored.
 
 Deprecations

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
@@ -560,7 +560,7 @@ class IRIS(DecompositionAnalysis):
                 b = np.zeros(M)
 
             # --------------------------------------------------------------------------
-            def solve_for_lambda(X, K, P0, lamda, S):
+            def solve_for_lambda(X, K, P0, lambda_, S):
                 """
                 QP optimization.
 
@@ -569,7 +569,7 @@ class IRIS(DecompositionAnalysis):
                 X: NDDataset of experimental spectra
                 K: NDDataset, kernel dataset
                 P0: the lambda independent part of P
-                lamda: regularization parameter
+                lambda_: regularization parameter
                 S: penalty function (sharpness)
                 verbose: print info
 
@@ -584,7 +584,7 @@ class IRIS(DecompositionAnalysis):
 
                 if self.qpsolver == "osqp":
                     for j in range(len(channels.data)):
-                        P = sparse.csc_matrix(P0 + 2 * lamda * S)
+                        P = sparse.csc_matrix(P0 + 2 * lambda_ * S)
                         qprob = osqp.OSQP()
                         if osqp.__version__ < "1.0.0":
                             qprob.setup(
@@ -605,18 +605,18 @@ class IRIS(DecompositionAnalysis):
                 else:  # quadprog solver
                     for j, channel in enumerate(channels.data):
                         try:
-                            P = P0 + 2 * lamda * S
+                            P = P0 + 2 * lambda_ * S
                             fi[:, j] = _quadprog.solve_qp(P, q[j].squeeze(), A, b)[0]
 
                         except ValueError:  # pragma: no cover
                             msg = (
                                 f"Warning:P is not positive definite for log10(lambda)="
-                                f"{np.log10(lamda):.2f} at {channel:.2f} "
+                                f"{np.log10(lambda_):.2f} at {channel:.2f} "
                                 f"{channels.units}, find nearest PD matrix"
                             )
                             warning_(msg)
                             try:
-                                P = _nearestPD(P0 + 2 * lamda * S, 0)
+                                P = _nearestPD(P0 + 2 * lambda_ * S, 0)
                                 fi[:, j] = _quadprog.solve_qp(P, q[j].squeeze(), A, b)[
                                     0
                                 ]
@@ -627,7 +627,7 @@ class IRIS(DecompositionAnalysis):
                                     "try with a small shift of diagonal elements..."
                                 )
                                 warning_(msg)
-                                P = _nearestPD(P0 + 2 * lamda * S, 1e-3)
+                                P = _nearestPD(P0 + 2 * lambda_ * S, 1e-3)
                                 fi[:, j] = _quadprog.solve_qp(P, q[j].squeeze(), A, b)[
                                     0
                                 ]
@@ -637,7 +637,7 @@ class IRIS(DecompositionAnalysis):
                 SMi = np.linalg.norm(np.dot(np.dot(np.transpose(fi), S), fi))
 
                 msg = (
-                    f"log10(lambda)={np.log10(lamda):.3f} -->  "
+                    f"log10(lambda)={np.log10(lambda_):.3f} -->  "
                     f"residuals = {RSSi:.3e}    "
                     f"regularization constraint  = {SMi:.3e}"
                 )
@@ -654,8 +654,14 @@ class IRIS(DecompositionAnalysis):
                 )
                 info_(msg)
 
-                for i, lamda_ in enumerate(lambdas):
-                    f[i], RSS[i], SM[i] = solve_for_lambda(X, K, P0, lamda_, S)
+                for i, lambda_value in enumerate(lambdas):
+                    f[i], RSS[i], SM[i] = solve_for_lambda(
+                        X,
+                        K,
+                        P0,
+                        lambda_value,
+                        S,
+                    )
 
             else:
                 msg = (
@@ -758,7 +764,7 @@ class IRIS(DecompositionAnalysis):
                 )
                 info_(msg)
 
-            # sort by lamba values
+            # sort by lambda values
             argsort = np.argsort(lambdas)
             lambdas = lambdas[argsort]
             RSS = RSS[argsort]
@@ -961,7 +967,7 @@ def _menger(x, y):
     if abs(numerator) <= EPSILON:
         return 0.0
 
-    # euclidian distances
+    # Euclidean distances
     r01 = (x[1] - x[0]) ** 2 + (y[1] - y[0]) ** 2
     r12 = (x[2] - x[1]) ** 2 + (y[2] - y[1]) ** 2
     r02 = (x[2] - x[0]) ** 2 + (y[2] - y[0]) ** 2

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
@@ -45,7 +45,7 @@ dataset
 dataset.y.select(3)
 
 # %%
-# plot the dataset (zoom on the begining of the fid)
+# plot the dataset (zoom on the beginning of the fid)
 prefs = scp.preferences
 prefs.figure.figsize = (9, 4)
 ax = dataset.plot(colorbar=True)
@@ -135,7 +135,7 @@ ax = sections.plot(marker="o", lw="1", ls=":", legend="best", colormap="jet")
 ax.set_xlim(0, 16000)
 
 # %%
-# The sections we have taken here represent the maximum heigths of the peaks.
+# The sections we have taken here represent the maximum heights of the peaks.
 # However it could may be interesting to have the area of the peak instead.
 # Let's use the left and right bases to perform the integration of the peaks.
 area = []
@@ -192,11 +192,11 @@ fitter.script = """
 
 _ = fitter.fit(s)
 
-spred = fitter.predict()
+prediction = fitter.predict()
 
 ax = fitter.plotmerit(
     s,
-    spred,
+    prediction,
     method="scatter",
     show_yaxis=True,
     title=f"fitting CP dynamic (peaks at {peaks.x[index].values})",
@@ -216,11 +216,11 @@ fitter.script = """
 
 _ = fitter.fit(s)
 
-spred = fitter.predict()
+prediction = fitter.predict()
 
 ax = fitter.plotmerit(
     s,
-    spred,
+    prediction,
     method="scatter",
     show_yaxis=True,
     title=f"fitting CP dynamic (peaks at {peaks.x[index].values})",
@@ -240,11 +240,11 @@ fitter.script = """
 
 _ = fitter.fit(s)
 
-spred = fitter.predict()
+prediction = fitter.predict()
 
 ax = fitter.plotmerit(
     s,
-    spred,
+    prediction,
     method="scatter",
     show_yaxis=True,
     title=f"fitting CP dynamic (peaks at {peaks.x[index].values})",

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmrglue.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmrglue.py
@@ -483,7 +483,7 @@ def index2trace_flat(shape, index):
 
 def trace2index_flat(shape, ntrace):
     """Calculate the index of a trace assuming a flat structure."""
-    # algorithm is to take quotient/remainers of sizes in reverse
+    # algorithm is to take quotient/remainders of sizes in reverse
     q = ntrace  # seed quotient with remained
     index = []
     for s in shape[:0:-1]:  # loop from last size to 2nd size

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py
@@ -934,7 +934,7 @@ def read_topspin(*paths, **kwargs):
         or the origin of the data, e.g., 'omnic', 'opus', ... It is often provided by the reader
         automatically, but can be set manually.
 
-        It is used for instance whn reading directory with different types of files, for merging
+        It is used for instance when reading directory with different types of files, for merging
         the datasets with compatible dimensions and different origin into different groups.
 
         It is also used when reading with the CSV protocol. In order to properly interpret CSV file

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -303,7 +303,7 @@ class DecompositionAnalysis(AnalysisConfigurable):
 
     @property
     def _Y_is_missing(self):
-        # check wether or not Y has been already defined
+        # check whether or not Y has been already defined
         try:
             if self._Y is None:
                 return True
@@ -329,15 +329,15 @@ class DecompositionAnalysis(AnalysisConfigurable):
         self._Y_preprocessed = Y.data
 
     def _transform(self, *args, **kwargs):  # pragma:  no cover
-        # to be overriden in subclass such as PCA, MCRALS, ...
+        # to be overridden in subclass such as PCA, MCRALS, ...
         raise NotImplementedError("transform has not yet been implemented")
 
     def _inverse_transform(self, *args, **kwargs):  # pragma:  no cover
-        # to be overriden in subclass such as PCA, MCRALS, ...
+        # to be overridden in subclass such as PCA, MCRALS, ...
         raise NotImplementedError("inverse_transform has not yet been implemented")
 
     def _get_components(self, n_components=None):  # pragma:  no cover
-        # to be overriden in subclass such as PCA, MCRALS, ...
+        # to be overridden in subclass such as PCA, MCRALS, ...
         raise NotImplementedError("get_components has not yet been implemented")
 
     # ----------------------------------------------------------------------------------
@@ -669,7 +669,7 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
     # Private methods that should be most of the time overloaded in subclass
     # ----------------------------------------------------------------------------------
     def _predict(self, *args, **kwargs):  # pragma:  no cover
-        # to be overriden in subclass such as PLSRegression, ...
+        # to be overridden in subclass such as PLSRegression, ...
         raise NotImplementedError("predict has not yet been implemented")
 
     # ----------------------------------------------------------------------------------
@@ -1145,7 +1145,7 @@ class LinearRegressionAnalysis(AnalysisConfigurable):
 
     @property
     def _Y_is_missing(self):
-        # check wether or not Y has been already defined
+        # check whether or not Y has been already defined
         try:
             if self._Y is None:
                 return True
@@ -1237,7 +1237,7 @@ class LinearRegressionAnalysis(AnalysisConfigurable):
         # model for example.
         self._outfit = self._fit(newX, newY, sample_weight=sample_weight)
 
-        # if the process was succesful,_fitted is set to True so that other method which
+        # if the process was successful,_fitted is set to True so that other method which
         # needs fit will be possibly used.
         self._fitted = True
         return self

--- a/src/spectrochempy/analysis/decomposition/fast_ica.py
+++ b/src/spectrochempy/analysis/decomposition/fast_ica.py
@@ -299,7 +299,7 @@ array of values drawn from a normal distribution is used."""
     )
     def St(self):
         r"""
-        The spectral profiles of the independant sources.
+        The spectral profiles of the independent sources.
 
         NDDataset of size (`n_components`, `n_features`). It is the transpose of the
         ``mixing_`` matrix returned by Scikit-Learn.

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -969,7 +969,7 @@ and `St`.
     def _C_2_NDDataset(self, C):
         # getconc takes the C NDDataset as first argument (to take advantage
         # of useful metadata). But the current C in fit method is a ndarray (without
-        # the masked rows and colums, nor the coord information: this
+        # the masked rows and columns, nor the coord information: this
         # function will create the corresponding dataset
         return C
 
@@ -1135,11 +1135,11 @@ and `St`.
 
     @tr.observe("_n_components")
     def _n_components_change(self, change):
-        # tiggered in _guess_profile
+        # triggered in _guess_profile
         if self._n_components > 0:
             # perform a validation of default configuration parameters
             # Indeed, if not forced here these parameters are validated only when they
-            # are set explicitely.
+            # are set explicitly.
             # Here is an ugly trick to force this validation. # TODO: better way?
             with warnings.catch_warnings():
                 warnings.simplefilter(action="ignore", category=FutureWarning)
@@ -1884,7 +1884,7 @@ def _pnnls(X, Y, nonneg=None, withres=False):
 
 
 def _unimodal_2D(a, axis, idxes, tol, mod):
-    # Force unimodality on given lines or columnns od a 2D ndarray
+    # Force unimodality on given lines or columns of a 2D ndarray
     #
     # a: ndarray
     #

--- a/src/spectrochempy/analysis/decomposition/simplisma.py
+++ b/src/spectrochempy/analysis/decomposition/simplisma.py
@@ -109,7 +109,7 @@ class SIMPLISMA(DecompositionAnalysis):
             raise ValueError(
                 "Passing arguments such as SIMPLISMA(X) is now deprecated. "
                 "Instead, use SIMPLISMA() followed by SIMPLISMA.fit(X). "
-                "See the documentation and exemples",
+                "See the documentation and examples",
             )
 
         # call the super class for initialisation
@@ -245,7 +245,7 @@ class SIMPLISMA(DecompositionAnalysis):
         sigma = np.std(X, axis=0)
         mu = np.mean(X, axis=0)
         alpha = (noise / 100) * np.max(mu)
-        lamda = np.sqrt(mu**2 + sigma**2)
+        lambda_ = np.sqrt(mu**2 + sigma**2)
         p = sigma / (mu + alpha)
 
         # scale dataset
@@ -264,7 +264,7 @@ class SIMPLISMA(DecompositionAnalysis):
         while not finished:
             # compute first purest variable and weights
             if j == 0:
-                w[j, :] = lamda**2 / (mu**2 + (sigma + alpha) ** 2)
+                w[j, :] = lambda_**2 / (mu**2 + (sigma + alpha) ** 2)
                 s[j, :] = sigma * w[j, :]
                 Pt[j, :] = p * w[j, :]
 

--- a/src/spectrochempy/analysis/kinetic/kineticutilities.py
+++ b/src/spectrochempy/analysis/kinetic/kineticutilities.py
@@ -75,7 +75,7 @@ def _interpret_equation(eq, species):
             coef = int(coef)
         except ValueError:
             raise ValueError(
-                f"Stoichiometric coeffcients must be integers. Could not "
+                f"Stoichiometric coefficients must be integers. Could not "
                 f"convert {coef} in int",
             ) from None
         if is_reactant:
@@ -354,7 +354,7 @@ class ActionMassKinetics(tr.HasTraits):
         for line in (self._B - self._A).T:
             prod_rate = ""
             if not line.any():
-                # only zeors => spectator species
+                # only zeros => spectator species
                 prod_rate = "0"
             else:
                 for j, n in enumerate(line):
@@ -758,7 +758,7 @@ class ActionMassKinetics(tr.HasTraits):
 
         Parameters
         ----------
-        Cexp : `NDDataset` or `list` ot `tuple` of NDDatasets
+        Cexp : `NDDataset` or `list` or `tuple` of NDDatasets
             Experimental concentration profiles on which to fit the model.
             each set of concentrations can contain more concentration profiles than those to fit.
         iexp : `int`

--- a/src/spectrochempy/application/preferences.py
+++ b/src/spectrochempy/application/preferences.py
@@ -226,9 +226,9 @@ class PreferencesSet(Meta):
         trait = app.plot_preferences.traits()[key]
         default = trait.default_value
         thelp = trait.help.replace("\n", " ").replace("\t", " ")
-        sav = ""
-        while thelp != sav:
-            sav = thelp
+        previous = ""
+        while thelp != previous:
+            previous = thelp
             thelp = thelp.replace("  ", " ")
         help = "\n".join(
             textwrap.wrap(
@@ -306,9 +306,9 @@ class PreferencesSet(Meta):
             if val.startswith("CapStyle") or val.startswith("JoinStyle"):
                 val = val.split(".")[-1]
 
-            sav = ""
-            while val != sav:
-                sav = val
+            previous = ""
+            while val != previous:
+                previous = val
                 val = val.replace("  ", " ")
             line = f"{key:40s} : {val}\n"
             if line[0] != sline:

--- a/src/spectrochempy/core/dataset/basearrays/ndarray.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndarray.py
@@ -1575,7 +1575,7 @@ class NDArray(tr.HasTraits):
 
         if self.ndim > 1:
             warnings.warn(
-                "We cannot set the labels for multidimentional data - Thus, these "
+                "We cannot set the labels for multidimensional data - Thus, these "
                 "labels are ignored",
                 stacklevel=2,
             )

--- a/src/spectrochempy/core/dataset/coord.py
+++ b/src/spectrochempy/core/dataset/coord.py
@@ -927,7 +927,7 @@ class Coord(NDMath, NDArray):
         -----
         The number of significant digits is used when linearizing the coordinates. It is
         also used when setting the coordinates values at the Coord initialization
-        or everytime the data array is changed.
+        or every time the data array is changed.
 
         """
         return self._sigdigits

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -1100,7 +1100,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         if name in self._coordset.names:
             idx = self._coordset.names.index(name)
             return self._coordset[idx]
-        error_(f"could not find this dimenson name: `{name}`")
+        error_(f"could not find this dimension name: `{name}`")
         return None
 
     @property
@@ -1465,7 +1465,7 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
         Returns
         -------
         `NDDataset`
-            Swaped dataset.
+            Swapped dataset.
 
         See Also
         --------

--- a/src/spectrochempy/core/readers/download.py
+++ b/src/spectrochempy/core/readers/download.py
@@ -119,7 +119,7 @@ def download_nist_ir(CAS, index="all"):
 
     out = []
     for i in index:
-        # sample adress (water, spectrum 1)
+        # sample address (water, spectrum 1)
         # https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C7732185&Index=1&Type=IR
         url = f"https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C{CAS}&Index={i}&Type=IR"
         try:
@@ -154,7 +154,7 @@ def download_nist_ir(CAS, index="all"):
 
         except Exception:
             raise OSError(
-                "Can't read this JCAMP file: please report the issue to Spectrochempy developpers",
+                "Can't read this JCAMP file: please report the issue to SpectroChemPy developers",
             ) from None
 
     if len(out) == 1:

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -468,7 +468,7 @@ def read_spa(*paths, **kwargs):
     Notes
     -----
     This method is an alias of `read_omnic`, except that the type of file
-    is contrain to ``.spa``.
+    is constrained to ``.spa``.
 
     Examples
     --------
@@ -1202,7 +1202,7 @@ def _read_srs(*args, **kwargs):
     sub_hs = b"\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00\x48\x43\x00\xc8\xaf\x47"
     sub_tg = b"\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00"
 
-    # find the first occurence and determine whether the srs is rapidscan or high
+    # find the first occurrence and determine whether the srs is rapidscan or high
     # speed real time
     fid.seek(0)
     bytestring = fid.read()
@@ -1415,7 +1415,7 @@ def _read_srs(*args, **kwargs):
             info = _read_header(fid, pos_info_data)
             names, data = _read_srs_spectra(fid, pos_data, info["ny"], info["nx"])
             # Note: info["history"] is empty in TG IR or GC series
-            # the position of the history is indiated at pos 856 or 878 depending on the
+            # the position of the history is indicated at pos 856 or 878 depending on the
             # file.
 
         # read the background if the user asked for it.
@@ -1503,7 +1503,7 @@ def _read_srs(*args, **kwargs):
 
 
 def _readbtext(fid, pos, size):
-    # Read some text in binary file of given size. If size is None, the etxt is read
+    # Read some text in binary file of given size. If size is None, the text is read
     # until b\0\ is encountered.
     # Returns utf-8 string
     fid.seek(pos)

--- a/src/spectrochempy/core/readers/read_quadera.py
+++ b/src/spectrochempy/core/readers/read_quadera.py
@@ -193,7 +193,7 @@ def _read_asc(*args, **kwargs):
         )
     if nchannels > 1 and colnames[3] != "Time":  # pragma: no cover
         warn(
-            "The number of columms per channel is not that expected: the reading of your .asc file  could yield "
+            "The number of columns per channel is not that expected: the reading of your .asc file  could yield "
             "please notify this to the developers of spectrochempy",
             stacklevel=2,
         )

--- a/src/spectrochempy/core/readers/read_spc.py
+++ b/src/spectrochempy/core/readers/read_spc.py
@@ -164,7 +164,7 @@ class _SpcFile:
     # File header (see: Galactic Universal Data Format Specification 9/4/97)
     # http://ensembles-eu.metoffice.gov.uk/met-res/aries/technical/GSPC_UDF.PDF
 
-    # Define some dicionaries for the SPC file format
+    # Define some dictionaries for the SPC file format
     xz_info = {
         0: ("axis title", None),
         1: ("Wavenumbers", "cm^-1"),
@@ -614,8 +614,8 @@ class _SpcFile:
         # } LOGSTC;
         offset = self._Flogoff
         logstc_format = s + "iiiii44s"
-        siz = struct.calcsize(logstc_format)
-        sel = content[offset : offset + siz]
+        size = struct.calcsize(logstc_format)
+        sel = content[offset : offset + size]
         (
             Logsizd,
             Logsizm,
@@ -632,7 +632,7 @@ class _SpcFile:
 
     def _extract_subfile_header(self, content, s):
         # **************************************************************************
-        # * This structure defines the subfile headers that preceed each trace in a
+        # * This structure defines the subfile headers that precede each trace in a
         # * multi-type file. Note that for evenly-spaced files, subtime and subnext are
         # * optional (and ignored) for all but the first subfile. The (subnext-subtime)
         # * for the first subfile determines the Z spacing for all evenly-spaced subfiles.
@@ -708,13 +708,13 @@ class _SpcFile:
         # * Another X,Y mode allows for separate X arrays and differing numbers of
         # * points for each subfile. This mode is normally used for Mass Spec Data.
         # * If the TXYXYS flag is set along with TXVALS, then each subfile has a
-        # * separate X array which follows the subfile header and preceeds the Y array.
+        # * separate X array which follows the subfile header and precedes the Y array.
         # * An additional subnpts subfile header entry gives the number of X,Y values
         # * for the subfile (rather than the fnpts entry in the main header). Under
         # * this mode, there may be a directory subfile pointers whose offset is
         # * stored in the fnpts main header entry. This directory consists of an
         # * array of ssfstc structures, one for each of the subfiles. Each ssfstc
-        # * gives the byte file offset of the begining of the subfile (that is, of
+        # * gives the byte file offset of the beginning of the subfile (that is, of
         # * its subfile header) and also gives the Z value (subtime) for the subfile
         # * and is byte size. This directory is normally saved at the end of the
         # * file after the last subfile. If the fnpts entry is zero, then no directory
@@ -767,7 +767,7 @@ class _SpcFile:
         # * overridden with null-terminated strings at the end of fcmnt. If the
         # * TALABS bit is set in ftflgs (or Z=ZTEXTL in old format), then the labels
         # * come from the fcatxt offset of the header. The X, Y, and Z labels
-        # * must each be zero-byte terminated and must occure in the stated (X,Y,Z)
+        # * must each be zero-byte terminated and must occur in the stated (X,Y,Z)
         # * order. If a label is only the terminating zero byte then the fxtype,
         # * fytype, or fztype (or Arbitrary Z) type label is used instead. The
         # * labels may not exceed 20 characters each and all three must fit in 30 bytes.
@@ -966,7 +966,7 @@ class _SpcFile:
         if self._txyxys:
             debug_("each subfile has own x's")
         if self._txvals:
-            debug_("floating x-value array preceeds y's")
+            debug_("floating x-value array precedes y's")
 
         # subfiles
         try:

--- a/src/spectrochempy/core/writers/exporter.py
+++ b/src/spectrochempy/core/writers/exporter.py
@@ -120,7 +120,7 @@ def write(dataset, filename=None, **kwargs):
     ----------------
     protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
         Protocol used for writing. If not provided, the correct protocol
-        is inferred (whnever it is possible) from the file name extension.
+        is inferred (whenever it is possible) from the file name extension.
     directory : str, optional
         Where to write the specified `filename` . If not specified, write in the current directory.
     description: str, optional

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -51,7 +51,7 @@ _ = f.T.plot(yscale="log", legend=f.k.labels)
 
 # %%
 # Note the use of coordinate 'k' (component axis) in the expression above.
-# Remember taht to find the actul names of the coordinates, the `dims`
+# Remember that to find the actual names of the coordinates, the `dims`
 # attribute can be used as in the following:
 f.dims
 

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
@@ -67,7 +67,7 @@ _ = guess.plot()
 #
 # We first create a MCR-ALS object named here ``mcr``.
 #
-# The `log_level` option can be set to ``"INFO"`` to get verbose ouput of
+# The `log_level` option can be set to ``"INFO"`` to get verbose output of
 # the MCR-ALS optimization steps.
 mcr = scp.MCRALS(log_level="INFO")
 

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
@@ -26,12 +26,12 @@ dataset = scp.read_omnic("irdata/nh4y-activation.spg")
 
 # %%
 # Mask some columns (features) which correspond to saturated parts of the spectra.
-# Note taht we use float number for defining the limits for masking as coordinates
+# Note that we use float number for defining the limits for masking as coordinates
 # (integer numbers would mean point index and s would lead t incorrect results)
 dataset[:, 882.0:1280.0] = scp.MASKED
 
 # %%
-# Make sure all data are positive. For this we use the math fonctionalities of NDDataset
+# Make sure all data are positive. For this we use the math functionalities of NDDataset
 # objects (:meth:`min` function to find the minimum value of the dataset
 # and the `-` operator for subtrating this value to all spectra of the dataset.
 dataset -= dataset.min()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
@@ -105,7 +105,7 @@ scores.y.labels = labels  # Note this does not replace previous labels,
 # but adds a column.
 
 # %%
-# now display thse
+# now display these
 _ = pca.plot_score(scores=scores, show_labels=True, labels_column=2)
 
 # %%

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -33,7 +33,7 @@ else:
 # values for each of the samples is also included.
 # The 5th dataset named `'m5spec'`, contains the NIR spectra of 80 corn samples recorded
 # on the same instrument. Let's assign this NDDataset specta to `X`, add few
-# informations and plot it:
+# information and plot it:
 
 # %%
 if ds_list is not None:

--- a/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
@@ -98,14 +98,14 @@ _ = new.plot()
 
 # %%
 # Note also that a colormap ('viridis') has been automatically set for the lines. This is because the y-dimension of the
-# dataset has float coordinates (they correspond to a time). In such a case tt is easy to add a colorbar expliciting the
-# colors <-> time value correspondance:
+# dataset has float coordinates (they correspond to a time). In such a case it is easy to add a colorbar explaining the
+# colors <-> time value correspondence:
 
 _ = new.plot(colorbar=True)
 
 # %%
 # If the y-dimension had no coordinates or consecutive integer coordinates starting by `0`or `1`, a categorical
-# color map would have been chosen. The default behavior can be overriden by explictly passing a colomap. For instance,
+# color map would have been chosen. The default behavior can be overridden by explicitly passing a colormap. For instance,
 # if we want to use a categorical colormap instead of a sequential one, we can do:
 
 _ = new[:, 0:20].plot(cmap="tab20")

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -67,7 +67,7 @@ _ = dataset.plot_image()
 # %%
 # finally extract grid scan data from a StreamLine HR measurement
 dataset = scp.read_wdf("ramandata/wire/mapping.wdf")
-# plot the dataset as an image (summming all wavenumbers)
+# plot the dataset as an image (summing all wavenumbers)
 _ = dataset.sum(dim=2).plot_image(equal_aspect=True)
 # plot the image taken at 1529cm-1
 _ = dataset[..., 1529.0].plot_image(equal_aspect=True)

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -145,11 +145,11 @@ _ = corrected.plot()
 # instead. This model is based on the work of Eilers and Boelens (2005)
 # and performs a baseline correction by iteratively fitting asymmetrically
 # weighted least squares regression curves to the data.
-# The `asls` model has two parameters: `mu` and `assymetry`.
+# The `asls` model has two parameters: `mu` and `asymmetry`.
 # The `mu` parameter is a regularisation parameters which control
 # the smoothness of the baseline. The larger `mu` is, the smoother
-# the baseline will be. The `assymetry` parameter is a parameter
-# which control the assymetry if the AsLS algorithm.
+# the baseline will be. The `asymmetry` parameter is a parameter
+# which controls the asymmetry of the AsLS algorithm.
 blc.multivariate = False  # use a sequential approach
 blc.model = "asls"
 blc.mu = 10**9

--- a/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
+++ b/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
@@ -152,7 +152,7 @@ _ = C.plot()
 
 blc.model = "asls"
 blc.log_level = (
-    "WARNING"  # supress output of asls (to long for the moment:  TODO optimize this)
+    "WARNING"  # suppress output of asls (too long for the moment: TODO optimize this)
 )
 _ = blc.fit(C[::10])
 corr = blc.transform()

--- a/src/spectrochempy/processing/alignement/align.py
+++ b/src/spectrochempy/processing/alignement/align.py
@@ -226,7 +226,7 @@ def align(dataset, *others, **kwargs):
                     ),
                 )
 
-            # do units transform if necesssary so coords can be compared
+            # do units transform if necessary so coords can be compared
             if coord.units != ref_coord.units:
                 coord.ito(ref_coord)
 

--- a/src/spectrochempy/processing/fft/fft.py
+++ b/src/spectrochempy/processing/fft/fft.py
@@ -183,7 +183,7 @@ def fft(dataset, size=None, sizeff=None, inv=False, **kwargs):
     # Select the last coordinates
     x = new.coordset[dim]
 
-    # Performs some dimentionality checking
+    # Performs some dimensionality checking
     error = False
     if (
         not inv

--- a/src/spectrochempy/processing/fft/shift.py
+++ b/src/spectrochempy/processing/fft/shift.py
@@ -282,7 +282,7 @@ def dc(dataset, **kwargs):
     Parameters
     ----------
     dataset : nddataset
-        The time domain daatset to be corrected.
+        The time domain dataset to be corrected.
     kwargs : dict, optional
         Additional parameters.
 

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -80,7 +80,7 @@ def concatenate(*datasets, **kwargs):
     ((55, 5549), (55, 5549), (55, 11098))
 
     """
-    # check uise
+    # check use
     if "force_stack" in kwargs:
         deprecated("force_stack", replace="method stack()", removed="0.11.0")
         return stack(datasets)

--- a/src/spectrochempy/utils/metaconfigurable.py
+++ b/src/spectrochempy/utils/metaconfigurable.py
@@ -73,7 +73,7 @@ class MetaConfigurable(Configurable):
         return d
 
     def trait_defaults(self, *names, **metadata):
-        # override traitlets trait default to take into accound changes in the config
+        # override traitlets trait default to take into account changes in the config
         # file
         defaults = super().trait_defaults(*names, **metadata)
         # modify with the loaded external config

--- a/src/spectrochempy/utils/testing.py
+++ b/src/spectrochempy/utils/testing.py
@@ -220,7 +220,7 @@ def compare_ndarrays(this, other, approx=False, decimal=6, data_only=False):
 
 
 def compare_coords(this, other, approx=False, decimal=3, data_only=False):
-    # TODO: compare base on signficant digit for coordinate instead of decimals
+    # TODO: compare based on significant digit for coordinate instead of decimals
     #  (that may not work for very small coordinates numbers)
     from spectrochempy.core.units import ur
 

--- a/tests/test_analysis/test_decomposition/test_mcrals.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals.py
@@ -368,11 +368,11 @@ def test_MCRALS_errors(model, data):
     C0 = model.C0
     mcr = MCRALS()
 
-    # inexistant keyword parameters
+    # nonexistent keyword parameters
     try:
-        _ = MCRALS(max_iter=25, inexistant=0, log_level="DEBUG")
+        _ = MCRALS(max_iter=25, nonexistent=0, log_level="DEBUG")
     except KeyError as exc:
-        assert "'inexistant' is not a valid" in exc.args[0]
+        assert "'nonexistent' is not a valid" in exc.args[0]
 
     # guess with wrong size of dimensions
     try:
@@ -396,7 +396,7 @@ def test_MCRALS_errors(model, data):
     assert "please check the" in e.value.args[0]
 
     with pytest.raises(tr.TraitError):
-        mcr.unimodSpec = "alls"
+        mcr.unimodSpec = "everything"
 
     with pytest.raises(tr.TraitError):
         mcr.unimodConc = None

--- a/tests/test_core/test_dataset/test_dataset_coords.py
+++ b/tests/test_core/test_dataset/test_dataset_coords.py
@@ -49,15 +49,15 @@ def test_nddataset_coordset():
     cadd = scp.Coord(labels=["d%d" % i for i in range(6)])
     coordtitles = ["wavelength", "time-on-stream", "temperature"]
     coordunits = ["cm^-1", "s", None]
-    daa = scp.NDDataset(
+    data = scp.NDDataset(
         dx,
         coordset=[coord0, coord1, coord2, cadd, coord2.copy()],
         title="absorbance",
         coordtitles=coordtitles,
         coordunits=coordunits,
     )
-    assert daa.coordset.titles == coordtitles[::-1]
-    assert daa.dims == ["z", "y", "x"]
+    assert data.coordset.titles == coordtitles[::-1]
+    assert data.dims == ["z", "y", "x"]
     # with a CoordSet
     c0, c1 = (
         scp.Coord(labels=["d%d" % i for i in range(6)]),
@@ -251,7 +251,7 @@ def test_nddataset_sorting(ds1):  # ds1 is defined in conftest
     dataset.sort(inplace=True, dim="z")
     labels = np.array(list("abc"))
     assert_array_equal(dataset.coordset["z"].labels, labels)
-    # nochange because the  axis is naturally iversed to force it
+    # no change because the axis is naturally inverted to force it
     # we need to specify descend
     dataset.sort(
         inplace=True, descend=False, dim="z"

--- a/tests/test_core/test_readers/test_read_soc.py
+++ b/tests/test_core/test_readers/test_read_soc.py
@@ -102,7 +102,7 @@ def test_read_soc_merge_behavior(tmp_path):
 
 
 def test_read_SOC(tmp_path):
-    """upload and read surface oftics exemple"""
+    """Upload and read a Surface Optics example."""
 
     # the following does not work
     baseurl = "https://github.com/chet-j-ski/SOC100_example_data/raw/main/"

--- a/tests/test_plugins/test_nmr_importer_handlers.py
+++ b/tests/test_plugins/test_nmr_importer_handlers.py
@@ -21,7 +21,7 @@ from spectrochempy_nmr import _topspin_remote_download_target
 
 
 def _norm(path: str) -> str:
-    """Normalise un chemin retourné par les handlers pour comparaison portable."""
+    """Normalize a path returned by handlers for portable comparison."""
     return path.rstrip("/\\").replace("\\", "/")
 
 


### PR DESCRIPTION
## Summary

This PR cleans repository spelling issues and enables `codespell` in pre-commit
now that the tree is clean.

## What changed

- fixed spelling issues across:
  - core source comments and docstrings
  - docs
  - examples
  - bundled plugins
- refined `.codespellrc` so repository-level spelling checks focus on real
  issues rather than structural noise
- added the `codespell` hook to `.pre-commit-config.yaml`
- updated contributor documentation to mention the new pre-commit spelling check

## Why

Before this PR, `codespell` output mixed together:
- real spelling mistakes
- fixture-path names
- historical module names
- short identifier false positives
- generated / third-party content

This PR separates those concerns:
- real typos are fixed
- noisy paths are skipped
- a few legitimate identifiers are ignored narrowly

That makes repository-level spelling checks enforceable.
