### PR TITLE
FIX: align plotmerit tutorial figure layout

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -499,15 +499,16 @@ errors  # should be an empty list if the script is valid
 # - `autoampl=True` adjusts initial amplitudes automatically;
 # - `amplitude_mode="height"` or `"area"` controls how line-shape amplitudes
 #   are initialized;
-# - `warm_start=True` reuses the previous fitted state when fitting repeatedly
-#   on related problems.
+# - `warm_start=True` preserves the current estimator configuration instead of
+#   forcing a full reset to default configuration values during estimator
+#   reinitialization.
 #
 # These options do not all answer the same question:
 #
 # - `method` chooses **how** the numerical search is run;
 # - `dry`, `autobase`, `autoampl`, and `amplitude_mode` help define **how the fit starts**;
-# - `warm_start` helps when you repeat fits in a sequence rather than solving a
-#   single isolated problem.
+# - `warm_start` is a broader estimator-state option and should not be read as
+#   a dedicated `Optimize` solver warm-start backend.
 
 # %% [markdown]
 # The availability of advanced post-fit quantities depends on the chosen method.
@@ -560,11 +561,18 @@ ax.autoscale(enable=True, axis="y")
 # %% [markdown]
 # `plotmerit()` overlays the experimental spectrum, the fitted profile, and the
 # residuals. Here we use a small residual offset to keep the three traces easy
-# to inspect in a notebook.
+# to inspect in a notebook. Short legend labels and an explicit legend position
+# keep the annotation clear on the compact tutorial figure.
 
 # %%
 som = fitted
-_ = f1.plotmerit(offset=15)
+_ = f1.plotmerit(
+    offset=15,
+    exp_label="exp",
+    calc_label="fit",
+    resid_label="res",
+    legend_loc="upper left",
+)
 
 
 # %% [markdown]

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -252,10 +252,17 @@ ax.autoscale(enable=True, axis="y")
 # %% [markdown]
 # `plotmerit()` overlays the corrected spectrum, the fitted profile, and the
 # residuals. As in the fitting tutorial, we use a small residual offset to keep
-# the comparison readable in a notebook.
+# the comparison readable in a notebook, with short legend labels to avoid
+# crowding the compact tutorial figure.
 
 # %%
-_ = opt.plotmerit(offset=15)
+_ = opt.plotmerit(
+    offset=15,
+    exp_label="exp",
+    calc_label="fit",
+    resid_label="res",
+    legend_loc="upper left",
+)
 
 # %% [markdown]
 # ## Summary

--- a/src/spectrochempy/plotting/composite/plotmerit.py
+++ b/src/spectrochempy/plotting/composite/plotmerit.py
@@ -16,12 +16,11 @@ plotmerit:
 
 __all__ = ["plot_merit", "plot_compare"]
 
-import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.lines import Line2D
 
-from spectrochempy.application.preferences import preferences as prefs
 from spectrochempy.plotting._render import render_lines
+from spectrochempy.utils.mplutils import get_figure
 from spectrochempy.utils.mplutils import make_label
 from spectrochempy.utils.mplutils import show as mpl_show
 
@@ -31,10 +30,9 @@ from spectrochempy.utils.mplutils import show as mpl_show
 
 
 def _make_default_axes():
-    """Create an axes using the current SpectroChemPy figure-size preference."""
-    figsize = tuple(prefs.figure.figsize)
-    _, ax = plt.subplots(figsize=figsize)
-    return ax
+    """Create an axes using the standard SpectroChemPy figure factory."""
+    fig = get_figure()
+    return fig.add_subplot(1, 1, 1)
 
 
 def plot_compare(
@@ -56,6 +54,10 @@ def plot_compare(
     exp_linewidth=1.0,
     calc_linewidth=1.6,
     resid_linewidth=1.0,
+    exp_label=None,
+    calc_label=None,
+    resid_label="difference",
+    legend_loc="best",
     kind=None,
     method=None,
     offset=None,
@@ -279,7 +281,7 @@ def plot_compare(
             color=orig_color[0],
             linestyle=orig_linestyle[0],
             marker=marker_kwargs.get("markers", [None])[0],
-            label=X.name,
+            label=exp_label or X.name,
         ),
         Line2D(
             [0],
@@ -287,7 +289,7 @@ def plot_compare(
             color=ref_color[0],
             linestyle=ref_linestyle[0],
             marker=marker_kwargs.get("markers", [None])[0],
-            label=X_ref.name,
+            label=calc_label or X_ref.name,
         ),
     ]
 
@@ -299,11 +301,11 @@ def plot_compare(
                 color=resid_color[0],
                 linestyle=resid_linestyle[0],
                 marker=marker_kwargs.get("markers", [None])[0],
-                label="difference",
+                label=resid_label,
             ),
         )
 
-    ax.legend(handles=handles, loc="best")
+    ax.legend(handles=handles, loc=legend_loc)
 
     # ----------------------------
     # Title

--- a/tests/test_plotting/test_composite_imports.py
+++ b/tests/test_plotting/test_composite_imports.py
@@ -105,8 +105,34 @@ class TestPlotMeritImports:
             ax = plot_compare(X, X_ref, show=False)
             width, height = ax.figure.get_size_inches()
             np.testing.assert_allclose((width, height), (7.0, 3.0))
+            assert ax.figure.get_tight_layout() is True
         finally:
             preferences.figure.figsize = original_figsize
+
+    def test_plot_compare_accepts_short_legend_labels_and_position(
+        self,
+        sample_1d_dataset,
+    ):
+        """Legend labels and location should be customizable for compact figures."""
+        from spectrochempy.plotting.composite.plotmerit import plot_compare
+
+        X = sample_1d_dataset
+        X_ref = X.copy()
+        X_ref.name = "fit"
+
+        ax = plot_compare(
+            X,
+            X_ref,
+            exp_label="exp",
+            calc_label="fit",
+            resid_label="res",
+            legend_loc="upper left",
+            show=False,
+        )
+
+        legend = ax.get_legend()
+        assert legend is not None
+        assert [text.get_text() for text in legend.get_texts()] == ["exp", "fit", "res"]
 
 
 class TestMultiplotImports:


### PR DESCRIPTION
Route standalone plotmerit / plot_compare figures through the standard SpectroChemPy figure factory so they inherit figure_autolayout, and add compact legend controls used by the fitting tutorials to avoid overlap.