### PR TITLE
FIX: align plotmerit figure size with plotting preferences

### DIFF
--- a/src/spectrochempy/plotting/composite/plotmerit.py
+++ b/src/spectrochempy/plotting/composite/plotmerit.py
@@ -20,6 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.lines import Line2D
 
+from spectrochempy.application.preferences import preferences as prefs
 from spectrochempy.plotting._render import render_lines
 from spectrochempy.utils.mplutils import make_label
 from spectrochempy.utils.mplutils import show as mpl_show
@@ -27,6 +28,13 @@ from spectrochempy.utils.mplutils import show as mpl_show
 # ======================================================================================
 # Generic comparison function
 # ======================================================================================
+
+
+def _make_default_axes():
+    """Create an axes using the current SpectroChemPy figure-size preference."""
+    figsize = tuple(prefs.figure.figsize)
+    _, ax = plt.subplots(figsize=figsize)
+    return ax
 
 
 def plot_compare(
@@ -71,7 +79,7 @@ def plot_compare(
     # Figure management (L3 only)
     # ----------------------------
     if ax is None:
-        _, ax = plt.subplots()
+        ax = _make_default_axes()
 
     if clear:
         ax.cla()
@@ -362,7 +370,7 @@ def plot_merit(
         # Plot all regularizations on same axes
         if index is None:
             if ax is None:
-                _, ax = plt.subplots()
+                ax = _make_default_axes()
 
             if clear:
                 ax.cla()

--- a/tests/test_plotting/test_composite_imports.py
+++ b/tests/test_plotting/test_composite_imports.py
@@ -90,6 +90,24 @@ class TestPlotMeritImports:
         np.testing.assert_allclose(ax.lines[1].get_ydata(), X.data)
         np.testing.assert_allclose(ax.lines[2].get_ydata(), X_ref.data)
 
+    def test_plot_compare_uses_scpy_figure_size_preference(self, sample_1d_dataset):
+        """Standalone comparison figures should follow the current SCPy figure size."""
+        from spectrochempy import preferences
+        from spectrochempy.plotting.composite.plotmerit import plot_compare
+
+        X = sample_1d_dataset
+        X_ref = X.copy()
+        X_ref.name = "fit"
+
+        original_figsize = tuple(preferences.figure.figsize)
+        preferences.figure.figsize = (7.0, 3.0)
+        try:
+            ax = plot_compare(X, X_ref, show=False)
+            width, height = ax.figure.get_size_inches()
+            np.testing.assert_allclose((width, height), (7.0, 3.0))
+        finally:
+            preferences.figure.figsize = original_figsize
+
 
 class TestMultiplotImports:
     """Test that multiplot module can be imported."""


### PR DESCRIPTION
## Summary

Make `plotmerit()` and `plot_compare()` honor `scp.preferences.figure.figsize`
when they create their own figure.

## Why

In the fitting tutorials, merit plots were rendered with Matplotlib's default
figure size instead of the SpectroChemPy plotting preference, which made them
visibly inconsistent with the surrounding tutorial figures.