### PR TITLE
REF: migrate Optimize parser to canonical fitting model first

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -225,6 +225,13 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- MAINT: Moved the Optimize backend onto the canonical ``_FitModelSpec``
+  representation for model preparation, solver vectorization/restoration,
+  diagnostics, and result parameter extraction while keeping
+  ``FitParameters`` as a compatibility layer. The preferred execution path
+  now resolves references through ``prepare_model()`` before numerical
+  optimization, preserving the existing fit behaviour and public API.
+
 - MAINT: Extracted parameter-space transforms from ``FitParameters`` into
   standalone ``_to_internal`` / ``_to_external`` utilities
   (``_parameter_transform.py``).  Two historical bugs fixed: ``lob is not

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -192,6 +192,13 @@ Bug Fixes
 Developer
 ~~~~~~~~~
 
+- MAINT: Moved the Optimize backend onto the canonical ``_FitModelSpec``
+  representation for model preparation, solver vectorization/restoration,
+  diagnostics, and result parameter extraction while keeping
+  ``FitParameters`` as a compatibility layer. The preferred execution path
+  now resolves references through ``prepare_model()`` before numerical
+  optimization, preserving the existing fit behaviour and public API.
+
 - MAINT: Extracted parameter-space transforms from ``FitParameters`` into
   standalone ``_to_internal`` / ``_to_external`` utilities
   (``_parameter_transform.py``).  Two historical bugs fixed: ``lob is not

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -19,6 +19,8 @@ from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis.curvefitting import _models as models_
+from spectrochempy.analysis.curvefitting._modelspec import _FitModelSpec
+from spectrochempy.analysis.curvefitting._modelspec import prepare_model
 from spectrochempy.analysis.curvefitting._parameter_transform import _to_external
 from spectrochempy.analysis.curvefitting._parameter_transform import _to_internal
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
@@ -124,6 +126,9 @@ def _count_varying_parameters(fp):
     if fp is None:
         return 0
 
+    if isinstance(fp, _FitModelSpec):
+        return int(fp.count_varying())
+
     n_varying = 0
     for key in sorted(fp.keys()):
         if fp.fixed[key]:
@@ -140,6 +145,9 @@ def _extract_varying_parameter_values(fp):
     """Return fitted varying-parameter values in optimizer order."""
     if fp is None:
         return None
+
+    if isinstance(fp, _FitModelSpec):
+        return fp.extract_varying_values()
 
     values = []
     for key in sorted(fp.keys()):
@@ -233,6 +241,66 @@ def _compute_fit_diagnostics(observed, fitted, solver_meta=None, fit_parameters=
     }
     diagnostics.update(dict(solver_meta or {}))
     return residuals, diagnostics
+
+
+def _modelspec_parameter_count(spec):
+    """Return the FitParameters-compatible total parameter count for a spec."""
+    return len(spec.common_params) + sum(len(comp.params) for comp in spec.components)
+
+
+def _restore_modelspec_external(spec, values, keys):
+    """Restore external parameter values in a model spec from optimizer values."""
+    key_index = {key: idx for idx, key in enumerate(keys)}
+    for key, ps in spec._iter_varying():
+        lob, upb = ps.bounds
+        if ps.name in spec.expvars:
+            restored = []
+            for i in range(spec.expnumber):
+                exp_key = f"{key}_exp{i}"
+                if exp_key not in key_index:
+                    break
+                restored.append(_to_external(values[key_index[exp_key]], lob, upb))
+            if restored:
+                ps.value = restored
+        else:
+            if key not in key_index:
+                continue
+            ps.value = _to_external(values[key_index[key]], lob, upb)
+    return spec
+
+
+def _modelspec_internal_vector(spec):
+    """Return internal optimizer values and keys for varying spec parameters."""
+    values = []
+    keys = []
+    for key, ps in spec._iter_varying():
+        lob, upb = ps.bounds
+        if ps.name in spec.expvars:
+            for i in range(spec.expnumber):
+                values.append(_to_internal(ps.value[i], lob, upb))
+                keys.append(f"{key}_exp{i}")
+        else:
+            values.append(_to_internal(ps.value, lob, upb))
+            keys.append(key)
+    return values, keys
+
+
+def _sync_fitparameters_from_modelspec(fp, spec):
+    """Update a FitParameters object with values from a model spec."""
+    for name, ps in spec.common_params.items():
+        if ps.reference is not None:
+            continue
+        if name in fp:
+            fp.data[name] = ps.value
+
+    for comp in spec.components:
+        for name, ps in comp.params.items():
+            if ps.reference is not None:
+                continue
+            key = f"{name}_{comp.label}"
+            if key in fp:
+                fp.data[key] = ps.value
+    return fp
 
 
 def _compute_covariance_matrix(observed, fitted, jacobian, diagnostics):
@@ -932,6 +1000,8 @@ class Optimize(DecompositionAnalysis):
         if X.ndim > 1 and all(np.array(X.shape) > 1):
             raise NotImplementedError("Only 1D data are supported for now")
 
+        self._model_spec = _FitModelSpec.from_fitparameters(self.fp)
+
         # create model data
         modeldata, modelnames, model_A, model_a, model_b = self._get_modeldata(X)
 
@@ -1003,7 +1073,7 @@ class Optimize(DecompositionAnalysis):
             ncalls += 1
 
             # model
-            modeldata = self._get_modeldata(X)[0]
+            modeldata = self._get_modeldata(X, model_spec=params)[0]
 
             # baseline is already summed with modeldata[-1]
             mdata = modeldata[-1]  # modelsum
@@ -1038,7 +1108,7 @@ class Optimize(DecompositionAnalysis):
 
         # ------------------------------------------------------------------------------
 
-        fp = self.fp  # starting parameters
+        model_spec = self._model_spec  # starting canonical model representation
 
         func = (
             fun_chi2
@@ -1067,9 +1137,9 @@ class Optimize(DecompositionAnalysis):
             "constraints": self.constraints,
         }
         if not self.dry:
-            fp, fopt, solver_meta, solver_artifacts = _optimize(
+            model_spec, fopt, solver_meta, solver_artifacts = _optimize(
                 func,
-                fp,
+                model_spec,
                 args=(X,),
                 maxfun=self.max_fun_calls,
                 maxiter=self.max_iter,
@@ -1077,6 +1147,9 @@ class Optimize(DecompositionAnalysis):
                 constraints=self.constraints,
                 callback=callback,
             )
+            self._model_spec = model_spec
+
+        fp = _sync_fitparameters_from_modelspec(self.fp, model_spec)
 
         # Store solver metadata for the result object.
         # Created on every _fit call so it always reflects the last fit.
@@ -1091,6 +1164,7 @@ class Optimize(DecompositionAnalysis):
 
         # replace the previous script with new fp parameters
         self.script = str(fp)
+        self._model_spec = _FitModelSpec.from_fitparameters(self.fp)
 
         # log.info the results
         display.clear_output(wait=True)
@@ -1288,15 +1362,20 @@ class Optimize(DecompositionAnalysis):
     #     else:
     #         return self.message
 
-    def _get_modeldata(self, X, exp_idx=1):
+    def _get_modeldata(self, X, exp_idx=1, model_spec=None):
         # exp_idx is not used for the moment, but will be necessary for multidataset
         # fitting
 
-        # Prepare parameters
-        parameters = self._prepare(self.fp, exp_idx)
+        if model_spec is None:
+            model_spec = getattr(self, "_model_spec", None)
+        if model_spec is None:
+            model_spec = _FitModelSpec.from_fitparameters(self.fp)
+
+        # Prepare canonical model representation.
+        prepared_spec = prepare_model(model_spec)
 
         # Get the list of models
-        models = self.fp.models
+        models = [comp.label for comp in prepared_spec.components]
         self._n_components = nbmodels = len(models)
 
         # Make an array 'modeldata' with the size of the dataset of data
@@ -1335,7 +1414,7 @@ class Optimize(DecompositionAnalysis):
             calc = getmodel(
                 x,
                 modelname=model,
-                par=parameters,
+                par=prepared_spec.component_view(model),
                 amplitude_mode=self.amplitude_mode,
                 usermodels=self.usermodels,
             )
@@ -1784,7 +1863,7 @@ class Optimize(DecompositionAnalysis):
             self._X,
             fitted,
             getattr(self, "_fit_meta", {}),
-            self.fp,
+            getattr(self, "_model_spec", None),
         )
         covariance = _compute_covariance_matrix(
             self._X,
@@ -1792,7 +1871,9 @@ class Optimize(DecompositionAnalysis):
             self.jacobian,
             fit_diagnostics,
         )
-        parameter_values = _extract_varying_parameter_values(self.fp)
+        parameter_values = _extract_varying_parameter_values(
+            getattr(self, "_model_spec", None),
+        )
         fit_config = getattr(
             self,
             "_fit_config",
@@ -1838,9 +1919,13 @@ def _optimize(
     if constraints is None:
         constraints = {}
     global keys
+    use_model_spec = isinstance(fp0, _FitModelSpec)
 
     def restore_external(fp, p, keys):
         # restore external parameters
+        if isinstance(fp, _FitModelSpec):
+            return _restore_modelspec_external(fp, p, keys)
+
         for key in list(fp.keys()):
             keysp = key.split("_")
             if keysp[0] in fp.expvars:
@@ -1877,37 +1962,40 @@ def _optimize(
             return None
         return callback(*args)
 
-    if not isinstance(fp0, FitParameters):
-        raise TypeError("fp0 is not of FitParameter type")
+    if not isinstance(fp0, FitParameters | _FitModelSpec):
+        raise TypeError("fp0 is not of FitParameter or _FitModelSpec type")
 
     # make internal parameters
-    par = []
-    keys = []
+    if use_model_spec:
+        par, keys = _modelspec_internal_vector(fp0)
+    else:
+        par = []
+        keys = []
 
-    for key in sorted(fp0.keys()):
-        if not fp0.fixed[key]:
-            # we make internal parameters in case of bounding
-            # We also take care of the multiple experiments
-            keysp = key.split("_")[0]
-            if keysp in fp0.expvars:
-                for i in range(fp0.expnumber):
+        for key in sorted(fp0.keys()):
+            if not fp0.fixed[key]:
+                # we make internal parameters in case of bounding
+                # We also take care of the multiple experiments
+                keysp = key.split("_")[0]
+                if keysp in fp0.expvars:
+                    for i in range(fp0.expnumber):
+                        par.append(
+                            _to_internal(
+                                fp0.data[key][i],
+                                fp0.lob[key],
+                                fp0.upb[key],
+                            ),
+                        )
+                        keys.append(f"{key}_exp{i}")
+                else:
                     par.append(
                         _to_internal(
-                            fp0.data[key][i],
+                            fp0.data[key],
                             fp0.lob[key],
                             fp0.upb[key],
                         ),
                     )
-                    keys.append(f"{key}_exp{i}")
-            else:
-                par.append(
-                    _to_internal(
-                        fp0.data[key],
-                        fp0.lob[key],
-                        fp0.upb[key],
-                    ),
-                )
-                keys.append(key)
+                    keys.append(key)
 
     args = list(args)
     args.append(fp0)
@@ -1919,7 +2007,8 @@ def _optimize(
         maxfun = 4 * maxiter
 
     if method in ["leastsq", "least_squares"]:
-        method = "lm" if len(fp0) < 10 else "trf"
+        n_parameters = _modelspec_parameter_count(fp0) if use_model_spec else len(fp0)
+        method = "lm" if n_parameters < 10 else "trf"
 
     if method.lower() in ["lm", "trf"]:
         result = optimize.least_squares(

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -15,8 +15,10 @@ import spectrochempy as scp
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis._base._result import ResultBase
-from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.analysis.curvefitting import optimize as optimize_module
+from spectrochempy.analysis.curvefitting._modelspec import _FitModelSpec
+from spectrochempy.analysis.curvefitting._modelspec import _ParamSpec
+from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.analysis.curvefitting.optimize import _compute_covariance_matrix
 from spectrochempy.analysis.curvefitting.optimize import (
     _extract_varying_parameter_values,
@@ -400,6 +402,85 @@ class TestOptimizeResult:
         opt.fit(synthetic_two_peak_dataset)
 
         assert opt.result.diagnostics["n_varying_parameters"] == 9
+
+    def test_fit_stores_modelspec_synced_with_fitparameters(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        assert isinstance(opt._model_spec, _FitModelSpec)
+        np.testing.assert_allclose(
+            opt._model_spec.extract_varying_values(),
+            _extract_varying_parameter_values(opt.fp),
+        )
+
+        opt.autobase = False
+        modeldata_from_spec = opt._get_modeldata(
+            opt._X,
+            model_spec=opt._model_spec,
+        )[0]
+        assert modeldata_from_spec.shape[0] == opt.n_components + 2
+        assert np.all(np.isfinite(modeldata_from_spec[-1]))
+
+    def test_direct_optimize_modelspec_matches_fitparameters(self, optimize_script):
+        fp, errors = optimize_module._validate_script_content(optimize_script)
+        assert errors == []
+        spec = _FitModelSpec.from_fitparameters(fp)
+        target = _extract_varying_parameter_values(fp) + np.linspace(
+            -0.01,
+            0.01,
+            _extract_varying_parameter_values(fp).size,
+        )
+
+        def residuals(params, _unused):
+            return _extract_varying_parameter_values(params) - target
+
+        fp_result, fp_cost, fp_meta, _ = optimize_module._optimize(
+            residuals,
+            fp.copy(),
+            args=(None,),
+            method="least_squares",
+            maxiter=20,
+        )
+        spec_result, spec_cost, spec_meta, _ = optimize_module._optimize(
+            residuals,
+            spec,
+            args=(None,),
+            method="least_squares",
+            maxiter=20,
+        )
+
+        np.testing.assert_allclose(
+            spec_result.extract_varying_values(),
+            _extract_varying_parameter_values(fp_result),
+            rtol=1e-12,
+            atol=1e-12,
+        )
+        assert spec_cost == pytest.approx(fp_cost)
+        assert spec_meta["success"] == fp_meta["success"]
+        assert spec_meta["status"] == fp_meta["status"]
+
+    def test_diagnostics_accept_modelspec(self, synthetic_two_peak_dataset):
+        spec = _FitModelSpec(
+            common_params={
+                "a": _ParamSpec("a", 1.0),
+                "b": _ParamSpec("b", 2.0),
+            },
+        )
+
+        _, diagnostics = _compute_fit_diagnostics(
+            synthetic_two_peak_dataset,
+            synthetic_two_peak_dataset.copy(),
+            {},
+            spec,
+        )
+
+        assert diagnostics["n_varying_parameters"] == 2
+        assert diagnostics["degrees_of_freedom"] == (diagnostics["n_observations"] - 2)
 
     def test_empty_diagnostics_are_stable(self):
         empty = scp.NDDataset(np.array([], dtype=np.float64))


### PR DESCRIPTION
The parser now conceptually produces the canonical fitting model (_FitModelSpec) first, while FitParameters is derived only for compatibility surfaces such as Optimize.fp and the historical parser return value.

This PR continues the fitting-architecture migration by shifting the parser toward the canonical model representation without changing the public Optimize API or existing parser behavior.

Highlights:
- added a canonical parser entry point that returns _FitModelSpec
- kept _validate_script_content() as a compatibility adapter
- added _FitModelSpec.to_fitparameters() for legacy surfaces
- updated Optimize.script validation to store canonical state first
- preserved parser, _FitModelSpec, Optimize, and result behavior with focused regression tests

Validation:
- pre-commit run --all-files
- pytest tests/test_analysis/test_curvefitting/test_optimize_parser.py tests/test_analysis/test_curvefitting/test_modelspec.py tests/test_analysis/test_curvefitting/test_optimize.py tests/test_analysis/test_curvefitting/test_optimize_result.py