### PR TITLE
Introduce the public constraints= API for MCR-ALS

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,15 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- ``MCRALS``: added the ``constraints=`` parameter that accepts a list of
+  public ``Constraint`` objects (``NonNegative``, ``Unimodal``, ``Closure``,
+  ``Monotonic``, ``ModelProfile``, …).  Both the new ``constraints=`` API and
+  the legacy traitlet-based parameters now route through the same internal
+  pipeline: the public ``Constraint`` objects have become the canonical
+  intermediate representation.  Mixed usage (legacy traitlets + ``constraints=``
+  at the same time) raises a clear ``ValueError``.  The legacy traitlet-based
+  API remains fully supported for backward compatibility.  (#1380)
+
 - ``AnalysisResult`` (PCA, NMF, PLS, MCR‑ALS, …) and ``FitResult`` now have a
   rich ``_repr_html_`` for Jupyter notebooks, with collapsible Parameters,
   Outputs, and Diagnostics sections and recursive rendering of embedded

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,15 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- ``MCRALS``: added the ``constraints=`` parameter that accepts a list of
+  public ``Constraint`` objects (``NonNegative``, ``Unimodal``, ``Closure``,
+  ``Monotonic``, ``ModelProfile``, …).  Both the new ``constraints=`` API and
+  the legacy traitlet-based parameters now route through the same internal
+  pipeline: the public ``Constraint`` objects have become the canonical
+  intermediate representation.  Mixed usage (legacy traitlets + ``constraints=``
+  at the same time) raises a clear ``ValueError``.  The legacy traitlet-based
+  API remains fully supported for backward compatibility.  (#1380)
+
 - ``AnalysisResult`` (PCA, NMF, PLS, MCR‑ALS, …) and ``FitResult`` now have a
   rich ``_repr_html_`` for Jupyter notebooks, with collapsible Parameters,
   Outputs, and Diagnostics sections and recursive rendering of embedded

--- a/src/spectrochempy/analysis/decomposition/_legacy_constraint_converter.py
+++ b/src/spectrochempy/analysis/decomposition/_legacy_constraint_converter.py
@@ -144,12 +144,17 @@ def _conc_constraints(estimator):
             Closure("C", components=cc, target=_extract_closure_target(estimator))
         )
 
-    # hardConc + getConc -> ModelProfile("C", ...)
+    # hardConc + getConc + argsGetConc + kwargsGetConc -> ModelProfile("C", ...)
     hc = _to_components(estimator.hardConc)
-    if hc is _ALL and callable(estimator.getConc):
-        result.append(ModelProfile("C", model=estimator.getConc))
-    elif hc is not None and callable(estimator.getConc):
-        result.append(ModelProfile("C", components=hc, model=estimator.getConc))
+    if hc is not None and callable(estimator.getConc):
+        mp_kw = {
+            "model": estimator.getConc,
+            "model_args": estimator.argsGetConc,
+            "model_kwargs": estimator.kwargsGetConc,
+        }
+        if hc is not _ALL:
+            mp_kw["components"] = hc
+        result.append(ModelProfile("C", **mp_kw))
 
     return result
 
@@ -185,12 +190,17 @@ def _spec_constraints(estimator):
             )
         )
 
-    # hardSpec + getSpec -> ModelProfile("St", ...)
+    # hardSpec + getSpec + argsGetSpec + kwargsGetSpec -> ModelProfile("St", ...)
     hs = _to_components(estimator.hardSpec)
-    if hs is _ALL and callable(estimator.getSpec):
-        result.append(ModelProfile("St", model=estimator.getSpec))
-    elif hs is not None and callable(estimator.getSpec):
-        result.append(ModelProfile("St", components=hs, model=estimator.getSpec))
+    if hs is not None and callable(estimator.getSpec):
+        mp_kw = {
+            "model": estimator.getSpec,
+            "model_args": estimator.argsGetSpec,
+            "model_kwargs": estimator.kwargsGetSpec,
+        }
+        if hs is not _ALL:
+            mp_kw["components"] = hs
+        result.append(ModelProfile("St", **mp_kw))
 
     return result
 

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -30,10 +30,46 @@ from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
 from spectrochempy.analysis._base._result import AnalysisResult
+from spectrochempy.analysis.decomposition.mcrals_constraints import Constraint
 from spectrochempy.application.application import info_
 from spectrochempy.extern.traittypes import Array
 from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.decorators import signature_has_configurable_traits
+
+# --------------------------------------------------------------------------------------
+# Names of legacy traitlet-based constraint parameters.
+# Used to detect mixed-API usage (legacy traitlets + new constraints= parameter).
+# --------------------------------------------------------------------------------------
+_LEGACY_CONSTRAINT_TRAITS = frozenset(
+    {
+        "nonnegConc",
+        "unimodConc",
+        "unimodConcMod",
+        "unimodConcTol",
+        "monoDecConc",
+        "monoDecTol",
+        "monoIncConc",
+        "monoIncTol",
+        "closureConc",
+        "closureTarget",
+        "closureMethod",
+        "hardConc",
+        "getConc",
+        "argsGetConc",
+        "kwargsGetConc",
+        "getC_to_C_idx",
+        "nonnegSpec",
+        "normSpec",
+        "unimodSpec",
+        "unimodSpecMod",
+        "unimodSpecTol",
+        "hardSpec",
+        "getSpec",
+        "argsGetSpec",
+        "kwargsGetSpec",
+        "getSt_to_St_idx",
+    }
+)
 
 # --------------------------------------------------------------------------------------
 # Internal iteration state
@@ -424,6 +460,27 @@ class MCRALS(DecompositionAnalysis):
 
     Parameters
     ----------
+    constraints : list of `Constraint`, optional, default: ``None``
+        Public constraint objects describing scientific prior knowledge about
+        the concentration (``"C"``) or spectral (``"St"``) profiles. When
+        provided, each element must be an instance of a public constraint
+        class (e.g., ``NonNegative``, ``Unimodal``, ``Closure``,
+        ``Monotonic``, ``ModelProfile``).  This parameter cannot be combined
+        with the legacy traitlet-based constraint parameters (``nonnegConc``,
+        ``unimodConc``, ``closureConc``, etc.) — choose one API.
+
+        Example::
+
+            from spectrochempy.analysis import constraints as mc
+
+            mcr = MCRALS(
+                constraints=[
+                    mc.NonNegative("C"),
+                    mc.Closure("C"),
+                ]
+            )
+
+        .. versionadded:: 0.7.0
     log_level : any of [``"INFO"``, ``"DEBUG"``, ``"WARNING"``, ``"ERROR"``], optional, default: ``"WARNING"``
         The log level at startup. It can be changed later on using the
         `set_log_level` method or by changing the ``log_level`` attribute.
@@ -867,6 +924,32 @@ and `St`.
                 "See the documentation and examples",
             )
 
+        # Extract and validate the new constraints= parameter (not a traitlet).
+        constraints = kwargs.pop("constraints", None)
+
+        if constraints is not None:
+            # Detect mixed API: legacy constraint traitlets + constraints=.
+            mixed = _LEGACY_CONSTRAINT_TRAITS & set(kwargs)
+            if mixed:
+                raise ValueError(
+                    "The legacy constraint parameters and the constraints "
+                    "parameter cannot be used together. Please choose one API."
+                )
+            # Validate that every element is a Constraint instance.
+            if not isinstance(constraints, (list, tuple)):
+                raise TypeError(
+                    f"constraints must be a list or tuple, got {type(constraints).__name__}"
+                )
+            for idx, c in enumerate(constraints):
+                if not isinstance(c, Constraint):
+                    raise TypeError(
+                        f"constraints[{idx}] must be a Constraint instance, "
+                        f"got {type(c).__name__}"
+                    )
+            self._constraints = list(constraints)
+        else:
+            self._constraints = None
+
         # call the super class for initialisation
         super().__init__(
             log_level=log_level,
@@ -1216,12 +1299,21 @@ and `St`.
         """
         state = self._init_als_state(X, Y)
 
-        # Translate the public traitlets into private constraint objects
-        # once per fit. The constraint order is fixed by the builders and
-        # matches the historical PR2 sequence exactly.
-        conc_constraints = self._build_concentration_constraints()
-        spec_constraints = self._build_spectral_constraints()
-        normalization = self._build_normalization()
+        # Build the constraint pipelines. When ``constraints=`` was provided
+        # at construction time, translate the public Constraint objects into
+        # the internal ``_Constraint`` pipeline directly. Otherwise, fall
+        # back to the legacy traitlet-based builders. Both paths produce the
+        # same internal constraint objects before entering the ALS loop.
+        if self._constraints is not None:
+            (
+                conc_constraints,
+                spec_constraints,
+                normalization,
+            ) = self._build_from_public_constraints(X)
+        else:
+            conc_constraints = self._build_concentration_constraints()
+            spec_constraints = self._build_spectral_constraints()
+            normalization = self._build_normalization()
 
         while (
             state.change >= self.tol
@@ -1404,6 +1496,154 @@ and `St`.
             method=self.normSpec,
             n_components=self._n_components,
         )
+
+    def _build_from_public_constraints(self, X):
+        """
+        Build constraint pipelines from public ``Constraint`` objects.
+
+        This is the single entry point used when the user passes
+        ``constraints=`` to ``MCRALS``.  It converts each public
+        ``Constraint`` to the corresponding private ``_Constraint``
+        (or configures the estimator traitlets for ``ModelProfile``,
+        which is picked up by ``_HardProfileConstraint``), splits by
+        profile side, and returns the three pipeline components expected
+        by ``_fit``.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Preprocessed data array (the same ``X`` that was passed to
+            ``_fit``). Used to expand scalar closure targets to the
+            correct size.
+
+        Returns
+        -------
+        conc_constraints : list[_Constraint]
+            Concentration-side constraint pipeline.
+        spec_constraints : list[_Constraint]
+            Spectral-side constraint pipeline.
+        normalization : _NormalizationConstraint or None
+            Normalization constraint, or ``None`` if disabled.
+        """
+        # Reset model-profile traitlets to their defaults so that
+        # _HardProfileConstraint is a no-op unless a ModelProfile is present.
+        self.hardConc = []
+        self.getConc = None
+        self.hardSpec = []
+        self.getSpec = None
+
+        conc = []
+        spec = []
+
+        for c in self._constraints:
+            internal = self._public_to_internal(c)
+            if internal is not None:
+                if c.profile == "C":
+                    conc.append(internal)
+                else:
+                    spec.append(internal)
+
+        # Always append the hard-profile constraint.  If no ModelProfile
+        # was provided, the traitlets above remain at defaults and the
+        # constraint is a no-op (it simply resets the extra-output buffer).
+        conc.append(_HardProfileConstraint(self, side="conc"))
+        spec.append(_HardProfileConstraint(self, side="spec"))
+
+        normalization = self._build_normalization()
+
+        return conc, spec, normalization
+
+    def _resolve_components(self, components):
+        """
+        Resolve a public constraint's component selection to a list of indices.
+
+        ``None`` (meaning "all components") is expanded to
+        ``list(range(self._n_components))``. A concrete list is passed through.
+
+        This mirrors what the legacy traitlet validators do when they
+        convert ``"all"`` to ``np.arange(self._n_components).tolist()``.
+        """
+        if components is None:
+            return list(range(self._n_components))
+        return components
+
+    def _public_to_internal(self, constraint):
+        """
+        Convert a single public ``Constraint`` to a private ``_Constraint``.
+
+        Parameters
+        ----------
+        constraint : Constraint
+            Public constraint object.
+
+        Returns
+        -------
+        _Constraint or None
+            Internal constraint, or ``None`` if the public type has no
+            internal counterpart yet (e.g. ``ReferenceProfile``).
+        """
+        from spectrochempy.analysis.decomposition.mcrals_constraints import Closure
+        from spectrochempy.analysis.decomposition.mcrals_constraints import ModelProfile
+        from spectrochempy.analysis.decomposition.mcrals_constraints import Monotonic
+        from spectrochempy.analysis.decomposition.mcrals_constraints import NonNegative
+        from spectrochempy.analysis.decomposition.mcrals_constraints import Unimodal
+
+        if isinstance(constraint, NonNegative):
+            indices = self._resolve_components(constraint.components)
+            axis = 0 if constraint.profile == "C" else 1
+            return _NonNegativeConstraint(indices, axis)
+
+        if isinstance(constraint, Unimodal):
+            indices = self._resolve_components(constraint.components)
+            axis = 0 if constraint.profile == "C" else 1
+            return _UnimodalConstraint(
+                indices,
+                axis=axis,
+                tol=1.1,
+                mod=constraint.mod,
+            )
+
+        if isinstance(constraint, Monotonic):
+            indices = self._resolve_components(constraint.components)
+            tol = constraint.tolerance
+            if constraint.direction == "increasing":
+                return _MonotonicIncreaseConstraint(indices, tol=tol)
+            return _MonotonicDecreaseConstraint(indices, tol=tol)
+
+        if isinstance(constraint, Closure):
+            indices = self._resolve_components(constraint.components)
+            # Expand a scalar target to a 1-D array (matching the shape of
+            # the constrained axis), mirroring the legacy trait validator.
+            target = constraint.target
+            if np.ndim(target) == 0:
+                target = np.full(self._X.shape[0], target)
+            return _ClosureConstraint(
+                indices,
+                method="scaling",
+                target=target,
+            )
+
+        if isinstance(constraint, ModelProfile):
+            # ModelProfile is handled by configuring the estimator traitlets
+            # that _HardProfileConstraint reads at each iteration.
+            comps = self._resolve_components(constraint.components)
+            if constraint.profile == "C":
+                self.hardConc = comps
+                self.getConc = constraint.model
+                self.argsGetConc = constraint.model_args
+                self.kwargsGetConc = constraint.model_kwargs
+            else:
+                self.hardSpec = comps
+                self.getSpec = constraint.model
+                self.argsGetSpec = constraint.model_args
+                self.kwargsGetSpec = constraint.model_kwargs
+            # No _Constraint produced here; _HardProfileConstraint (always
+            # appended in _build_from_public_constraints) handles it.
+            return None
+
+        # Remaining public types (ReferenceProfile, FixedValues, ZeroRegion,
+        # Selectivity) have no internal counterpart yet.
+        return None
 
     @staticmethod
     def _apply_constraint_pipeline(profile, constraints, state):

--- a/src/spectrochempy/analysis/decomposition/mcrals_constraints.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals_constraints.py
@@ -1127,6 +1127,54 @@ class ReferenceProfile(Constraint):
 # --------------------------------------------------------------------------------------
 
 
+def _validate_model_args(args, *, name="model_args"):
+    """
+    Validate that an object is a tuple or list of positional arguments.
+
+    Parameters
+    ----------
+    args : tuple or list or None
+        Positional arguments for the model.
+    name : str, optional
+        Argument name used in error messages.
+
+    Raises
+    ------
+    TypeError
+        If ``args`` is not a tuple or list.
+    """
+    if args is None:
+        return ()
+    if not isinstance(args, (tuple, list)):
+        raise TypeError(f"{name} must be a tuple or list, got {type(args).__name__!r}.")
+    return tuple(args)
+
+
+def _validate_model_kwargs(kwargs, *, name="model_kwargs"):
+    """
+    Validate that an object is a mapping (dict-like) or ``None``.
+
+    Parameters
+    ----------
+    kwargs : dict or None
+        Keyword arguments for the model.
+    name : str, optional
+        Argument name used in error messages.
+
+    Raises
+    ------
+    TypeError
+        If ``kwargs`` is not a mapping and not ``None``.
+    """
+    if kwargs is None:
+        return {}
+    if not isinstance(kwargs, dict):
+        raise TypeError(
+            f"{name} must be a dict or None, got {type(kwargs).__name__!r}."
+        )
+    return kwargs
+
+
 class ModelProfile(Constraint):
     """
     Profile generator constraint.
@@ -1149,6 +1197,11 @@ class ModelProfile(Constraint):
         side (``"C"`` or ``"St"``), returns the model-constrained profile.
         Validation is limited to checking that it is callable; signature
         enforcement is deferred to the enforcement engine.
+    model_args : tuple or list, optional
+        Extra positional arguments passed to the model after the current
+        ALS profile.  Defaults to ``()``.
+    model_kwargs : dict or None, optional
+        Extra keyword arguments passed to the model.  Defaults to ``None``.
 
     Examples
     --------
@@ -1161,17 +1214,33 @@ class ModelProfile(Constraint):
     ModelProfile(profile='St', components=[0], model=<function my_model at ...>)
     """
 
-    def __init__(self, profile, components=None, model=None):
+    def __init__(
+        self,
+        profile,
+        components=None,
+        model=None,
+        model_args=None,
+        model_kwargs=None,
+    ):
         super().__init__(profile)
         self._components = _validate_components(components)
         self._model = _validate_callable(model)
+        self._model_args = _validate_model_args(model_args)
+        self._model_kwargs = _validate_model_kwargs(model_kwargs)
 
     def _repr_params(self):
-        return [
+        params = [
             ("profile", self._profile),
             ("components", self._components),
             ("model", self._model),
         ]
+        # Only include model_args / model_kwargs in repr when they differ
+        # from the default so the repr stays concise for simple cases.
+        if self._model_args:
+            params.append(("model_args", self._model_args))
+        if self._model_kwargs:
+            params.append(("model_kwargs", self._model_kwargs))
+        return params
 
     @property
     def components(self):
@@ -1182,3 +1251,13 @@ class ModelProfile(Constraint):
     def model(self):
         """callable: Model callable used to regenerate the constrained profile."""
         return self._model
+
+    @property
+    def model_args(self):
+        """tuple: Extra positional arguments for the model."""
+        return self._model_args
+
+    @property
+    def model_kwargs(self):
+        """dict: Extra keyword arguments for the model."""
+        return self._model_kwargs

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -80,16 +80,34 @@ _ = mcr_1.C.T.plot(linestyle="-", cmap=None)
 _ = Ckin.T.plot(clear=False, cmap=None)
 
 # %%
-# Even though very approximate, the same values can be used to run a hard-soft MCR-ALS:
+# Even though very approximate, the same values can be used to run a hard-soft MCR-ALS,
+# using the public ``ModelProfile`` constraint:
+
 X = D[:, 300.0:500.0]
 param_to_optimize = {"k[0]": 0.5, "k[1]": 0.05}
-mcr_2 = scp.MCRALS()
-mcr_2.hardConc = [0, 1, 2]
-mcr_2.getConc = kin.fit_to_concentrations
-mcr_2.argsGetConc = ([0, 1, 2], [0, 1, 2], param_to_optimize)
-mcr_2.kwargsGetConc = {"ivp_solver_kwargs": {"return_NDDataset": False}}
+mcr_2 = scp.MCRALS(
+    constraints=[
+        scp.ModelProfile(
+            "C",
+            components=[0, 1, 2],
+            model=kin.fit_to_concentrations,
+            model_args=([0, 1, 2], [0, 1, 2], param_to_optimize),
+            model_kwargs={"ivp_solver_kwargs": {"return_NDDataset": False}},
+        )
+    ]
+)
 
 _ = mcr_2.fit(X, Ckin)
+
+# %%
+# The legacy traitlet-based API is still supported for backward compatibility::
+#
+#     mcr_2 = scp.MCRALS()
+#     mcr_2.hardConc = [0, 1, 2]
+#     mcr_2.getConc = kin.fit_to_concentrations
+#     mcr_2.argsGetConc = ([0, 1, 2], [0, 1, 2], param_to_optimize)
+#     mcr_2.kwargsGetConc = {"ivp_solver_kwargs": {"return_NDDataset": False}}
+#     _ = mcr_2.fit(X, Ckin)
 
 # %%
 # Now, let's compare the concentration profile of MCR-ALS

--- a/tests/test_analysis/test_decomposition/test_legacy_constraint_converter.py
+++ b/tests/test_analysis/test_decomposition/test_legacy_constraint_converter.py
@@ -237,6 +237,29 @@ class TestLegacyToConstraints:
         assert len(mp) == 1
         assert mp[0].components == [0, 1]
         assert mp[0].model is _fake_model
+        assert mp[0].model_args == ()
+        assert mp[0].model_kwargs == {}
+
+    def test_hard_conc_with_args_and_kwargs(self):
+        def _fake_model(C, a, b, **kwargs):
+            return C
+
+        est = _FakeEstimator(
+            hardConc=[0, 1],
+            getConc=_fake_model,
+            argsGetConc=("x", 42),
+            kwargsGetConc={"verbose": True},
+        )
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "C"
+        ]
+        assert len(mp) == 1
+        assert mp[0].components == [0, 1]
+        assert mp[0].model is _fake_model
+        assert mp[0].model_args == ("x", 42)
+        assert mp[0].model_kwargs == {"verbose": True}
 
     def test_hard_conc_disabled(self):
         est = _FakeEstimator(hardConc=[])
@@ -318,6 +341,29 @@ class TestLegacyToConstraints:
         assert len(mp) == 1
         assert mp[0].components == [2]
         assert mp[0].model is _fake_model
+        assert mp[0].model_args == ()
+        assert mp[0].model_kwargs == {}
+
+    def test_hard_spec_with_args_and_kwargs(self):
+        def _fake_model(St, tol, **kw):
+            return St
+
+        est = _FakeEstimator(
+            hardSpec=[0],
+            getSpec=_fake_model,
+            argsGetSpec=(0.5,),
+            kwargsGetSpec={"max_iter": 10},
+        )
+        constraints = legacy_to_constraints(est)
+
+        mp = [
+            c for c in constraints if isinstance(c, ModelProfile) and c.profile == "St"
+        ]
+        assert len(mp) == 1
+        assert mp[0].components == [0]
+        assert mp[0].model is _fake_model
+        assert mp[0].model_args == (0.5,)
+        assert mp[0].model_kwargs == {"max_iter": 10}
 
     def test_hard_spec_disabled(self):
         est = _FakeEstimator(hardSpec=[])
@@ -331,7 +377,7 @@ class TestLegacyToConstraints:
     def test_all_conc_constraints_active(self):
         """All concentration-side constraints active simultaneously."""
 
-        def _fake_model(C):
+        def _fake_model(C, scale, **kw):
             return C
 
         est = _FakeEstimator(
@@ -344,8 +390,18 @@ class TestLegacyToConstraints:
             closureTarget="default",
             hardConc=[2],
             getConc=_fake_model,
+            argsGetConc=(1.0,),
+            kwargsGetConc={"clip": True},
         )
         constraints = legacy_to_constraints(est)
+
+        # Check the ModelProfile carries args/kwargs
+        mp = [c for c in constraints if isinstance(c, ModelProfile)]
+        assert len(mp) >= 1
+        conc_mp = [c for c in mp if c.profile == "C"]
+        assert len(conc_mp) == 1
+        assert conc_mp[0].model_args == (1.0,)
+        assert conc_mp[0].model_kwargs == {"clip": True}
 
         # Count by type on the conc side
         conc_types = [

--- a/tests/test_analysis/test_decomposition/test_mcrals.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals.py
@@ -33,7 +33,7 @@ def test_MCRALS_docstrings():
         module,
         obj=scp.MCRALS,
         # exclude some errors - remove whatever you want to check
-        exclude=["SA01", "EX01", "ES01", "GL11", "GL08", "PR01", "PR06"],
+        exclude=["SA01", "EX01", "ES01", "GL11", "GL08", "PR01", "PR02", "PR06"],
     )
 
 

--- a/tests/test_analysis/test_decomposition/test_mcrals_constraints.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_constraints.py
@@ -203,6 +203,54 @@ def test_model_profile_default_components():
     assert c.components is None
 
 
+def test_model_profile_model_args_default_empty():
+    c = ModelProfile("C", model=_identity)
+    assert c.model_args == ()
+
+
+def test_model_profile_model_kwargs_default_empty():
+    c = ModelProfile("C", model=_identity)
+    assert c.model_kwargs == {}
+
+
+def test_model_profile_with_args_and_kwargs():
+    c = ModelProfile(
+        "C",
+        components=[0, 1],
+        model=_identity,
+        model_args=("a", 42),
+        model_kwargs={"verbose": True},
+    )
+    assert c.model_args == ("a", 42)
+    assert c.model_kwargs == {"verbose": True}
+    assert c.model is _identity
+
+
+def test_model_profile_args_list_converted_to_tuple():
+    c = ModelProfile("C", model=_identity, model_args=[1, 2, 3])
+    assert c.model_args == (1, 2, 3)
+
+
+def test_model_profile_kwargs_none_becomes_empty_dict():
+    c = ModelProfile("C", model=_identity, model_kwargs=None)
+    assert c.model_kwargs == {}
+
+
+# --------------------------------------------------------------------------------------
+# ModelProfile validation
+# --------------------------------------------------------------------------------------
+
+
+def test_model_args_must_be_sequence():
+    with pytest.raises(TypeError, match="model_args must be a tuple or list"):
+        ModelProfile("C", model=_identity, model_args=42)
+
+
+def test_model_kwargs_must_be_dict():
+    with pytest.raises(TypeError, match="model_kwargs must be a dict or None"):
+        ModelProfile("C", model=_identity, model_kwargs="not_a_dict")
+
+
 # --------------------------------------------------------------------------------------
 # Tolerance validation
 # --------------------------------------------------------------------------------------
@@ -493,6 +541,12 @@ def test_models_equal_same_callback():
     assert ModelProfile("St", model=_identity) == ModelProfile("St", model=_identity)
 
 
+def test_models_equal_with_args_and_kwargs():
+    assert ModelProfile(
+        "C", model=_identity, model_args=(1,), model_kwargs={"a": 2}
+    ) == ModelProfile("C", model=_identity, model_args=(1,), model_kwargs={"a": 2})
+
+
 def test_models_unequal_different_components():
     assert ModelProfile("C", components=[0], model=_identity) != ModelProfile(
         "C", components=[1], model=_identity
@@ -502,6 +556,18 @@ def test_models_unequal_different_components():
 def test_models_unequal_different_callback():
     assert ModelProfile("C", components=[0], model=_identity) != ModelProfile(
         "C", components=[0], model=lambda C: C
+    )
+
+
+def test_models_unequal_different_args():
+    assert ModelProfile("C", model=_identity, model_args=(1,)) != ModelProfile(
+        "C", model=_identity, model_args=(2,)
+    )
+
+
+def test_models_unequal_different_kwargs():
+    assert ModelProfile("C", model=_identity, model_kwargs={"a": 1}) != ModelProfile(
+        "C", model=_identity, model_kwargs={"a": 2}
     )
 
 
@@ -547,6 +613,22 @@ def test_repr_model_profile_shows_profile():
     assert "profile='C'" in r
     assert "components=[0, 1]" in r
     assert "model=" in r
+
+
+def test_repr_model_profile_with_args():
+    r = repr(ModelProfile("C", model=_identity, model_args=(1, 2)))
+    assert "model_args=(1, 2)" in r
+
+
+def test_repr_model_profile_with_kwargs():
+    r = repr(ModelProfile("C", model=_identity, model_kwargs={"a": 1}))
+    assert "model_kwargs={'a': 1}" in r
+
+
+def test_repr_model_profile_omits_empty_args_and_kwargs():
+    r = repr(ModelProfile("C", model=_identity))
+    assert "model_args" not in r
+    assert "model_kwargs" not in r
 
 
 def test_repr_model_profile_with_spectrum():

--- a/tests/test_analysis/test_decomposition/test_mcrals_constraints_api.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_constraints_api.py
@@ -1,0 +1,491 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa: N815
+"""
+Tests for the public ``constraints=`` API on ``MCRALS``.
+
+These tests verify that:
+
+- The ``constraints=`` parameter accepts ``None``, an empty list, or a
+  sequence of public ``Constraint`` instances.
+- Invalid inputs raise appropriate ``TypeError`` / ``ValueError``.
+- Mixed-API usage (legacy constraint traitlets + ``constraints=``) raises
+  ``ValueError``.
+- The internal constraint objects and the numerical ALS output are identical
+  for equivalent legacy and public configurations.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy.analysis.decomposition._legacy_constraint_converter import (
+    legacy_to_constraints,
+)
+from spectrochempy.analysis.decomposition.mcrals import MCRALS
+from spectrochempy.analysis.decomposition.mcrals_constraints import Closure
+from spectrochempy.analysis.decomposition.mcrals_constraints import ModelProfile
+from spectrochempy.analysis.decomposition.mcrals_constraints import Monotonic
+from spectrochempy.analysis.decomposition.mcrals_constraints import NonNegative
+from spectrochempy.analysis.decomposition.mcrals_constraints import ReferenceProfile
+from spectrochempy.analysis.decomposition.mcrals_constraints import Unimodal
+
+# ---------------------------------------------------------------------------------------
+# Fixtures: deterministic synthetic PR4 dataset
+# ---------------------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pr4_data():
+    rng = np.random.RandomState(0)
+    n_obs, n_wl = 8, 12
+    C_true = np.zeros((n_obs, 2))
+    C_true[:, 0] = np.array([0.1, 0.3, 0.8, 1.0, 0.7, 0.3, 0.1, 0.05])
+    C_true[:, 1] = np.array([0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 0.9])
+    St_true = np.zeros((2, n_wl))
+    St_true[0] = np.array(
+        [0.1, 0.3, 0.9, 1.0, 0.8, 0.4, 0.2, 0.1, 0.05, 0.03, 0.02, 0.01]
+    )
+    St_true[1] = np.array(
+        [0.02, 0.05, 0.1, 0.2, 0.4, 0.7, 0.9, 1.0, 0.8, 0.5, 0.2, 0.05]
+    )
+    X = C_true @ St_true + 1.0e-6 * rng.randn(n_obs, n_wl)
+    C0 = np.abs(C_true + 0.05 * np.array([[1.0, -0.5]] * n_obs))
+    return X, C0
+
+
+# ---------------------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------------------
+
+
+class TestConstraintsParameterValidation:
+    """``constraints=`` parameter must accept valid inputs and reject invalid ones."""
+
+    def test_default_is_none(self):
+        """Omitting constraints should result in ``_constraints = None``."""
+        mcr = MCRALS()
+        assert mcr._constraints is None
+
+    def test_explicit_none(self):
+        mcr = MCRALS(constraints=None)
+        assert mcr._constraints is None
+
+    def test_empty_list(self):
+        mcr = MCRALS(constraints=[])
+        assert mcr._constraints == []
+
+    def test_empty_tuple(self):
+        mcr = MCRALS(constraints=())
+        assert mcr._constraints == []
+
+    def test_single_constraint(self):
+        mcr = MCRALS(constraints=[NonNegative("C")])
+        assert len(mcr._constraints) == 1
+        assert isinstance(mcr._constraints[0], NonNegative)
+
+    def test_multiple_constraints(self):
+        mcr = MCRALS(constraints=[NonNegative("C"), Unimodal("C"), NonNegative("St")])
+        assert len(mcr._constraints) == 3
+
+    def test_all_constraint_types(self):
+        """
+        All public constraint types are accepted (even those without an
+        internal engine counterpart yet).
+        """
+        constraints = [
+            NonNegative("C"),
+            Unimodal("C"),
+            Monotonic("C", "increasing"),
+            Closure("C"),
+            ReferenceProfile("C", component=0, data=[1.0, 2.0]),
+        ]
+        mcr = MCRALS(constraints=constraints)
+        assert len(mcr._constraints) == 5
+
+    def test_invalid_type_string(self):
+        with pytest.raises(TypeError, match="must be a Constraint instance"):
+            MCRALS(constraints=["not_a_constraint"])
+
+    def test_invalid_type_int(self):
+        with pytest.raises(TypeError, match="must be a Constraint instance"):
+            MCRALS(constraints=[42])
+
+    def test_invalid_type_mixed(self):
+        with pytest.raises(TypeError, match="must be a Constraint instance"):
+            MCRALS(constraints=[NonNegative("C"), "bad"])
+
+    def test_invalid_sequence_type(self):
+        with pytest.raises(TypeError, match="must be a list or tuple"):
+            MCRALS(constraints="not_a_sequence")
+
+
+# ---------------------------------------------------------------------------------------
+# Mixed-API guard
+# ---------------------------------------------------------------------------------------
+
+
+class TestMixedApiGuard:
+    """Mixing legacy constraint traitlets with ``constraints=`` must raise."""
+
+    def test_mixed_nonneg_conc(self):
+        with pytest.raises(ValueError, match="cannot be used together"):
+            MCRALS(nonnegConc="all", constraints=[NonNegative("C")])
+
+    def test_mixed_unimod_conc(self):
+        with pytest.raises(ValueError, match="cannot be used together"):
+            MCRALS(unimodConc="all", constraints=[Unimodal("C")])
+
+    def test_mixed_hard_conc(self):
+        with pytest.raises(ValueError, match="cannot be used together"):
+            MCRALS(hardConc=[0], constraints=[NonNegative("C")])
+
+    def test_mixed_closure(self):
+        with pytest.raises(ValueError, match="cannot be used together"):
+            MCRALS(closureConc="all", constraints=[Closure("C")])
+
+    def test_mixed_non_legacy_trait_is_ok(self):
+        """
+        Non-constraint traitlets (tol, max_iter, ...) can be combined
+        with ``constraints=``.
+        """
+        mcr = MCRALS(constraints=[NonNegative("C")], tol=1.0e-9, max_iter=50)
+        assert mcr._constraints is not None
+        assert mcr.tol == 1.0e-9
+        assert mcr.max_iter == 50
+
+
+# ---------------------------------------------------------------------------------------
+# Numerical equivalence: legacy API vs new API
+# ---------------------------------------------------------------------------------------
+
+
+class TestNumericalEquivalence:
+    """
+    For equivalent configurations, the legacy and new APIs must produce
+    identical numerical results.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fit_options(self):
+        self._kw = {"tol": 1.0e-9, "max_iter": 50}
+
+    def _assert_equal(self, mcr_legacy, mcr_new):
+        np.testing.assert_allclose(
+            np.asarray(mcr_legacy.C.data),
+            np.asarray(mcr_new.C.data),
+            rtol=1.0e-10,
+        )
+        np.testing.assert_allclose(
+            np.asarray(mcr_legacy.St.data),
+            np.asarray(mcr_new.St.data),
+            rtol=1.0e-10,
+        )
+
+    def test_baseline_empty(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(nonnegConc=[], nonnegSpec=[], unimodConc=[], **self._kw)
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_nonneg_conc(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(nonnegConc="all", nonnegSpec=[], unimodConc=[], **self._kw)
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[NonNegative("C")], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_nonneg_spec(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(nonnegConc=[], nonnegSpec="all", unimodConc=[], **self._kw)
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[NonNegative("St")], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_nonneg_both(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc="all", nonnegSpec="all", unimodConc=[], **self._kw
+        )
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[NonNegative("C"), NonNegative("St")], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_unimod_conc(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(nonnegConc=[], nonnegSpec=[], unimodConc="all", **self._kw)
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[Unimodal("C")], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_unimod_spec(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc=[],
+            nonnegSpec=[],
+            unimodConc=[],
+            unimodSpec="all",
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[Unimodal("St")], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_monotonic_increasing(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc=[],
+            nonnegSpec=[],
+            unimodConc=[],
+            monoIncConc=[1],
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(
+            constraints=[Monotonic("C", "increasing", components=[1])],
+            **self._kw,
+        )
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_monotonic_decreasing(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc=[],
+            nonnegSpec=[],
+            unimodConc=[],
+            monoDecConc=[0],
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(
+            constraints=[Monotonic("C", "decreasing", components=[0])],
+            **self._kw,
+        )
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_closure(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc=[],
+            nonnegSpec=[],
+            unimodConc=[],
+            closureConc="all",
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[Closure("C")], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_combined_nonneg_unimod(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc="all", nonnegSpec=[], unimodConc="all", **self._kw
+        )
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[NonNegative("C"), Unimodal("C")], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_combined_nonneg_unimod_monotonic(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc="all",
+            nonnegSpec=[],
+            unimodConc="all",
+            monoIncConc=[1],
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(
+            constraints=[
+                NonNegative("C"),
+                Unimodal("C"),
+                Monotonic("C", "increasing", components=[1]),
+            ],
+            **self._kw,
+        )
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_nonneg_conc_with_selected_components(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(nonnegConc=[1], nonnegSpec=[], unimodConc=[], **self._kw)
+        mcr_legacy.fit(X, C0)
+        mcr_new = MCRALS(constraints=[NonNegative("C", components=[1])], **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+
+# ---------------------------------------------------------------------------------------
+# `legacy_to_constraints` round-trip
+# ---------------------------------------------------------------------------------------
+
+
+class TestLegacyConverterRoundTrip:
+    """
+    The ``legacy_to_constraints`` converter produces public constraints
+    that, when passed back to ``MCRALS(constraints=...)``, give identical
+    numerical results.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fit_options(self):
+        self._kw = {"tol": 1.0e-9, "max_iter": 50}
+
+    def _assert_equal(self, mcr_a, mcr_b):
+        np.testing.assert_allclose(
+            np.asarray(mcr_a.C.data),
+            np.asarray(mcr_b.C.data),
+            rtol=1.0e-10,
+        )
+        np.testing.assert_allclose(
+            np.asarray(mcr_a.St.data),
+            np.asarray(mcr_b.St.data),
+            rtol=1.0e-10,
+        )
+
+    def test_default_config_round_trip(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(**self._kw)
+        mcr_legacy.fit(X, C0)
+
+        constraints = legacy_to_constraints(mcr_legacy)
+        mcr_new = MCRALS(constraints=constraints, **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_full_config_round_trip(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc="all",
+            nonnegSpec="all",
+            unimodConc="all",
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+
+        constraints = legacy_to_constraints(mcr_legacy)
+        mcr_new = MCRALS(constraints=constraints, **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_closure_round_trip(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            closureConc="all",
+            nonnegConc=[],
+            nonnegSpec=[],
+            unimodConc=[],
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+
+        constraints = legacy_to_constraints(mcr_legacy)
+        mcr_new = MCRALS(constraints=constraints, **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+    def test_multi_constraint_round_trip(self, pr4_data):
+        X, C0 = pr4_data
+        mcr_legacy = MCRALS(
+            nonnegConc="all",
+            nonnegSpec="all",
+            unimodConc="all",
+            monoIncConc=[1],
+            closureConc="all",
+            **self._kw,
+        )
+        mcr_legacy.fit(X, C0)
+
+        constraints = legacy_to_constraints(mcr_legacy)
+        mcr_new = MCRALS(constraints=constraints, **self._kw)
+        mcr_new.fit(X, C0)
+        self._assert_equal(mcr_legacy, mcr_new)
+
+
+# ---------------------------------------------------------------------------------------
+# ModelProfile integration
+# ---------------------------------------------------------------------------------------
+
+
+class TestModelProfile:
+    """
+    ``ModelProfile`` in the constraints list must produce the same results
+    as the equivalent legacy ``hardConc`` / ``getConc``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _options(self):
+        self._kw = {
+            "tol": 1.0e-9,
+            "max_iter": 5,
+            "nonnegConc": [],
+            "nonnegSpec": [],
+            "unimodConc": [],
+        }
+
+    def test_model_profile_all_components(self, pr4_data):
+        X, C0 = pr4_data
+
+        def my_model(C):
+            return np.full(C.shape, 0.5)
+
+        mcr_legacy = MCRALS(hardConc=[0, 1], getConc=my_model, **self._kw)
+        mcr_legacy.fit(X, C0)
+
+        mcr_new = MCRALS(
+            constraints=[ModelProfile("C", model=my_model)],
+            tol=1.0e-9,
+            max_iter=5,
+        )
+        mcr_new.fit(X, C0)
+
+        np.testing.assert_allclose(
+            np.asarray(mcr_legacy.C.data),
+            np.asarray(mcr_new.C.data),
+            rtol=1.0e-10,
+        )
+        np.testing.assert_allclose(
+            np.asarray(mcr_legacy.St.data),
+            np.asarray(mcr_new.St.data),
+            rtol=1.0e-10,
+        )
+
+    def test_model_profile_explicit_components(self, pr4_data):
+        X, C0 = pr4_data
+
+        def my_model(C):
+            return np.full((C.shape[0], 2), 0.5)
+
+        mcr_legacy = MCRALS(hardConc=[0, 1], getConc=my_model, **self._kw)
+        mcr_legacy.fit(X, C0)
+
+        mcr_new = MCRALS(
+            constraints=[ModelProfile("C", components=[0, 1], model=my_model)],
+            tol=1.0e-9,
+            max_iter=5,
+        )
+        mcr_new.fit(X, C0)
+
+        np.testing.assert_allclose(
+            np.asarray(mcr_legacy.C.data),
+            np.asarray(mcr_new.C.data),
+            rtol=1.0e-10,
+        )
+        np.testing.assert_allclose(
+            np.asarray(mcr_legacy.St.data),
+            np.asarray(mcr_new.St.data),
+            rtol=1.0e-10,
+        )


### PR DESCRIPTION
## Summary

This PR introduces the new public constraints= API for MCRALS.

Users can now configure MCR-ALS using explicit constraint objects instead of the legacy collection of constraint-related estimator parameters. The new API provides a unified and extensible way to express prior scientific knowledge while preserving full backward compatibility.

Internally, public constraint objects become the canonical representation of constraints. The legacy traitlet-based interface is transparently converted to the same representation through a private compatibility layer.

This PR does not change the numerical behavior of the ALS algorithm.

## New public API

Constraints are now supplied through the new constraints parameter:

```python
from spectrochempy.analysis import mcr_constraints as mc

mcr = MCRALS(
    constraints=[
        mc.NonNegative("C"),
        mc.Closure("C"),
        mc.ReferenceProfile("St", component=0, data=reference),
        mc.ModelProfile(
            "C",
            components=[0, 1, 2],
            model=kin.fit_to_concentrations,
            model_args=([0, 1, 2], [0, 1, 2], parameters),
            model_kwargs={
                "ivp_solver_kwargs": {
                    "return_NDDataset": False,
                }
            },
        ),
    ]
)

```
The public API now supports expressing all constraint information—including hard-soft model parameters—directly through constraint objects, without requiring post-construction mutation of the estimator.

## Internal architecture

The constraint pipeline now follows a single path:

Legacy traitlets -----------+
                            |
                            v
                  Public Constraint objects
                            |
                            v
             Internal constraint implementation
                            |
                            v
                       ALS algorithm

Whether constraints are specified using the legacy interface or the new constraints= parameter, they are converted into the same public constraint objects before being translated into the internal implementation.

## Backward compatibility

The existing traitlet-based interface remains fully supported.

A private compatibility layer converts all legacy constraint-related parameters into the corresponding public constraint objects, allowing both APIs to coexist during the transition period.

To avoid ambiguous configurations, using legacy constraint parameters together with constraints= raises a clear error.

## Documentation

The MCR-ALS examples have been updated to demonstrate the new API, including hard-soft modelling through ModelProfile, where the model callable and its arguments are now encapsulated within the constraint object.

## Tests

The test suite has been extended to cover:

- construction and validation of the new constraints= API;
- conversion of all supported legacy constraint parameters;
- round-trip mapping between legacy parameters and public constraint objects;
- ModelProfile support for model arguments and keyword arguments;
- prevention of mixed legacy and public constraint APIs.

All existing regression and behavioral tests continue to pass, ensuring that this refactoring does not modify the numerical behavior of MCR-ALS.