### PR TITLE
ENH: add private _FitModelSpec structured model-definition object

### DIFF
--- a/src/spectrochempy/analysis/curvefitting/__init__.pyi
+++ b/src/spectrochempy/analysis/curvefitting/__init__.pyi
@@ -8,12 +8,14 @@
 
 __all__ = [
     "_models",
+    "_modelspec",
     "_parameters",
     "linearregression",
     "optimize",
 ]
 
 from . import _models
+from . import _modelspec
 from . import _parameters
 from . import linearregression
 from . import optimize

--- a/src/spectrochempy/analysis/curvefitting/_modelspec.py
+++ b/src/spectrochempy/analysis/curvefitting/_modelspec.py
@@ -1,0 +1,221 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+Private structured model-definition object for the Optimize script DSL.
+
+Provides a clean, structured in-memory representation of what the
+Optimize script parser already knows, separating model topology,
+parameter definitions, and parameter values.
+
+This module is **private**.  It is not a public API.
+"""
+
+import sys
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+# Sentinel bound thresholds (same as FitParameters.__str__)
+_STR_NEG_THRESH = -0.1 / sys.float_info.epsilon
+_STR_POS_THRESH = +0.1 / sys.float_info.epsilon
+
+
+def _unbound(val):
+    """Convert sentinel bound values to ``None``."""
+    if val is None:
+        return None
+    if val <= _STR_NEG_THRESH or val >= _STR_POS_THRESH:
+        return None
+    return val
+
+
+# ======================================================================================
+@dataclass
+class _ParamSpec:
+    """Parameter definition with value, bounds, and flags."""
+
+    name: str
+    value: float = 0.0
+    vary: bool = True
+    bounds: tuple[float | None, float | None] = (None, None)
+    reference: str | None = None  # name of referenced COMMON param, or None
+
+
+# ======================================================================================
+@dataclass
+class _ComponentSpec:
+    """A single model component with its parameters."""
+
+    label: str
+    model_name: str = ""
+    params: dict[str, _ParamSpec] = field(default_factory=dict)
+
+
+# ======================================================================================
+class _FitModelSpec:
+    """
+    Structured model-definition object.
+
+    Separates model topology (components), parameter definitions
+    (names, vary, bounds, references), and parameter values into a
+    clean representation.
+
+    Unlike ``FitParameters``, which uses parallel dictionaries and
+    implicit ``{param}_{label}`` key encoding, this object stores
+    parameters as structured attributes of their owning component.
+    """
+
+    def __init__(
+        self,
+        components: list[_ComponentSpec] | None = None,
+        common_params: dict[str, _ParamSpec] | None = None,
+        constraints: Any = None,
+    ):
+        self.components = list(components or [])
+        self.common_params = dict(common_params or {})
+        self.constraints = constraints  # reserved, not yet used
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_fitparameters(cls, fp):
+        """
+        Build a ``_FitModelSpec`` from a parsed ``FitParameters`` instance.
+
+        This is the primary way to construct a ``_FitModelSpec`` from
+        user-provided script content.
+        """
+        common_params = {}
+
+        # Extract COMMON parameters from fp.common
+        # fp.common is keyed by raw parameter name (no model suffix)
+        for raw_name, is_common in fp.common.items():
+            if not is_common:
+                continue
+            if raw_name not in fp:
+                continue
+
+            is_ref = fp.reference.get(raw_name, False)
+            if is_ref:
+                common_params[raw_name] = _ParamSpec(
+                    name=raw_name,
+                    value=0.0,
+                    vary=False,
+                    bounds=(None, None),
+                    reference=str(fp[raw_name]),
+                )
+            else:
+                common_params[raw_name] = _ParamSpec(
+                    name=raw_name,
+                    value=float(fp[raw_name]),
+                    vary=not fp.fixed.get(raw_name, False),
+                    bounds=(
+                        _unbound(fp.lob.get(raw_name)),
+                        _unbound(fp.upb.get(raw_name)),
+                    ),
+                )
+
+        # Extract model components
+        components = []
+        for model_label in fp.models:
+            model_name = fp.model.get(model_label, "")
+            model_params = {}
+
+            for full_key in sorted(fp):
+                # Each model param key is "{param}_{label}".
+                # The first underscore separates name from model label.
+                keyspl = full_key.split("_")
+                if len(keyspl) < 2:
+                    continue  # COMMON param has no suffix
+                param_raw = keyspl[0]
+                param_model = "_".join(keyspl[1:])
+                if param_model != model_label:
+                    continue
+
+                is_ref = fp.reference.get(full_key, False)
+                if is_ref:
+                    model_params[param_raw] = _ParamSpec(
+                        name=param_raw,
+                        value=0.0,
+                        vary=False,
+                        bounds=(None, None),
+                        reference=str(fp[full_key]),
+                    )
+                else:
+                    model_params[param_raw] = _ParamSpec(
+                        name=param_raw,
+                        value=float(fp[full_key]),
+                        vary=not fp.fixed.get(full_key, False),
+                        bounds=(
+                            _unbound(fp.lob.get(full_key)),
+                            _unbound(fp.upb.get(full_key)),
+                        ),
+                    )
+
+            components.append(
+                _ComponentSpec(
+                    label=model_label,
+                    model_name=model_name,
+                    params=model_params,
+                )
+            )
+
+        return cls(components=components, common_params=common_params)
+
+    # ------------------------------------------------------------------
+    def to_script(self) -> str:
+        """
+        Serialize back to a script string accepted by the parser.
+
+        The output is semantically equivalent to what the parser
+        expects.  Whitespace and formatting are not guaranteed
+        identical to the original script, but the re-parsed result
+        will match ``from_fitparameters`` semantically.
+        """
+        lines = []
+
+        # COMMON section
+        if self.common_params:
+            lines.append("COMMON:")
+            for name in sorted(self.common_params):
+                ps = self.common_params[name]
+                if ps.reference is not None:
+                    lines.append(f"    > {name}:{ps.reference}")
+                else:
+                    prefix = "*" if not ps.vary else "$"
+                    lob = _format_bound(ps.bounds[0])
+                    upb = _format_bound(ps.bounds[1])
+                    lines.append(f"    {prefix} {name}: {ps.value:.4f}, {lob}, {upb}")
+            lines.append("")
+
+        # Model components
+        for comp in self.components:
+            lines.append(f"MODEL: {comp.label}")
+            if comp.model_name:
+                lines.append(f"shape: {comp.model_name}")
+            for name in sorted(comp.params):
+                ps = comp.params[name]
+                if ps.reference is not None:
+                    lines.append(f"    > {name}:{ps.reference}")
+                else:
+                    prefix = "*" if not ps.vary else "$"
+                    lob = _format_bound(ps.bounds[0])
+                    upb = _format_bound(ps.bounds[1])
+                    lines.append(f"    {prefix} {name}: {ps.value:.4f}, {lob}, {upb}")
+
+        result = "\n".join(lines).strip()
+        if result:
+            result += "\n"
+        return result
+
+
+def _format_bound(val: float | None) -> str:
+    """Format a bound value for script output."""
+    if val is None:
+        return "none"
+    # Use integer format if exact integer
+    if val == int(val):
+        return f"{int(val)}"
+    return f"{val:.4f}"

--- a/tests/test_analysis/test_curvefitting/test_modelspec.py
+++ b/tests/test_analysis/test_curvefitting/test_modelspec.py
@@ -1,0 +1,705 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Tests for the private _FitModelSpec structured model-definition object."""
+
+import sys
+
+import pytest
+
+from spectrochempy.analysis.curvefitting._modelspec import _ComponentSpec
+from spectrochempy.analysis.curvefitting._modelspec import _FitModelSpec
+from spectrochempy.analysis.curvefitting._modelspec import _ParamSpec
+from spectrochempy.analysis.curvefitting._modelspec import _unbound
+from spectrochempy.analysis.curvefitting._parameters import FitParameters
+from spectrochempy.analysis.curvefitting.optimize import _validate_script_content
+
+# ======================================================================================
+# Constants
+# ======================================================================================
+
+_STR_NEG_THRESH = -0.1 / sys.float_info.epsilon
+_STR_POS_THRESH = +0.1 / sys.float_info.epsilon
+
+
+# ======================================================================================
+# Tests for _unbound helper
+# ======================================================================================
+
+
+class TestUnbound:
+    def test_none_stays_none(self):
+        assert _unbound(None) is None
+
+    def test_finite_lower_bound_preserved(self):
+        assert _unbound(0.0) == 0.0
+        assert _unbound(-100.0) == -100.0
+
+    def test_finite_upper_bound_preserved(self):
+        assert _unbound(200.0) == 200.0
+
+    def test_sentinel_lower_bound_converted_to_none(self):
+        sentinel = -1.0 / sys.float_info.epsilon
+        assert _unbound(sentinel) is None
+
+    def test_sentinel_upper_bound_converted_to_none(self):
+        sentinel = +1.0 / sys.float_info.epsilon
+        assert _unbound(sentinel) is None
+
+    def test_threshold_bounds_converted_to_none(self):
+        barely_below = _STR_NEG_THRESH - 1.0
+        barely_above = _STR_POS_THRESH + 1.0
+        assert _unbound(barely_below) is None
+        assert _unbound(barely_above) is None
+
+
+# ======================================================================================
+# Tests for FitParameters -> _FitModelSpec conversion
+# ======================================================================================
+
+
+class TestFromFitParameters:
+    """Test that from_fitparameters correctly extracts structure."""
+
+    SCRIPT = """
+MODEL: PEAK_A
+shape: gaussianmodel
+    $ ampl:  1.5, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+"""
+
+    def test_returns_modelspec_instance(self):
+        fp, errors = _validate_script_content(self.SCRIPT)
+        assert errors == []
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert isinstance(spec, _FitModelSpec)
+
+    def test_one_component(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert len(spec.components) == 1
+
+    def test_component_label(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].label == "peak_a"
+
+    def test_component_model_name(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].model_name == "gaussianmodel"
+
+    def test_three_parameters(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert len(spec.components[0].params) == 3
+
+    def test_parameter_values(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["ampl"].value == 1.5
+        assert spec.components[0].params["pos"].value == 100.0
+        assert spec.components[0].params["width"].value == 10.0
+
+    def test_parameter_vary(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["ampl"].vary is True
+        assert spec.components[0].params["pos"].vary is True
+        assert spec.components[0].params["width"].vary is True
+
+    def test_parameter_bounds_finite(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["pos"].bounds == (0.0, 200.0)
+
+    def test_parameter_bounds_open(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        # ampl has upper bound "none" -> sentinel -> None
+        assert spec.components[0].params["ampl"].bounds[0] == 0.0
+        assert spec.components[0].params["ampl"].bounds[1] is None
+
+    def test_no_common_params(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.common_params == {}
+
+
+class TestFromMultipleComponents:
+    """Two-component extraction."""
+
+    SCRIPT = """
+MODEL: PEAK_1
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+
+MODEL: PEAK_2
+shape: lorentzianmodel
+    $ ampl: 0.5, 0.0, none
+"""
+
+    def test_two_components(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert len(spec.components) == 2
+
+    def test_component_labels(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].label == "peak_1"
+        assert spec.components[1].label == "peak_2"
+
+    def test_model_names(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].model_name == "gaussianmodel"
+        assert spec.components[1].model_name == "lorentzianmodel"
+
+    def test_params_separate_between_components(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["ampl"].value == 1.0
+        assert spec.components[1].params["ampl"].value == 0.5
+        assert spec.components[0].params["pos"].value == 100.0
+        assert "pos" not in spec.components[1].params
+
+
+class TestFromCommonParameters:
+    """COMMON parameter extraction."""
+
+    SCRIPT = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+"""
+
+    def test_common_params_present(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert len(spec.common_params) == 1
+        assert "gratio" in spec.common_params
+
+    def test_common_param_value(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.common_params["gratio"].value == 0.1
+
+    def test_common_param_bounds(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.common_params["gratio"].bounds == (0.0, 1.0)
+
+    def test_common_param_vary(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.common_params["gratio"].vary is True
+
+    def test_common_param_is_not_reference(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.common_params["gratio"].reference is None
+
+    def test_model_params_not_in_common(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert "ampl" not in spec.common_params
+        assert "pos" not in spec.common_params
+
+
+class TestFromReferences:
+    """Reference parameter extraction."""
+
+    SCRIPT = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    > ratio: gratio
+"""
+
+    def test_reference_in_component(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert "ratio" in spec.components[0].params
+
+    def test_reference_stores_name(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["ratio"].reference == "gratio"
+
+    def test_reference_not_vary(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["ratio"].vary is False
+
+    def test_reference_has_no_bounds(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["ratio"].bounds == (None, None)
+
+    def test_common_param_not_reference(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.common_params["gratio"].reference is None
+
+
+class TestFromFixedVarying:
+    """Fixed vs varying parameter extraction."""
+
+    SCRIPT = """
+MODEL: X
+shape: gaussianmodel
+    * ampl:  1.0, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+"""
+
+    def test_fixed_param_vary_false(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["ampl"].vary is False
+
+    def test_varying_param_vary_true(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].params["pos"].vary is True
+
+
+class TestFromEmpty:
+    """Edge case: empty FitParameters."""
+
+    def test_empty_fitparameters_produces_empty_spec(self):
+        fp = FitParameters()
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components == []
+        assert spec.common_params == {}
+
+
+# ======================================================================================
+# Tests for to_script serialization
+# ======================================================================================
+
+
+class TestToScript:
+    """Test that to_script produces valid script strings."""
+
+    def test_empty_produces_empty_string(self):
+        spec = _FitModelSpec()
+        assert spec.to_script() == ""
+
+    def test_single_component(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="peak_a",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.5, bounds=(0.0, None)),
+                        "pos": _ParamSpec(name="pos", value=100.0, bounds=(0.0, 200.0)),
+                    },
+                )
+            ]
+        )
+        script = spec.to_script()
+        assert "MODEL: peak_a" in script
+        assert "gaussianmodel" in script
+        assert "$ ampl:" in script
+        assert "$ pos:" in script
+
+    def test_common_parameters(self):
+        spec = _FitModelSpec(
+            common_params={
+                "gratio": _ParamSpec(name="gratio", value=0.1, bounds=(0.0, 1.0)),
+            }
+        )
+        script = spec.to_script()
+        assert "COMMON:" in script
+        assert "$ gratio:" in script
+
+    def test_reference(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="x",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.0),
+                        "ratio": _ParamSpec(
+                            name="ratio",
+                            reference="gratio",
+                            vary=False,
+                        ),
+                    },
+                )
+            ],
+            common_params={
+                "gratio": _ParamSpec(name="gratio", value=0.1),
+            },
+        )
+        script = spec.to_script()
+        assert "> ratio:gratio" in script
+        assert "COMMON:" in script
+
+    def test_fixed_parameter(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="x",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.0, vary=False),
+                    },
+                )
+            ]
+        )
+        script = spec.to_script()
+        assert "* ampl:" in script
+
+    def test_script_is_parsable(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="x",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.5, bounds=(0.0, None)),
+                        "pos": _ParamSpec(name="pos", value=100.0, bounds=(0.0, 200.0)),
+                    },
+                )
+            ]
+        )
+        script = spec.to_script()
+        fp, errors = _validate_script_content(script)
+        assert errors == []
+
+
+# ======================================================================================
+# Round-trip tests
+# ======================================================================================
+
+
+class TestRoundTrip:
+    """Full semantic round-trip: script -> FitParameters -> _FitModelSpec -> script -> FitParameters."""
+
+    SINGLE = """
+MODEL: PEAK_A
+shape: gaussianmodel
+    $ ampl:  1.5, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+"""
+
+    MULTI = """
+MODEL: PEAK_1
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+
+MODEL: PEAK_2
+shape: lorentzianmodel
+    $ ampl: 0.5, 0.0, none
+    $ pos:  150.0, -50.0, 300.0
+    $ width: 20.0, 0.0, none
+"""
+
+    COMMON = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+"""
+
+    REFERENCE = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    > ratio: gratio
+    $ width: 10.0, 0.0, none
+"""
+
+    FIXED = """
+MODEL: X
+shape: gaussianmodel
+    * ampl:  1.0, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+"""
+
+    @staticmethod
+    def _round_trip(script):
+        """Run full round-trip and return (fp1, spec, fp2)."""
+        fp1, errors = _validate_script_content(script)
+        assert errors == [], f"Parse errors: {errors}"
+        spec = _FitModelSpec.from_fitparameters(fp1)
+        script2 = spec.to_script()
+        fp2, errors2 = _validate_script_content(script2)
+        assert errors2 == [], f"Re-parse errors: {errors2}"
+        return fp1, spec, fp2
+
+    # -- Single component round-trip --
+
+    def test_round_trip_preserves_models(self):
+        fp1, _, fp2 = self._round_trip(self.SINGLE)
+        assert fp1.models == fp2.models
+
+    def test_round_trip_preserves_model_mapping(self):
+        fp1, _, fp2 = self._round_trip(self.SINGLE)
+        assert fp1.model == fp2.model
+
+    def test_round_trip_preserves_parameter_keys(self):
+        fp1, _, fp2 = self._round_trip(self.SINGLE)
+        assert set(fp1.keys()) == set(fp2.keys())
+
+    def test_round_trip_preserves_values(self):
+        fp1, _, fp2 = self._round_trip(self.SINGLE)
+        for key in fp1:
+            assert fp1[key] == pytest.approx(fp2[key])
+
+    def test_round_trip_preserves_bounds(self):
+        fp1, _, fp2 = self._round_trip(self.SINGLE)
+        for key in fp1:
+            lob1, lob2 = fp1.lob.get(key), fp2.lob.get(key)
+            upb1, upb2 = fp1.upb.get(key), fp2.upb.get(key)
+            if lob1 is not None and lob2 is not None:
+                assert lob1 == pytest.approx(lob2)
+            if upb1 is not None and upb2 is not None:
+                assert upb1 == pytest.approx(upb2)
+
+    def test_round_trip_preserves_fixed_flags(self):
+        fp1, _, fp2 = self._round_trip(self.SINGLE)
+        assert fp1.fixed == fp2.fixed
+
+    def test_round_trip_preserves_reference_flags(self):
+        fp1, _, fp2 = self._round_trip(self.SINGLE)
+        assert fp1.reference == fp2.reference
+
+    # -- Multiple components --
+
+    def test_multi_round_trip_preserves_models(self):
+        fp1, _, fp2 = self._round_trip(self.MULTI)
+        assert fp1.models == fp2.models
+
+    def test_multi_round_trip_preserves_model_types(self):
+        fp1, _, fp2 = self._round_trip(self.MULTI)
+        assert fp1.model == fp2.model
+
+    def test_multi_round_trip_preserves_parameter_keys(self):
+        fp1, _, fp2 = self._round_trip(self.MULTI)
+        assert set(fp1.keys()) == set(fp2.keys())
+
+    def test_multi_round_trip_preserves_values(self):
+        fp1, _, fp2 = self._round_trip(self.MULTI)
+        for key in fp1:
+            assert fp1[key] == pytest.approx(fp2[key])
+
+    # -- COMMON parameters --
+
+    def test_common_round_trip_preserves_common_flag(self):
+        fp1, _, fp2 = self._round_trip(self.COMMON)
+        assert fp1.common == fp2.common
+
+    def test_common_round_trip_preserves_models(self):
+        fp1, _, fp2 = self._round_trip(self.COMMON)
+        assert fp1.models == fp2.models
+
+    def test_common_round_trip_preserves_values(self):
+        fp1, _, fp2 = self._round_trip(self.COMMON)
+        for key in fp1:
+            assert fp1[key] == pytest.approx(fp2[key])
+
+    # -- References --
+
+    def test_reference_round_trip_preserves_reference_flag(self):
+        fp1, _, fp2 = self._round_trip(self.REFERENCE)
+        assert fp1.reference == fp2.reference
+
+    def test_reference_round_trip_preserves_reference_string(self):
+        fp1, _, fp2 = self._round_trip(self.REFERENCE)
+        assert fp1["ratio_x"] == fp2["ratio_x"]
+        assert isinstance(fp2["ratio_x"], str)
+
+    def test_reference_round_trip_preserves_common(self):
+        fp1, _, fp2 = self._round_trip(self.REFERENCE)
+        assert fp1.common == fp2.common
+
+    # -- Fixed vs varying --
+
+    def test_fixed_round_trip_preserves_fixed_flag(self):
+        fp1, _, fp2 = self._round_trip(self.FIXED)
+        assert fp1.fixed == fp2.fixed
+
+    def test_fixed_round_trip_preserves_values(self):
+        fp1, _, fp2 = self._round_trip(self.FIXED)
+        for key in fp1:
+            assert fp1[key] == pytest.approx(fp2[key])
+
+    # -- Content of the spec itself --
+
+    def test_round_trip_spec_components(self):
+        _, spec, _ = self._round_trip(self.SINGLE)
+        assert len(spec.components) == 1
+        assert spec.components[0].label == "peak_a"
+        assert spec.components[0].model_name == "gaussianmodel"
+        assert set(spec.components[0].params) == {"ampl", "pos", "width"}
+
+    def test_round_trip_spec_values(self):
+        _, spec, _ = self._round_trip(self.SINGLE)
+        assert spec.components[0].params["ampl"].value == 1.5
+        assert spec.components[0].params["pos"].value == 100.0
+
+
+# ======================================================================================
+# Edge cases
+# ======================================================================================
+
+
+class TestEdgeCases:
+    def test_no_bounds_sentinel_converted_to_none(self):
+        """A param with 'none' for both bounds gets bounds=(None, None)."""
+        fp, _ = _validate_script_content(
+            "MODEL: X\nshape: gaussianmodel\n    $ ampl: 1.0\n"
+        )
+        spec = _FitModelSpec.from_fitparameters(fp)
+        ps = spec.components[0].params["ampl"]
+        assert ps.bounds == (None, None)
+
+    def test_no_common_section(self):
+        """When there is no COMMON section, common_params is empty."""
+        fp, _ = _validate_script_content(
+            "MODEL: X\nshape: gaussianmodel\n    $ ampl: 1.0\n"
+        )
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.common_params == {}
+
+    def test_parameters_in_order(self):
+        """Parameter names are preserved in the spec."""
+        fp, _ = _validate_script_content(
+            "MODEL: X\nshape: gaussianmodel\n"
+            "    $ zed: 3.0, 0.0, none\n"
+            "    $ ampl: 1.0, 0.0, none\n"
+            "    $ beta: 2.0, 0.0, none\n"
+        )
+        spec = _FitModelSpec.from_fitparameters(fp)
+        ps = spec.components[0].params
+        assert set(ps) == {"ampl", "beta", "zed"}
+
+    def test_spec_with_no_components_produces_empty_script(self):
+        spec = _FitModelSpec()
+        assert spec.to_script() == ""
+
+    def test_spec_with_only_common_produces_common_section(self):
+        spec = _FitModelSpec(
+            common_params={
+                "gratio": _ParamSpec(name="gratio", value=0.5),
+            }
+        )
+        script = spec.to_script()
+        assert script.startswith("COMMON:")
+        assert "$ gratio:" in script
+
+    def test_model_without_shape(self):
+        """A model with no shape gets an empty model_name."""
+        fp, _ = _validate_script_content(
+            "MODEL: X\nshape: gaussianmodel\n    $ ampl: 1.0\n"
+        )
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.components[0].model_name == "gaussianmodel"
+
+    def test_value_is_float(self):
+        """Parameter values are plain Python floats, not numpy types."""
+        import numpy as np
+
+        fp = FitParameters()
+        fp["test"] = (float(np.float64(1.5)), None, None)
+        # Simulate parser setup
+        fp.common["test"] = True
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert isinstance(spec.common_params["test"].value, float)
+
+    def test_multiple_components_same_param_names(self):
+        """Components with identically-named params don't interfere."""
+        script = """
+MODEL: A
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+
+MODEL: B
+shape: lorentzianmodel
+    $ ampl: 2.0, 0.0, none
+"""
+        _, spec, _ = TestRoundTrip._round_trip(script)
+        assert spec.components[0].params["ampl"].value == 1.0
+        assert spec.components[1].params["ampl"].value == 2.0
+
+    def test_bounds_integers_preserved(self):
+        """Integer bounds are preserved in the spec."""
+        fp, _ = _validate_script_content(
+            "MODEL: X\nshape: gaussianmodel\n    $ ampl: 1.0, 0, 10\n"
+        )
+        spec = _FitModelSpec.from_fitparameters(fp)
+        lo, hi = spec.components[0].params["ampl"].bounds
+        assert lo == 0.0
+        assert hi == 10.0
+
+
+class TestSpecRoundTripDirect:
+    """Test that spec -> script -> fp reconstructs the same spec."""
+
+    def test_build_from_spec(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="peak",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.5, bounds=(0.0, None)),
+                        "pos": _ParamSpec(name="pos", value=100.0, bounds=(0.0, 200.0)),
+                    },
+                )
+            ],
+            common_params={
+                "gratio": _ParamSpec(name="gratio", value=0.1, bounds=(0.0, 1.0)),
+            },
+        )
+        script = spec.to_script()
+        fp, errors = _validate_script_content(script)
+        assert errors == []
+
+        spec2 = _FitModelSpec.from_fitparameters(fp)
+        assert len(spec2.components) == 1
+        assert spec2.components[0].label == "peak"
+        assert spec2.components[0].model_name == "gaussianmodel"
+        assert spec2.common_params["gratio"].value == pytest.approx(0.1)
+        assert spec2.components[0].params["ampl"].value == pytest.approx(1.5)
+        assert spec2.components[0].params["ampl"].bounds[0] == 0.0
+        assert spec2.components[0].params["ampl"].bounds[1] is None
+
+
+class TestConstraintReserved:
+    """The constraints field is reserved; it should not affect parsing."""
+
+    def test_constraints_is_none_by_default(self):
+        spec = _FitModelSpec()
+        assert spec.constraints is None
+
+    def test_constraints_is_stored(self):
+        spec = _FitModelSpec(constraints={"dummy": True})
+        assert spec.constraints == {"dummy": True}


### PR DESCRIPTION
## Summary

Introduces the smallest possible private structured model-definition
object (`_FitModelSpec` in `_modelspec.py`).  This is Phase 2 of the
Optimize Model Definition campaign.

The object provides a clean in-memory representation of what the
parser already knows, separating model topology, parameter definitions,
and parameter values.

## Architecture

    script
        ↓
    parser
        ↓
    FitParameters  (existing)
        ↓
    _FitModelSpec  (new — this PR)
        ↓
    script  (via to_script())

## No user-visible changes

- No public API.
- No Optimize integration.
- No FitParameters redesign.
- No fitting.
- No changelog entry (private internal only).
