### PR TITLE
CI: make conda plugin builds non-blocking for core releases

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -395,6 +395,7 @@ jobs:
             --json
 
       - name: Build conda plugin package
+        continue-on-error: ${{ !(github.event_name == 'release' && startsWith(github.ref_name, matrix.plugin.name)) }}
         uses: prefix-dev/rattler-build-action@v0.2.38
         env:
           CONDA_BLD_PATH: ../output

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -622,6 +622,22 @@ entrées sont incorrectes car :
 - [ ] Répéter pour chaque plugin (nmr → iris → tensor → hypercomplex → carroucell)
 - [ ] Réactiver l'intégration GitHub → Zenodo (avant la prochaine release core)
 
+### Conda plugin builds
+
+- [ ] Pendant une release core (`spectrochempy-vX.Y.Z`), le workflow
+      `build_package.yml` construit également les plugins conda comme
+      **vérification de compatibilité** (les packages sont uploadés sur le
+      label `dev` d'Anaconda.org, pas sur `main`)
+- [ ] L'échec de ces builds plugins n'est **pas bloquant** pour la release
+      core — le build step utilise `continue-on-error: true` pour les
+      événements qui ne sont pas des releases plugins
+- [ ] Causes possibles d'échec non-bloquant :
+      - Contrainte de version du core dans `recipe.yaml` pas encore mise à
+        jour (ex: `>=0.10,<0.11` alors que le core est maintenant `0.11.0`)
+      - Problème de résolution de dépendances conda avec le nouveau core
+- [ ] Si l'échec est bloquant pour une **release plugin** (tag
+      `spectrochempy-XXX-vX.Y.Z`), corriger `recipe.yaml` avant de publier
+
 ### TestPyPI cleanup
 
 - [ ] Les pushes sur `master` publient automatiquement le core sur TestPyPI


### PR DESCRIPTION
Pendant une release core (`spectrochempy-vX.Y.Z`), le workflow `build_package.yml` construit les plugins conda comme vérification de compatibilité. En cas de désynchronisation des contraintes (ex: `recipe.yaml` pas encore mis à jour), l'échec marque toute la run en rouge alors que le core est déjà publié avec succès.

**Modifications :**
- `continue-on-error: true` sur le step "Build conda plugin package" pour les événements qui ne sont pas des releases plugins (core release, push, PR)
- Pour une **release plugin** (tag `spectrochempy-XXX-vX.Y.Z`), l'échec reste bloquant
- Documentation de ce comportement dans `maintainers/release-process.md`
