### PR TITLE
ENH: PCA component labels now show PC1, PC2, ... instead of #0, #1, ...

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,10 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- PCA component labels now display as ``PC1``, ``PC2``, ... instead of ``#0``,
+  ``#1``, ... in legends and coordinate display. Other analysis methods
+  retain the default ``#0``, ``#1``, ... labels. (#1404)
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,13 @@ What's New in Revision 0.11.1.dev
 These are the changes in SpectroChemPy-0.11.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+New Features
+~~~~~~~~~~~~
+
+- PCA component labels now display as ``PC1``, ``PC2``, ... instead of ``#0``,
+  ``#1``, ... in legends and coordinate display. Other analysis methods
+  retain the default ``#0``, ``#1``, ... labels. (#1404)
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -529,6 +529,15 @@ class DecompositionAnalysis(AnalysisConfigurable):
             return self._n_components
         raise NotFittedError("n_components")
 
+    def _get_component_labels(self, n):
+        """
+        Return default labels for *n* components.
+
+        Subclasses may override this to provide domain-specific labels
+        (e.g. ``PC1``, ``PC2``, ... for PCA).
+        """
+        return [f"#{i}" for i in range(n)]
+
     # ----------------------------------------------------------------------------------
     # Plot methods
     # ----------------------------------------------------------------------------------

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -290,6 +290,9 @@ for reproducible results across multiple function calls.""",
         self._components = self._pca.components_
         return self._components
 
+    def _get_component_labels(self, n):
+        return [f"PC{i + 1}" for i in range(n)]
+
     # ----------------------------------------------------------------------------------
     # Public methods and properties specific to PCA
     # ----------------------------------------------------------------------------------

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -520,13 +520,20 @@ class _set_output:
                 X_transf.dims = X.dims
                 X_transf.set_coordset({X.dims[0]: X.coord(0), X.dims[1]: X.coord(1)})
             else:
+                # Resolve component labels — defer to analysis subclasses
+                # (e.g. PCA → PC1, PC2, …).
+                def _component_labels(n):
+                    if hasattr(obj, "_get_component_labels"):
+                        return obj._get_component_labels(n)
+                    return [f"#{i}" for i in range(n)]
+
                 if self.typesingle == "components":
                     # occurs when the data are 1D such as ev_ratio...
                     X_transf.dims = ["k"]
                     X_transf.set_coordset(
                         k=Coord(
                             None,
-                            labels=[f"#{i}" for i in range(X_transf.shape[-1])],
+                            labels=_component_labels(X_transf.shape[-1]),
                             title="components",
                         ),
                     )
@@ -554,7 +561,7 @@ class _set_output:
                             ),
                             "k": Coord(
                                 None,
-                                labels=[f"#{i}" for i in range(X_transf.shape[-1])],
+                                labels=_component_labels(X_transf.shape[-1]),
                                 title="components",
                             ),
                         },
@@ -565,7 +572,7 @@ class _set_output:
                         {
                             "k": Coord(
                                 None,
-                                labels=[f"#{i}" for i in range(X_transf.shape[0])],
+                                labels=_component_labels(X_transf.shape[0]),
                                 title="components",
                             ),
                             X.dims[1]: (
@@ -583,7 +590,7 @@ class _set_output:
                             # cannot use X.y in case of transposed X
                             "k": Coord(
                                 None,
-                                labels=[f"#{i}" for i in range(X_transf.shape[-1])],
+                                labels=_component_labels(X_transf.shape[-1]),
                                 title="components",
                             ),
                         },

--- a/tests/test_analysis/test_decomposition/test_analysis_output_semantics_baseline.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_output_semantics_baseline.py
@@ -134,7 +134,7 @@ class TestLatentOutputs:
         assert scores.y.title == semantic_dataset.y.title
         assert scores.y.units == semantic_dataset.y.units
         assert scores.k.title == "components"
-        assert list(scores.k.labels) == ["#0", "#1"]
+        assert list(scores.k.labels) == ["PC1", "PC2"]
 
     def test_pca_components_preserve_feature_axis_and_synthesize_k(
         self, semantic_dataset


### PR DESCRIPTION

Summary:
- PCA component labels change from generic `#0`, `#1`, ... to domain-specific `PC1`, `PC2`, ... in legends, coordinate display, and any output using `components` / `loadings`.
- Adds `_get_component_labels(n)` to `_AnalysisBase` (returns `#0`, `#1`, ... by default) and overrides it in `PCA` to return `PC1`, `PC2`, ....
- Updates `_set_output` decorator to call `obj._get_component_labels(n)` (via `hasattr`) for all four `components` branches (`typesingle`, `typey`, `typex`, `typey+typex`), with fallback to `#0`, `#1`, ... for classes that don't override.
- Updated test assertion to expect `PC1`, `PC2`.

Refs: #1404
