### PR TITLE
MAINT: migrate Optimize parser to canonical fitting model first

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -231,6 +231,9 @@ Developer
   ``FitParameters`` as a compatibility layer. The preferred execution path
   now resolves references through ``prepare_model()`` before numerical
   optimization, preserving the existing fit behaviour and public API.
+  The parser now also produces the canonical model representation first and
+  only derives ``FitParameters`` for legacy compatibility surfaces such as
+  ``Optimize.fp`` and the historical parser return value.
 
 - MAINT: Extracted parameter-space transforms from ``FitParameters`` into
   standalone ``_to_internal`` / ``_to_external`` utilities

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -198,6 +198,9 @@ Developer
   ``FitParameters`` as a compatibility layer. The preferred execution path
   now resolves references through ``prepare_model()`` before numerical
   optimization, preserving the existing fit behaviour and public API.
+  The parser now also produces the canonical model representation first and
+  only derives ``FitParameters`` for legacy compatibility surfaces such as
+  ``Optimize.fp`` and the historical parser return value.
 
 - MAINT: Extracted parameter-space transforms from ``FitParameters`` into
   standalone ``_to_internal`` / ``_to_external`` utilities

--- a/src/spectrochempy/analysis/curvefitting/_modelspec.py
+++ b/src/spectrochempy/analysis/curvefitting/_modelspec.py
@@ -22,6 +22,8 @@ from typing import Any
 
 import numpy as np
 
+from spectrochempy.analysis.curvefitting._parameters import FitParameters
+
 # Sentinel bound thresholds (same as FitParameters.__str__)
 _STR_NEG_THRESH = -0.1 / sys.float_info.epsilon
 _STR_POS_THRESH = +0.1 / sys.float_info.epsilon
@@ -33,6 +35,13 @@ def _unbound(val):
         return None
     if val <= _STR_NEG_THRESH or val >= _STR_POS_THRESH:
         return None
+    return val
+
+
+def _bound_to_legacy_sentinel(val, *, lower):
+    """Convert canonical ``None`` bounds to the historical FitParameters sentinel."""
+    if val is None:
+        return -1.0 / sys.float_info.epsilon if lower else +1.0 / sys.float_info.epsilon
     return val
 
 
@@ -230,6 +239,50 @@ class _FitModelSpec:
         if result:
             result += "\n"
         return result
+
+    # ------------------------------------------------------------------
+    def to_fitparameters(self):
+        """
+        Build a legacy ``FitParameters`` compatibility view from this model spec.
+
+        This keeps the parser target architecture canonical while preserving
+        historical ``Optimize.fp`` and ``_validate_script_content()`` behavior.
+        """
+        fp = FitParameters()
+        fp.expvars = list(self.expvars)
+        fp.expnumber = self.expnumber
+
+        for name, ps in self.common_params.items():
+            fp.common[name] = True
+            fp.reference[name] = ps.reference is not None
+            if ps.reference is not None:
+                fp[name] = ps.reference
+                continue
+            fp[name] = (
+                ps.value,
+                _bound_to_legacy_sentinel(ps.bounds[0], lower=True),
+                _bound_to_legacy_sentinel(ps.bounds[1], lower=False),
+                not ps.vary,
+            )
+
+        for comp in self.components:
+            fp.models.append(comp.label)
+            fp.model[comp.label] = comp.model_name
+            for name, ps in comp.params.items():
+                fp.common[name] = False
+                key = f"{name}_{comp.label}"
+                fp.reference[key] = ps.reference is not None
+                if ps.reference is not None:
+                    fp[key] = ps.reference
+                    continue
+                fp[key] = (
+                    ps.value,
+                    _bound_to_legacy_sentinel(ps.bounds[0], lower=True),
+                    _bound_to_legacy_sentinel(ps.bounds[1], lower=False),
+                    not ps.vary,
+                )
+
+        return fp
 
     # ------------------------------------------------------------------
     def _iter_varying(self):

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -19,7 +19,9 @@ from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import FitResult
 from spectrochempy.analysis.curvefitting import _models as models_
+from spectrochempy.analysis.curvefitting._modelspec import _ComponentSpec
 from spectrochempy.analysis.curvefitting._modelspec import _FitModelSpec
+from spectrochempy.analysis.curvefitting._modelspec import _ParamSpec
 from spectrochempy.analysis.curvefitting._modelspec import prepare_model
 from spectrochempy.analysis.curvefitting._parameter_transform import _to_external
 from spectrochempy.analysis.curvefitting._parameter_transform import _to_internal
@@ -303,6 +305,15 @@ def _sync_fitparameters_from_modelspec(fp, spec):
     return fp
 
 
+def _modelspec_parameter_names(spec):
+    """Return flat historical parameter names for a canonical model spec."""
+    names = set(spec.common_params)
+    for comp in spec.components:
+        for name in comp.params:
+            names.add(f"{name}_{comp.label}")
+    return names
+
+
 def _compute_covariance_matrix(observed, fitted, jacobian, diagnostics):
     """
     Compute an approximate parameter covariance matrix from the retained Jacobian.
@@ -449,32 +460,19 @@ def _extract_solver_artifacts(method, result):
     }
 
 
-def _validate_script_content(script, usermodels=None):
+def _parse_script_to_modelspec(script, usermodels=None):
     """
-    Parse and validate a curve-fitting script without running an optimisation.
+    Parse and validate a curve-fitting script into the canonical model spec.
 
-    Parameters
-    ----------
-    script : str
-        The script to validate.
-    usermodels : dict or None
-        Optional user-defined model registry (same format as
-        :attr:`Optimize.usermodels`).
-
-    Returns
-    -------
-    fp : FitParameters
-        Parsed parameters (always returned, even when *errors* is non-empty).
-    errors : list of ScriptError
-        Empty list when the script is valid.
+    Returns the canonical fitting model plus the historical list of parser
+    errors. This is the architectural parser entry point; compatibility helpers
+    may derive ``FitParameters`` from the returned model spec when needed.
     """
-    fp = FitParameters()
+    spec = _FitModelSpec()
     errors = []
 
-    modlabel = None
-    common = False
-    fixed = False
-    reference = False
+    current_component = None
+    in_common_block = False
     models_missing_shape = set()
 
     lines = script.split("\n")
@@ -502,11 +500,7 @@ def _validate_script_content(script, usermodels=None):
 
         if key.startswith("model"):
             modlabel = values.lower().strip()
-            if modlabel not in fp.models:
-                fp.models.append(modlabel)
-                if modlabel:
-                    models_missing_shape.add(modlabel)
-            else:
+            if any(comp.label == modlabel for comp in spec.components):
                 errors.append(
                     ScriptError(
                         lc,
@@ -514,16 +508,21 @@ def _validate_script_content(script, usermodels=None):
                         f"Duplicate model label: '{modlabel}'",
                     ),
                 )
-            common = False
+            else:
+                current_component = _ComponentSpec(label=modlabel)
+                spec.components.append(current_component)
+                if modlabel:
+                    models_missing_shape.add(modlabel)
+            in_common_block = False
             continue
 
         if key.startswith("common") or key.startswith("vars"):
-            common = True
-            modlabel = "common"
+            current_component = None
+            in_common_block = True
             continue
 
         if key.startswith("shape"):
-            if modlabel is None or modlabel == "common":
+            if current_component is None or in_common_block:
                 errors.append(
                     ScriptError(
                         lc,
@@ -532,7 +531,7 @@ def _validate_script_content(script, usermodels=None):
                     ),
                 )
                 continue
-            models_missing_shape.discard(modlabel)
+            models_missing_shape.discard(current_component.label)
             shape = values.lower().strip()
             if not shape:
                 errors.append(
@@ -555,11 +554,11 @@ def _validate_script_content(script, usermodels=None):
                     ),
                 )
                 continue
-            fp.model[modlabel] = shape
-            common = False
+            current_component.model_name = shape
+            in_common_block = False
             continue
 
-        if modlabel is None and not common:
+        if current_component is None and not in_common_block:
             errors.append(
                 ScriptError(
                     lc,
@@ -570,17 +569,16 @@ def _validate_script_content(script, usermodels=None):
             )
             continue
 
-        # parameter prefix --------------------------------------------------
         if key.startswith("*"):
-            fixed = True
+            vary = False
             reference = False
             key = key[1:].strip()
         elif key.startswith("$"):
-            fixed = False
+            vary = True
             reference = False
             key = key[1:].strip()
         elif key.startswith(">"):
-            fixed = True
+            vary = False
             reference = True
             key = key[1:].strip()
         else:
@@ -594,7 +592,6 @@ def _validate_script_content(script, usermodels=None):
             )
             continue
 
-        # value / bounds ----------------------------------------------------
         s = values.split(",")
         s = [ss.strip() for ss in s]
         if len(s) > 1 and ("[" in s[0]) and ("]" in s[1]):
@@ -622,46 +619,79 @@ def _validate_script_content(script, usermodels=None):
         if len(s) == 1:
             s.extend(["none", "none"])
         value, mini, maxi = s
-        if mini.strip().lower() in ["none", ""]:
-            mini = str(-1.0 / sys.float_info.epsilon)
-        if maxi.strip().lower() in ["none", ""]:
-            maxi = str(+1.0 / sys.float_info.epsilon)
-        if modlabel != "common":
-            ks = f"{key}_{modlabel}"
-            fp.common[key] = False
+
+        if reference:
+            param_spec = _ParamSpec(
+                name=key, value=0.0, vary=False, reference=value.strip()
+            )
         else:
-            ks = f"{key}"
-            fp.common[key] = True
-        fp.reference[ks] = reference
-        if not reference:
             val = value.strip()
             try:
                 val = eval(str(val))  # noqa: S307
             except Exception as exc:
+                flat_key = (
+                    key if in_common_block else f"{key}_{current_component.label}"
+                )
                 errors.append(
                     ScriptError(
                         lc,
                         line,
-                        f"Cannot evaluate value for '{ks}': {exc}",
+                        f"Cannot evaluate value for '{flat_key}': {exc}",
                     ),
                 )
                 continue
-            fp[ks] = val, mini.strip(), maxi.strip(), fixed
-        else:
-            fp[ks] = value.strip()
 
-    # Post-parse: check that every model has a shape definition
-    for label in list(models_missing_shape):
-        if label not in fp.model:
-            errors.append(
-                ScriptError(
-                    0,
-                    "",
-                    f"Model '{label}' has no shape definition",
-                ),
+            min_bound = (
+                None if mini.strip().lower() in ["none", ""] else float(mini.strip())
+            )
+            max_bound = (
+                None if maxi.strip().lower() in ["none", ""] else float(maxi.strip())
+            )
+            param_spec = _ParamSpec(
+                name=key,
+                value=val,
+                vary=vary,
+                bounds=(min_bound, max_bound),
             )
 
-    return fp, errors
+        if in_common_block:
+            spec.common_params[key] = param_spec
+        else:
+            current_component.params[key] = param_spec
+
+    for label in list(models_missing_shape):
+        errors.append(
+            ScriptError(
+                0,
+                "",
+                f"Model '{label}' has no shape definition",
+            ),
+        )
+
+    return spec, errors
+
+
+def _validate_script_content(script, usermodels=None):
+    """
+    Parse and validate a curve-fitting script without running an optimisation.
+
+    Parameters
+    ----------
+    script : str
+        The script to validate.
+    usermodels : dict or None
+        Optional user-defined model registry (same format as
+        :attr:`Optimize.usermodels`).
+
+    Returns
+    -------
+    fp : FitParameters
+        Parsed parameters (always returned, even when *errors* is non-empty).
+    errors : list of ScriptError
+        Empty list when the script is valid.
+    """
+    spec, errors = _parse_script_to_modelspec(script, usermodels=usermodels)
+    return spec.to_fitparameters(), errors
 
 
 def _normalize_constraint_spec(constraint):
@@ -714,9 +744,12 @@ def _validate_constraints_content(constraints, fit_parameters=None):
             ),
         ]
 
-    known_parameters = (
-        set(fit_parameters.keys()) if fit_parameters is not None else set()
-    )
+    if isinstance(fit_parameters, _FitModelSpec):
+        known_parameters = _modelspec_parameter_names(fit_parameters)
+    else:
+        known_parameters = (
+            set(fit_parameters.keys()) if fit_parameters is not None else set()
+        )
     errors = []
 
     for index, raw_constraint in enumerate(constraints_list):
@@ -1000,7 +1033,9 @@ class Optimize(DecompositionAnalysis):
         if X.ndim > 1 and all(np.array(X.shape) > 1):
             raise NotImplementedError("Only 1D data are supported for now")
 
-        self._model_spec = _FitModelSpec.from_fitparameters(self.fp)
+        self._model_spec = getattr(self, "_model_spec", None)
+        if self._model_spec is None:
+            self._model_spec = _FitModelSpec.from_fitparameters(self.fp)
 
         # create model data
         modeldata, modelnames, model_A, model_a, model_b = self._get_modeldata(X)
@@ -1221,11 +1256,12 @@ class Optimize(DecompositionAnalysis):
 
     @tr.validate("script")
     def _script_validate(self, proposal):
-        fp, errors = _validate_script_content(proposal.value, self.usermodels)
+        spec, errors = _parse_script_to_modelspec(proposal.value, self.usermodels)
         if errors:
             err = errors[0]
             raise ValueError(str(err))
-        self.fp = fp
+        self._model_spec = spec
+        self.fp = spec.to_fitparameters()
         return proposal.value
 
     @tr.validate("constraints")
@@ -1272,7 +1308,7 @@ class Optimize(DecompositionAnalysis):
         """
         if script is None:
             script = self.script
-        _, errors = _validate_script_content(script, self.usermodels)
+        _, errors = _parse_script_to_modelspec(script, self.usermodels)
         return errors
 
     def validate_constraints(self, constraints=None, script=None):
@@ -1309,9 +1345,7 @@ class Optimize(DecompositionAnalysis):
         if script is None:
             script = self.script
 
-        fit_parameters, script_errors = _validate_script_content(
-            script, self.usermodels
-        )
+        model_spec, script_errors = _parse_script_to_modelspec(script, self.usermodels)
         if script_errors:
             return [
                 ConstraintError(
@@ -1322,7 +1356,7 @@ class Optimize(DecompositionAnalysis):
                 ),
             ]
 
-        return _validate_constraints_content(constraints, fit_parameters)
+        return _validate_constraints_content(constraints, model_spec)
 
     # ----------------------------------------------------------------------------------
     # Private methods

--- a/tests/test_analysis/test_curvefitting/test_modelspec.py
+++ b/tests/test_analysis/test_curvefitting/test_modelspec.py
@@ -20,6 +20,7 @@ from spectrochempy.analysis.curvefitting.optimize import _count_varying_paramete
 from spectrochempy.analysis.curvefitting.optimize import (
     _extract_varying_parameter_values,
 )
+from spectrochempy.analysis.curvefitting.optimize import _parse_script_to_modelspec
 from spectrochempy.analysis.curvefitting.optimize import _validate_script_content
 from spectrochempy.analysis.curvefitting.optimize import getmodel
 
@@ -698,6 +699,55 @@ class TestSpecRoundTripDirect:
         assert spec2.components[0].params["ampl"].value == pytest.approx(1.5)
         assert spec2.components[0].params["ampl"].bounds[0] == 0.0
         assert spec2.components[0].params["ampl"].bounds[1] is None
+
+
+class TestCanonicalParserOutput:
+    """Canonical parser output remains equivalent to the compatibility adapter."""
+
+    SCRIPT = """
+COMMON:
+    $ gratio: 0.3, 0.0, 1.0
+
+MODEL: PEAK_A
+shape: gaussianmodel
+    * ampl:  1.5, 0.0, none
+    $ pos:   100.0, 0.0, 200.0
+    > ratio: gratio
+    $ width: 10.0, none, none
+"""
+
+    @staticmethod
+    def _assert_fitparameters_equivalent(left, right):
+        assert left.models == right.models
+        assert left.model == right.model
+        assert set(left.keys()) == set(right.keys())
+        assert left.common == right.common
+        assert left.reference == right.reference
+        assert left.fixed == right.fixed
+        for key in left:
+            assert left[key] == right[key]
+            assert left.lob.get(key) == right.lob.get(key)
+            assert left.upb.get(key) == right.upb.get(key)
+
+    def test_direct_parser_matches_fitparameters_adapter(self):
+        direct_spec, direct_errors = _parse_script_to_modelspec(self.SCRIPT)
+        compat_fp, compat_errors = _validate_script_content(self.SCRIPT)
+
+        assert direct_errors == []
+        assert compat_errors == []
+
+        compat_spec = _FitModelSpec.from_fitparameters(compat_fp)
+        assert direct_spec.to_script() == compat_spec.to_script()
+
+    def test_to_fitparameters_preserves_historical_parser_semantics(self):
+        direct_spec, errors = _parse_script_to_modelspec(self.SCRIPT)
+        compat_fp, compat_errors = _validate_script_content(self.SCRIPT)
+
+        assert errors == []
+        assert compat_errors == []
+
+        adapted_fp = direct_spec.to_fitparameters()
+        self._assert_fitparameters_equivalent(adapted_fp, compat_fp)
 
 
 class TestConstraintReserved:


### PR DESCRIPTION
The parser now conceptually produces the canonical fitting model (_FitModelSpec) first, while FitParameters is derived only for compatibility surfaces such as Optimize.fp and the historical parser return value.

This PR continues the fitting-architecture migration by shifting the parser toward the canonical model representation without changing the public Optimize API or existing parser behavior.

Highlights:
- added a canonical parser entry point that returns _FitModelSpec
- kept _validate_script_content() as a compatibility adapter
- added _FitModelSpec.to_fitparameters() for legacy surfaces
- updated Optimize.script validation to store canonical state first
- preserved parser, _FitModelSpec, Optimize, and result behavior with focused regression tests

Validation:
- pre-commit run --all-files
- pytest tests/test_analysis/test_curvefitting/test_optimize_parser.py tests/test_analysis/test_curvefitting/test_modelspec.py tests/test_analysis/test_curvefitting/test_optimize.py tests/test_analysis/test_curvefitting/test_optimize_result.py