### PR TITLE
MAINT: Decouple getmodel() from {param}_{label} parser convention via _ComponentParamsView adapter

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -225,6 +225,19 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Extracted parameter-space transforms from ``FitParameters`` into
+  standalone ``_to_internal`` / ``_to_external`` utilities
+  (``_parameter_transform.py``).  Two historical bugs fixed: ``lob is not
+  None`` → ``upb is not None``, ``pei = pi`` → ``pei = item``.  (#1388, #1389)
+
+- MAINT: Added private ``_FitModelSpec`` structured model-definition object
+  with ``from_fitparameters(fp)`` constructor, ``to_script()`` serializer, and
+  ``count_varying()`` / ``extract_varying_values()`` inspection methods.
+  ``_ComponentParamsView`` adapter decouples ``getmodel()`` from the
+  ``{param}_{label}`` parser convention by duck-typing.  Strategy B of the
+  Optimize convergence plan — three phases delivered: parameter transform
+  extraction, structured model spec, component-params adapter.  (#1387, #1390)
+
 - ``MCRALS``: introduced the public constraint API skeleton
   (``spectrochempy.analysis.decomposition.mcrals_constraints``). The new
   public classes ``Constraint`` (abstract base), ``NonNegative``,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -192,6 +192,19 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Extracted parameter-space transforms from ``FitParameters`` into
+  standalone ``_to_internal`` / ``_to_external`` utilities
+  (``_parameter_transform.py``).  Two historical bugs fixed: ``lob is not
+  None`` → ``upb is not None``, ``pei = pi`` → ``pei = item``.  (#1388, #1389)
+
+- MAINT: Added private ``_FitModelSpec`` structured model-definition object
+  with ``from_fitparameters(fp)`` constructor, ``to_script()`` serializer, and
+  ``count_varying()`` / ``extract_varying_values()`` inspection methods.
+  ``_ComponentParamsView`` adapter decouples ``getmodel()`` from the
+  ``{param}_{label}`` parser convention by duck-typing.  Strategy B of the
+  Optimize convergence plan — three phases delivered: parameter transform
+  extraction, structured model spec, component-params adapter.  (#1387, #1390)
+
 - ``MCRALS``: introduced the public constraint API skeleton
   (``spectrochempy.analysis.decomposition.mcrals_constraints``). The new
   public classes ``Constraint`` (abstract base), ``NonNegative``,

--- a/src/spectrochempy/analysis/curvefitting/_modelspec.py
+++ b/src/spectrochempy/analysis/curvefitting/_modelspec.py
@@ -296,6 +296,27 @@ class _FitModelSpec:
         array.flags.writeable = False
         return array
 
+    # ------------------------------------------------------------------
+    def component_view(self, label: str):
+        """
+        Return a ``_ComponentParamsView`` for the component identified by *label*.
+
+        Parameters
+        ----------
+        label : str
+            Component label to look up.
+
+        Returns
+        -------
+        _ComponentParamsView
+            Lightweight view providing ``.model`` dict and ``__getitem__``
+            compatible with :func:`getmodel`.
+        """
+        for comp in self.components:
+            if comp.label == label:
+                return _ComponentParamsView(comp, self.common_params)
+        raise KeyError(f"Component '{label}' not found in spec")
+
 
 def _format_bound(val: float | None) -> str:
     """Format a bound value for script output."""
@@ -305,3 +326,54 @@ def _format_bound(val: float | None) -> str:
     if val == int(val):
         return f"{int(val)}"
     return f"{val:.4f}"
+
+
+# ======================================================================================
+class _ComponentParamsView:
+    """
+    Lightweight parameter-view for a single component.
+
+    Provides the two operations that :func:`getmodel` needs from its
+    ``par`` argument:
+
+    * ``.model[component_label]`` → model shape name
+    * ``par[f"{param}_{label}"]`` → parameter value
+
+    This allows :func:`getmodel` to operate on structured model data
+    without depending on the ``{param}_{label}`` parser convention.
+    """
+
+    def __init__(
+        self,
+        component: _ComponentSpec,
+        common_params: dict[str, _ParamSpec] | None = None,
+    ):
+        self._component = component
+        self._common = dict(common_params or {})
+
+        # .model dict for getmodel: {label: model_name}
+        self.model = {component.label: component.model_name}
+
+    # ------------------------------------------------------------------
+    def __getitem__(self, key: str):
+        # Key is f"{param}_{label}" — strip the known label suffix
+        suffix = f"_{self._component.label}"
+        raw_name = key[: -len(suffix)] if key.endswith(suffix) else key
+
+        # Look up in component params first
+        if raw_name in self._component.params:
+            return float(self._component.params[raw_name].value)
+
+        # Fall back to common params
+        if raw_name in self._common:
+            return float(self._common[raw_name].value)
+
+        raise KeyError(key)
+
+    # ------------------------------------------------------------------
+    def __contains__(self, key):
+        try:
+            self[key]
+            return True
+        except KeyError:
+            return False

--- a/tests/test_analysis/test_curvefitting/test_modelspec.py
+++ b/tests/test_analysis/test_curvefitting/test_modelspec.py
@@ -20,6 +20,7 @@ from spectrochempy.analysis.curvefitting.optimize import (
     _extract_varying_parameter_values,
 )
 from spectrochempy.analysis.curvefitting.optimize import _validate_script_content
+from spectrochempy.analysis.curvefitting.optimize import getmodel
 
 # ======================================================================================
 # Constants
@@ -977,3 +978,199 @@ shape: lorentzianmodel
         spec_values = spec.extract_varying_values()
         fp_values = _extract_varying_parameter_values(fp)
         np.testing.assert_array_almost_equal(spec_values, fp_values)
+
+
+# ======================================================================================
+# Tests for _ComponentParamsView
+# ======================================================================================
+
+
+class TestComponentParamsView:
+    """Test the _ComponentParamsView adapter."""
+
+    def test_model_dict(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="peak_a",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.5),
+                    },
+                )
+            ]
+        )
+        view = spec.component_view("peak_a")
+        assert view.model == {"peak_a": "gaussianmodel"}
+
+    def test_getitem_by_param_name(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="peak_a",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.5),
+                        "pos": _ParamSpec(name="pos", value=100.0),
+                    },
+                )
+            ]
+        )
+        view = spec.component_view("peak_a")
+        assert view["ampl_peak_a"] == 1.5
+        assert view["pos_peak_a"] == 100.0
+
+    def test_getitem_fallback_to_common(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="x",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.0),
+                    },
+                )
+            ],
+            common_params={
+                "gratio": _ParamSpec(name="gratio", value=0.1),
+            },
+        )
+        view = spec.component_view("x")
+        # Common params accessible by bare name
+        assert view["gratio"] == 0.1
+
+    def test_getitem_raises_keyerror_for_unknown(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="x",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.0),
+                    },
+                )
+            ]
+        )
+        view = spec.component_view("x")
+        with pytest.raises(KeyError):
+            view["nonexistent_x"]
+
+    def test_contains(self):
+        spec = _FitModelSpec(
+            components=[
+                _ComponentSpec(
+                    label="x",
+                    model_name="gaussianmodel",
+                    params={
+                        "ampl": _ParamSpec(name="ampl", value=1.0),
+                    },
+                )
+            ]
+        )
+        view = spec.component_view("x")
+        assert "ampl_x" in view
+        assert "nonexistent_x" not in view
+
+    def test_component_view_raises_for_missing_label(self):
+        spec = _FitModelSpec()
+        with pytest.raises(KeyError, match="not found in spec"):
+            spec.component_view("nonexistent")
+
+
+class TestGetModelEquivalence:
+    """Test that getmodel produces identical results with _ComponentParamsView."""
+
+    SCRIPT = """
+MODEL: PEAK
+shape: gaussianmodel
+    $ ampl: 1.5, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+"""
+
+    def _build_view(self, script, component_label):
+        """Parse script, return (fp, view) for equivalence testing."""
+        fp, errors = _validate_script_content(script)
+        assert errors == []
+        spec = _FitModelSpec.from_fitparameters(fp)
+        view = spec.component_view(component_label)
+        return fp, view
+
+    def test_model_dict_matches_fp(self):
+        """The view's .model dict matches fp.model for the same label."""
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        view = spec.component_view("peak")
+        # fp.model maps label → shape name
+        assert view.model["peak"] == fp.model["peak"]
+
+    def test_parameter_values_match(self):
+        """Parameter values from the view match those from FitParameters."""
+        fp, _ = _validate_script_content(self.SCRIPT)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        view = spec.component_view("peak")
+
+        for raw_name in spec.components[0].params:
+            fp_key = f"{raw_name}_peak"
+            assert view[fp_key] == float(fp[fp_key])
+
+    def test_getmodel_equivalence_single_component(self):
+        """Getmodel output is identical with _ComponentParamsView vs FitParameters."""
+        fp, view = self._build_view(self.SCRIPT, "peak")
+        x = np.linspace(-50, 50, 201, dtype=np.float64)
+
+        result_fp = getmodel(x, modelname="peak", par=fp)
+        result_view = getmodel(x, modelname="peak", par=view)
+
+        np.testing.assert_array_almost_equal(result_fp, result_view)
+
+    def test_getmodel_equivalence_multiple_components(self):
+        """Getmodel equivalence for every component."""
+        script = """
+MODEL: A
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+    $ pos:  100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+
+MODEL: B
+shape: lorentzianmodel
+    $ ampl: 0.5, 0.0, none
+    $ pos:  150.0, 0.0, 300.0
+    $ width: 20.0, 0.0, none
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        x = np.linspace(-50, 50, 201, dtype=np.float64)
+
+        for comp in spec.components:
+            view = spec.component_view(comp.label)
+            result_fp = getmodel(x, modelname=comp.label, par=fp)
+            result_view = getmodel(x, modelname=comp.label, par=view)
+            np.testing.assert_array_almost_equal(result_fp, result_view)
+
+    def test_view_with_common_params(self):
+        """Getmodel with a view that includes common params (no references)."""
+        # Script without references — all param values are direct floats
+        script = """
+COMMON:
+    $ gratio: 0.3, 0.0, 1.0
+
+MODEL: X
+shape: gaussianmodel
+    $ ampl:  1.0, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+    $ width: 10.0, 0.0, none
+"""
+        fp, _ = _validate_script_content(script)
+        spec = _FitModelSpec.from_fitparameters(fp)
+        x = np.linspace(50, 150, 201, dtype=np.float64)
+
+        # fp-based getmodel: par[f"ampl_x"], etc. — all exist directly
+        result_fp = getmodel(x, modelname="x", par=fp)
+
+        # view-based getmodel: view["ampl_x"], etc. — component params + common fallback
+        view = spec.component_view("x")
+        result_view = getmodel(x, modelname="x", par=view)
+
+        np.testing.assert_array_almost_equal(result_fp, result_view)


### PR DESCRIPTION
## Summary

Phase B3 of the Optimize convergence plan.  Adds a duck-typed
`_ComponentParamsView` adapter so that `getmodel()` can consume
structured model data without depending on the `{param}_{label}`
parser convention.

## Changes

- **`_ComponentParamsView`** — lightweight adapter providing
  `.model[label]` and `par[f"{param}_{label}"]` lookups from a
  `_ComponentSpec`, with fallback to common params
- **`_FitModelSpec.component_view(label)`** — factory method
- **11 tests** — 6 direct adapter tests, 5 numerical getmodel
  equivalence tests (single component, multiple components,
  COMMON params)
- **Changelog** consolidating B1–B3 entries in Developer section

## Design

`getmodel()` already accepts its `par` argument by duck typing, so
no changes to the function itself were needed.  The adapter breaks the
strongest remaining coupling to the parser convention without touching
`FitParameters`, the parser, or any public API.

## Files changed

| File | Change |
|---|---|
| `_modelspec.py` | +72 lines (view class + factory) |
| `test_modelspec.py` | +197 lines (11 new tests) |
| `changelog.rst` | B1–B3 consolidating entry |
| `latest.rst` | regenerated from changelog |

## Validation

- 389 curvefitting tests pass
- `ruff check` and `ruff format` clean
- No public API changes
- `getmodel()` unchanged