### PR TITLE
ENH: add FitResult confidence intervals

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -481,9 +481,11 @@ components = f1.result.components
 # of freedom. `f1.result.variance` and `f1.result.stderr` expose the diagonal
 # terms and standard errors derived from that covariance, and
 # `f1.result.correlation` exposes the normalized parameter-correlation matrix.
-# These quantities are only available when a backend provides a stable Jacobian
-# and should not be confused with confidence intervals or a full uncertainty
-# report.
+# `f1.result.confidence_intervals` now exposes approximate two-sided 95%
+# confidence intervals derived from the fitted values, standard errors, and a
+# Student-t critical value based on the residual degrees of freedom. These
+# quantities are only available when a backend provides a stable Jacobian and
+# should not be confused with a full uncertainty report.
 
 # Show the result
 _ = ndOHcorr.plot()

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -230,6 +230,9 @@ components = fit_result.components
     "correlation_shape": None
     if fit_result.correlation is None
     else fit_result.correlation.shape,
+    "confidence_intervals_shape": None
+    if fit_result.confidence_intervals is None
+    else fit_result.confidence_intervals.shape,
     "covariance_shape": None
     if fit_result.covariance is None
     else fit_result.covariance.shape,

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -58,7 +58,11 @@ New Features
   diagonal and the corresponding approximate parameter standard errors through
   the same availability rules. ``FitResult.correlation`` now exposes the
   corresponding approximate parameter-correlation matrix, normalized from the
-  covariance and standard errors with the same availability rules. Existing
+  covariance and standard errors with the same availability rules.
+  ``FitResult.confidence_intervals`` now exposes approximate two-sided 95%
+  confidence intervals for the fitted varying parameters, derived from the
+  fitted values, standard errors, and Student-t critical values using the
+  residual degrees of freedom. Existing
   ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -54,7 +54,11 @@ New Features
   diagonal and the corresponding approximate parameter standard errors through
   the same availability rules. ``FitResult.correlation`` now exposes the
   corresponding approximate parameter-correlation matrix, normalized from the
-  covariance and standard errors with the same availability rules. Existing
+  covariance and standard errors with the same availability rules.
+  ``FitResult.confidence_intervals`` now exposes approximate two-sided 95%
+  confidence intervals for the fitted varying parameters, derived from the
+  fitted values, standard errors, and Student-t critical values using the
+  residual degrees of freedom. Existing
   ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:

--- a/src/spectrochempy/analysis/_base/_result.py
+++ b/src/spectrochempy/analysis/_base/_result.py
@@ -6,6 +6,7 @@
 """Result object infrastructure for analysis and fit outputs."""
 
 import numpy as np
+from scipy import stats
 
 from spectrochempy.utils.print import DisplayItem
 from spectrochempy.utils.print import DisplaySection
@@ -205,6 +206,9 @@ class FitResult(ResultBase):
         variance=None,
         stderr=None,
         correlation=None,
+        parameter_values=None,
+        confidence_intervals=None,
+        confidence_level=0.95,
     ):
         super().__init__(
             estimator=estimator,
@@ -216,6 +220,9 @@ class FitResult(ResultBase):
         self._variance = variance
         self._stderr = stderr
         self._correlation = correlation
+        self._parameter_values = parameter_values
+        self._confidence_intervals = confidence_intervals
+        self._confidence_level = confidence_level
 
     @property
     def covariance(self):
@@ -304,3 +311,47 @@ class FitResult(ResultBase):
             correlation.flags.writeable = False
             self._correlation = correlation
         return self._correlation
+
+    @property
+    def confidence_level(self):
+        """Confidence level used for :attr:`confidence_intervals`."""
+        return self._confidence_level
+
+    @property
+    def confidence_intervals(self):
+        """
+        Approximate two-sided confidence intervals for varying parameters.
+
+        Returns
+        -------
+        ndarray or None
+            Immutable array of shape ``(n_parameters, 2)`` containing lower and
+            upper bounds for approximate 95% confidence intervals derived from
+            the fitted parameter values, standard errors, and Student-t critical
+            value based on the residual degrees of freedom. Returns ``None``
+            when the required uncertainty information is unavailable.
+        """
+        stderr = self.stderr
+        values = self._parameter_values
+        degrees_of_freedom = int(self.diagnostics.get("degrees_of_freedom", 0))
+
+        if (
+            self._confidence_intervals is None
+            and stderr is not None
+            and values is not None
+            and degrees_of_freedom > 0
+        ):
+            values = np.asarray(values, dtype=np.float64)
+            if values.shape != stderr.shape:
+                return None
+
+            alpha = 1.0 - float(self._confidence_level)
+            t_value = stats.t.ppf(1.0 - (alpha / 2.0), degrees_of_freedom)
+            if not np.isfinite(t_value):
+                return None
+
+            delta = t_value * stderr
+            intervals = np.column_stack((values - delta, values + delta))
+            intervals.flags.writeable = False
+            self._confidence_intervals = intervals
+        return self._confidence_intervals

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -102,6 +102,27 @@ def _count_varying_parameters(fp):
     return int(n_varying)
 
 
+def _extract_varying_parameter_values(fp):
+    """Return fitted varying-parameter values in optimizer order."""
+    if fp is None:
+        return None
+
+    values = []
+    for key in sorted(fp.keys()):
+        if fp.fixed[key]:
+            continue
+        key_prefix = key.split("_")[0]
+        value = fp[key]
+        if key_prefix in fp.expvars:
+            values.extend(np.asarray(value, dtype=np.float64).reshape(-1).tolist())
+        else:
+            values.append(float(value))
+
+    array = np.array(values, dtype=np.float64)
+    array.flags.writeable = False
+    return array
+
+
 def _compute_fit_diagnostics(observed, fitted, solver_meta=None, fit_parameters=None):
     """Compute residual output and basic fit-quality diagnostics."""
     if getattr(observed, "size", None) == 0 or getattr(fitted, "size", None) == 0:
@@ -1411,6 +1432,7 @@ class Optimize(DecompositionAnalysis):
             self.jacobian,
             fit_diagnostics,
         )
+        parameter_values = _extract_varying_parameter_values(self.fp)
 
         return FitResult(
             estimator="Optimize",
@@ -1428,6 +1450,7 @@ class Optimize(DecompositionAnalysis):
             },
             diagnostics=fit_diagnostics,
             covariance=covariance,
+            parameter_values=parameter_values,
         )
 
 

--- a/tests/test_analysis/test_base/test_result_base.py
+++ b/tests/test_analysis/test_base/test_result_base.py
@@ -172,6 +172,22 @@ class TestFitResult:
         np.testing.assert_allclose(result.correlation, expected)
         assert result.correlation.flags.writeable is False
 
+    def test_confidence_intervals_property(self):
+        covariance = np.array([[4.0, 1.0], [1.0, 9.0]])
+        values = np.array([10.0, 20.0])
+        result = FitResult(
+            estimator="Optimize",
+            covariance=covariance,
+            parameter_values=values,
+            diagnostics={"degrees_of_freedom": 10},
+        )
+        intervals = result.confidence_intervals
+        assert intervals is not None
+        assert intervals.shape == (2, 2)
+        assert intervals.flags.writeable is False
+        assert np.all(intervals[:, 0] <= values)
+        assert np.all(values <= intervals[:, 1])
+
 
 class TestResultBaseHTMLRepr:
     """Behavioral tests for the HTML representation of ResultBase."""

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -18,6 +18,9 @@ from spectrochempy.analysis._base._result import ResultBase
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.analysis.curvefitting import optimize as optimize_module
 from spectrochempy.analysis.curvefitting.optimize import _compute_covariance_matrix
+from spectrochempy.analysis.curvefitting.optimize import (
+    _extract_varying_parameter_values,
+)
 from spectrochempy.analysis.curvefitting.optimize import _compute_fit_diagnostics
 from tests.test_analysis.result_test_helpers import assert_fit_returns_self
 from tests.test_analysis.result_test_helpers import assert_result_basics
@@ -278,6 +281,17 @@ class TestOptimizeResult:
         assert np.all(
             np.abs(correlation[np.triu_indices_from(correlation, k=1)]) <= 1.0 + 1e-12
         )
+        confidence_intervals = opt.result.confidence_intervals
+        values = _extract_varying_parameter_values(opt.fp)
+        assert confidence_intervals is not None
+        assert confidence_intervals.flags.writeable is False
+        assert confidence_intervals.shape == (
+            opt.result.diagnostics["n_varying_parameters"],
+            2,
+        )
+        assert opt.result.confidence_level == pytest.approx(0.95)
+        assert np.all(confidence_intervals[:, 0] <= values)
+        assert np.all(values <= confidence_intervals[:, 1])
 
     def test_rss_matches_residual_sum_of_squares(
         self, synthetic_two_peak_dataset, optimize_script
@@ -380,6 +394,7 @@ class TestOptimizeResult:
         assert opt.result.variance is None
         assert opt.result.stderr is None
         assert opt.result.correlation is None
+        assert opt.result.confidence_intervals is None
 
     # ----------------------------------------------------------------------------------
     # Solver artifacts
@@ -442,6 +457,7 @@ class TestOptimizeResult:
         assert opt.result.variance is None
         assert opt.result.stderr is None
         assert opt.result.correlation is None
+        assert opt.result.confidence_intervals is None
 
     def test_jacobian_absent_for_basinhopping_backend(
         self, synthetic_two_peak_dataset, optimize_script, monkeypatch
@@ -478,6 +494,7 @@ class TestOptimizeResult:
         assert opt.result.variance is None
         assert opt.result.stderr is None
         assert opt.result.correlation is None
+        assert opt.result.confidence_intervals is None
 
     def test_jacobian_absent_for_dry_fit(
         self, synthetic_two_peak_dataset, optimize_script
@@ -493,6 +510,7 @@ class TestOptimizeResult:
         assert opt.result.variance is None
         assert opt.result.stderr is None
         assert opt.result.correlation is None
+        assert opt.result.confidence_intervals is None
 
     def test_fit_result_does_not_expose_jacobian(
         self, synthetic_two_peak_dataset, optimize_script
@@ -532,6 +550,10 @@ class TestOptimizeResult:
             opt.result.diagnostics["n_varying_parameters"],
         )
         assert opt.result.correlation.shape == covariance.shape
+        assert opt.result.confidence_intervals.shape == (
+            opt.result.diagnostics["n_varying_parameters"],
+            2,
+        )
 
     # ----------------------------------------------------------------------------------
     # Representation


### PR DESCRIPTION
## Summary

- add `FitResult.confidence_intervals`
- add `FitResult.confidence_level`
- derive approximate two-sided 95% confidence intervals from fitted parameter
  values, standard errors, and Student-t critical values
- keep the flat `FitResult` API adopted for the FitResult enrichment campaign
- document the confidence-interval convention and availability rules

## API

This PR continues the current flat uncertainty surface:

- `result.covariance`
- `result.variance`
- `result.stderr`
- `result.correlation`
- `result.confidence_intervals`

## Notes

- intervals are approximate local intervals
- confidence level is fixed at `0.95` in this PR
- intervals are available only when fitted parameter values, stderr, and
  positive residual degrees of freedom are available
- this PR does not introduce parameter tables, solution objects, or
  richer reporting helpers

## Validation

- `conda run -n scpy-core python -m pytest tests/test_analysis/test_curvefitting/test_optimize_result.py tests/test_analysis/test_base/test_result_base.py`
- `conda run -n scpy-core python -m ruff check ...`
- `conda run -n scpy-core python -m ruff format --check ...`