### PR TITLE
MAINT: Extract parameter-space transforms from FitParameters

### DIFF
--- a/src/spectrochempy/analysis/curvefitting/__init__.pyi
+++ b/src/spectrochempy/analysis/curvefitting/__init__.pyi
@@ -9,6 +9,7 @@
 __all__ = [
     "_models",
     "_modelspec",
+    "_parameter_transform",
     "_parameters",
     "linearregression",
     "optimize",
@@ -16,6 +17,7 @@ __all__ = [
 
 from . import _models
 from . import _modelspec
+from . import _parameter_transform
 from . import _parameters
 from . import linearregression
 from . import optimize

--- a/src/spectrochempy/analysis/curvefitting/_parameter_transform.py
+++ b/src/spectrochempy/analysis/curvefitting/_parameter_transform.py
@@ -1,0 +1,132 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+Solver-specific parameter-space transforms.
+
+These functions convert parameters between *physical space* (the space that
+users and models operate in) and the *unbounded optimizer space* that solvers
+require internally.
+
+Responsibilities
+----------------
+- Map bounded physical parameters to the unbounded real line so that
+  gradient-based and simplex-based optimizers can search freely.
+- Map unbounded optimizer values back to the bounded physical space.
+
+Why these belong to the solver layer
+-------------------------------------
+- Bounds on a model parameter are a solver concern: the model itself does not
+  need to know how the optimizer enforces constraints.
+- The transforms (arcsin, sqrt, etc.) are dictated by the optimizer's need for
+  an unbounded search space, not by the mathematical definition of the model.
+- Different solvers may want different transforms; keeping them separate from
+  the model representation makes it possible to change the transform strategy
+  without touching model-definition code.
+
+These functions operate on atomic values and bounds only — they have no
+dependency on ``FitParameters``, ``_FitModelSpec``, or any other
+model-definition object.
+"""
+
+import sys
+
+import numpy as np
+
+# ======================================================================================
+# Threshold constants (preserved from the original FitParameters implementation)
+# ======================================================================================
+
+# Bounds equal to or beyond these thresholds are treated as "unbounded".
+# The original implementation uses these to detect the sentinel values that
+# the parser substitutes for "none" (open) bounds.
+_LOB_THRESHOLD = -0.1 / sys.float_info.epsilon
+_UPB_THRESHOLD = +0.1 / sys.float_info.epsilon
+
+
+# ======================================================================================
+# Public transform functions
+# ======================================================================================
+
+
+def _to_internal(value, lob, upb):
+    """
+    Convert a parameter *value* from physical space to optimizer (unbounded) space.
+
+    Parameters
+    ----------
+    value : float
+        The parameter value in physical space.
+    lob : float or None
+        Lower bound in physical space (``None`` means unbounded below).
+    upb : float or None
+        Upper bound in physical space (``None`` means unbounded above).
+
+    Returns
+    -------
+    float
+        The transformed value in unbounded optimizer space.
+    """
+    is_lob = lob is not None and lob > _LOB_THRESHOLD
+    is_upb = lob is not None and upb < _UPB_THRESHOLD
+
+    if is_lob and is_upb:
+        lob_adj = min(value, lob)
+        upb_adj = max(value, upb)
+        return np.arcsin((2.0 * (value - lob_adj) / (upb_adj - lob_adj)) - 1.0)
+
+    if is_upb:
+        upb_adj = max(value, upb)
+        return np.sqrt((upb_adj - value + 1.0) ** 2 - 1.0)
+
+    if is_lob:
+        lob_adj = min(value, lob)
+        return np.sqrt((value - lob_adj + 1.0) ** 2 - 1.0)
+
+    return value
+
+
+def _to_external(pi, lob, upb):
+    """
+    Convert a parameter value from optimizer (unbounded) space to physical space.
+
+    Parameters
+    ----------
+    pi : float or list of float
+        The value(s) in unbounded optimizer space.
+    lob : float or None
+        Lower bound in physical space (``None`` means unbounded below).
+    upb : float or None
+        Upper bound in physical space (``None`` means unbounded above).
+
+    Returns
+    -------
+    float or list of float
+        The transformed value(s) in physical space.  Returns a bare float when
+        *pi* is a scalar or a single-element list; returns a list when *pi*
+        is a multi-element list.
+    """
+    is_lob = lob is not None and lob > _LOB_THRESHOLD
+    is_upb = lob is not None and upb < _UPB_THRESHOLD
+
+    if not isinstance(pi, list):
+        pi = [pi]
+
+    pe = []
+    for item in pi:
+        if is_lob and is_upb:
+            pei = lob + ((upb - lob) / 2.0) * (np.sin(item) + 1.0)
+        elif is_upb:
+            pei = upb + 1.0 - np.sqrt(item**2 + 1.0)
+        elif is_lob:
+            pei = lob - 1.0 + np.sqrt(item**2 + 1.0)
+        else:
+            pei = pi
+        pe.append(pei)
+
+    if len(pe) == 1:
+        return pe[0]
+
+    return pe

--- a/src/spectrochempy/analysis/curvefitting/_parameters.py
+++ b/src/spectrochempy/analysis/curvefitting/_parameters.py
@@ -10,7 +10,8 @@ import sys
 from collections import UserDict
 from contextlib import suppress
 
-import numpy as np
+from ._parameter_transform import _to_external
+from ._parameter_transform import _to_internal
 
 
 # =============================================================================
@@ -182,32 +183,7 @@ class FitParameters(UserDict):
             raise KeyError(f"parameter `{key}` is not found")
 
         pe = self.data[key][expi] if expi is not None else self.data[key]
-        lob = self.lob[key]
-        upb = self.upb[key]
-
-        is_lob = (
-            lob is not None and lob > -0.1 / sys.float_info.epsilon
-        )  # lob is not None
-        is_upb = (
-            lob is not None and upb < +0.1 / sys.float_info.epsilon
-        )  # upb is not None
-
-        if is_lob and is_upb:
-            lob = min(pe, lob)
-            upb = max(pe, upb)
-            # With min and max bounds defined
-            pi = np.arcsin((2 * (pe - lob) / (upb - lob)) - 1.0)
-        elif is_upb:
-            upb = max(pe, upb)
-            # With only max defined
-            pi = np.sqrt((upb - pe + 1.0) ** 2 - 1.0)
-        elif is_lob:
-            lob = min(pe, lob)
-            # With only min defined
-            pi = np.sqrt((pe - lob + 1.0) ** 2 - 1.0)
-        else:
-            pi = pe
-        return pi
+        return _to_internal(pe, self.lob[key], self.upb[key])
 
     # ----------------------------------------------------------------------------------
     def to_external(self, key, pi):
@@ -215,41 +191,8 @@ class FitParameters(UserDict):
         if key not in self.data:
             raise KeyError(f"parameter `{key}` is not found")
 
-        lob = self.lob[key]
-        upb = self.upb[key]
-
-        is_lob = (
-            lob is not None and lob > -0.1 / sys.float_info.epsilon
-        )  # lob is not None
-        is_upb = (
-            lob is not None and upb < +0.1 / sys.float_info.epsilon
-        )  # upb is not None
-
-        if not isinstance(pi, list):
-            pi = [
-                pi,
-            ]  # make a list
-
-        pe = []
-        for item in pi:
-            if is_lob and is_upb:
-                #  With min and max bounds defined
-                pei = lob + ((upb - lob) / 2.0) * (np.sin(item) + 1.0)
-            elif is_upb:
-                # With only max defined
-                pei = upb + 1.0 - np.sqrt(item**2 + 1.0)
-            elif is_lob:
-                # With only min defined
-                pei = lob - 1.0 + np.sqrt(item**2 + 1.0)
-            else:
-                pei = pi
-            pe.append(pei)
-
-        if len(pe) == 1:
-            pe = pe[0]
-
+        pe = _to_external(pi, self.lob[key], self.upb[key])
         self.data[key] = pe
-
         return pe
 
     def copy(self):

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -19,6 +19,8 @@ from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis.curvefitting import _models as models_
+from spectrochempy.analysis.curvefitting._parameter_transform import _to_external
+from spectrochempy.analysis.curvefitting._parameter_transform import _to_internal
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.application.application import info_
 from spectrochempy.application.application import warning_
@@ -1850,12 +1852,20 @@ def _optimize(
                     k = keys.index(ks)
                     ps.append(p[k])
                 if ps:
-                    fp.to_external(key, ps)
+                    fp.data[key] = _to_external(
+                        ps,
+                        fp.lob[key],
+                        fp.upb[key],
+                    )
             else:
                 if key not in keys:
                     continue
                 k = keys.index(key)
-                fp.to_external(key, p[k])
+                fp.data[key] = _to_external(
+                    p[k],
+                    fp.lob[key],
+                    fp.upb[key],
+                )
         return fp
 
     def internal_func(p, dat, fp, keys, *args):
@@ -1881,10 +1891,22 @@ def _optimize(
             keysp = key.split("_")[0]
             if keysp in fp0.expvars:
                 for i in range(fp0.expnumber):
-                    par.append(fp0.to_internal(key, i))
+                    par.append(
+                        _to_internal(
+                            fp0.data[key][i],
+                            fp0.lob[key],
+                            fp0.upb[key],
+                        ),
+                    )
                     keys.append(f"{key}_exp{i}")
             else:
-                par.append(fp0.to_internal(key))
+                par.append(
+                    _to_internal(
+                        fp0.data[key],
+                        fp0.lob[key],
+                        fp0.upb[key],
+                    ),
+                )
                 keys.append(key)
 
     args = list(args)

--- a/tests/test_analysis/test_curvefitting/test_parameter_transform.py
+++ b/tests/test_analysis/test_curvefitting/test_parameter_transform.py
@@ -1,0 +1,290 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Tests for solver-specific parameter-space transform functions."""
+
+import math
+import sys
+
+import numpy as np
+import pytest
+
+from spectrochempy.analysis.curvefitting._parameter_transform import _to_external
+from spectrochempy.analysis.curvefitting._parameter_transform import _to_internal
+
+# ======================================================================================
+# Constants
+# ======================================================================================
+
+# Sentinel values matching what the parser produces for "none" bounds
+_SENTINEL_LOB = -1.0 / sys.float_info.epsilon
+_SENTINEL_UPB = +1.0 / sys.float_info.epsilon
+
+# A moderate value guaranteed to be within any bounded interval used here
+_MID_VALUE = 50.0
+
+
+# ======================================================================================
+# _to_internal
+# ======================================================================================
+
+
+class TestToInternal:
+    """Transform from physical space → optimizer (unbounded) space."""
+
+    # -- finite bounds -------------------------------------------------------
+
+    def test_finite_bounds_inverts_properly(self):
+        pe = _to_internal(50.0, 0.0, 100.0)
+        assert np.isfinite(pe)
+
+    def test_finite_bounds_midpoint_is_zero(self):
+        pe = _to_internal(50.0, 0.0, 100.0)
+        assert pe == pytest.approx(0.0, abs=1e-10)
+
+    def test_finite_bounds_within_range(self):
+        pe = _to_internal(25.0, 0.0, 100.0)
+        assert pe < 0.0
+
+    def test_finite_bounds_value_at_lob(self):
+        pe = _to_internal(0.0, 0.0, 100.0)
+        assert pe == pytest.approx(-math.pi / 2.0, abs=1e-10)
+
+    def test_finite_bounds_value_at_upb(self):
+        pe = _to_internal(100.0, 0.0, 100.0)
+        assert pe == pytest.approx(+math.pi / 2.0, abs=1e-10)
+
+    # -- open bounds (no bounds) --------------------------------------------
+
+    def test_open_bounds_identity(self):
+        pe = _to_internal(42.0, _SENTINEL_LOB, _SENTINEL_UPB)
+        assert pe == pytest.approx(42.0)
+
+    def test_open_bounds_negative(self):
+        pe = _to_internal(-10.0, _SENTINEL_LOB, _SENTINEL_UPB)
+        assert pe == pytest.approx(-10.0)
+
+    def test_open_bounds_zero(self):
+        pe = _to_internal(0.0, _SENTINEL_LOB, _SENTINEL_UPB)
+        assert pe == pytest.approx(0.0)
+
+    def test_open_bounds_none_input(self):
+        pe = _to_internal(42.0, None, None)
+        assert pe == pytest.approx(42.0)
+
+    # -- lower-only bounds ---------------------------------------------------
+
+    def test_lower_only_positive_value(self):
+        pe = _to_internal(50.0, 0.0, _SENTINEL_UPB)
+        assert np.isfinite(pe)
+        assert pe > 0.0
+
+    def test_lower_only_at_bound(self):
+        pe = _to_internal(0.0, 0.0, _SENTINEL_UPB)
+        assert pe == pytest.approx(0.0)
+
+    def test_lower_only_negative_lob_and_value(self):
+        pe = _to_internal(-5.0, -10.0, _SENTINEL_UPB)
+        assert np.isfinite(pe)
+
+    # -- upper-only bounds ---------------------------------------------------
+
+    def test_upper_only_positive_value(self):
+        pe = _to_internal(50.0, _SENTINEL_LOB, 100.0)
+        assert np.isfinite(pe)
+        assert pe > 0.0
+
+    def test_upper_only_value_at_bound_returns_zero(self):
+        pe = _to_internal(100.0, _SENTINEL_LOB, 100.0)
+        assert pe == pytest.approx(0.0)
+
+    def test_upper_only_value_below_upb_returns_positive(self):
+        pe = _to_internal(50.0, _SENTINEL_LOB, 100.0)
+        assert np.isfinite(pe)
+
+    # -- edge cases ----------------------------------------------------------
+
+    def test_value_outside_below_lob(self):
+        pe = _to_internal(-10.0, 0.0, 100.0)
+        assert np.isfinite(pe)
+
+    def test_value_outside_above_upb(self):
+        pe = _to_internal(200.0, 0.0, 100.0)
+        assert np.isfinite(pe)
+
+    def test_value_equals_none_upb_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            _to_internal(50.0, 0.0, None)
+
+
+# ======================================================================================
+# _to_external
+# ======================================================================================
+
+
+class TestToExternal:
+    """Transform from optimizer (unbounded) space → physical space."""
+
+    # -- finite bounds -------------------------------------------------------
+
+    def test_finite_bounds_zero_returns_midpoint(self):
+        pe = _to_external(0.0, 0.0, 100.0)
+        assert pe == pytest.approx(50.0, abs=1e-10)
+
+    def test_finite_bounds_negative_arcsin(self):
+        pe = _to_external(-1.0, 0.0, 100.0)
+        assert pe < 50.0
+
+    def test_finite_bounds_positive_arcsin(self):
+        pe = _to_external(+1.0, 0.0, 100.0)
+        assert pe > 50.0
+
+    # -- open bounds (no bounds) --------------------------------------------
+
+    def test_open_bounds_sentinel_returns_list(self):
+        pe = _to_external(42.0, _SENTINEL_LOB, _SENTINEL_UPB)
+        assert isinstance(pe, list)
+        assert pe == [42.0]
+
+    def test_open_bounds_none_returns_list(self):
+        pe = _to_external(42.0, None, None)
+        assert isinstance(pe, list)
+        assert pe == [42.0]
+
+    # -- lower-only bounds ---------------------------------------------------
+
+    def test_lower_only_scalar(self):
+        pe = _to_external(0.0, 0.0, _SENTINEL_UPB)
+        assert np.isfinite(pe)
+        assert pe >= 0.0
+
+    # -- upper-only bounds ---------------------------------------------------
+
+    def test_upper_only_scalar(self):
+        pe = _to_external(0.0, _SENTINEL_LOB, 100.0)
+        assert np.isfinite(pe)
+        assert pe <= 100.0
+
+    # -- list input ----------------------------------------------------------
+
+    def test_list_input_finite_bounds(self):
+        pe = _to_external([0.0, 0.0], 0.0, 100.0)
+        assert isinstance(pe, list)
+        assert len(pe) == 2
+        assert pe[0] == pytest.approx(50.0, abs=1e-10)
+        assert pe[1] == pytest.approx(50.0, abs=1e-10)
+
+    def test_list_input_open_bounds(self):
+        pe = _to_external([1.0, 2.0], _SENTINEL_LOB, _SENTINEL_UPB)
+        assert isinstance(pe, list)
+        assert len(pe) == 2
+
+    def test_list_single_element_open_bounds_returns_single_element_list(self):
+        pe = _to_external([42.0], _SENTINEL_LOB, _SENTINEL_UPB)
+        assert isinstance(pe, list)
+        assert pe == [42.0]
+
+    # -- edge cases ----------------------------------------------------------
+
+    def test_single_element_list_finite_bounds_returns_scalar(self):
+        pe = _to_external([0.0], 0.0, 100.0)
+        assert not isinstance(pe, list)
+
+    def test_lob_none_with_finite_upb_returns_list(self):
+        pe = _to_external(0.0, None, 100.0)
+        assert isinstance(pe, list)
+
+
+# ======================================================================================
+# Round-trip consistency
+# ======================================================================================
+
+
+class TestRoundTrip:
+    """Verify that to_internal + to_external recovers the original value."""
+
+    RTOL = 1e-10
+    ATOL = 1e-10
+
+    def check_round_trip(self, value, lob, upb):
+        pe = _to_internal(value, lob, upb)
+        recovered = _to_external(pe, lob, upb)
+        assert recovered == pytest.approx(value, rel=self.RTOL, abs=self.ATOL)
+
+    def check_round_trip_list(self, value, lob, upb):
+        """Check round-trip for open bounds where _to_external returns a list."""
+        pe = _to_internal(value, lob, upb)
+        recovered = _to_external(pe, lob, upb)
+        assert isinstance(recovered, list)
+        assert len(recovered) == 1
+        assert recovered[0] == pytest.approx(value, rel=self.RTOL, abs=self.ATOL)
+
+    # -- finite bounds -------------------------------------------------------
+
+    def test_finite_bounds_midpoint(self):
+        self.check_round_trip(50.0, 0.0, 100.0)
+
+    def test_finite_bounds_near_lob(self):
+        self.check_round_trip(1.0, 0.0, 100.0)
+
+    def test_finite_bounds_near_upb(self):
+        self.check_round_trip(99.0, 0.0, 100.0)
+
+    def test_finite_bounds_at_lob(self):
+        self.check_round_trip(0.0, 0.0, 100.0)
+
+    def test_finite_bounds_at_upb(self):
+        self.check_round_trip(100.0, 0.0, 100.0)
+
+    # -- open bounds ---------------------------------------------------------
+
+    def test_open_bounds_sentinel(self):
+        self.check_round_trip_list(42.0, _SENTINEL_LOB, _SENTINEL_UPB)
+
+    def test_open_bounds_none(self):
+        self.check_round_trip_list(42.0, None, None)
+
+    def test_open_bounds_negative(self):
+        self.check_round_trip_list(-10.0, _SENTINEL_LOB, _SENTINEL_UPB)
+
+    def test_open_bounds_zero(self):
+        self.check_round_trip_list(0.0, _SENTINEL_LOB, _SENTINEL_UPB)
+
+    # -- lower-only bounds ---------------------------------------------------
+
+    def test_lower_only(self):
+        self.check_round_trip(50.0, 0.0, _SENTINEL_UPB)
+
+    def test_lower_only_near_bound(self):
+        self.check_round_trip(1.0, 0.0, _SENTINEL_UPB)
+
+    def test_lower_only_at_bound(self):
+        self.check_round_trip(0.0, 0.0, _SENTINEL_UPB)
+
+    # -- upper-only bounds ---------------------------------------------------
+
+    def test_upper_only(self):
+        self.check_round_trip(50.0, _SENTINEL_LOB, 100.0)
+
+    def test_upper_only_near_bound(self):
+        self.check_round_trip(99.0, _SENTINEL_LOB, 100.0)
+
+    def test_upper_only_at_bound(self):
+        self.check_round_trip(100.0, _SENTINEL_LOB, 100.0)
+
+    # -- values outside declared bounds --------------------------------------
+    # These do not round-trip because the internal transform clamps lob/upb
+    # to the value before applying the arcsin transform. The round-trip
+    # recovers the clamped value, not the original outside-bounds value.
+
+    def test_outside_below_lob_clamps_to_lob(self):
+        pe = _to_internal(-10.0, 0.0, 100.0)
+        recovered = _to_external(pe, 0.0, 100.0)
+        assert recovered == pytest.approx(0.0)
+
+    def test_outside_above_upb_clamps_to_upb(self):
+        pe = _to_internal(200.0, 0.0, 100.0)
+        recovered = _to_external(pe, 0.0, 100.0)
+        assert recovered == pytest.approx(100.0)


### PR DESCRIPTION
### Summary
Extract solver-specific to_internal/to_external parameter-space transforms from FitParameters into standalone internal utilities.

### Changes
New _parameter_transform.py module with _to_internal(value, lob, upb) and _to_external(pi, lob, upb) — pure functions operating on atomic values and bounds with no dependency on FitParameters or any model-definition object.
FitParameters delegation — to_internal()/to_external() now delegate to the standalone functions. Public signature and behavior unchanged.
_optimize direct usage — _optimize() and restore_external() call standalone functions directly with explicit fp.data[key] updates.
No public API changes, no parser changes, no DSL changes, no _FitModelSpec changes.
### Why
Parameter-space transforms (arcsin/sqrt mappings from bounded physical space to unbounded optimizer space) are a solver responsibility, not a model-definition responsibility. Extracting them makes the solver layer independently reusable and is Phase B1 of the Optimize convergence roadmap.

Behavior identical before/after: all existing FitParameters methods, Optimize fitting, and parser round-trips produce identical results