### PR TITLE
ENH: add covariance to FitResult

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -475,8 +475,11 @@ components = f1.result.components
 #
 # Raw solver artifacts stay on the estimator. Least-squares-backed methods keep
 # the retained Jacobian on `f1.jacobian`, while `simplex`, `basinhopping`, and
-# dry fits return `None`. This is preparatory infrastructure for future
-# uncertainty estimation and is intentionally not exposed through `FitResult`.
+# dry fits return `None`. `f1.result.covariance` is the first scientific
+# interpretation built on top of that Jacobian: it is an approximate local
+# least-squares covariance matrix, scaled by the residual variance and degrees
+# of freedom. It is only available when a backend provides a stable Jacobian and
+# should not be confused with confidence intervals or a full uncertainty report.
 
 # Show the result
 _ = ndOHcorr.plot()

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -226,6 +226,9 @@ components = fit_result.components
     "degrees_of_freedom": fit_result.diagnostics["degrees_of_freedom"],
     "reduced_chi_square": fit_result.diagnostics["reduced_chi_square"],
     "success": fit_result.diagnostics["success"],
+    "covariance_shape": None
+    if fit_result.covariance is None
+    else fit_result.covariance.shape,
 }
 
 # %% [markdown]

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -49,7 +49,11 @@ New Features
   ``adjusted_r_squared``, plus normalized solver ``success``, ``status``,
   and ``message`` fields. ``Optimize`` also retains the raw least-squares
   Jacobian on ``opt.jacobian`` when a backend naturally provides one, while
-  methods without a native Jacobian expose ``None``. Existing
+  methods without a native Jacobian expose ``None``. ``FitResult.covariance``
+  now exposes the first uncertainty-oriented scientific interpretation built
+  from that Jacobian: an approximate local least-squares covariance matrix for
+  the fitted varying parameters, available only when the backend provides a
+  stable Jacobian and the residual degrees of freedom are positive. Existing
   ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -45,7 +45,11 @@ New Features
   ``adjusted_r_squared``, plus normalized solver ``success``, ``status``,
   and ``message`` fields. ``Optimize`` also retains the raw least-squares
   Jacobian on ``opt.jacobian`` when a backend naturally provides one, while
-  methods without a native Jacobian expose ``None``. Existing
+  methods without a native Jacobian expose ``None``. ``FitResult.covariance``
+  now exposes the first uncertainty-oriented scientific interpretation built
+  from that Jacobian: an approximate local least-squares covariance matrix for
+  the fitted varying parameters, available only when the backend provides a
+  stable Jacobian and the residual degrees of freedom are positive. Existing
   ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:

--- a/src/spectrochempy/analysis/_base/_result.py
+++ b/src/spectrochempy/analysis/_base/_result.py
@@ -192,4 +192,33 @@ class FitResult(ResultBase):
     Typical diagnostics include convergence and goodness-of-fit metrics.
     """
 
-    pass
+    def __init__(
+        self,
+        *,
+        estimator,
+        parameters=None,
+        outputs=None,
+        diagnostics=None,
+        covariance=None,
+    ):
+        super().__init__(
+            estimator=estimator,
+            parameters=parameters,
+            outputs=outputs,
+            diagnostics=diagnostics,
+        )
+        self._covariance = covariance
+
+    @property
+    def covariance(self):
+        """
+        Approximate covariance matrix of the fitted varying parameters.
+
+        Returns
+        -------
+        ndarray or None
+            Approximate covariance matrix computed from the retained least-squares
+            Jacobian when available and mathematically meaningful. Returns ``None``
+            when covariance is unavailable.
+        """
+        return self._covariance

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -76,6 +76,15 @@ def _freeze_jacobian_artifact(jacobian):
     return array
 
 
+def _freeze_covariance_matrix(covariance):
+    """Return an immutable ndarray snapshot of a computed covariance matrix."""
+    if covariance is None:
+        return None
+    array = np.array(covariance, copy=True, dtype=np.float64)
+    array.flags.writeable = False
+    return array
+
+
 def _count_varying_parameters(fp):
     """Count free parameters using the same rule as the optimizer internals."""
     if fp is None:
@@ -151,6 +160,69 @@ def _compute_fit_diagnostics(observed, fitted, solver_meta=None, fit_parameters=
     }
     diagnostics.update(dict(solver_meta or {}))
     return residuals, diagnostics
+
+
+def _compute_covariance_matrix(observed, fitted, jacobian, diagnostics):
+    """
+    Compute an approximate parameter covariance matrix from the retained Jacobian.
+
+    The approximation follows the local linear least-squares convention:
+
+        covariance = sigma^2 * pinv(J.T @ J)
+
+    where ``sigma^2`` is the residual variance estimate based on the reduced
+    chi-square (equivalently ``rss / degrees_of_freedom``).
+
+    Returns
+    -------
+    ndarray or None
+        Immutable covariance matrix when available, otherwise ``None``.
+    """
+    if jacobian is None:
+        return None
+
+    if observed is None or fitted is None:
+        return None
+
+    degrees_of_freedom = int(diagnostics.get("degrees_of_freedom", 0))
+    sigma2 = diagnostics.get("reduced_chi_square", np.nan)
+    n_varying_parameters = int(diagnostics.get("n_varying_parameters", 0))
+
+    if degrees_of_freedom <= 0 or n_varying_parameters <= 0:
+        return None
+
+    sigma2 = float(sigma2)
+    if not np.isfinite(sigma2):
+        return None
+
+    jacobian_array = np.asarray(jacobian, dtype=np.float64)
+    if jacobian_array.ndim != 2:
+        return None
+
+    residual_data = np.ma.masked_invalid(
+        np.ma.asarray((observed - fitted).real.masked_data)
+    )
+    valid_mask = ~np.ma.getmaskarray(residual_data)
+    valid_mask &= np.isfinite(np.ma.getdata(residual_data))
+    valid_rows = valid_mask.reshape(-1)
+
+    if jacobian_array.shape[1] != n_varying_parameters:
+        return None
+
+    if jacobian_array.shape[0] == valid_rows.size:
+        jacobian_used = jacobian_array[valid_rows]
+    elif jacobian_array.shape[0] == int(diagnostics.get("n_observations", 0)):
+        jacobian_used = jacobian_array
+    else:
+        return None
+
+    if jacobian_used.shape[0] <= 0:
+        return None
+
+    information = jacobian_used.T @ jacobian_used
+    covariance = sigma2 * np.linalg.pinv(information, hermitian=True)
+    covariance = 0.5 * (covariance + covariance.T)
+    return _freeze_covariance_matrix(covariance)
 
 
 def _normalize_solver_meta(method, result, warnmess=None):
@@ -317,8 +389,7 @@ def _validate_script_content(script, usermodels=None):
                     ScriptError(
                         lc,
                         line,
-                        f"Model {shape} not found in spectrochempy"
-                        f" nor in usermodels.",
+                        f"Model {shape} not found in spectrochempy nor in usermodels.",
                     ),
                 )
                 continue
@@ -382,8 +453,7 @@ def _validate_script_content(script, usermodels=None):
                 ScriptError(
                     lc,
                     line,
-                    "only two items;"
-                    " value, min, max (or value only) should be defined",
+                    "only two items; value, min, max (or value only) should be defined",
                 ),
             )
             continue
@@ -1335,6 +1405,12 @@ class Optimize(DecompositionAnalysis):
             getattr(self, "_fit_meta", {}),
             self.fp,
         )
+        covariance = _compute_covariance_matrix(
+            self._X,
+            fitted,
+            self.jacobian,
+            fit_diagnostics,
+        )
 
         return FitResult(
             estimator="Optimize",
@@ -1351,6 +1427,7 @@ class Optimize(DecompositionAnalysis):
                 "residuals": residuals,
             },
             diagnostics=fit_diagnostics,
+            covariance=covariance,
         )
 
 

--- a/tests/test_analysis/test_base/test_result_base.py
+++ b/tests/test_analysis/test_base/test_result_base.py
@@ -148,6 +148,11 @@ class TestFitResult:
         result = FitResult(estimator="Optimize", outputs={"fitted": fitted})
         assert result.fitted is fitted
 
+    def test_covariance_property(self):
+        covariance = np.eye(2)
+        result = FitResult(estimator="Optimize", covariance=covariance)
+        np.testing.assert_array_equal(result.covariance, covariance)
+
 
 class TestResultBaseHTMLRepr:
     """Behavioral tests for the HTML representation of ResultBase."""

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -17,6 +17,7 @@ from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.analysis.curvefitting import optimize as optimize_module
+from spectrochempy.analysis.curvefitting.optimize import _compute_covariance_matrix
 from spectrochempy.analysis.curvefitting.optimize import _compute_fit_diagnostics
 from tests.test_analysis.result_test_helpers import assert_fit_returns_self
 from tests.test_analysis.result_test_helpers import assert_result_basics
@@ -242,6 +243,28 @@ class TestOptimizeResult:
         assert np.isfinite(diag["adjusted_r_squared"])
         assert diag["adjusted_r_squared"] <= diag["r_squared"]
         assert isinstance(diag["status"], int | type(None))
+        assert opt.result.covariance is not None
+
+    def test_covariance_available_for_least_squares_fit(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        covariance = opt.result.covariance
+
+        assert covariance is not None
+        assert covariance.flags.writeable is False
+        assert covariance.shape == (
+            opt.result.diagnostics["n_varying_parameters"],
+            opt.result.diagnostics["n_varying_parameters"],
+        )
+        np.testing.assert_allclose(covariance, covariance.T)
+        assert np.all(np.isfinite(np.diag(covariance)))
+        assert np.all(np.diag(covariance) >= 0.0)
 
     def test_rss_matches_residual_sum_of_squares(
         self, synthetic_two_peak_dataset, optimize_script
@@ -318,6 +341,10 @@ class TestOptimizeResult:
         assert np.isnan(diagnostics["reduced_chi_square"])
         assert np.isnan(diagnostics["adjusted_r_squared"])
 
+        jacobian = np.eye(3)
+        covariance = _compute_covariance_matrix(observed, fitted, jacobian, diagnostics)
+        assert covariance is None
+
     def test_dry_fit_exposes_conservative_solver_status(
         self, synthetic_two_peak_dataset, optimize_script
     ):
@@ -336,6 +363,7 @@ class TestOptimizeResult:
         assert diag["degrees_of_freedom"] == (
             diag["n_observations"] - diag["n_varying_parameters"]
         )
+        assert opt.result.covariance is None
 
     # ----------------------------------------------------------------------------------
     # Solver artifacts
@@ -394,6 +422,7 @@ class TestOptimizeResult:
         opt.fit(synthetic_two_peak_dataset)
 
         assert opt.jacobian is None
+        assert opt.result.covariance is None
 
     def test_jacobian_absent_for_basinhopping_backend(
         self, synthetic_two_peak_dataset, optimize_script, monkeypatch
@@ -426,6 +455,7 @@ class TestOptimizeResult:
         opt.fit(synthetic_two_peak_dataset)
 
         assert opt.jacobian is None
+        assert opt.result.covariance is None
 
     def test_jacobian_absent_for_dry_fit(
         self, synthetic_two_peak_dataset, optimize_script
@@ -437,6 +467,7 @@ class TestOptimizeResult:
         opt.fit(synthetic_two_peak_dataset)
 
         assert opt.jacobian is None
+        assert opt.result.covariance is None
 
     def test_fit_result_does_not_expose_jacobian(
         self, synthetic_two_peak_dataset, optimize_script
@@ -451,6 +482,24 @@ class TestOptimizeResult:
         assert "jacobian" not in opt.result.diagnostics
         with pytest.raises(AttributeError):
             _ = opt.result.jacobian
+
+    def test_covariance_available_for_leastsq_alias(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.method = "leastsq"
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        covariance = opt.result.covariance
+
+        assert covariance is not None
+        assert covariance.shape == (
+            opt.result.diagnostics["n_varying_parameters"],
+            opt.result.diagnostics["n_varying_parameters"],
+        )
 
     # ----------------------------------------------------------------------------------
     # Representation


### PR DESCRIPTION
## Summary

- add `FitResult.covariance` as the first uncertainty-oriented scientific result
- compute covariance from the retained least-squares Jacobian using
  `sigma² * pinv(J.T @ J)`
- keep the Jacobian itself on `Optimize` as a solver artifact
- document covariance availability and limitations
- add focused tests for least-squares, leastsq, simplex, basinhopping, and dry fits

## Notes

This PR is intentionally limited to covariance estimation only.

It does not yet implement:
- parameter standard deviations
- confidence intervals
- correlation matrix
- AIC/BIC
- result.solution