### PR TITLE
FIX: restore py:percent cell markers in fitting docs

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -548,12 +548,21 @@ components = f1.result.components
 # diagnostics are also available in `f1.result.diagnostics`, including
 # `aic` and `bic`.
 
-# Show the result
+# %% [markdown]
+# The fitted components remain regular datasets, so they can be plotted
+# directly against the corrected spectrum.
+
+# %%
 _ = ndOHcorr.plot()
 ax = (components[:]).plot(clear=False)
 ax.autoscale(enable=True, axis="y")
 
-# plotmerit
+# %% [markdown]
+# `plotmerit()` overlays the experimental spectrum, the fitted profile, and the
+# residuals. Here we use a small residual offset to keep the three traces easy
+# to inspect in a notebook.
+
+# %%
 som = fitted
 _ = f1.plotmerit(offset=15)
 

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -249,6 +249,11 @@ _ = nd_oh_corr.plot()
 ax = components[:].plot(clear=False)
 ax.autoscale(enable=True, axis="y")
 
+# %% [markdown]
+# `plotmerit()` overlays the corrected spectrum, the fitted profile, and the
+# residuals. As in the fitting tutorial, we use a small residual offset to keep
+# the comparison readable in a notebook.
+
 # %%
 _ = opt.plotmerit(offset=15)
 


### PR DESCRIPTION
## Summary

This PR isolates the remaining Jupytext `py:percent` marker fixes after the main Optimize documentation changes were already merged separately.

It updates:

- `docs/sources/userguide/analysis/fitting.py`
- `docs/sources/userguide/analysis/peak_analysis_workflow.py`

## Why

These files still needed explicit markdown/code cell boundaries so the notebook-style tutorials render correctly and remain consistent with the rest of the documentation.