### PR TITLE
FIX: make plotmerit comparisons clearer and restore offset behavior

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -494,7 +494,7 @@ ax.autoscale(enable=True, axis="y")
 
 # plotmerit
 som = fitted
-_ = f1.plotmerit(offset=0, kind="scatter")
+_ = f1.plotmerit(offset=15)
 
 
 # %% [markdown]

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -248,7 +248,7 @@ ax = components[:].plot(clear=False)
 ax.autoscale(enable=True, axis="y")
 
 # %%
-_ = opt.plotmerit(offset=0, kind="scatter")
+_ = opt.plotmerit(offset=15)
 
 # %% [markdown]
 # ## Summary

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -155,6 +155,13 @@ Bug Fixes
   available, and legacy ``lines`` / ``pen`` aliases continue to work across
   dimensional fallbacks.
 
+- ``plotmerit()`` / ``plot_compare()`` are now clearer for fit inspection:
+  the reconstructed trace remains visible even for near-perfect overlaps, the
+  historical ``kind="scatter"`` / ``method="scatter"`` options now produce
+  real marker-based rendering, ``nb_traces`` is honored in the current plotting
+  path, and ``offset`` once again separates the residual trace from the main
+  signal to improve notebook readability.
+
 - Fixed several processing regressions and edge cases: multi-dimensional ZPD
   detection in interferogram apodization is more reliable, ``rs()``, ``ls()``,
   and ``roll()`` now shift multi-dimensional data along the correct axis,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -147,6 +147,13 @@ Bug Fixes
   available, and legacy ``lines`` / ``pen`` aliases continue to work across
   dimensional fallbacks.
 
+- ``plotmerit()`` / ``plot_compare()`` are now clearer for fit inspection:
+  the reconstructed trace remains visible even for near-perfect overlaps, the
+  historical ``kind="scatter"`` / ``method="scatter"`` options now produce
+  real marker-based rendering, ``nb_traces`` is honored in the current plotting
+  path, and ``offset`` once again separates the residual trace from the main
+  signal to improve notebook readability.
+
 - Fixed several processing regressions and edge cases: multi-dimensional ZPD
   detection in interferogram apodization is more reliable, ``rs()``, ``ls()``,
   and ``roll()`` now shift multi-dimensional data along the correct axis,

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -107,7 +107,7 @@ ax.autoscale(enable=True, axis="y")
 # %%
 # plotmerit
 som = f1.inverse_transform()
-_ = f1.plotmerit(ndOH, som, method="scatter", markevery=5, markersize=2, lw=2)
+_ = f1.plotmerit(ndOH, som, offset=15)
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/plotting/composite/plotmerit.py
+++ b/src/spectrochempy/plotting/composite/plotmerit.py
@@ -39,6 +39,20 @@ def plot_compare(
     title=None,
     show_yaxis=True,
     show=True,
+    exp_c=None,
+    calc_c=None,
+    resid_c=None,
+    exp_linestyle="-",
+    calc_linestyle="--",
+    resid_linestyle="-",
+    exp_linewidth=1.0,
+    calc_linewidth=1.6,
+    resid_linewidth=1.0,
+    kind=None,
+    method=None,
+    offset=None,
+    nb_traces="all",
+    **kwargs,
 ):
     """
     Compare two datasets (X vs X_ref) with optional residual.
@@ -77,6 +91,16 @@ def plot_compare(
 
     n_traces, n_points = X.shape
 
+    if nb_traces != "all":
+        nb_traces = int(nb_traces)
+        if nb_traces <= 0:
+            raise ValueError("nb_traces must be a positive integer or 'all'.")
+        if nb_traces < n_traces:
+            indices = np.linspace(0, n_traces - 1, nb_traces, dtype=int)
+            X = X[indices]
+            X_ref = X_ref[indices]
+            n_traces = nb_traces
+
     # ----------------------------
     # Compute data arrays
     # ----------------------------
@@ -84,6 +108,18 @@ def plot_compare(
     ref_data = np.asarray(X_ref.masked_data)
 
     res_data = np.asarray((X - X_ref).masked_data) if residual else None
+
+    plot_orig_data = orig_data.copy()
+    plot_ref_data = ref_data.copy()
+    plot_res_data = res_data.copy() if residual else None
+
+    if residual and offset not in (None, 0):
+        signal_min = min(np.nanmin(orig_data), np.nanmin(ref_data))
+        signal_max = max(np.nanmax(orig_data), np.nanmax(ref_data))
+        signal_range = signal_max - signal_min
+        offset_scale = signal_range if signal_range > 0 else 1.0
+        residual_offset = (float(offset) / 100.0) * offset_scale
+        plot_res_data = plot_res_data - residual_offset
 
     # ----------------------------
     # X coordinate extraction
@@ -104,22 +140,45 @@ def plot_compare(
     xdata = np.asarray(xdata)
 
     # ----------------------------
-    # Semantic colors (fixed)
+    # Semantic styles (fixed)
     # ----------------------------
-    orig_color = ["tab:blue"]
-    ref_color = ["tab:orange"]
-    resid_color = ["0.6"]
+    orig_color = ["tab:blue" if exp_c is None else exp_c]
+    ref_color = ["tab:orange" if calc_c is None else calc_c]
+    resid_color = ["0.6" if resid_c is None else resid_c]
+    orig_linestyle = [exp_linestyle] * n_traces
+    ref_linestyle = [calc_linestyle] * n_traces
+    resid_linestyle = [resid_linestyle] * n_traces
+
+    plot_kind = (kind or method or "line").lower()
+    marker_kwargs = {}
+    if plot_kind == "scatter":
+        orig_linestyle = ["None"] * n_traces
+        ref_linestyle = ["None"] * n_traces
+        resid_linestyle = ["None"] * n_traces
+        marker_kwargs = {
+            "markers": [kwargs.pop("marker", "o")] * n_traces,
+            "markersizes": [kwargs.pop("markersize", 3)] * n_traces,
+        }
+        kwargs.pop("lw", None)
+        kwargs.pop("linewidth", None)
+    elif plot_kind != "line":
+        raise ValueError("kind/method must be 'line' or 'scatter'.")
+
+    if "lw" in kwargs:
+        exp_linewidth = calc_linewidth = resid_linewidth = kwargs.pop("lw")
+    if "linewidth" in kwargs:
+        exp_linewidth = calc_linewidth = resid_linewidth = kwargs.pop("linewidth")
 
     # ----------------------------
     # Z-order policy
-    # residual < reconstructed < experimental
+    # residual < experimental < reconstructed
+    #
+    # Keeping the reconstructed profile on top makes near-perfect fits visible
+    # instead of hiding the orange line entirely under the experimental trace.
     # ----------------------------
     resid_z = [0] * n_traces
-    ref_z = [1] * n_traces
-    orig_z = [2] * n_traces
-
-    linewidth = 1.0
-
+    orig_z = [1] * n_traces
+    ref_z = [2] * n_traces
     # ----------------------------
     # Render residual first
     # ----------------------------
@@ -127,27 +186,15 @@ def plot_compare(
         render_lines(
             ax,
             xdata,
-            res_data,
+            plot_res_data,
             colors=resid_color,
-            linestyles=["-"] * n_traces,
-            linewidths=[linewidth] * n_traces,
+            linestyles=resid_linestyle,
+            linewidths=[resid_linewidth] * n_traces,
             zorders=resid_z,
             reverse=False,
+            **marker_kwargs,
+            **kwargs,
         )
-
-    # ----------------------------
-    # Render reconstructed
-    # ----------------------------
-    render_lines(
-        ax,
-        xdata,
-        ref_data,
-        colors=ref_color,
-        linestyles=["-"] * n_traces,
-        linewidths=[linewidth] * n_traces,
-        zorders=ref_z,
-        reverse=False,
-    )
 
     # ----------------------------
     # Render experimental
@@ -155,12 +202,31 @@ def plot_compare(
     render_lines(
         ax,
         xdata,
-        orig_data,
+        plot_orig_data,
         colors=orig_color,
-        linestyles=["-"] * n_traces,
-        linewidths=[linewidth] * n_traces,
+        linestyles=orig_linestyle,
+        linewidths=[exp_linewidth] * n_traces,
+        alpha=0.85,
         zorders=orig_z,
         reverse=False,
+        **marker_kwargs,
+        **kwargs,
+    )
+
+    # ----------------------------
+    # Render reconstructed
+    # ----------------------------
+    render_lines(
+        ax,
+        xdata,
+        plot_ref_data,
+        colors=ref_color,
+        linestyles=ref_linestyle,
+        linewidths=[calc_linewidth] * n_traces,
+        zorders=ref_z,
+        reverse=False,
+        **marker_kwargs,
+        **kwargs,
     )
 
     # ----------------------------
@@ -168,12 +234,12 @@ def plot_compare(
     # ----------------------------
     ax.set_xlim(xdata.min(), xdata.max())
 
+    plotted_arrays = [plot_orig_data, plot_ref_data]
     if residual:
-        y_min = np.nanmin(res_data)
-    else:
-        y_min = min(np.nanmin(orig_data), np.nanmin(ref_data))
+        plotted_arrays.append(plot_res_data)
 
-    y_max = max(np.nanmax(orig_data), np.nanmax(ref_data))
+    y_min = min(np.nanmin(arr) for arr in plotted_arrays)
+    y_max = max(np.nanmax(arr) for arr in plotted_arrays)
 
     data_range = y_max - y_min
     pad = 0.02 * data_range if data_range > 0 else 0.02
@@ -199,12 +265,35 @@ def plot_compare(
     # Legend
     # ----------------------------
     handles = [
-        Line2D([0], [0], color="tab:blue", label=X.name),
-        Line2D([0], [0], color="tab:orange", label=X_ref.name),
+        Line2D(
+            [0],
+            [0],
+            color=orig_color[0],
+            linestyle=orig_linestyle[0],
+            marker=marker_kwargs.get("markers", [None])[0],
+            label=X.name,
+        ),
+        Line2D(
+            [0],
+            [0],
+            color=ref_color[0],
+            linestyle=ref_linestyle[0],
+            marker=marker_kwargs.get("markers", [None])[0],
+            label=X_ref.name,
+        ),
     ]
 
     if residual:
-        handles.append(Line2D([0], [0], color="0.6", label="difference"))
+        handles.append(
+            Line2D(
+                [0],
+                [0],
+                color=resid_color[0],
+                linestyle=resid_linestyle[0],
+                marker=marker_kwargs.get("markers", [None])[0],
+                label="difference",
+            ),
+        )
 
     ax.legend(handles=handles, loc="best")
 
@@ -310,6 +399,7 @@ def plot_merit(
                 title=title,
                 show_yaxis=show_yaxis,
                 show=show,
+                **kwargs,
             )
 
         # Iterable of indices
@@ -327,6 +417,7 @@ def plot_merit(
                 title=title,
                 show_yaxis=show_yaxis,
                 show=show,
+                **kwargs,
             )
             axes_list.append(ax_i)
 
@@ -345,6 +436,7 @@ def plot_merit(
             title=title,
             show_yaxis=show_yaxis,
             show=show,
+            **kwargs,
         )
 
     raise ValueError(

--- a/tests/test_plotting/test_composite_imports.py
+++ b/tests/test_plotting/test_composite_imports.py
@@ -9,6 +9,8 @@ Minimal tests for composite plotting modules to improve coverage.
 These tests ensure the modules can be imported and basic functions are callable.
 """
 
+import numpy as np
+
 
 class TestPlotMeritImports:
     """Test that plotmerit module can be imported and has expected functions."""
@@ -24,6 +26,69 @@ class TestPlotMeritImports:
         from spectrochempy.plotting.composite.plotmerit import plot_compare
 
         assert callable(plot_compare)
+
+    def test_plot_compare_makes_reconstructed_trace_visible(self, sample_1d_dataset):
+        """The reconstructed profile should remain visually distinct."""
+        from spectrochempy.plotting.composite.plotmerit import plot_compare
+
+        X = sample_1d_dataset
+        X_ref = X.copy()
+        X_ref.name = "fit"
+
+        ax = plot_compare(X, X_ref, show=False)
+
+        assert len(ax.lines) == 3
+        assert ax.lines[1].get_color() == "tab:blue"
+        assert ax.lines[2].get_color() == "tab:orange"
+        assert ax.lines[2].get_linestyle() == "--"
+
+    def test_plot_compare_scatter_mode_uses_markers(self, sample_1d_dataset):
+        """Scatter mode should render point markers rather than solid lines."""
+        from spectrochempy.plotting.composite.plotmerit import plot_compare
+
+        X = sample_1d_dataset
+        X_ref = X.copy()
+        X_ref.name = "fit"
+
+        ax = plot_compare(X, X_ref, kind="scatter", show=False)
+
+        assert len(ax.lines) == 3
+        for line in ax.lines:
+            assert line.get_marker() == "o"
+            assert line.get_linestyle() == "None"
+
+    def test_plot_compare_nb_traces_limits_display(self, sample_2d_dataset):
+        """nb_traces should reduce the number of rendered traces."""
+        from spectrochempy.plotting.composite.plotmerit import plot_compare
+
+        X = sample_2d_dataset
+        X_ref = X.copy()
+        X_ref.name = "fit"
+
+        ax = plot_compare(X, X_ref, nb_traces=3, show=False)
+
+        assert len(ax.lines) == 9
+
+    def test_plot_compare_offset_moves_residual_down(self, sample_1d_dataset):
+        """Offset should separate the residual from the main traces."""
+        from spectrochempy.plotting.composite.plotmerit import plot_compare
+
+        X = sample_1d_dataset
+        X_ref = X * 0.9
+        X_ref.name = "fit"
+
+        ax = plot_compare(X, X_ref, offset=20, show=False)
+
+        signal_range = max(np.nanmax(X.data), np.nanmax(X_ref.data)) - min(
+            np.nanmin(X.data),
+            np.nanmin(X_ref.data),
+        )
+        expected_shift = 0.2 * signal_range
+        expected_residual = (X - X_ref).data - expected_shift
+
+        np.testing.assert_allclose(ax.lines[0].get_ydata(), expected_residual)
+        np.testing.assert_allclose(ax.lines[1].get_ydata(), X.data)
+        np.testing.assert_allclose(ax.lines[2].get_ydata(), X_ref.data)
 
 
 class TestMultiplotImports:


### PR DESCRIPTION
## Summary

This PR improves `plotmerit()` / `plot_compare()` so fit-comparison plots are easier to read and better aligned with the documented API.

## What changed

- make the reconstructed profile remain visible even for near-perfect fits
- render the reconstructed trace with a distinct dashed style
- make `kind="scatter"` and legacy `method="scatter"` produce actual marker-based rendering
- restore a useful `offset` behavior by shifting only the residual trace downward
- support `nb_traces` in the current plotting path
- update fitting and peak-analysis examples to use the clearer default rendering with residual offset
- add focused plotting tests for:
  - reconstructed trace visibility
  - scatter rendering
  - `offset` behavior
  - `nb_traces` handling

## Why

In the current workflow examples, `plotmerit()` was hard to interpret:
- the fitted curve could disappear under the experimental trace
- `scatter` was accepted but had no real effect
- `offset` was documented but not implemented

This PR makes the plot more useful for notebook-based fit inspection without changing the overall fitting workflow.

## Notes

Current `offset` semantics are intentionally conservative:
- it is expressed as a percentage of the main signal range
- it shifts only the residual
- it does not yet stack multi-trace groups