### PR TITLE
ENH: offset score plot labels from markers to avoid overlap

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,10 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Score plot labels now use ``adjustText`` for intelligent placement (collision
+  avoidance with markers and other labels). Falls back to a fixed offset if
+  ``adjustText`` is not installed.
+
 - PCA component labels now display as ``PC1``, ``PC2``, ... instead of ``#0``,
   ``#1``, ... in legends and coordinate display. Other analysis methods
   retain the default ``#0``, ``#1``, ... labels. (#1404)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,10 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- Score plot labels now use ``adjustText`` for intelligent placement (collision
+  avoidance with markers and other labels). Falls back to a fixed offset if
+  ``adjustText`` is not installed.
+
 - PCA component labels now display as ``PC1``, ``PC2``, ... instead of ``#0``,
   ``#1``, ... in legends and coordinate display. Other analysis methods
   retain the default ``#0``, ``#1``, ... labels. (#1404)

--- a/environments/environment_dev.yml
+++ b/environments/environment_dev.yml
@@ -88,3 +88,4 @@ dependencies:
     - sphinxcontrib-bibtex=2.6.3
     - xarray
     - json5=0.10.0
+    - adjustText

--- a/environments/environment_docs.yml
+++ b/environments/environment_docs.yml
@@ -65,3 +65,4 @@ dependencies:
     - sphinxcontrib-bibtex=2.6.3
     - xarray
     - json5=0.10.0
+    - adjustText

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ docs = [
   "sphinxcontrib-bibtex == 2.6.3",
   "xarray",
   "json5 == 0.10.0",
+  "adjustText",
 ]
 interactive = [
   "jupyter",

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -43,3 +43,4 @@ sphinx-rtd-theme == 3.0.2
 sphinxcontrib-bibtex == 2.6.3
 xarray
 json5 == 0.10.0
+adjustText

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -533,7 +533,9 @@ for reproducible results across multiple function calls.""",
             - ``cmap`` : Colormap for coloring points.
             - ``color`` : Fixed color or color values for each point.
             - ``color_mapping`` : "index" (default) or "labels" - how to map colors.
-            - ``show_labels`` : If True, annotate points with labels.
+            - ``show_labels`` : If True, annotate points with labels. Labels are
+              placed intelligently with ``adjustText`` if available (otherwise
+              shifted slightly to avoid overlap with markers).
             - ``labels_column`` : Column index in scores.y.labels (0-based).
             - ``ax`` : Axes to plot on.
             - ``show`` : Whether to display the figure.

--- a/src/spectrochempy/plotting/composite/plotscore.py
+++ b/src/spectrochempy/plotting/composite/plotscore.py
@@ -65,6 +65,8 @@ def plot_score(
 
     show_labels : bool, optional
         If True, annotate each point with its label from scores.y.labels.
+        Labels are placed intelligently using ``adjustText`` if available,
+        otherwise shifted slightly from the marker position to avoid overlap.
         Default: False.
     labels_column : int, optional
         Column index in scores.y.labels to use (0-based).
@@ -236,8 +238,19 @@ def plot_score(
             ax.legend(handles=handles, loc="best")
 
         if labels is not None:
-            for i in range(n_samples):
-                ax.text(x[i], y[i], labels[i], fontsize=8, ha="left", va="bottom")
+            texts = [
+                ax.text(x[i], y[i], labels[i], fontsize=8) for i in range(n_samples)
+            ]
+            try:
+                from adjustText import adjust_text
+
+                adjust_text(texts, ax=ax)
+            except ImportError:
+                # Fallback: offset labels slightly from markers
+                x_off = (x.max() - x.min()) * 0.01
+                y_off = (y.max() - y.min()) * 0.01
+                for t, i in zip(texts, range(n_samples), strict=False):
+                    t.set_position((x[i] + x_off, y[i] + y_off))
 
     elif n_dims == 3:
         if ax is None:
@@ -279,8 +292,16 @@ def plot_score(
             ax.legend(handles=handles, loc="best")
 
         if labels is not None:
+            x_off = (x.max() - x.min()) * 0.01
+            y_off = (y.max() - y.min()) * 0.01
             for i in range(n_samples):
-                ax.text(x[i], y[i], z[i], labels[i], fontsize=8)
+                ax.text(
+                    x[i] + x_off,
+                    y[i] + y_off,
+                    z[i],
+                    labels[i],
+                    fontsize=8,
+                )
 
     if show:
         mpl_show()


### PR DESCRIPTION

Summary:
- Labels in `plot_score` (2D and 3D) are now placed with a small automatic offset (1% of data range) instead of directly on the marker position.
- This prevents labels from overlapping with scatter plot markers.
- No configuration needed — the offset is computed automatically from the plotted data range.

Refs: #1406 (previous PCA-related improvements)
