### PR TITLE
MAINT: clarify and validate Optimize user API

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -459,6 +459,32 @@ errors  # should be an empty list if the script is valid
 # references are recognised.
 
 # %% [markdown]
+# `Optimize` also exposes `validate_constraints()` for lightweight validation of
+# constraint specifications before fitting. At the moment this is deliberately a
+# narrow surface: it validates the structure of recognized constraint specs and
+# any referenced parameter names from the script, but it should not yet be read
+# as a complete guarantee of backend-level constraint enforcement.
+#
+# The currently supported minimal schema is intentionally small. For example,
+# the following constraint specification is accepted and normalized:
+#
+# %%
+constraint_spec = {"max_connections": 2}
+f1.validate_constraints(constraint_spec)
+f1.constraints = constraint_spec
+f1.constraints
+
+# %% [markdown]
+# This currently demonstrates **validation and normalization of the public
+# constraint surface**. It should not yet be read as a promise of rich
+# constraint semantics during optimization. The short form shown above is
+# normalized to the canonical stored form:
+#
+# - short form: `{"max_connections": 2}`
+# - canonical form:
+#   `{"type": "max_connections", "limit": 2, "parameters": None}`
+
+# %% [markdown]
 # #### Choosing a fitting method
 #
 # `Optimize` currently exposes four public values for `method`:
@@ -468,25 +494,35 @@ errors  # should be an empty list if the script is valid
 # - `simplex`
 # - `basinhopping`
 #
-# In practice, these fall into three families:
+# In practice, these fall into three maintained families:
 #
-# | Public method | Type of search | Current internal path | Jacobian / covariance path |
-# | --- | --- | --- | --- |
-# | `least_squares` | local least-squares fit | SciPy `least_squares()` | yes, when available |
-# | `leastsq` | local least-squares fit | same SciPy `least_squares()` path | yes, when available |
-# | `simplex` | local derivative-free search | SciPy simplex (`fmin`) path | no |
-# | `basinhopping` | global-style exploratory search | SciPy `basinhopping()` | no |
+# | Public method | Current role | Type of search | Current internal path | Jacobian / covariance path |
+# | --- | --- | --- | --- | --- |
+# | `least_squares` | recommended local least-squares entrypoint | local least-squares fit | SciPy `least_squares()` | yes, when available |
+# | `leastsq` | compatibility alias | local least-squares fit | same SciPy `least_squares()` path | yes, when available |
+# | `simplex` | derivative-free local fallback | local derivative-free search | SciPy simplex (`fmin`) path | no |
+# | `basinhopping` | exploratory global-style option | global-style exploratory search | SciPy `basinhopping()` | no |
 #
-# A practical rule of thumb is:
+# The main user-facing guidance is:
 #
 # - start with `least_squares` for ordinary peak fitting and most well-initialized models;
-# - try `simplex` when you want a derivative-free local search;
-# - try `basinhopping` only when the landscape is difficult enough to justify a slower global-style exploration.
+# - treat `leastsq` mainly as a backwards-compatible spelling, not as a distinct maintained strategy;
+# - try `simplex` when you want a derivative-free local search and can accept losing the least-squares uncertainty path;
+# - try `basinhopping` only when the landscape is difficult enough to justify a slower exploratory search.
 #
 # The current implementation automatically chooses between the least-squares
 # backend variants `lm` and `trf` depending on the size of the varying-parameter
 # problem. This choice is internal: users select the high-level `method`, not
 # the low-level SciPy backend directly.
+
+# %%
+method_summary = {
+    "recommended_default": "least_squares",
+    "compatibility_alias": "leastsq",
+    "derivative_free_local": "simplex",
+    "exploratory_global": "basinhopping",
+}
+method_summary
 
 # %% [markdown]
 # #### Other useful fitting modes
@@ -533,6 +569,27 @@ components = f1.result.components
 # existing direct estimator surface. Direct access such as `f1.components`,
 # `f1.predict()`, and plotting helpers remains supported.
 #
+# `f1.result.parameters` stores the configuration snapshot of the completed
+# run: method choice, iteration limits, and fit-preparation options such as
+# `dry`, `autobase`, `autoampl`, `amplitude_mode`, and normalized
+# `constraints`. It should be read as **run configuration**, not as a table of
+# solved scientific parameter values.
+#
+# %%
+{
+    key: f1.result.parameters[key]
+    for key in (
+        "method",
+        "max_iter",
+        "dry",
+        "autobase",
+        "autoampl",
+        "amplitude_mode",
+        "constraints",
+    )
+}
+
+# %% [markdown]
 # Raw solver artifacts stay on the estimator. Least-squares-backed methods keep
 # the retained Jacobian on `f1.jacobian`, while `simplex`, `basinhopping`, and
 # dry fits return `None`. `f1.result.covariance` is the first scientific

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -215,11 +215,27 @@ fit_result
 # `FitResult` groups fitted outputs and diagnostics.  The existing estimator
 # surface (`opt.predict()`, `opt.components`, plotting helpers, and so on)
 # remains available, but `opt.result` is the stable result object for inspection.
+#
+# `fit_result.parameters` stores the configuration snapshot of the completed
+# run, not a solved parameter table. It records how the fit was executed
+# (`method`, `dry`, `autobase`, `autoampl`, and related settings), while the
+# diagnostics and uncertainty surfaces describe the result of that run.
 
 # %%
 components = fit_result.components
 
 {
+    "run_parameters": {
+        key: fit_result.parameters[key]
+        for key in (
+            "method",
+            "max_iter",
+            "dry",
+            "autobase",
+            "autoampl",
+            "amplitude_mode",
+        )
+    },
     "r_squared": fit_result.diagnostics["r_squared"],
     "adjusted_r_squared": fit_result.diagnostics["adjusted_r_squared"],
     "rmse": fit_result.diagnostics["rmse"],

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -39,7 +39,11 @@ New Features
 - The analysis user guide now includes a reference peak-analysis workflow
   tutorial connecting peak detection, ``PeakFindingResult``, ``PeakTable``,
   CSV export, manual script writing, script validation, and ``Optimize.fit()``
-  in one end-to-end example.
+  in one end-to-end example. The `Optimize` user-facing documentation now also
+  clarifies method selection (`least_squares`, `leastsq`, `simplex`,
+  `basinhopping`), the meaning of ``FitResult.parameters`` as run
+  configuration, and the lightweight ``validate_constraints()`` /
+  ``constraints`` normalization surface for constraint validation before fit.
 
 - ``FitResult`` from ``Optimize.result`` now exposes a residual dataset as
   ``result.outputs["residuals"]`` / ``result.residuals`` and basic fit-quality

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -35,7 +35,11 @@ New Features
 - The analysis user guide now includes a reference peak-analysis workflow
   tutorial connecting peak detection, ``PeakFindingResult``, ``PeakTable``,
   CSV export, manual script writing, script validation, and ``Optimize.fit()``
-  in one end-to-end example.
+  in one end-to-end example. The `Optimize` user-facing documentation now also
+  clarifies method selection (`least_squares`, `leastsq`, `simplex`,
+  `basinhopping`), the meaning of ``FitResult.parameters`` as run
+  configuration, and the lightweight ``validate_constraints()`` /
+  ``constraints`` normalization surface for constraint validation before fit.
 
 - ``FitResult`` from ``Optimize.result`` now exposes a residual dataset as
   ``result.outputs["residuals"]`` / ``result.residuals`` and basic fit-quality

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -534,11 +534,32 @@ def _validate_script_content(script, usermodels=None):
 @signature_has_configurable_traits
 class Optimize(DecompositionAnalysis):
     """
-    Non-linear Least-Square Optimization and Curve-Fitting.
+    Non-linear curve fitting driven by the SpectroChemPy fitting DSL.
 
-    Works on a 1D or 2D dataset.
+    `Optimize` combines:
 
-    # TODO: complete this description
+    - script-based model definition through :attr:`script`;
+    - pre-fit validation through :meth:`validate_script`;
+    - multiple public optimization-method families through :attr:`method`;
+    - estimator-level access to raw solver artifacts such as :attr:`jacobian`;
+    - grouped scientific outputs and diagnostics through :attr:`result`.
+
+    The current public `method` values are:
+
+    - ``"least_squares"``
+    - ``"leastsq"``
+    - ``"simplex"``
+    - ``"basinhopping"``
+
+    Least-squares-backed methods are the only ones that currently expose the
+    retained Jacobian and the resulting uncertainty path on
+    :class:`~spectrochempy.analysis._base._result.FitResult`
+    (covariance, standard errors, correlation, and confidence intervals).
+
+    Notes
+    -----
+    The current implementation supports only 1D fitting. Multi-dimensional
+    datasets are not yet handled by :meth:`fit`.
 
     Parameters
     ----------
@@ -546,13 +567,11 @@ class Optimize(DecompositionAnalysis):
         The log level at startup. It can be changed later on using the
         `set_log_level` method or by changing the ``log_level`` attribute.
     warm_start : `bool`, optional, default: `False`
-        When fitting repeatedly on the same dataset, but for multiple
-        parameter values (such as to find the value maximizing performance),
-        reuse the solution of the previous call to fit and add more components
-        (if available) in a sequential manner.
-
-        When `warm_start` is `True`, the existing fitted model attributes is used to
-        initialize the new model in a subsequent call to `fit`.
+        Preserve the current estimator configuration instead of forcing a full
+        reset to default configuration values during estimator reinitialization.
+        This is a general estimator-state option shared with other
+        SpectroChemPy analysis classes; it should not be interpreted as a
+        dedicated `Optimize` solver-backend feature.
 
     """
 
@@ -579,7 +598,12 @@ class Optimize(DecompositionAnalysis):
     method = tr.CaselessStrEnum(
         ["least_squares", "leastsq", "simplex", "basinhopping"],
         default_value="least_squares",
-        help="Optimization method (see scipy.optimize docs for details).",
+        help=(
+            "High-level optimization-method selector. "
+            "'least_squares' and 'leastsq' use the least-squares backend path; "
+            "'simplex' uses a derivative-free local search; "
+            "'basinhopping' uses a global-style exploratory search."
+        ),
     ).tag(config=True)
 
     script = tr.Unicode(help="Script defining models and parameters for fitting.").tag(
@@ -592,24 +616,23 @@ class Optimize(DecompositionAnalysis):
 
     dry = tr.Bool(
         default_value=False,
-        help="If True perform a dry run. "
-        "Mainly used to check the validity of the input parameters.",
+        help="If True, assemble the starting model without running the optimizer.",
     ).tag(config=True)
 
     autobase = tr.Bool(
         default_value=False,
-        help="Whether to apply an automatic baseline correction.",
+        help="Whether to estimate and apply a linear baseline correction automatically.",
     ).tag(config=True)
 
     autoampl = tr.Bool(
         default_value=False,
-        help="Whether to apply an automatic amplitude correction.",
+        help="Whether to estimate initial amplitudes automatically during setup.",
     ).tag(config=True)
 
     amplitude_mode = tr.CaselessStrEnum(
         ["area", "height"],
         default_value="height",
-        help="Initial amplitude setting mode.",
+        help="How line-shape amplitudes are interpreted during initialisation.",
     ).tag(config=True)
 
     # ----------------------------------------------------------------------------------
@@ -637,7 +660,9 @@ class Optimize(DecompositionAnalysis):
         log_level : str, optional
             Logging level, by default "WARNING".
         warm_start : bool, optional
-            If True, use warm start, by default False.
+            Preserve the current estimator configuration rather than resetting
+            it to defaults during estimator reinitialization. This does not
+            add any dedicated `Optimize` backend-specific warm-start strategy.
         **kwargs : dict
             Additional keyword arguments.
         """

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -57,6 +57,38 @@ class ScriptError:
         return f"Line {self.line}: {self.message}\n  {self.text}"
 
 
+class ConstraintError:
+    """
+    Structured error returned by :meth:`Optimize.validate_constraints`.
+
+    Attributes
+    ----------
+    index : int
+        0-indexed index of the offending constraint specification.
+    constraint : any
+        The offending constraint object as provided by the user.
+    message : str
+        Human-readable explanation of the error.
+    """
+
+    __slots__ = ("index", "constraint", "message")
+
+    def __init__(self, index, constraint, message):
+        self.index = index
+        self.constraint = constraint
+        self.message = message
+
+    def __repr__(self):
+        return (
+            "ConstraintError("
+            f"index={self.index}, constraint={self.constraint!r}, "
+            f"message={self.message!r})"
+        )
+
+    def __str__(self):
+        return f"Constraint {self.index}: {self.message}\n  {self.constraint!r}"
+
+
 # ======================================================================================
 # Module-level helpers
 # ======================================================================================
@@ -530,6 +562,160 @@ def _validate_script_content(script, usermodels=None):
     return fp, errors
 
 
+def _normalize_constraint_spec(constraint):
+    """Normalize accepted constraint spellings to a common dict form."""
+    if isinstance(constraint, dict) and "max_connections" in constraint:
+        extra_keys = set(constraint) - {"max_connections", "parameters"}
+        if extra_keys:
+            return (
+                None,
+                f"Unsupported keys for max_connections constraint: {sorted(extra_keys)!r}",
+            )
+        return {
+            "type": "max_connections",
+            "limit": constraint["max_connections"],
+            "parameters": constraint.get("parameters"),
+        }, None
+
+    if isinstance(constraint, dict):
+        return dict(constraint), None
+
+    return None, "Each constraint must be a dict specification."
+
+
+def _validate_constraints_content(constraints, fit_parameters=None):
+    r"""
+    Validate lightweight constraint specifications without running a fit.
+
+    Supported minimal schemas currently include:
+
+    - ``{\"max_connections\": <positive int>}``
+    - ``{\"type\": \"max_connections\", \"limit\": <positive int>, \"parameters\": [...]}``
+
+    Validation is limited to structure and parameter-name references. It does
+    not guarantee that the current optimization backend will enforce every
+    accepted constraint semantically.
+    """
+    if constraints in (None, {}, []):
+        return []
+
+    if isinstance(constraints, dict):
+        constraints_list = [constraints]
+    elif isinstance(constraints, (list, tuple)):
+        constraints_list = list(constraints)
+    else:
+        return [
+            ConstraintError(
+                0,
+                constraints,
+                "Constraints must be a dict or a list/tuple of dicts.",
+            ),
+        ]
+
+    known_parameters = (
+        set(fit_parameters.keys()) if fit_parameters is not None else set()
+    )
+    errors = []
+
+    for index, raw_constraint in enumerate(constraints_list):
+        constraint, normalization_error = _normalize_constraint_spec(raw_constraint)
+        if normalization_error is not None:
+            errors.append(
+                ConstraintError(index, raw_constraint, normalization_error),
+            )
+            continue
+
+        constraint_type = str(constraint.get("type", "")).strip().lower()
+        if constraint_type != "max_connections":
+            errors.append(
+                ConstraintError(
+                    index,
+                    raw_constraint,
+                    "Unsupported constraint type. Currently only 'max_connections' "
+                    "is recognized by validate_constraints().",
+                ),
+            )
+            continue
+
+        limit = constraint.get("limit")
+        try:
+            limit_int = int(limit)
+        except Exception:
+            errors.append(
+                ConstraintError(
+                    index,
+                    raw_constraint,
+                    "Constraint 'limit' must be an integer.",
+                ),
+            )
+            continue
+
+        if limit_int <= 0:
+            errors.append(
+                ConstraintError(
+                    index,
+                    raw_constraint,
+                    "Constraint 'limit' must be a positive integer.",
+                ),
+            )
+
+        parameters = constraint.get("parameters")
+        if parameters is None:
+            continue
+
+        if not isinstance(parameters, (list, tuple)) or not parameters:
+            errors.append(
+                ConstraintError(
+                    index,
+                    raw_constraint,
+                    "Constraint 'parameters' must be a non-empty list or tuple of parameter names.",
+                ),
+            )
+            continue
+
+        invalid_names = [
+            name for name in parameters if not isinstance(name, str) or not name
+        ]
+        if invalid_names:
+            errors.append(
+                ConstraintError(
+                    index,
+                    raw_constraint,
+                    "Constraint 'parameters' entries must be non-empty strings.",
+                ),
+            )
+            continue
+
+        if known_parameters:
+            missing = [name for name in parameters if name not in known_parameters]
+            if missing:
+                errors.append(
+                    ConstraintError(
+                        index,
+                        raw_constraint,
+                        f"Unknown parameter name(s) referenced by constraint: {missing!r}",
+                    ),
+                )
+
+    return errors
+
+
+def _canonicalize_constraints(constraints):
+    """Return a normalized constraints payload for estimator storage."""
+    if constraints in (None, {}, []):
+        return None
+
+    if isinstance(constraints, dict):
+        constraint, _ = _normalize_constraint_spec(constraints)
+        return constraint
+
+    canonical_constraints = []
+    for constraint in constraints:
+        normalized, _ = _normalize_constraint_spec(constraint)
+        canonical_constraints.append(normalized)
+    return canonical_constraints
+
+
 # ======================================================================================
 @signature_has_configurable_traits
 class Optimize(DecompositionAnalysis):
@@ -551,10 +737,33 @@ class Optimize(DecompositionAnalysis):
     - ``"simplex"``
     - ``"basinhopping"``
 
+    In current SpectroChemPy releases, ``"least_squares"`` is the clearest
+    recommended entrypoint for ordinary local least-squares fitting.
+    ``"leastsq"`` is still accepted as a public compatibility alias, but it
+    currently uses the same least-squares backend family rather than defining a
+    separate maintained fitting strategy of its own.
+
     Least-squares-backed methods are the only ones that currently expose the
     retained Jacobian and the resulting uncertainty path on
     :class:`~spectrochempy.analysis._base._result.FitResult`
     (covariance, standard errors, correlation, and confidence intervals).
+
+    Method selection
+    ----------------
+    In current SpectroChemPy releases, the practical guidance is:
+
+    - use ``"least_squares"`` as the default choice for ordinary local
+      least-squares fitting;
+    - treat ``"leastsq"`` mainly as a compatibility alias rather than as a
+      separate maintained strategy;
+    - use ``"simplex"`` when you explicitly want a derivative-free local
+      search and can accept losing the least-squares uncertainty path;
+    - reserve ``"basinhopping"`` for harder landscapes where a slower
+      exploratory global-style search is justified.
+
+    The low-level SciPy least-squares backend variant (currently ``lm`` or
+    ``trf``) is still selected internally; users choose the high-level
+    SpectroChemPy `method`, not the backend variant directly.
 
     Notes
     -----
@@ -600,7 +809,8 @@ class Optimize(DecompositionAnalysis):
         default_value="least_squares",
         help=(
             "High-level optimization-method selector. "
-            "'least_squares' and 'leastsq' use the least-squares backend path; "
+            "'least_squares' is the preferred local least-squares entrypoint; "
+            "'leastsq' is a compatibility alias using the same backend family; "
             "'simplex' uses a derivative-free local search; "
             "'basinhopping' uses a global-style exploratory search."
         ),
@@ -812,6 +1022,16 @@ class Optimize(DecompositionAnalysis):
             "jacobian": None,
             "jacobian_backend": None,
         }
+        fit_config = {
+            "method": self.method,
+            "max_iter": self.max_iter,
+            "max_fun_calls": self.max_fun_calls,
+            "dry": self.dry,
+            "autobase": self.autobase,
+            "autoampl": self.autoampl,
+            "amplitude_mode": self.amplitude_mode,
+            "constraints": self.constraints,
+        }
         if not self.dry:
             fp, fopt, solver_meta, solver_artifacts = _optimize(
                 func,
@@ -832,6 +1052,7 @@ class Optimize(DecompositionAnalysis):
             "ncalls": ncalls,
             **solver_meta,
         }
+        self._fit_config = fit_config
         self._solver_artifacts = solver_artifacts
 
         # replace the previous script with new fp parameters
@@ -899,6 +1120,19 @@ class Optimize(DecompositionAnalysis):
         self.fp = fp
         return proposal.value
 
+    @tr.validate("constraints")
+    def _constraints_validate(self, proposal):
+        constraints = proposal.value
+        if constraints in (None, {}, []):
+            return None
+
+        fit_parameters = self.fp
+        errors = _validate_constraints_content(constraints, fit_parameters)
+        if errors:
+            raise ValueError(str(errors[0]))
+
+        return _canonicalize_constraints(constraints)
+
     # ----------------------------------------------------------------------------------
     # Public API
     # ----------------------------------------------------------------------------------
@@ -932,6 +1166,55 @@ class Optimize(DecompositionAnalysis):
             script = self.script
         _, errors = _validate_script_content(script, self.usermodels)
         return errors
+
+    def validate_constraints(self, constraints=None, script=None):
+        """
+        Validate lightweight constraint specifications without running a fit.
+
+        This method currently validates:
+
+        - the overall constraints container shape;
+        - recognized constraint keys / types;
+        - references to parameter names defined by the fitting script.
+
+        It does not guarantee that every accepted constraint is fully enforced
+        by the current optimization backend. The present goal is to provide a
+        stable validation surface before broader constraint execution semantics
+        are expanded.
+
+        Parameters
+        ----------
+        constraints : dict or sequence of dict, optional
+            Constraint specification(s) to validate. If ``None`` (default),
+            validates :attr:`constraints`.
+        script : str, optional
+            Script used to resolve parameter names. If ``None`` (default), uses
+            the currently assigned :attr:`script`.
+
+        Returns
+        -------
+        list of :class:`ConstraintError`
+            Empty list when the constraint specification is valid.
+        """
+        if constraints is None:
+            constraints = self.constraints
+        if script is None:
+            script = self.script
+
+        fit_parameters, script_errors = _validate_script_content(
+            script, self.usermodels
+        )
+        if script_errors:
+            return [
+                ConstraintError(
+                    0,
+                    constraints,
+                    "Cannot validate constraints because the fitting script is invalid. "
+                    f"First script error: {script_errors[0].message}",
+                ),
+            ]
+
+        return _validate_constraints_content(constraints, fit_parameters)
 
     # ----------------------------------------------------------------------------------
     # Private methods
@@ -1476,16 +1759,24 @@ class Optimize(DecompositionAnalysis):
             fit_diagnostics,
         )
         parameter_values = _extract_varying_parameter_values(self.fp)
-
-        return FitResult(
-            estimator="Optimize",
-            parameters={
+        fit_config = getattr(
+            self,
+            "_fit_config",
+            {
                 "method": self.method,
                 "max_iter": self.max_iter,
                 "max_fun_calls": self.max_fun_calls,
+                "dry": self.dry,
                 "autobase": self.autobase,
+                "autoampl": self.autoampl,
                 "amplitude_mode": self.amplitude_mode,
+                "constraints": self.constraints,
             },
+        )
+
+        return FitResult(
+            estimator="Optimize",
+            parameters=fit_config.copy(),
             outputs={
                 "fitted": fitted,
                 "components": self.components,
@@ -1537,7 +1828,7 @@ def _optimize(
 
     def internal_func(p, dat, fp, keys, *args):
         fp = restore_external(fp, p, keys)
-        return func(fp, dat, *args)
+        return func(fp, dat)
 
     def internal_callback(*args):
         if callback is None:

--- a/tests/test_analysis/test_curvefitting/test_optimize.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize.py
@@ -9,6 +9,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 import spectrochempy as scp
+from spectrochempy.analysis.curvefitting.optimize import ConstraintError
 from spectrochempy.analysis.curvefitting.optimize import ScriptError
 
 
@@ -178,6 +179,132 @@ class TestValidateScript:
         _ = opt.validate_script()
         # validate_script must not mutate self.fp
         assert opt.fp is fp_before
+
+
+class TestValidateConstraints:
+    """Tests for Optimize.validate_constraints()."""
+
+    def test_empty_constraints_are_valid(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        assert opt.validate_constraints(None) == []
+        assert opt.validate_constraints({}) == []
+        assert opt.validate_constraints([]) == []
+
+    def test_max_connections_short_form_is_valid(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        errors = opt.validate_constraints({"max_connections": 2})
+        assert errors == []
+
+    def test_max_connections_long_form_with_parameters_is_valid(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        errors = opt.validate_constraints(
+            {
+                "type": "max_connections",
+                "limit": 2,
+                "parameters": ["pos_line_1", "width_line_1"],
+            }
+        )
+        assert errors == []
+
+    def test_constraints_must_be_mapping_or_sequence_of_mappings(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        errors = opt.validate_constraints("bad")
+        assert len(errors) == 1
+        assert "dict or a list/tuple" in errors[0].message
+
+    def test_unknown_constraint_type_is_reported(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        errors = opt.validate_constraints(
+            {"type": "order", "parameters": ["pos_line_1"]}
+        )
+        assert len(errors) == 1
+        assert "Unsupported constraint type" in errors[0].message
+
+    def test_unknown_parameter_name_is_reported(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        errors = opt.validate_constraints(
+            {
+                "type": "max_connections",
+                "limit": 1,
+                "parameters": ["pos_line_1", "missing_parameter"],
+            }
+        )
+        assert len(errors) == 1
+        assert "Unknown parameter name" in errors[0].message
+        assert "missing_parameter" in errors[0].message
+
+    def test_invalid_limit_is_reported(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        errors = opt.validate_constraints({"max_connections": 0})
+        assert len(errors) == 1
+        assert "positive integer" in errors[0].message
+
+    def test_invalid_script_blocks_constraint_validation(self):
+        opt = scp.Optimize()
+        errors = opt.validate_constraints(
+            {"max_connections": 1},
+            script="MODEL: X\nshape gaussianmodel\n",
+        )
+        assert len(errors) == 1
+        assert "fitting script is invalid" in errors[0].message
+
+    def test_constraint_error_attributes(self):
+        err = ConstraintError(index=1, constraint={"max_connections": 2}, message="bad")
+        assert err.index == 1
+        assert err.constraint == {"max_connections": 2}
+        assert err.message == "bad"
+
+    def test_constraint_error_repr_and_str(self):
+        err = ConstraintError(index=1, constraint={"max_connections": 2}, message="bad")
+        assert "ConstraintError" in repr(err)
+        assert "Constraint 1" in str(err)
+
+    def test_constraints_trait_normalizes_short_form(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        opt.constraints = {"max_connections": 2}
+        assert opt.constraints == {
+            "type": "max_connections",
+            "limit": 2,
+            "parameters": None,
+        }
+
+    def test_constraints_trait_normalizes_sequence(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        opt.constraints = [{"max_connections": 2}]
+        assert opt.constraints == [
+            {"type": "max_connections", "limit": 2, "parameters": None}
+        ]
+
+    def test_constraints_trait_rejects_unknown_parameter(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        with pytest.raises(ValueError, match="Unknown parameter name"):
+            opt.constraints = {
+                "type": "max_connections",
+                "limit": 1,
+                "parameters": ["missing_parameter"],
+            }
+
+    def test_fit_does_not_crash_when_constraints_are_present(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.constraints = {"max_connections": 2}
+
+        result = opt.fit(synthetic_two_peak_dataset)
+
+        assert result is opt
 
 
 # -----------------------------------------------------------------------------------

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -128,8 +128,11 @@ class TestOptimizeResult:
             "method",
             "max_iter",
             "max_fun_calls",
+            "dry",
             "autobase",
+            "autoampl",
             "amplitude_mode",
+            "constraints",
         ):
             assert name in params, f"{name} missing from result.parameters"
 
@@ -144,8 +147,11 @@ class TestOptimizeResult:
         params = opt.result.parameters
         assert params["method"] == "least_squares"
         assert params["max_iter"] == 10
+        assert params["dry"] is False
         assert params["autobase"] is True
+        assert params["autoampl"] is False
         assert params["amplitude_mode"] == "height"
+        assert params["constraints"] is None
 
     def test_parameters_match_estimator_config(
         self, synthetic_two_peak_dataset, optimize_script
@@ -153,14 +159,58 @@ class TestOptimizeResult:
         opt = scp.Optimize()
         opt.script = optimize_script
         opt.autobase = True
+        opt.autoampl = True
         opt.max_iter = 20
         opt.method = "simplex"
         opt.amplitude_mode = "area"
+        opt.constraints = {"max_connections": 2}
         opt.fit(synthetic_two_peak_dataset)
         params = opt.result.parameters
         assert params["method"] == "simplex"
         assert params["max_iter"] == 20
+        assert params["autoampl"] is True
         assert params["amplitude_mode"] == "area"
+        assert params["constraints"] == {
+            "type": "max_connections",
+            "limit": 2,
+            "parameters": None,
+        }
+
+    def test_parameters_capture_dry_mode(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.dry = True
+
+        opt.fit(synthetic_two_peak_dataset)
+
+        params = opt.result.parameters
+        assert params["dry"] is True
+
+    def test_parameters_are_a_snapshot_of_fit_config(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.autoampl = True
+        opt.max_iter = 20
+        opt.method = "simplex"
+
+        opt.fit(synthetic_two_peak_dataset)
+
+        opt.method = "least_squares"
+        opt.autoampl = False
+        opt.max_iter = 5
+        opt.constraints = {"max_connections": 1}
+
+        params = opt.result.parameters
+        assert params["method"] == "simplex"
+        assert params["autoampl"] is True
+        assert params["max_iter"] == 20
+        assert params["constraints"] is None
 
     # ----------------------------------------------------------------------------------
     # Diagnostics


### PR DESCRIPTION
Clarify the current public `Optimize` user API without redesigning the fitting engine.

This PR improves the user-facing `Optimize` surface in docs and source docstrings, and adds a small amount of supporting API validation around constraints.

### Main changes:
- clarify method-selection guidance for `least_squares`, `leastsq`, `simplex`, and `basinhopping`
- document that `least_squares` is the recommended local least-squares entrypoint and `leastsq` is currently a compatibility alias
- clarify the current `warm_start` meaning so it is not presented as an `Optimize`-specific solver warm start
- clarify that `FitResult.parameters` is a snapshot of run configuration, not a solved scientific parameter table
- expose additional run-configuration fields consistently on `FitResult.parameters`, including normalized `constraints`
- add `validate_constraints()` with structured `ConstraintError` reporting for lightweight constraint validation
- normalize accepted `constraints` payloads on assignment
- document the currently supported minimal `constraints` schema and its normalized canonical form
- update the changelog entry for the broader `Optimize` user-facing improvements

### Notes:
- this PR does not redesign `Optimize`
- it does not introduce a broad maintained constraint engine
- current constraint work is intentionally limited to validation, normalization, and configuration traceability