### PR TITLE
MAINT: add count_varying() and extract_varying_values() to _FitModelSpec

### DIFF
--- a/src/spectrochempy/analysis/curvefitting/_modelspec.py
+++ b/src/spectrochempy/analysis/curvefitting/_modelspec.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
 
+import numpy as np
+
 # Sentinel bound thresholds (same as FitParameters.__str__)
 _STR_NEG_THRESH = -0.1 / sys.float_info.epsilon
 _STR_POS_THRESH = +0.1 / sys.float_info.epsilon
@@ -38,7 +40,7 @@ class _ParamSpec:
     """Parameter definition with value, bounds, and flags."""
 
     name: str
-    value: float = 0.0
+    value: float | list[float] = 0.0
     vary: bool = True
     bounds: tuple[float | None, float | None] = (None, None)
     reference: str | None = None  # name of referenced COMMON param, or None
@@ -73,10 +75,14 @@ class _FitModelSpec:
         components: list[_ComponentSpec] | None = None,
         common_params: dict[str, _ParamSpec] | None = None,
         constraints: Any = None,
+        expvars: list[str] | None = None,
+        expnumber: int = 1,
     ):
         self.components = list(components or [])
         self.common_params = dict(common_params or {})
         self.constraints = constraints  # reserved, not yet used
+        self.expvars = list(expvars or [])
+        self.expnumber = expnumber
 
     # ------------------------------------------------------------------
     @classmethod
@@ -107,9 +113,13 @@ class _FitModelSpec:
                     reference=str(fp[raw_name]),
                 )
             else:
+                if raw_name in fp.expvars:
+                    value = list(fp[raw_name])
+                else:
+                    value = float(fp[raw_name])
                 common_params[raw_name] = _ParamSpec(
                     name=raw_name,
-                    value=float(fp[raw_name]),
+                    value=value,
                     vary=not fp.fixed.get(raw_name, False),
                     bounds=(
                         _unbound(fp.lob.get(raw_name)),
@@ -144,9 +154,13 @@ class _FitModelSpec:
                         reference=str(fp[full_key]),
                     )
                 else:
+                    if param_raw in fp.expvars:
+                        value = list(fp[full_key])
+                    else:
+                        value = float(fp[full_key])
                     model_params[param_raw] = _ParamSpec(
                         name=param_raw,
-                        value=float(fp[full_key]),
+                        value=value,
                         vary=not fp.fixed.get(full_key, False),
                         bounds=(
                             _unbound(fp.lob.get(full_key)),
@@ -162,7 +176,12 @@ class _FitModelSpec:
                 )
             )
 
-        return cls(components=components, common_params=common_params)
+        return cls(
+            components=components,
+            common_params=common_params,
+            expvars=list(fp.expvars),
+            expnumber=fp.expnumber,
+        )
 
     # ------------------------------------------------------------------
     def to_script(self) -> str:
@@ -209,6 +228,73 @@ class _FitModelSpec:
         if result:
             result += "\n"
         return result
+
+    # ------------------------------------------------------------------
+    def _iter_varying(self):
+        """
+        Yield ``(sorted_key, param_spec)`` for varying parameters.
+
+        Iteration order matches ``sorted(fp.keys())`` from
+        ``FitParameters`` for consistent behavior.
+        """
+        items: list[tuple[str, _ParamSpec]] = []
+
+        for name, ps in self.common_params.items():
+            items.append((name, ps))
+
+        for comp in self.components:
+            for name, ps in comp.params.items():
+                key = f"{name}_{comp.label}"
+                items.append((key, ps))
+
+        items.sort(key=lambda x: x[0])
+
+        for key, ps in items:
+            if not ps.vary:
+                continue
+            yield key, ps
+
+    # ------------------------------------------------------------------
+    def count_varying(self) -> int:
+        """
+        Count free parameters using the same rule as the optimizer.
+
+        Returns
+        -------
+        int
+            Number of varying parameters.
+        """
+        n_varying = 0
+        for _key, ps in self._iter_varying():
+            if ps.name in self.expvars:
+                n_varying += self.expnumber
+            else:
+                n_varying += 1
+        return n_varying
+
+    # ------------------------------------------------------------------
+    def extract_varying_values(self):
+        """
+        Return fitted varying-parameter values in optimizer order.
+
+        Returns
+        -------
+        ndarray or None
+            Frozen 1-D array of varying parameter values, or ``None``
+            when the model has no varying parameters.
+        """
+        values: list[float] = []
+        for _key, ps in self._iter_varying():
+            if ps.name in self.expvars:
+                values.extend(
+                    np.asarray(ps.value, dtype=np.float64).reshape(-1).tolist(),
+                )
+            else:
+                values.append(float(ps.value))
+
+        array = np.array(values, dtype=np.float64)
+        array.flags.writeable = False
+        return array
 
 
 def _format_bound(val: float | None) -> str:

--- a/tests/test_analysis/test_curvefitting/test_modelspec.py
+++ b/tests/test_analysis/test_curvefitting/test_modelspec.py
@@ -7,6 +7,7 @@
 
 import sys
 
+import numpy as np
 import pytest
 
 from spectrochempy.analysis.curvefitting._modelspec import _ComponentSpec
@@ -14,6 +15,10 @@ from spectrochempy.analysis.curvefitting._modelspec import _FitModelSpec
 from spectrochempy.analysis.curvefitting._modelspec import _ParamSpec
 from spectrochempy.analysis.curvefitting._modelspec import _unbound
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
+from spectrochempy.analysis.curvefitting.optimize import _count_varying_parameters
+from spectrochempy.analysis.curvefitting.optimize import (
+    _extract_varying_parameter_values,
+)
 from spectrochempy.analysis.curvefitting.optimize import _validate_script_content
 
 # ======================================================================================
@@ -703,3 +708,272 @@ class TestConstraintReserved:
     def test_constraints_is_stored(self):
         spec = _FitModelSpec(constraints={"dummy": True})
         assert spec.constraints == {"dummy": True}
+
+
+# ======================================================================================
+# Tests for count_varying
+# ======================================================================================
+
+
+class TestCountVarying:
+    """Test _FitModelSpec.count_varying()."""
+
+    SCRIPT = """
+MODEL: PEAK_A
+shape: gaussianmodel
+    $ ampl:  1.5, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+"""
+
+    def test_all_varying(self):
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.count_varying() == 3
+
+    def test_one_fixed(self):
+        fp, _ = _validate_script_content(
+            "MODEL: X\nshape: gaussianmodel\n"
+            "    * ampl: 1.0, 0.0, none\n"
+            "    $ pos:  100.0, 0.0, 200.0\n"
+        )
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.count_varying() == 1
+
+    def test_all_fixed(self):
+        fp, _ = _validate_script_content(
+            "MODEL: X\nshape: gaussianmodel\n"
+            "    * ampl: 1.0, 0.0, none\n"
+            "    * pos:  100.0, 0.0, 200.0\n"
+        )
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.count_varying() == 0
+
+    def test_with_common(self):
+        script = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.count_varying() == 3
+
+    def test_with_reference(self):
+        script = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    > ratio: gratio
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        # gratio varies, ampl varies, ratio is reference (fixed) → 2
+        assert spec.count_varying() == 2
+
+    def test_multiple_components(self):
+        script = """
+MODEL: A
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+
+MODEL: B
+shape: lorentzianmodel
+    $ ampl: 0.5, 0.0, none
+    $ pos:  150.0, 0.0, 300.0
+    $ width: 10.0, 0.0, none
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.count_varying() == 5
+
+    def test_empty_spec(self):
+        spec = _FitModelSpec()
+        assert spec.count_varying() == 0
+
+    def test_none_fp(self):
+        assert _count_varying_parameters(None) == 0
+
+    def test_equivalence_with_fp_helper(self):
+        """Numerical equivalence with the existing FitParameters-based helper."""
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.count_varying() == _count_varying_parameters(fp)
+
+    def test_equivalence_with_common(self):
+        script = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+    * fixed_c: 5.0, 0.0, 10.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    * pos:   100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        assert spec.count_varying() == _count_varying_parameters(fp)
+        # gratio varies, ampl varies, width varies → 3
+        assert spec.count_varying() == 3
+
+
+# ======================================================================================
+# Tests for extract_varying_values
+# ======================================================================================
+
+
+class TestExtractVaryingValues:
+    """Test _FitModelSpec.extract_varying_values()."""
+
+    def test_single_component(self):
+        script = """
+MODEL: PEAK
+shape: gaussianmodel
+    $ ampl: 1.5, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        values = spec.extract_varying_values()
+        assert isinstance(values, np.ndarray)
+        assert values.shape == (2,)
+        assert values[0] == 1.5  # ampl_peak
+        assert values[1] == 100.0  # pos_peak
+
+    def test_fixed_param_excluded(self):
+        script = """
+MODEL: X
+shape: gaussianmodel
+    * ampl: 1.0, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        values = spec.extract_varying_values()
+        assert values.shape == (1,)
+        assert values[0] == 100.0
+
+    def test_all_fixed_returns_array(self):
+        script = """
+MODEL: X
+shape: gaussianmodel
+    * ampl: 1.0, 0.0, none
+    * pos:  100.0, 0.0, 200.0
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        values = spec.extract_varying_values()
+        assert isinstance(values, np.ndarray)
+        assert values.shape == (0,)
+
+    def test_with_common(self):
+        script = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        values = spec.extract_varying_values()
+        assert values.shape == (2,)
+        # Sorted key order: ampl_x < gratio
+        assert values[0] == 1.0  # ampl_x
+        assert values[1] == 0.1  # gratio
+
+    def test_reference_excluded(self):
+        script = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    > ratio: gratio
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        values = spec.extract_varying_values()
+        assert values.shape == (2,)
+        # Sorted key order: ampl_x < gratio
+        assert values[0] == 1.0  # ampl_x
+        assert values[1] == 0.1  # gratio
+
+    def test_empty_spec_returns_empty_array(self):
+        spec = _FitModelSpec()
+        values = spec.extract_varying_values()
+        assert isinstance(values, np.ndarray)
+        assert values.shape == (0,)
+
+    def test_none_fp(self):
+        assert _extract_varying_parameter_values(None) is None
+
+    def test_deterministic_ordering(self):
+        """Parameter ordering is deterministic across multiple calls."""
+        script = """
+COMMON:
+    $ zed:   99.0, 0.0, 200.0
+    $ alpha: 0.5, 0.0, 1.0
+
+MODEL: B
+shape: lorentzianmodel
+    $ width: 20.0, 0.0, none
+
+MODEL: A
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        v1 = spec.extract_varying_values().tolist()
+        v2 = spec.extract_varying_values().tolist()
+        assert v1 == v2
+
+    def test_equivalence_with_fp_helper(self):
+        """Numerical equivalence with the existing FitParameters-based helper."""
+        script = """
+COMMON:
+    $ gratio: 0.1, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.5, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        spec_values = spec.extract_varying_values()
+        fp_values = _extract_varying_parameter_values(fp)
+        assert spec_values.shape == fp_values.shape
+        np.testing.assert_array_almost_equal(spec_values, fp_values)
+
+    def test_equivalence_multi_component(self):
+        script = """
+MODEL: A
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+
+MODEL: B
+shape: lorentzianmodel
+    * ampl: 0.5, 0.0, none
+    $ pos:  150.0, 0.0, 300.0
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        spec_values = spec.extract_varying_values()
+        fp_values = _extract_varying_parameter_values(fp)
+        np.testing.assert_array_almost_equal(spec_values, fp_values)


### PR DESCRIPTION
## Summary

Move model-inspection responsibilities from `FitParameters`-based helpers to
the structured `_FitModelSpec` representation (Phase B2 of the approved
convergence strategy).

## Changes

- **`_FitModelSpec.count_varying()`** — counts varying parameters by iterating
  components and common params, handling `expvars`/`expnumber` expansion.
- **`_FitModelSpec.extract_varying_values()`** — returns a frozen ndarray of
  varying parameter values in `sorted(fp.keys())` order.
- **`_iter_varying()`** — private ordered iterator over varying params, sorting
  generated `{name}_{label}` keys to match `FitParameters` order.
- **`from_fitparameters()`** — now copies `expvars`/`expnumber` and handles
  list-valued experiment-dependent parameters.
- **`_ParamSpec.value`** — type broadened to `float | list[float]`.

## Design decisions

- The existing `_count_varying_parameters` and `_extract_varying_parameter_values`
  helpers in `optimize.py` retain their original implementations (no delegation).
  Delegation is not possible because `from_fitparameters` requires parser-populated
  `fp.common` dict, but `FitParameters` can be constructed directly.
- The spec methods are new capabilities that downstream migration phases can adopt
  when `_FitModelSpec` becomes the primary internal representation.