### PR TITLE
DOC: Showcase SCP-native idioms in examples, userguide, and docstrings (#1370)

### DIFF
--- a/docs/sources/userguide/objects/dataset/dataset.py
+++ b/docs/sources/userguide/objects/dataset/dataset.py
@@ -226,11 +226,7 @@ d1D.dims
 # instance constructor
 
 # %%
-a = np.random.rand(2, 4, 6)
-a
-
-# %%
-d3D = NDDataset(a)
+d3D = NDDataset.random((2, 4, 6))
 d3D.title = "energy"
 d3D.author = "Someone"
 d3D.name = "3D dataset creation"
@@ -243,8 +239,8 @@ d3D
 # We can also add all information in a single statement
 
 # %%
-d3D = NDDataset(
-    a,
+d3D = NDDataset.random(
+    (2, 4, 6),
     dims=["u", "v", "t"],
     title="Energy",
     author="Someone",

--- a/docs/sources/userguide/processing/math_operations.py
+++ b/docs/sources/userguide/processing/math_operations.py
@@ -269,7 +269,7 @@ _ = out.plot(figsize=(6, 2.5))
 # Obviously numpy exponential functions applies only to dimensionless array. Else an error is generated.
 
 # %%
-x = scp.NDDataset(np.arange(5), units="m")
+x = scp.arange(5, units="m")
 try:
     np.exp(x)  # A dimensionality error will be generated
 except DimensionalityError as e:
@@ -602,7 +602,7 @@ da
 # row)
 
 # %%
-da = scp.NDDataset(np.arange(40).reshape(10, 4))
+da = scp.arange(40).reshape((10, 4))
 da
 
 # %%

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -53,3 +53,14 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- DOC: Improved example gallery to showcase SpectroChemPy-native idioms
+  (``Coord.linspace``, ``Coord.arange``, ``scp.abs``) for coordinate creation
+   and dataset operations, replacing redundant ``np.linspace`` + ``Coord``
+   wrapping patterns, ``np.abs`` usage, list-comprehension synthetic data
+   generators (``scp.fromfunction``), ``np.random.normal`` on datasets
+   (``scp.normal``), ``np.arange`` wrapped in NDDataset (``scp.arange``),
+   and ``np.random.rand`` + NDDataset constructor (``NDDataset.random``).
+   Also updated API docstring examples to use ``scp.gaussian``,
+   ``Coord.linspace``, ``scp.arange``, and ``NDDataset.random``
+   instead of raw NumPy equivalents. (#1370)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,3 +11,17 @@ What's New in Revision 0.11.1.dev
 
 These are the changes in SpectroChemPy-0.11.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Developer
+~~~~~~~~~
+
+- DOC: Improved example gallery to showcase SpectroChemPy-native idioms
+  (``Coord.linspace``, ``Coord.arange``, ``scp.abs``) for coordinate creation
+   and dataset operations, replacing redundant ``np.linspace`` + ``Coord``
+   wrapping patterns, ``np.abs`` usage, list-comprehension synthetic data
+   generators (``scp.fromfunction``), ``np.random.normal`` on datasets
+   (``scp.normal``), ``np.arange`` wrapped in NDDataset (``scp.arange``),
+   and ``np.random.rand`` + NDDataset constructor (``NDDataset.random``).
+   Also updated API docstring examples to use ``scp.gaussian``,
+   ``Coord.linspace``, ``scp.arange``, and ``NDDataset.random``
+   instead of raw NumPy equivalents. (#1370)

--- a/src/spectrochempy/analysis/kinetic/kineticutilities.py
+++ b/src/spectrochempy/analysis/kinetic/kineticutilities.py
@@ -126,7 +126,7 @@ class ActionMassKinetics(tr.HasTraits):
     # A simple A → B → C:
     >>> reactions = ("A -> B", "B -> C")
     >>> species_concentrations = {"A": 1.0, "B": 0.0, "C": 0.0}
-    >>> time = np.arange(0, 10)
+    >>> time = scp.arange(0, 10)
     >>> k_exp = np.array(((1.0e8, 52.0e3), (1.0e8, 50.0e3)))
     >>> kin_exp = scp.ActionMassKinetics(reactions, species_concentrations, k_exp, T=298.0)
     >>> C_exp = kin_exp.integrate(time)
@@ -137,7 +137,7 @@ class ActionMassKinetics(tr.HasTraits):
     # are set using lists or tuples of the same length, even if only one is changed:
     >>> species_concentrations = ({"A": 1.0, "B": 0.0, "C": 0.0}, {"A": 1.0, "B": 0.0, "C": 0.0})
     >>> T = (298.0, 308.0)
-    >>> time = (np.arange(0, 10), np.arange(0, 5))
+    >>> time = (scp.arange(0, 10), scp.arange(0, 5))
     >>> kin_exp = scp.ActionMassKinetics(reactions, species_concentrations, k_exp, T=T)
     >>> C_exp = kin_exp.integrate(time)
     >>> info_(f"Concentrations at {T[0]}K, t = 4 : {C_exp[0][4.].data}")

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -536,19 +536,31 @@ def find_peaks(
     Examples
     --------
     Basic peak finding with a synthetic spectrum:
-    >>> x = np.linspace(0.0, 10.0, 501)
-    >>> y = np.exp(-((x - 3.0) ** 2) / 0.08) + 0.8 * np.exp(-((x - 7.0) ** 2) / 0.12)
-    >>> ds = scp.NDDataset(y, coordset=[scp.Coord(x, title="x", units="cm^-1")])
+
+    >>> x = scp.Coord.linspace(0.0, 10.0, 501, title="x", units="cm^-1")
+    >>> y = (scp.gaussian(x, ampl=1.0, pos=3.0, width=0.5, normalized=False)
+    ...    + scp.gaussian(x, ampl=0.8, pos=7.0, width=0.6, normalized=False))
+    >>> ds = scp.NDDataset(y, coordset=[x])
     >>> peaks, props = ds.find_peaks(height=0.5)
     >>> len(peaks)
     2
 
     Physical-unit spacing constraints are accepted when coordinates carry units:
+
+    >>> x = scp.Coord.linspace(0.0, 10.0, 501, title="x", units="cm^-1")
+    >>> y = (scp.gaussian(x, ampl=1.0, pos=3.0, width=0.5, normalized=False)
+    ...    + scp.gaussian(x, ampl=0.8, pos=7.0, width=0.6, normalized=False))
+    >>> ds = scp.NDDataset(y, coordset=[x])
     >>> peaks, props = ds.find_peaks(distance="1 cm^-1", width=0.2)
     >>> len(peaks)
     2
 
     Return a structured result when a tabular/export representation is useful:
+
+    >>> x = scp.Coord.linspace(0.0, 10.0, 501, title="x", units="cm^-1")
+    >>> y = (scp.gaussian(x, ampl=1.0, pos=3.0, width=0.5, normalized=False)
+    ...    + scp.gaussian(x, ampl=0.8, pos=7.0, width=0.6, normalized=False))
+    >>> ds = scp.NDDataset(y, coordset=[x])
     >>> result = ds.find_peaks(height=0.5, as_result=True)
     >>> rows = result.to_dict()
     >>> len(rows)

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -1054,7 +1054,7 @@ class NDMath:
         NDDataset: [float64] a.u. (size: 5549)
         >>> m.x
         Coord: [float64] cm⁻¹ (size: 5549)
-        >>> m = scp.average(nd, dim='y', weights=np.arange(55))
+        >>> m = scp.average(nd, dim='y', weights=scp.arange(55))
         >>> m.data
         array([   1.789,    1.789, ...,    1.222,     1.22])
 
@@ -1751,13 +1751,13 @@ class NDMath:
 
         1) from the API
 
-        >>> x = np.arange(6, dtype=int)
+        >>> x = scp.arange(6, dtype=int)
         >>> scp.full_like(x, 1)
         NDDataset: [float64] unitless (size: 6)
 
         2) as a classmethod
 
-        >>> x = np.arange(6, dtype=int)
+        >>> x = scp.arange(6, dtype=int)
         >>> scp.NDDataset.full_like(x, 1)
         NDDataset: [float64] unitless (size: 6)
 
@@ -2151,7 +2151,7 @@ class NDMath:
 
         Examples
         --------
-        >>> x = np.arange(6)
+        >>> x = scp.arange(6)
         >>> x = x.reshape((2, 3))
         >>> x = scp.NDDataset(x, units='s')
         >>> x
@@ -2665,7 +2665,7 @@ class NDMath:
 
         Examples
         --------
-        >>> x = np.arange(6)
+        >>> x = scp.arange(6)
         >>> x = x.reshape((2, 3))
         >>> nd = scp.NDDataset(x, units='s')
         >>> nd

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -27,14 +27,13 @@ import spectrochempy as scp
 # 1) simulated chromatogram
 # *************************
 
-t = scp.Coord(np.arange(15), units="minutes", title="time")  # time coordinates
+t = scp.Coord.arange(15, units="minutes", title="time")  # time coordinates
 c = scp.Coord(range(2), title="components")  # component coordinates
 
-data = np.zeros((2, 15), dtype=np.float64)
-data[0, 3:8] = [1, 3, 6, 3, 1]  # compound 1
-data[1, 5:11] = [1, 3, 5, 3, 1, 0.5]  # compound 2
+dsc = scp.zeros((2, 15), dtype=np.float64, coords=[c, t])
+dsc[0, 3:8] = [1, 3, 6, 3, 1]  # compound 1
+dsc[1, 5:11] = [1, 3, 5, 3, 1, 0.5]  # compound 2
 
-dsc = scp.NDDataset(data=data, coords=[c, t])
 _ = dsc.plot(title="concentration")
 
 # %%
@@ -42,7 +41,7 @@ _ = dsc.plot(title="concentration")
 # **********************
 
 spec = np.array([[2.0, 3.0, 4.0, 2.0], [3.0, 4.0, 2.0, 1.0]])
-w = scp.Coord(np.arange(1, 5, 1), units="nm", title="wavelength")
+w = scp.Coord.arange(1, 5, 1, units="nm", title="wavelength")
 
 dss = scp.NDDataset(data=spec, coords=[c, w])
 _ = dss.plot(title="spectra")
@@ -52,7 +51,7 @@ _ = dss.plot(title="spectra")
 # ************************
 
 dataset = scp.dot(dsc.T, dss)
-dataset.data = np.random.normal(dataset.data, 0.1)
+dataset += scp.normal(scale=0.1, size=dataset.shape)
 dataset.title = "intensity"
 
 _ = dataset.plot(title="calculated dataset")
@@ -79,7 +78,7 @@ _ = efa.b_ev.T.plot(yscale="log", legend=efa.b_ev.k.labels)
 # and so we can use it to set a cut of values
 n_pc = efa.n_components = 2
 
-efa.cutoff = np.max(efa.f_ev[:, n_pc].data)
+efa.cutoff = efa.f_ev[:, n_pc].max()
 f2 = efa.f_ev[:, :n_pc]
 b2 = efa.b_ev[:, :n_pc]
 

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
@@ -13,7 +13,6 @@ FastICA example
 # %%
 # Import the spectrochempy API package
 import spectrochempy as scp
-import numpy as np
 
 # %%
 # Independent component analysis (ICA) is a computational method for separating a multivariate signal such as spectra
@@ -28,10 +27,9 @@ X = scp.read("matlabdata/als2004dataset.MAT")[-1]
 
 X.title = "absorbance"
 X.units = "absorbance"
-X.set_coordset(
-    np.arange(X.shape[0], dtype="float"), None
-)  # y coordinates as floats to trigger sequential colormap
-X.y.title = "elution time"
+X.y = scp.Coord.arange(
+    X.shape[0], dtype="float", title="elution time"
+)  # floats to trigger sequential colormap
 X.y.units = "min"
 X.x.title = "wavelength"
 _ = X.plot()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
@@ -18,11 +18,6 @@ and then we plot one section (a 2D plane)
 # Creation
 # --------
 # Now we will create a 3D NDDataset from scratch
-#
-# Data
-# ++++++
-# here we make use of numpy array functions to create the data for coordinates
-# axis and the array of data
 import numpy as np
 
 # %%
@@ -31,42 +26,42 @@ import spectrochempy as scp
 
 
 # %%
-# We create the data for the coordinates axis and the array of data
-c0 = np.linspace(200.0, 300.0, 3)
-c1 = np.linspace(0.0, 60.0, 100)
-c2 = np.linspace(4000.0, 1000.0, 100)
-nd_data = np.array(
-    [
-        np.array([np.sin(2.0 * np.pi * c2 / 4000.0) * np.exp(-y / 60) for y in c1]) * t
-        for t in c0
-    ]
-)
-
-# %%
 # Coordinates
 # +++++++++++
-# The `Coord` object allow making an array of coordinates
-# with additional metadata such as units, labels, title, etc
-coord0 = scp.Coord(
-    data=c0,
+# The `Coord` object allows creating an array of coordinates directly with
+# ``Coord.linspace``, attaching metadata (units, labels, title) in a single
+# step — no separate numpy array needed.
+coord0 = scp.Coord.linspace(
+    200.0,
+    300.0,
+    3,
     labels=["cold", "normal", "hot"],
     units="K",
     title="temperature",
 )
-coord1 = scp.Coord(data=c1, labels=None, units="minutes", title="time-on-stream")
-coord2 = scp.Coord(data=c2, labels=None, units="cm^-1", title="wavenumber")
+coord1 = scp.Coord.linspace(0.0, 60.0, 100, units="minutes", title="time-on-stream")
+coord2 = scp.Coord.linspace(4000.0, 1000.0, 100, units="cm^-1", title="wavenumber")
 
 # %%
 # Labels can be useful for instance for indexing
 a = coord0["normal"]
 print(a)
 
+
 # %%
-# nd-Dataset
-# +++++++++++
-# The `NDDataset` object allow making the array of data with units, etc...
-mydataset = scp.NDDataset(
-    nd_data, coordset=[coord0, coord1, coord2], title="Absorbance", units="absorbance"
+# Data and nd-Dataset
+# +++++++++++++++++++
+# ``scp.fromfunction`` builds an NDDataset directly from a Python function.
+# The function receives the coordinate arrays and returns the intensity values.
+def synth_func(temperature, time, wavenumber):
+    return np.sin(2.0 * np.pi * wavenumber / 4000.0) * np.exp(-time / 60) * temperature
+
+
+mydataset = scp.fromfunction(
+    synth_func,
+    coordset=[coord0, coord1, coord2],
+    title="Absorbance",
+    units="absorbance",
 )
 mydataset.description = """Dataset example created for this tutorial.
 It's a 3-D dataset (with dimensionless intensity: absorbance )"""

--- a/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
@@ -16,51 +16,50 @@ and then we plot one section (a 2D plane)
 # Creation
 # --------
 # Now we will create a 3D NDDataset from scratch
-#
-# Data
-# ++++++
-# here we make use of numpy array functions to create the data for coordinates
-# axis and the array of data
 import numpy as np
 
 # %%
 # As usual, we start by loading the spectrochempy library
 import spectrochempy as scp
 
-# %%
-# We create the data for the coordinates axis and the array of data
-c0 = np.linspace(200.0, 300.0, 3)
-c1 = np.linspace(0.0, 60.0, 100)
-c2 = np.linspace(4000.0, 1000.0, 100)
-nd_data = np.array(
-    [
-        np.array([np.sin(2.0 * np.pi * c2 / 4000.0) * np.exp(-y / 60) for y in c1]) * t
-        for t in c0
-    ]
-)
 
 # %%
 # Coordinates
 # +++++++++++
-# The `Coord` object allow making an array of coordinates
-# with additional metadata such as units, labels, title, etc
-coord0 = scp.Coord(
-    data=c0, labels=["cold", "normal", "hot"], units="K", title="temperature"
+# The `Coord` object allows creating an array of coordinates directly with
+# ``Coord.linspace``, attaching metadata (units, labels, title) in a single
+# step — no separate numpy array needed.
+coord0 = scp.Coord.linspace(
+    200.0,
+    300.0,
+    3,
+    labels=["cold", "normal", "hot"],
+    units="K",
+    title="temperature",
 )
-coord1 = scp.Coord(data=c1, labels=None, units="minutes", title="time-on-stream")
-coord2 = scp.Coord(data=c2, labels=None, units="cm^-1", title="wavenumber")
+coord1 = scp.Coord.linspace(0.0, 60.0, 100, units="minutes", title="time-on-stream")
+coord2 = scp.Coord.linspace(4000.0, 1000.0, 100, units="cm^-1", title="wavenumber")
 
 # %%
 # Labels can be useful for instance for indexing
 a = coord0["normal"]
 print(a)
 
+
 # %%
-# nd-Dataset
-# +++++++++++
-# The `NDDataset` object allow making the array of data with units, etc...
-mydataset = scp.NDDataset(
-    nd_data, coordset=[coord0, coord1, coord2], title="Absorbance", units="absorbance"
+# Data and nd-Dataset
+# +++++++++++++++++++
+# ``scp.fromfunction`` builds an NDDataset directly from a Python function.
+# The function receives the coordinate arrays and returns the intensity values.
+def synth_func(temperature, time, wavenumber):
+    return np.sin(2.0 * np.pi * wavenumber / 4000.0) * np.exp(-time / 60) * temperature
+
+
+mydataset = scp.fromfunction(
+    synth_func,
+    coordset=[coord0, coord1, coord2],
+    title="Absorbance",
+    units="absorbance",
 )
 mydataset.description = """Dataset example created for this tutorial.
 It's a 3-D dataset (with dimensionless intensity: absorbance )"""
@@ -99,11 +98,11 @@ _ = new.plot(method="image", colorbar=True)
 # If a dataset contains only positive values, the default colormap is
 # sequential (`viridis`):
 
-_ = np.abs(new).plot(method="image", colorbar=True)
+_ = scp.abs(new).plot(method="image", colorbar=True)
 
 # %% Contour plots are also available, with the same default colormap as for the image method:
 _ = new.plot(method="map")
-_ = np.abs(new).plot(method="map")
+_ = scp.abs(new).plot(method="map")
 
 # %%
 # Note that the scp allows one to use this syntax too:

--- a/src/spectrochempy/plotting/composite/plotscore.py
+++ b/src/spectrochempy/plotting/composite/plotscore.py
@@ -91,9 +91,9 @@ def plot_score(
 
     Examples
     --------
-    >>> import numpy as np
+    >>> import spectrochempy as scp
     >>> from spectrochempy import plot_score
-    >>> scores = np.random.randn(50, 5)
+    >>> scores = scp.random(size=(50, 5))
     >>> ax = plot_score(scores, components=(1, 2), show=False)
 
     With label-based coloring:

--- a/src/spectrochempy/processing/psd/psd.py
+++ b/src/spectrochempy/processing/psd/psd.py
@@ -147,9 +147,8 @@ class PSD(BaseConfigurable):
     Examples
     --------
     >>> import spectrochempy as scp
-    >>> import numpy as np
     >>> # Raw 2D input (120 spectra, 1000 channels)
-    >>> X = scp.NDDataset(np.random.rand(120, 1000))
+    >>> X = scp.random(size=(120, 1000))
     >>> psd = scp.PSD(n_spectra_per_cycle=60, demodulation='matrix')
     >>> result = psd.transform(X)
     >>> result.in_phase

--- a/src/spectrochempy/utils/docutils.py
+++ b/src/spectrochempy/utils/docutils.py
@@ -134,7 +134,7 @@ class _DocstringValidator(Validator):
 
         flags = doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL
         finder = doctest.DocTestFinder()
-        runner = doctest.DocTestRunner(optionflags=flags)
+        runner = doctest.DocTestRunner(verbose=False, optionflags=flags)
         context = {"np": numpy, "scp": spectrochempy}
         error_msgs = ""
         current_dir = set(os.listdir())


### PR DESCRIPTION
Replace NumPy patterns with SpectroChemPy-native idioms across example gallery, userguide, and API docstrings:

- `Coord.linspace` / `Coord.arange` for coordinate creation
- `scp.fromfunction` for synthetic data
- `scp.normal`, `scp.random`, `scp.gaussian` for random data / peak profiles
- `scp.zeros`, `scp.abs`, `scp.arange` for array creation and math
- `NDDataset.random`, `.max()` for dataset operations

Fixes #1370