### PR TITLE
ENH: add AIC and BIC diagnostics to FitResult

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -485,7 +485,9 @@ components = f1.result.components
 # confidence intervals derived from the fitted values, standard errors, and a
 # Student-t critical value based on the residual degrees of freedom. These
 # quantities are only available when a backend provides a stable Jacobian and
-# should not be confused with a full uncertainty report.
+# should not be confused with a full uncertainty report. Model-comparison
+# diagnostics are also available in `f1.result.diagnostics`, including
+# `aic` and `bic`.
 
 # Show the result
 _ = ndOHcorr.plot()

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -225,6 +225,8 @@ components = fit_result.components
     "rmse": fit_result.diagnostics["rmse"],
     "degrees_of_freedom": fit_result.diagnostics["degrees_of_freedom"],
     "reduced_chi_square": fit_result.diagnostics["reduced_chi_square"],
+    "aic": fit_result.diagnostics["aic"],
+    "bic": fit_result.diagnostics["bic"],
     "success": fit_result.diagnostics["success"],
     "stderr_shape": None if fit_result.stderr is None else fit_result.stderr.shape,
     "correlation_shape": None

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -62,7 +62,10 @@ New Features
   ``FitResult.confidence_intervals`` now exposes approximate two-sided 95%
   confidence intervals for the fitted varying parameters, derived from the
   fitted values, standard errors, and Student-t critical values using the
-  residual degrees of freedom. Existing
+  residual degrees of freedom. ``FitResult.diagnostics`` now also exposes
+  Gaussian-residual model-comparison criteria ``aic`` and ``bic`` derived from
+  the residual sum of squares, observation count, and effective varying-
+  parameter count. Existing
   ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -58,7 +58,10 @@ New Features
   ``FitResult.confidence_intervals`` now exposes approximate two-sided 95%
   confidence intervals for the fitted varying parameters, derived from the
   fitted values, standard errors, and Student-t critical values using the
-  residual degrees of freedom. Existing
+  residual degrees of freedom. ``FitResult.diagnostics`` now also exposes
+  Gaussian-residual model-comparison criteria ``aic`` and ``bic`` derived from
+  the residual sum of squares, observation count, and effective varying-
+  parameter count. Existing
   ``result.fitted`` and ``result.components`` behavior is preserved.
 
 - SpectroChemPy now exposes top-level helpers for common 1D line shapes:

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -168,6 +168,22 @@ def _compute_fit_diagnostics(observed, fitted, solver_meta=None, fit_parameters=
     else:
         reduced_chi_square = float("nan")
 
+    if count > 0:
+        mean_squared_residual = rss / count
+        if mean_squared_residual < 0.0 or not np.isfinite(mean_squared_residual):
+            aic = float("nan")
+            bic = float("nan")
+        elif mean_squared_residual == 0.0:
+            aic = float("-inf")
+            bic = float("-inf")
+        else:
+            log_likelihood_term = float(count * np.log(mean_squared_residual))
+            aic = float(log_likelihood_term + (2.0 * n_varying_parameters))
+            bic = float(log_likelihood_term + (n_varying_parameters * np.log(count)))
+    else:
+        aic = float("nan")
+        bic = float("nan")
+
     diagnostics = {
         "n_observations": count,
         "n_varying_parameters": n_varying_parameters,
@@ -178,6 +194,8 @@ def _compute_fit_diagnostics(observed, fitted, solver_meta=None, fit_parameters=
         "r_squared": r_squared,
         "reduced_chi_square": reduced_chi_square,
         "adjusted_r_squared": adjusted_r_squared,
+        "aic": aic,
+        "bic": bic,
     }
     diagnostics.update(dict(solver_meta or {}))
     return residuals, diagnostics

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -187,6 +187,8 @@ class TestOptimizeResult:
             "r_squared",
             "reduced_chi_square",
             "adjusted_r_squared",
+            "aic",
+            "bic",
             "success",
             "status",
             "message",
@@ -212,6 +214,8 @@ class TestOptimizeResult:
         assert isinstance(diag["r_squared"], float)
         assert isinstance(diag["reduced_chi_square"], float)
         assert isinstance(diag["adjusted_r_squared"], float)
+        assert isinstance(diag["aic"], float)
+        assert isinstance(diag["bic"], float)
         assert isinstance(diag["success"], bool)
         assert isinstance(diag["message"], str)
 
@@ -245,6 +249,17 @@ class TestOptimizeResult:
         )
         assert np.isfinite(diag["adjusted_r_squared"])
         assert diag["adjusted_r_squared"] <= diag["r_squared"]
+        expected_aic = (
+            diag["n_observations"] * np.log(diag["rss"] / diag["n_observations"])
+            + 2 * diag["n_varying_parameters"]
+        )
+        expected_bic = (
+            diag["n_observations"] * np.log(diag["rss"] / diag["n_observations"])
+            + diag["n_varying_parameters"] * np.log(diag["n_observations"])
+        )
+        assert diag["aic"] == pytest.approx(expected_aic)
+        assert diag["bic"] == pytest.approx(expected_bic)
+        assert diag["bic"] >= diag["aic"]
         assert isinstance(diag["status"], int | type(None))
         assert opt.result.covariance is not None
 
@@ -351,6 +366,8 @@ class TestOptimizeResult:
         assert np.isnan(diagnostics["r_squared"])
         assert np.isnan(diagnostics["reduced_chi_square"])
         assert np.isnan(diagnostics["adjusted_r_squared"])
+        assert np.isnan(diagnostics["aic"])
+        assert np.isnan(diagnostics["bic"])
 
     def test_non_positive_degrees_of_freedom_are_stable(self):
         observed = scp.NDDataset(np.array([1.0, 2.0, 3.0], dtype=np.float64))
@@ -367,6 +384,8 @@ class TestOptimizeResult:
         assert diagnostics["degrees_of_freedom"] == 0
         assert np.isnan(diagnostics["reduced_chi_square"])
         assert np.isnan(diagnostics["adjusted_r_squared"])
+        assert diagnostics["aic"] == float("-inf")
+        assert diagnostics["bic"] == float("-inf")
 
         jacobian = np.eye(3)
         covariance = _compute_covariance_matrix(observed, fitted, jacobian, diagnostics)
@@ -390,6 +409,8 @@ class TestOptimizeResult:
         assert diag["degrees_of_freedom"] == (
             diag["n_observations"] - diag["n_varying_parameters"]
         )
+        assert np.isfinite(diag["aic"]) or np.isneginf(diag["aic"])
+        assert np.isfinite(diag["bic"]) or np.isneginf(diag["bic"])
         assert opt.result.covariance is None
         assert opt.result.variance is None
         assert opt.result.stderr is None

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -253,10 +253,9 @@ class TestOptimizeResult:
             diag["n_observations"] * np.log(diag["rss"] / diag["n_observations"])
             + 2 * diag["n_varying_parameters"]
         )
-        expected_bic = (
-            diag["n_observations"] * np.log(diag["rss"] / diag["n_observations"])
-            + diag["n_varying_parameters"] * np.log(diag["n_observations"])
-        )
+        expected_bic = diag["n_observations"] * np.log(
+            diag["rss"] / diag["n_observations"]
+        ) + diag["n_varying_parameters"] * np.log(diag["n_observations"])
         assert diag["aic"] == pytest.approx(expected_aic)
         assert diag["bic"] == pytest.approx(expected_bic)
         assert diag["bic"] >= diag["aic"]


### PR DESCRIPTION
## Summary

This PR completes the FitResult enrichment campaign by adding AIC and BIC to `FitResult.diagnostics`.

## What changed

- add `result.diagnostics["aic"]`
- add `result.diagnostics["bic"]`
- compute both criteria from the existing residual diagnostics:
  - `n_observations`
  - `rss`
  - `n_varying_parameters`
- document the new diagnostics in the fitting guide and peak-analysis workflow
- add focused tests for:
  - diagnostic presence
  - scalar type
  - numerical consistency with the implemented formulas
  - stable edge-case behavior

## Convention

This PR uses the standard Gaussian-residual forms:

- `AIC = n * ln(RSS / n) + 2k`
- `BIC = n * ln(RSS / n) + k * ln(n)`

with:

- `n = n_observations`
- `RSS = result.diagnostics["rss"]`
- `k = n_varying_parameters`

## Edge-case behavior

- empty data: `nan`
- invalid residual mean square: `nan`
- exact zero residual sum of squares: `-inf`

Unlike reduced chi-square and covariance-based uncertainty outputs, AIC and BIC do not require positive residual degrees of freedom.

## Why

This closes the current FitResult roadmap with lightweight model-comparison diagnostics, without changing the existing result-object structure or introducing a new parameter-solution surface.

## Notes

This PR completes the planned FitResult enrichment sequence. The next step should be a campaign-level reassessment before expanding optimizer backends or method-selection guidance.