### PR TITLE
ENH: legacy constraints converter for mcrals

### DIFF
--- a/src/spectrochempy/analysis/decomposition/__init__.pyi
+++ b/src/spectrochempy/analysis/decomposition/__init__.pyi
@@ -7,6 +7,7 @@
 # ruff: noqa
 
 __all__ = [
+    "_legacy_constraint_converter",
     "cp",
     "efa",
     "fast_ica",
@@ -19,6 +20,7 @@ __all__ = [
     "svd",
 ]
 
+from . import _legacy_constraint_converter
 from . import cp
 from . import efa
 from . import fast_ica

--- a/src/spectrochempy/analysis/decomposition/_legacy_constraint_converter.py
+++ b/src/spectrochempy/analysis/decomposition/_legacy_constraint_converter.py
@@ -1,0 +1,281 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+Private converter from legacy MCRALS traitlet configuration to public Constraint objects.
+
+This module translates the existing (traitlet-based) estimator parameters of
+:class:`~spectrochempy.analysis.decomposition.mcrals.MCRALS` into instances
+of the public constraint classes defined in
+:mod:`spectrochempy.analysis.decomposition.mcrals_constraints`.
+
+The converter is purely declarative: it reads the current traitlet values and
+produces the corresponding public constraint objects.  It does **not** modify
+the estimator, does **not** change any numerical behaviour, and is **not**
+connected to the internal ALS constraint engine.
+
+Typical usage::
+
+    from spectrochempy.analysis.decomposition._legacy_constraint_converter import (
+        legacy_to_constraints,
+    )
+
+    mcr = MCRALS(...)
+    constraints = legacy_to_constraints(mcr)
+
+Use ``constraints`` as the ``constraints=`` keyword argument to ``MCRALS``
+once the public API is connected to the engine (future PR).
+"""
+
+__all__ = ["legacy_to_constraints"]
+
+from spectrochempy.analysis.decomposition.mcrals_constraints import Closure
+from spectrochempy.analysis.decomposition.mcrals_constraints import ModelProfile
+from spectrochempy.analysis.decomposition.mcrals_constraints import Monotonic
+from spectrochempy.analysis.decomposition.mcrals_constraints import NonNegative
+from spectrochempy.analysis.decomposition.mcrals_constraints import Unimodal
+
+# ---------------------------------------------------------------------------------------
+# Sentinel used to indicate "all components".
+# ---------------------------------------------------------------------------------------
+_ALL = object()
+
+
+def legacy_to_constraints(estimator):
+    """
+    Convert legacy MCRALS traitlets to public Constraint objects.
+
+    Parameters
+    ----------
+    estimator : MCRALS
+        The MCRALS estimator instance whose traitlets will be read.
+
+    Returns
+    -------
+    list[Constraint]
+        List of public constraint objects representing the current
+        estimator configuration.
+
+    Notes
+    -----
+    The returned list is ordered by profile side (concentration first,
+    then spectral).  Within each side the order matches the historical
+    constraint application order used in the internal engine:
+    non-negativity → unimodality → monotonicity → closure → model-based
+    (hard-profile) constraints.
+
+    Normalization (``normSpec``) is a joint operation on both ``C`` and
+    ``St`` and has no corresponding public constraint class at this time;
+    it is not emitted by this converter.
+    """
+    constraints = []
+    constraints.extend(_conc_constraints(estimator))
+    constraints.extend(_spec_constraints(estimator))
+    return constraints
+
+
+# ---------------------------------------------------------------------------------------
+# Concentration-side converters
+# ---------------------------------------------------------------------------------------
+
+
+def _conc_constraints(estimator):
+    """Build the list of public constraints for the concentration side."""
+    result = []
+
+    # nonnegConc -> NonNegative("C", ...)
+    nn = _to_components(estimator.nonnegConc)
+    if nn is _ALL:
+        result.append(NonNegative("C"))
+    elif nn is not None:
+        result.append(NonNegative("C", components=nn))
+
+    # unimodConc -> Unimodal("C", ...)
+    um = _to_components(estimator.unimodConc)
+    if um is _ALL:
+        result.append(
+            Unimodal("C", mod=_str_or_default(estimator.unimodConcMod, "strict"))
+        )
+    elif um is not None:
+        result.append(
+            Unimodal(
+                "C",
+                components=um,
+                mod=_str_or_default(estimator.unimodConcMod, "strict"),
+            )
+        )
+
+    # monoIncConc -> Monotonic("C", "increasing", ...)
+    mi = _to_components(estimator.monoIncConc)
+    if mi is _ALL:
+        result.append(Monotonic("C", "increasing", tolerance=estimator.monoIncTol))
+    elif mi is not None:
+        result.append(
+            Monotonic(
+                "C",
+                "increasing",
+                components=mi,
+                tolerance=estimator.monoIncTol,
+            )
+        )
+
+    # monoDecConc -> Monotonic("C", "decreasing", ...)
+    md = _to_components(estimator.monoDecConc)
+    if md is _ALL:
+        result.append(Monotonic("C", "decreasing", tolerance=estimator.monoDecTol))
+    elif md is not None:
+        result.append(
+            Monotonic(
+                "C",
+                "decreasing",
+                components=md,
+                tolerance=estimator.monoDecTol,
+            )
+        )
+
+    # closureConc -> Closure("C", ...)
+    cc = _to_components(estimator.closureConc)
+    if cc is _ALL:
+        result.append(Closure("C", target=_extract_closure_target(estimator)))
+    elif cc is not None:
+        result.append(
+            Closure("C", components=cc, target=_extract_closure_target(estimator))
+        )
+
+    # hardConc + getConc -> ModelProfile("C", ...)
+    hc = _to_components(estimator.hardConc)
+    if hc is _ALL and callable(estimator.getConc):
+        result.append(ModelProfile("C", model=estimator.getConc))
+    elif hc is not None and callable(estimator.getConc):
+        result.append(ModelProfile("C", components=hc, model=estimator.getConc))
+
+    return result
+
+
+# ---------------------------------------------------------------------------------------
+# Spectral-side converters
+# ---------------------------------------------------------------------------------------
+
+
+def _spec_constraints(estimator):
+    """Build the list of public constraints for the spectral side."""
+    result = []
+
+    # nonnegSpec -> NonNegative("St", ...)
+    nn = _to_components(estimator.nonnegSpec)
+    if nn is _ALL:
+        result.append(NonNegative("St"))
+    elif nn is not None:
+        result.append(NonNegative("St", components=nn))
+
+    # unimodSpec -> Unimodal("St", ...)
+    um = _to_components(estimator.unimodSpec)
+    if um is _ALL:
+        result.append(
+            Unimodal("St", mod=_str_or_default(estimator.unimodSpecMod, "strict"))
+        )
+    elif um is not None:
+        result.append(
+            Unimodal(
+                "St",
+                components=um,
+                mod=_str_or_default(estimator.unimodSpecMod, "strict"),
+            )
+        )
+
+    # hardSpec + getSpec -> ModelProfile("St", ...)
+    hs = _to_components(estimator.hardSpec)
+    if hs is _ALL and callable(estimator.getSpec):
+        result.append(ModelProfile("St", model=estimator.getSpec))
+    elif hs is not None and callable(estimator.getSpec):
+        result.append(ModelProfile("St", components=hs, model=estimator.getSpec))
+
+    return result
+
+
+# ---------------------------------------------------------------------------------------
+# Conversion helpers
+# ---------------------------------------------------------------------------------------
+
+
+def _to_components(value):
+    """
+    Normalise a legacy traitlet value.
+
+    Parameters
+    ----------
+    value : str or list or ndarray or None
+        The raw traitlet value.
+
+    Returns
+    -------
+    _ALL, list[int], or None
+        * ``_ALL`` means "the constraint applies to all components"
+          (call the public constructor without ``components``).
+        * ``list[int]`` means "the constraint applies to the listed components".
+        * ``None`` means the constraint is inactive and should not be emitted.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return _ALL if value == "all" else None
+    # list, tuple, or ndarray
+    try:
+        lst = list(value)
+    except TypeError:
+        return None
+    if not lst:
+        return None
+    return [int(i) for i in lst]
+
+
+def _extract_closure_target(estimator):
+    """
+    Extract the closure target from the legacy ``closureTarget`` traitlet.
+
+    The legacy ``closureTarget`` is either the string ``"default"`` (which
+    resolves to an array of ones at fit time) or an array of per-observation
+    target values.  The public :class:`Closure` constraint accepts both
+    scalars and array-like targets, so this helper passes array-like values
+    through directly.
+
+    Parameters
+    ----------
+    estimator : MCRALS
+        The estimator instance.
+
+    Returns
+    -------
+    float or array-like
+        The closure target.  ``"default"`` is mapped to the scalar ``1.0``.
+    """
+    target = estimator.closureTarget
+    if isinstance(target, str):
+        return 1.0  # "default"
+    return target
+
+
+def _str_or_default(value, default):
+    """
+    Return ``value`` if it is a string, otherwise ``default``.
+
+    Some traitlet validators (e.g. ``unimodConcMod``) are enums that are
+    always a string.  This helper handles the general case where the
+    value might be a non-string before the validator has run.
+
+    Parameters
+    ----------
+    value : object
+        The traitlet value.
+    default : str
+        Default to return if ``value`` is not a string.
+
+    Returns
+    -------
+    str
+    """
+    if isinstance(value, str):
+        return value
+    return default

--- a/src/spectrochempy/analysis/decomposition/mcrals_constraints.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals_constraints.py
@@ -251,38 +251,82 @@ def _validate_target(target, *, name="target"):
     """
     Validate a closure target.
 
-    The target is a positive number that the selected components should
-    sum to (e.g. ``1.0`` for unit-sum closure). A zero target would
-    imply all selected components are identically zero, which is not a
-    meaningful closure and is rejected.
+    The target is either:
+
+    * a positive scalar number that the selected components should sum to
+      at every row (e.g. ``1.0`` for unit-sum closure), or
+    * an array-like of per-row target values.
+
+    A zero scalar target would imply all selected components are
+    identically zero, which is not a meaningful closure and is rejected.
+    Array-like targets are validated only for being an admissible
+    array-like — shape and positivity checks are deferred to the
+    enforcement engine.
 
     Parameters
     ----------
-    target : float
-        Closure target.
+    target : float or array-like
+        Closure target.  A scalar must be strictly positive.  An
+        array-like is passed through without copying or shape validation.
     name : str, optional
         Argument name used in error messages.
 
     Raises
     ------
     TypeError
-        If ``target`` is not a real number.
+        If ``target`` is a boolean, a string, ``None``, or another
+        non-numeric, non-iterable object.
     ValueError
-        If ``target`` is not strictly positive.
+        If ``target`` is a scalar that is not strictly positive.
 
     Returns
     -------
-    float
-        The validated target as a float.
+    float or object
+        The validated target.  Scalars are returned as ``float``;
+        array-likes are returned unchanged (no copy).
     """
-    if isinstance(target, bool) or not isinstance(target, (int, float)):
-        raise TypeError(
-            f"{name} must be a positive real number, got {type(target).__name__!r}."
-        )
-    t = float(target)
-    if t <= 0.0:
-        raise ValueError(f"{name} must be strictly positive, got {t!r}.")
-    return t
+    if isinstance(target, bool):
+        raise TypeError(f"{name} must be a numeric scalar or array-like, got bool.")
+    # Scalar case: must be a positive number.
+    if isinstance(target, (int, float)):
+        t = float(target)
+        if t <= 0.0:
+            raise ValueError(f"{name} must be strictly positive, got {t!r}.")
+        return t
+    # Array-like case: delegate to the generic array-like validator.
+    # None, strings, and scalars are already rejected above.
+    return _validate_array_like(target, name=name)
+
+
+def _targets_equal(a, b):
+    """
+    Compare two closure-target values, handling array-likes correctly.
+
+    Scalars are compared with ``==``.  Array-likes are compared via
+    :func:`numpy.array_equal` so that element-wise comparison yields a
+    single boolean (rather than a per-element array that would confuse
+    tuple comparison in the base-class ``__eq__``).
+
+    Parameters
+    ----------
+    a : float or array-like
+    b : float or array-like
+
+    Returns
+    -------
+    bool
+    """
+    a_is_scalar = isinstance(a, (int, float))
+    b_is_scalar = isinstance(b, (int, float))
+    if a_is_scalar and b_is_scalar:
+        return a == b
+    if a_is_scalar != b_is_scalar:
+        return False
+    # Both are array-like.
+    try:
+        return bool(np.array_equal(a, b))
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _validate_region(region, *, name="region"):
@@ -686,8 +730,10 @@ class Closure(Constraint):
     components : list[int], optional
         Component indices included in the closure. ``None`` (default)
         means "all components".
-    target : float, optional
-        Target sum for the selected components. Default is ``1.0``.
+    target : float or array-like, optional
+        Target sum for the selected components.  A scalar is applied
+        to every row; an array-like supplies one target per row.
+        Default is ``1.0``.
 
     Examples
     --------
@@ -696,6 +742,9 @@ class Closure(Constraint):
     Closure(profile='C', components=None, target=1.0)
     >>> Closure("C", components=[0, 1], target=100.0)
     Closure(profile='C', components=[0, 1], target=100.0)
+    >>> import numpy as np
+    >>> Closure("C", target=np.array([1.0, 1.0, 1.0]))
+    Closure(profile='C', components=None, target=array([1., 1., 1.]))
     """
 
     def __init__(self, profile, components=None, target=1.0):
@@ -717,8 +766,29 @@ class Closure(Constraint):
 
     @property
     def target(self):
-        """float: Target sum for the selected components."""
+        """Float or array-like: Target sum for the selected components."""
         return self._target
+
+    # -- equality --------------------------------------------------------
+    # Override base-class ``__eq__`` so that array-valued targets are
+    # compared element-wise via ``np.array_equal`` rather than through
+    # the default tuple-element comparison (which would fail when one
+    # element is a numpy array).
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+        if self._profile != other._profile:
+            return False
+        if self._components != other._components:
+            return False
+        return _targets_equal(self._target, other._target)
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
 
 
 class Unimodal(Constraint):

--- a/tests/test_analysis/test_decomposition/test_legacy_constraint_converter.py
+++ b/tests/test_analysis/test_decomposition/test_legacy_constraint_converter.py
@@ -1,0 +1,448 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa: N815
+"""
+Tests for the private legacy traitlet-to-constraint converter.
+
+These tests verify that each existing MCRALS constraint-related traitlet
+is translated into the expected public Constraint object with the correct
+attributes.  No numerical behaviour is tested here.
+"""
+
+import numpy as np
+
+from spectrochempy.analysis.decomposition._legacy_constraint_converter import (
+    legacy_to_constraints,
+)
+from spectrochempy.analysis.decomposition.mcrals_constraints import Closure
+from spectrochempy.analysis.decomposition.mcrals_constraints import ModelProfile
+from spectrochempy.analysis.decomposition.mcrals_constraints import Monotonic
+from spectrochempy.analysis.decomposition.mcrals_constraints import NonNegative
+from spectrochempy.analysis.decomposition.mcrals_constraints import Unimodal
+
+# -----------------------------------------------------------------------------------
+# Fixtures: estimator-like objects that mimic the relevant traitlet API
+# -----------------------------------------------------------------------------------
+
+
+class _FakeEstimator:
+    """
+    Minimal stub that exposes the traitlets that the converter reads.
+
+    This avoids instantiating the full ``MCRALS`` estimator (which requires
+    a complex dependency chain).  Each parameter is a plain attribute.
+    """
+
+    def __init__(self, **kwargs):
+        defaults = {
+            "nonnegConc": "all",
+            "unimodConc": "all",
+            "unimodConcMod": "strict",
+            "unimodConcTol": 1.1,
+            "monoIncConc": [],
+            "monoIncTol": 1.1,
+            "monoDecConc": [],
+            "monoDecTol": 1.1,
+            "closureConc": [],
+            "closureMethod": "scaling",
+            "closureTarget": "default",
+            "hardConc": [],
+            "getConc": None,
+            "argsGetConc": (),
+            "kwargsGetConc": {},
+            "getC_to_C_idx": "default",
+            "nonnegSpec": "all",
+            "unimodSpec": [],
+            "unimodSpecMod": "strict",
+            "unimodSpecTol": 1.1,
+            "hardSpec": [],
+            "getSpec": None,
+            "argsGetSpec": (),
+            "kwargsGetSpec": {},
+            "getSt_to_St_idx": "default",
+            "normSpec": None,
+        }
+        defaults.update(kwargs)
+        for key, val in defaults.items():
+            setattr(self, key, val)
+
+
+# -----------------------------------------------------------------------------------
+# Full conversion
+# -----------------------------------------------------------------------------------
+
+
+class TestLegacyToConstraints:
+    """Integration tests for the top-level ``legacy_to_constraints`` function."""
+
+    def test_default_configuration(self):
+        """
+        Default unfitted estimator produces the always-active constraints.
+
+        Expected (with all defaults):
+          - NonNegative("C", components=None)   [nonnegConc="all"]
+          - Unimodal("C", components=None)       [unimodConc="all"]
+          - NonNegative("St", components=None)   [nonnegSpec="all"]
+        """
+        est = _FakeEstimator()
+        constraints = legacy_to_constraints(est)
+
+        assert len(constraints) == 3
+
+        assert isinstance(constraints[0], NonNegative)
+        assert constraints[0].profile == "C"
+        assert constraints[0].components is None
+
+        assert isinstance(constraints[1], Unimodal)
+        assert constraints[1].profile == "C"
+        assert constraints[1].components is None
+        assert constraints[1].mod == "strict"
+
+        assert isinstance(constraints[2], NonNegative)
+        assert constraints[2].profile == "St"
+        assert constraints[2].components is None
+
+    def test_empty_nonneg_conc(self):
+        """``nonnegConc=[]`` suppresses the NonNegative(C) constraint."""
+        est = _FakeEstimator(nonnegConc=[])
+        constraints = legacy_to_constraints(est)
+
+        c_nn = [
+            c for c in constraints if isinstance(c, NonNegative) and c.profile == "C"
+        ]
+        assert len(c_nn) == 0
+
+    def test_nonneg_conc_explicit_components(self):
+        est = _FakeEstimator(nonnegConc=[0, 2])
+        constraints = legacy_to_constraints(est)
+
+        nn = [c for c in constraints if isinstance(c, NonNegative) and c.profile == "C"]
+        assert len(nn) == 1
+        assert nn[0].components == [0, 2]
+
+    def test_unimod_conc_disabled(self):
+        est = _FakeEstimator(unimodConc=[])
+        constraints = legacy_to_constraints(est)
+
+        um = [c for c in constraints if isinstance(c, Unimodal) and c.profile == "C"]
+        assert len(um) == 0
+
+    def test_unimod_conc_smooth_mod(self):
+        est = _FakeEstimator(unimodConc=[0], unimodConcMod="smooth")
+        constraints = legacy_to_constraints(est)
+
+        um = [c for c in constraints if isinstance(c, Unimodal) and c.profile == "C"]
+        assert len(um) == 1
+        assert um[0].components == [0]
+        assert um[0].mod == "smooth"
+
+    def test_unimod_conc_strict_mod_default(self):
+        est = _FakeEstimator(unimodConc=[0, 1])
+        constraints = legacy_to_constraints(est)
+
+        um = [c for c in constraints if isinstance(c, Unimodal) and c.profile == "C"]
+        assert len(um) == 1
+        assert um[0].mod == "strict"
+
+    def test_mono_inc_conc(self):
+        est = _FakeEstimator(monoIncConc=[1], monoIncTol=1.5)
+        constraints = legacy_to_constraints(est)
+
+        mi = [
+            c
+            for c in constraints
+            if isinstance(c, Monotonic)
+            and c.profile == "C"
+            and c.direction == "increasing"
+        ]
+        assert len(mi) == 1
+        assert mi[0].components == [1]
+        assert mi[0].tolerance == 1.5
+
+    def test_mono_dec_conc(self):
+        est = _FakeEstimator(monoDecConc=[0], monoDecTol=1.2)
+        constraints = legacy_to_constraints(est)
+
+        md = [
+            c
+            for c in constraints
+            if isinstance(c, Monotonic)
+            and c.profile == "C"
+            and c.direction == "decreasing"
+        ]
+        assert len(md) == 1
+        assert md[0].components == [0]
+        assert md[0].tolerance == 1.2
+
+    def test_mono_inc_and_dec_both_active(self):
+        est = _FakeEstimator(monoIncConc=[0], monoDecConc=[1])
+        constraints = legacy_to_constraints(est)
+
+        monos = [c for c in constraints if isinstance(c, Monotonic)]
+        assert len(monos) == 2
+        directions = {m.direction for m in monos}
+        assert directions == {"increasing", "decreasing"}
+
+    def test_closure_conc_default_target(self):
+        """Default ``closureTarget`` should be extracted as ``1.0``."""
+        est = _FakeEstimator(closureConc="all", closureTarget="default")
+        constraints = legacy_to_constraints(est)
+
+        cc = [c for c in constraints if isinstance(c, Closure)]
+        assert len(cc) == 1
+        assert cc[0].target == 1.0
+
+    def test_closure_conc_array_target_uniform(self):
+        """Uniform array target is passed through directly."""
+        arr = np.ones(10)
+        est = _FakeEstimator(closureConc=[0, 1], closureTarget=arr)
+        constraints = legacy_to_constraints(est)
+
+        cc = [c for c in constraints if isinstance(c, Closure)]
+        assert len(cc) == 1
+        assert cc[0].target is arr
+        np.testing.assert_array_equal(cc[0].target, np.ones(10))
+
+    def test_closure_conc_array_target_non_uniform(self):
+        """Non-uniform array target is passed through directly."""
+        arr = np.array([2.0, 3.0, 4.0])
+        est = _FakeEstimator(closureConc=[0], closureTarget=arr)
+        constraints = legacy_to_constraints(est)
+
+        cc = [c for c in constraints if isinstance(c, Closure)]
+        assert len(cc) == 1
+        assert cc[0].target is arr
+        np.testing.assert_array_equal(cc[0].target, arr)
+
+    def test_closure_conc_disabled(self):
+        est = _FakeEstimator(closureConc=[])
+        constraints = legacy_to_constraints(est)
+
+        cc = [c for c in constraints if isinstance(c, Closure)]
+        assert len(cc) == 0
+
+    def test_hard_conc_with_get_conc(self):
+        def _fake_model(C):
+            return C
+
+        est = _FakeEstimator(hardConc=[0, 1], getConc=_fake_model)
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "C"
+        ]
+        assert len(mp) == 1
+        assert mp[0].components == [0, 1]
+        assert mp[0].model is _fake_model
+
+    def test_hard_conc_disabled(self):
+        est = _FakeEstimator(hardConc=[])
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "C"
+        ]
+        assert len(mp) == 0
+
+    def test_hard_conc_active_but_no_model(self):
+        """
+        If ``hardConc`` is non-empty but ``getConc`` is ``None``,
+        no ``ModelProfile`` is emitted because there is no model to bind.
+        """
+        est = _FakeEstimator(hardConc=[0], getConc=None)
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "C"
+        ]
+        assert len(mp) == 0
+
+    def test_hard_conc_model_not_callable_skipped(self):
+        """If ``getConc`` is not callable, no ``ModelProfile`` is emitted."""
+        est = _FakeEstimator(hardConc=[0], getConc="not_callable")
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "C"
+        ]
+        assert len(mp) == 0
+
+    def test_nonneg_spec_components(self):
+        est = _FakeEstimator(nonnegSpec=[0, 1])
+        constraints = legacy_to_constraints(est)
+
+        nn = [
+            c for c in constraints if isinstance(c, NonNegative) and c.profile == "St"
+        ]
+        assert len(nn) == 1
+        assert nn[0].components == [0, 1]
+
+    def test_nonneg_spec_disabled(self):
+        est = _FakeEstimator(nonnegSpec=[])
+        constraints = legacy_to_constraints(est)
+
+        nn = [
+            c for c in constraints if isinstance(c, NonNegative) and c.profile == "St"
+        ]
+        assert len(nn) == 0
+
+    def test_unimod_spec(self):
+        est = _FakeEstimator(unimodSpec=[0], unimodSpecMod="smooth")
+        constraints = legacy_to_constraints(est)
+
+        um = [c for c in constraints if isinstance(c, Unimodal) and c.profile == "St"]
+        assert len(um) == 1
+        assert um[0].components == [0]
+        assert um[0].mod == "smooth"
+
+    def test_unimod_spec_disabled(self):
+        est = _FakeEstimator(unimodSpec=[])
+        constraints = legacy_to_constraints(est)
+
+        um = [c for c in constraints if isinstance(c, Unimodal) and c.profile == "St"]
+        assert len(um) == 0
+
+    def test_hard_spec_with_get_spec(self):
+        def _fake_model(St):
+            return St
+
+        est = _FakeEstimator(hardSpec=[2], getSpec=_fake_model)
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "St"
+        ]
+        assert len(mp) == 1
+        assert mp[0].components == [2]
+        assert mp[0].model is _fake_model
+
+    def test_hard_spec_disabled(self):
+        est = _FakeEstimator(hardSpec=[])
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "St"
+        ]
+        assert len(mp) == 0
+
+    def test_all_conc_constraints_active(self):
+        """All concentration-side constraints active simultaneously."""
+
+        def _fake_model(C):
+            return C
+
+        est = _FakeEstimator(
+            nonnegConc="all",
+            unimodConc=[0, 1],
+            unimodConcMod="smooth",
+            monoIncConc=[0],
+            monoDecConc=[1],
+            closureConc="all",
+            closureTarget="default",
+            hardConc=[2],
+            getConc=_fake_model,
+        )
+        constraints = legacy_to_constraints(est)
+
+        # Count by type on the conc side
+        conc_types = [
+            "NonNegative",
+            "Unimodal",
+            "Monotonic",
+            "Monotonic",
+            "Closure",
+            "ModelProfile",
+        ]
+
+        type_names = [type(c).__name__ for c in constraints]
+
+        for t in conc_types:
+            assert t in type_names, f"Missing {t}"
+
+    def test_not_connected_to_engine(self):
+        """
+        Creating constraints via the converter must not affect the estimator.
+
+        This is a smoke test that the converter is purely declarative.
+        """
+        est = _FakeEstimator()
+        original = est.nonnegConc
+        _ = legacy_to_constraints(est)
+        assert est.nonnegConc == original
+
+    def test_preserves_public_api_contract(self):
+        """
+        The converter must only produce public Constraint subclasses
+        (NonNegative, Closure, Unimodal, Monotonic, ModelProfile).
+        """
+        est = _FakeEstimator(
+            nonnegConc="all",
+            unimodConc=[0],
+            monoIncConc=[1],
+            closureConc="all",
+            hardConc=[2],
+            getConc=lambda C: C,
+            nonnegSpec="all",
+        )
+        constraints = legacy_to_constraints(est)
+
+        allowed_types = {NonNegative, Closure, Unimodal, Monotonic, ModelProfile}
+        for c in constraints:
+            assert type(c) in allowed_types, f"Unexpected constraint type: {type(c)}"
+
+
+# -----------------------------------------------------------------------------------
+# Edge cases
+# -----------------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_norm_spec_ignored(self):
+        """``normSpec`` is not represented as a public constraint."""
+        est = _FakeEstimator(normSpec="max")
+        constraints = legacy_to_constraints(est)
+        default_est = _FakeEstimator()
+        assert len(constraints) == len(legacy_to_constraints(default_est))
+
+    def test_closure_method_not_translated(self):
+        """``closureMethod`` is an enforcement detail, not a constraint parameter."""
+        est_scaling = _FakeEstimator(closureConc="all", closureMethod="scaling")
+        est_constsum = _FakeEstimator(closureConc="all", closureMethod="constantSum")
+        c1 = legacy_to_constraints(est_scaling)
+        c2 = legacy_to_constraints(est_constsum)
+        # Both produce the same Closure object (method is not a parameter)
+        closure1 = [c for c in c1 if isinstance(c, Closure)]
+        closure2 = [c for c in c2 if isinstance(c, Closure)]
+        assert len(closure1) == 1
+        assert closure1 == closure2
+
+    def test_unimod_tol_not_translated(self):
+        """
+        ``unimodConcTol`` is an enforcement detail, not a parameter of public
+        ``Unimodal``.
+        """
+        est = _FakeEstimator(unimodConc="all", unimodConcTol=2.0)
+        constraints = legacy_to_constraints(est)
+        um = [c for c in constraints if isinstance(c, Unimodal)]
+        assert len(um) == 1
+        assert um[0].mod == "strict"
+
+    def test_hard_conc_empty_ignores_get_conc(self):
+        """
+        An empty ``hardConc`` suppresses ``ModelProfile`` even when
+        ``getConc`` is a valid callable.
+        """
+
+        def _fake_model(C):
+            return C
+
+        est = _FakeEstimator(hardConc=[], getConc=_fake_model)
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "C"
+        ]
+        assert len(mp) == 0

--- a/tests/test_analysis/test_decomposition/test_mcrals_constraints.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_constraints.py
@@ -314,6 +314,46 @@ def test_closure_target_must_be_positive():
         Closure("C", target=-1.0)
 
 
+def test_closure_array_target_list():
+    target = [1.0, 2.0, 3.0]
+    c = Closure("C", target=target)
+    assert c.target is target
+    assert c.target == [1.0, 2.0, 3.0]
+
+
+def test_closure_array_target_tuple():
+    target = (1.0, 2.0)
+    c = Closure("C", target=target)
+    assert c.target is target
+
+
+def test_closure_array_target_numpy():
+    target = np.array([1.0, 1.0, 1.0])
+    c = Closure("C", target=target)
+    assert c.target is target
+
+
+def test_closure_array_target_list_with_components():
+    c = Closure("C", components=[0, 1], target=[2.0, 2.0])
+    assert c.components == [0, 1]
+    assert c.target == [2.0, 2.0]
+
+
+def test_closure_bool_target_rejected():
+    with pytest.raises(TypeError, match="bool"):
+        Closure("C", target=True)
+
+
+def test_closure_string_target_rejected():
+    with pytest.raises(TypeError, match="string|str"):
+        Closure("C", target="default")
+
+
+def test_closure_none_target_rejected():
+    with pytest.raises(TypeError, match="None"):
+        Closure("C", target=None)
+
+
 def test_zero_region_requires_two_entries():
     with pytest.raises(ValueError, match="exactly two"):
         ZeroRegion("C", region=(0,))
@@ -382,6 +422,32 @@ def test_unequal_constraints_different_components():
 
 def test_unequal_constraints_different_target():
     assert Closure("C", target=1.0) != Closure("C", target=2.0)
+
+
+def test_closure_equal_with_array_target():
+    assert Closure("C", target=[1.0, 2.0]) == Closure("C", target=[1.0, 2.0])
+
+
+def test_closure_equal_with_numpy_array_target():
+    assert Closure("C", target=np.array([1.0, 2.0])) == Closure(
+        "C", target=np.array([1.0, 2.0])
+    )
+
+
+def test_closure_unequal_array_target():
+    assert Closure("C", target=[1.0, 2.0]) != Closure("C", target=[3.0, 4.0])
+
+
+def test_closure_unequal_scalar_vs_array():
+    assert Closure("C", target=1.0) != Closure("C", target=[1.0, 1.0])
+    assert Closure("C", target=[1.0, 1.0]) != Closure("C", target=1.0)
+
+
+def test_closure_equal_reference_vs_copy():
+    target = np.array([1.0, 2.0, 3.0])
+    c1 = Closure("C", target=target)
+    c2 = Closure("C", target=target.copy())
+    assert c1 == c2
 
 
 def test_unequal_constraints_different_direction():


### PR DESCRIPTION
introduces a compatibility layer that converts the existing legacy traitlet-based configuration into the new public constraint objects.

Goal

Implement a private legacy constraint converter.

Legacy MCRALS traitlets
        ↓
Private legacy converter
        ↓
Public Constraint objects
        ↓
Internal constraint engine (future PR)

This PR must not change any numerical behavior. It is purely an architectural refactoring.