### PR TITLE
FIX: display legend in 2D lines/stack plots when legend=True is passed

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Display legend in 2D lines/stack plots when ``legend=True`` is passed as a
+  plotting keyword argument. Previously the ``legend`` kwarg was silently
+  ignored by the 2D plot backend, so lines rendered with auto-populated labels
+  from coordinate metadata never showed a legend. (#1404)
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,14 @@ What's New in Revision 0.11.1.dev
 These are the changes in SpectroChemPy-0.11.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+Bug Fixes
+~~~~~~~~~
+
+- Display legend in 2D lines/stack plots when ``legend=True`` is passed as a
+  plotting keyword argument. Previously the ``legend`` kwarg was silently
+  ignored by the 2D plot backend, so lines rendered with auto-populated labels
+  from coordinate metadata never showed a legend. (#1404)
+
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -1306,6 +1306,9 @@ def plot_2D(dataset, method=None, **kwargs):
         if method == "waterfall":
             kwargs["colorbar"] = colorbar
 
+        # Extract legend kwarg - only used for lines/stack methods
+        legend = kwargs.pop("legend", None)
+
         # Get the data to plot
         # ---------------------------------------------------------------
         # if we want to plot the transposed dataset
@@ -2017,6 +2020,22 @@ def plot_2D(dataset, method=None, **kwargs):
             ax.set_xlim(user_xlim)
         if user_ylim is not None:
             ax.set_ylim(user_ylim)
+
+        # Display legend for lines/stack methods when requested
+        # legend can be:
+        #   - True: show with auto-populated labels
+        #   - str: show at given location
+        #   - list/ndarray: use as explicit labels
+        #   - False / None: no legend
+        if method in ("lines", "stack") and legend is not None:
+            if isinstance(legend, str):
+                _ = ax.legend(loc=legend)
+            elif legend is True:
+                _ = ax.legend()
+            elif isinstance(legend, bool):
+                pass  # legend=False — do nothing
+            else:
+                _ = ax.legend(labels=list(legend))
 
         return ax
 


### PR DESCRIPTION

Summary:
- The `legend` keyword argument was silently ignored by the 2D plot backend (`plot2d.py:plot_2D`). Lines rendered with auto-populated labels from coordinate labels (commit a7265820d) never showed a legend because `ax.legend()` was never called.
- This fix pops `legend` from kwargs early and calls `ax.legend()` after rendering for `lines`/ `stack` methods.
- `legend=True` uses default legend location; `legend="best"` uses that location; `legend=False` or omitted suppresses the legend.
- Example: `pca.loadings.plot(legend=True)` now correctly shows a legend.
- Changelog entry added.

Out of scope:
- Improving the default component labels (`#0`, `#1`, etc.) — that is a separate issue in `_set_output` / `_wrap_ndarray_output_to_nddataset`.

Refs: #1404
