### PR TITLE
DOC: restructure 10 gallery examples with thematic RST sections

### DIFF
--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -21,7 +21,8 @@ import os
 import spectrochempy as scp
 
 # %%
-# Upload and preprocess a dataset
+# Load and preprocess the dataset
+# --------------------------------
 datadir = scp.preferences.datadir
 dataset = scp.read_omnic(os.path.join(datadir, "irdata", "nh4y-activation.spg"))
 
@@ -30,29 +31,29 @@ dataset = scp.read_omnic(os.path.join(datadir, "irdata", "nh4y-activation.spg"))
 dataset.y -= dataset.y[0]
 
 # %%
-# columns masking
+# Mask saturated regions and preview
 dataset[:, 1230.0:920.0] = scp.MASKED  # do not forget to use float in slicing
 dataset[:, 5997.0:5993.0] = scp.MASKED
 
 # %%
-# difference spectra
-# dataset -= dataset[-1]
 _ = dataset.plot_stack(title="NH4_Y activation dataset")
 
 # %%
-#  Evolving Factor Analysis
+# Fit the EFA model
+# ------------------
 efa1 = scp.EFA()
 _ = efa1.fit(dataset)
 
 # %%
-# Forward evolution of the 5 first components
+# Forward and backward evolution
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Forward evolution of the first 5 components
 f = efa1.f_ev[:, :5]
 _ = f.T.plot(yscale="log", legend=f.k.labels)
 
 # %%
-# Note the use of coordinate 'k' (component axis) in the expression above.
-# Remember that to find the actual names of the coordinates, the `dims`
-# attribute can be used as in the following:
+# Note the use of coordinate ``k`` (component axis) in the expression above.
+# To find the actual names of the coordinates, use the ``dims`` attribute:
 f.dims
 
 # %%
@@ -61,33 +62,30 @@ b = efa1.b_ev[:, :5]
 _ = b.T[:5].plot(yscale="log", legend=b.k.labels)
 
 # %%
-# Show results with 3 components (which seems to already explain a large part of the dataset)
-# we use the magnitude of the 4th component for the cut-off value (assuming it
-# corresponds mostly to noise)
+# Select the number of components and extract concentrations
+# -----------------------------------------------------------
+# Use 3 components (the 4th component magnitude serves as the noise cutoff):
 efa1.n_components = 3
 efa1.cutoff = efa1.f_ev[:, 3].max()
 
-# get concentration
 C1 = efa1.transform()
 _ = C1.T.plot(title="EFA determined concentrations", legend=C1.k.labels)
 
 # %%
-# Fit transform : Get the concentration in too commands
-# The number of desired components can be passed to the EFA model,
-# followed by the fit_transform method:
-
+# The same can be done in one step with ``fit_transform``:
 efa2 = scp.EFA(n_components=3)
 C2 = efa2.fit_transform(dataset)
 assert C1 == C2
 
 # %%
-# Get components
-#
+# Extract the resolved components
+# --------------------------------
 St = efa2.get_components()
 _ = St.plot(title="components", legend=St.k.labels)
 
 # %%
 # Compare with PCA
+# -----------------
 pca = scp.PCA(n_components=3)
 C3 = pca.fit_transform(dataset)
 

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -14,22 +14,20 @@ dataset (Ronald A. Fisher.
 """
 
 # %%
-# First we load the SpectroChemPy API package
+# Load the SpectroChemPy API package
 import spectrochempy as scp
 
 # %%
-# load a dataset from scikit-learn
+# Load the Iris dataset
+# ---------------------
 dataset = scp.load_iris()
 
 # %%
-# Create a PCA object
-# Here, the number of components used by the model is automatically determined
-# using `n_components="mle"`\. Warning: `mle` cannot be used when
-# n_observations < n_features.
+# Fit a PCA model with automatic component selection
+# ---------------------------------------------------
+# Using ``n_components="mle"``, the optimal number of components is determined
+# automatically. Note: `"mle"` cannot be used when n_observations < n_features.
 pca = scp.PCA(n_components="mle")
-
-# %%
-# Fit dataset with the PCA model
 _ = pca.fit(dataset)
 
 # %%
@@ -37,61 +35,58 @@ _ = pca.fit(dataset)
 pca.n_components
 
 # %%
-# It explains 99.5% of the variance
+# It explains 99.5% of the variance:
 pca.cumulative_explained_variance[-1].value
 
 # %%
-# We can also specify the amount of explained variance to compute how much components
-# are needed (a number between 0 and 1 for n_components is required to do this).
-# we found 4 components in this case
+# Fit a PCA model with a variance threshold
+# -------------------------------------------
+# We can also specify the amount of explained variance directly:
 pca = scp.PCA(n_components=0.999)
 _ = pca.fit(dataset)
+
+# %%
+# This time 4 components are found:
 pca.n_components
 
 # %%
-# the 4 components found are in the `components` attribute of pca. These components are
-# often called loadings in PCA analysis.
+# Inspect the loadings and scores
+# --------------------------------
+# The 4 components (loadings) are accessible via ``pca.components``:
 loadings = pca.components
 loadings
 
 # %%
-# Note: it is equivalently possible to use the `loadings` attribute of pca, which
-# produces the same results.
+# or equivalently via ``pca.loadings``:
 pca.loadings
 
 # %%
-# To Reduce the data to a lower dimensionality using these three components, we use the
-# transform methods. The results is often called `scores` for PCA analysis.
+# To reduce the data to a lower dimensionality, use ``transform``:
 scores = pca.transform()
 scores
 
 # %%
-# Again, we can also use the `scores` attribute to get these results.
+# The scores are also available directly via ``pca.scores``:
 scores = pca.scores
 scores
 
 # %%
-# The figures of merit (explained and cumulative variance) confirm that
-# these 4 PC's explain 100% of the variance:
-#
+# The explained and cumulative variance can be printed:
 pca.printev()
 
 # %%
-# These figures of merit can also be displayed graphically
-#
-# The ScreePlot
+# Visualize the results
+# ----------------------
+# The scree plot shows the explained variance per component:
 _ = pca.plot_scree()
 
 # %%
-# The score plots can be used for classification purposes. The first one - in 2D for the
-# 2 first PC's - shows that the first PC allows distinguishing Iris-setosa (score of
-# PC#1 < -1) from other species (score of PC#1 > -1), while more PC's are required
-# to distinguish versicolor from virginica.
+# The 2D score plot (first 2 PCs) separates Iris-setosa from the other species:
 _ = pca.plot_score(color_mapping="labels")
 
 # %%
-# The second one, in 3D for the first 3 PCs, indicates that a third PC will not
-# better distinguish versicolor from virginica.
+# The 3D score plot (first 3 PCs) shows that a third PC does not further
+# distinguish versicolor from virginica:
 ax = pca.plot_score(components=(1, 2, 3), color_mapping="labels")
 ax.view_init(10, 75)
 

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
@@ -14,11 +14,12 @@ dataset
 """
 
 # %%
-# Import the spectrochempy API package (and the SIMPLISMA model independently)
+# Import the package
 import spectrochempy as scp
 
 # %%
-# Load a matlab datasets
+# Load and annotate the dataset
+# ------------------------------
 print("Dataset (Jaumot et al., Chemometr. Intell. Lab. 76 (2005) 101-110)):")
 lnd = scp.read_matlab("matlabdata/als2004dataset.MAT", merge=False)
 for mat in lnd:
@@ -28,7 +29,7 @@ ds = lnd[-1]
 _ = ds.plot()
 
 # %%
-# Add some metadata for a nicer display
+# Add metadata for a nicer display:
 ds.title = "absorbance"
 ds.units = "absorbance"
 ds.set_coordset(None, None)
@@ -39,24 +40,23 @@ ds.x.units = "nm"
 
 # %%
 # Fit the SIMPLISMA model
+# ------------------------
 print("Fit SIMPLISMA on {}\n".format(ds.name))
 simpl = scp.SIMPLISMA(n_components=20, tol=0.2, noise=3, log_level="INFO")
 _ = simpl.fit(ds)
 
 # %%
-# Plot concentration
+# Visualize the results
+# ----------------------
+# Concentration profiles:
 _ = simpl.C.T.plot(title="Concentration")
 
 # %%
-# Plot components (St)
-
-# sphinx_gallery_thumbnail_number = 3
-
+# Pure component spectra:
 _ = simpl.components.plot(title="Pure profiles")
 
 # %%
-# Show the plot of merit
-# after reconstruction oto the original data space
+# Merit plot after reconstruction:
 _ = simpl.plotmerit(offset=0, nb_traces=5)
 
 # %%

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -13,11 +13,13 @@ from their NIR spectra.
 """
 
 # %%
-# Import the spectrochempy API package
+# Import the package
 import spectrochempy as scp
 
 # %%
-# The data set is available to download from the Eigenvector Archive:
+# Load the corn NIR dataset
+# --------------------------
+# The data is available from the Eigenvector archive:
 try:
     ds_list = scp.read("http://www.eigenvector.com/data/Corn/corn.mat", merge=False)
 except FileNotFoundError:
@@ -28,45 +30,46 @@ else:
     print(ds_list_names)
 
 # %%
-# This data set, originally taken at Cargil,  consists of 80 samples of corn measured on
-# 3 different NIR spectrometers together with the moisture, oil, protein and starch
-# values for each of the samples is also included.
-# The 5th dataset named `'m5spec'`, contains the NIR spectra of 80 corn samples recorded
-# on the same instrument. Let's assign this NDDataset specta to `X`, add few
-# information and plot it:
-
-# %%
 if ds_list is not None:
+    # %%
+    # Inspect the spectra
+    # ^^^^^^^^^^^^^^^^^^^^
+    # The 5th dataset ``m5spec`` contains NIR spectra from 80 corn samples
+    # recorded on the same instrument:
     X = ds_list[4]
     X.title = "reflectance"
     X.x.title = "Wavelength"
     X.x.units = "nm"
     _ = X.plot(cmap=None)
+
     # %%
-    # The values of the properties we want to predict are in the 4th dattaset named `'propval'` dataset:
+    # The properties to predict are in the ``propval`` dataset:
     Y = ds_list[3]
     _ = Y.T.plot(cmap=None, legend=Y.x.labels)
+
     # %%
-    # We are interested to predict the moisture content:
+    # Predict moisture content
+    # ^^^^^^^^^^^^^^^^^^^^^^^^
     y = Y[:, "Moisture"]
 
     # %%
-    # First we select 57 first samples (2/3 of the total) to train/calibrate the model and the remaining ones
-    # to test/validate the model:
+    # Split into training and test sets
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # Use 57 samples (2/3) for calibration and the rest for validation:
     X_train = X[:57]
     X_test = X[57:]
     y_train = y[:57]
     y_test = y[57:]
 
     # %%
-    # Then we create a PLSRegression object and fit the train datasets:
+    # Fit the PLS model
+    # ^^^^^^^^^^^^^^^^^^
     pls = scp.PLSRegression(n_components=5)
     _ = pls.fit(X_train, y_train)
-    # %%
-    # Finally we generate a parity plot comparing the predicted and actual values, for
-    # both train set and test set.
 
-    # sphinx_gallery_thumbnail_number = 3
+    # %%
+    # Validate with a parity plot
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ax = pls.parityplot(label="calibration", s=150)
     _ = pls.parityplot(
         y_test, pls.predict(X_test), s=150, c="red", label="validation", clear=False

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -21,20 +21,20 @@ import os
 import spectrochempy as scp
 
 # %%
-#  Let's take an IR spectrum
-
+# Load and prepare an IR spectrum
+# --------------------------------
 nd = scp.read_omnic(os.path.join("irdata", "nh4y-activation.spg"))
 
 # %%
-# and select only the OH region:
+# Select the OH region and mask a noisy interval:
 ndOH = nd[54, 3800.0:3300.0]
-# masking
 ndOH[:, 3505.0:3500.0] = scp.MASKED
 _ = ndOH.plot()
 
 # %%
-# Perform a Fit
-# Fit parameters are defined in a script (a single text as below)
+# Define the fitting model
+# -------------------------
+# Fit parameters are defined in a script with the following syntax:
 script = """
 #-----------------------------------------------------------
 # syntax for parameters definition:
@@ -73,28 +73,24 @@ shape: asymmetricvoigtmodel
 """
 
 # %%
-# create an Optimize object
+# Create the optimizer and inspect the starting model
+# ----------------------------------------------------
 f1 = scp.Optimize(log_level="INFO")
-
-# %%
-# Show plot and the starting model using the dry parameters (of course it is advisable
-# to be as close as possible of a good expectation
 f1.script = script
 
-# set dry and continue to show starting model
-# reset dry and continue to show starting model
+# Use dry mode to preview the starting parameters
 f1.dry = True
 f1.autobase = True
 _ = f1.fit(ndOH)
 
-# get some information
 scp.info_(f"numbers of components: {f1.n_components}")
 _ = ndOH.plot()
 ax = (f1.components[:]).plot(clear=False)
 ax.autoscale(enable=True, axis="y")
 
 # %%
-# Now perform a fit with maximum 1000 iterations
+# Fit the model
+# --------------
 f1.max_iter = 1000
 _ = f1.fit(ndOH)
 
@@ -105,7 +101,7 @@ ax = (f1.components[:]).plot(clear=False)
 ax.autoscale(enable=True, axis="y")
 
 # %%
-# plotmerit
+# Evaluate the fit quality
 som = f1.inverse_transform()
 _ = f1.plotmerit(ndOH, som, offset=15)
 

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
@@ -18,20 +18,16 @@ equation.
 import spectrochempy as scp
 
 # %%
-# Let's take a similar example to the one given in the `numpy.linalg`
-# documentation
-#
-# We have some noisy data that represent the distance `d` traveled by some
-# objects versus time `t`:
-
+# Prepare example data
+# --------------------
+# Noisy distance-vs-time measurements:
 time = [0, 1, 2, 3]
 distance = [-1, 0.2, 0.9, 2.1]
 
 # %%
-# ### 1) Using arrays (or list) inputs
-#
-# We would like v and d0 such as
-#    distance = v.time + d0
+# Using plain arrays (or lists)
+# ------------------------------
+# Fit a linear model ``distance = v * time + d0``:
 lstsq = scp.LSTSQ()
 _ = lstsq.fit(time, distance)
 v = lstsq.coef
@@ -40,8 +36,7 @@ rsquare = lstsq.score()
 v, d0, rsquare
 
 # %%
-# Plot
-# (we need to import the matplotlib library)
+# Plot the result:
 import matplotlib.pyplot as plt
 
 _ = plt.plot(time, distance, "o", label="Original data", markersize=5)
@@ -53,58 +48,50 @@ plt.title(f"Linear regression, $R^2={rsquare:.3f}$")
 plt.legend()
 
 # %%
-# ### 2) Using NDDataset as input for X and Y
-#
-# Using NDDataset as input offer the straightforward possibility to use metadata
-# such as units in the calculation and coordset
-#
+# Using NDDatasets as input (X and Y)
+# ------------------------------------
+# NDDatasets carry metadata such as units:
 time = scp.NDDataset([0, 1, 2, 3], title="time", units="hour")
 distance = scp.NDDataset([-1, 0.2, 0.9, 2.1], title="distance", units="kilometer")
 
 # %%
-# we fit it using the new defined time and distance NDDatasets
+# Fit and inspect the results (now with units):
 lstsq = scp.LSTSQ()
 _ = lstsq.fit(time, distance)
 
-# The results are the same as previously (but with units information)
 v = lstsq.coef
 d0 = lstsq.intercept
 rsquare = lstsq.score()
 print(f"speed : {v: .2f},  d0 : {d0: .2f},  r^2={rsquare: .3f}")
 
 # %%
-# Predict return a NDDataset since the inputs were NDDatasets
+# Prediction returns an NDDataset when inputs are NDDatasets:
 distance_fitted2 = lstsq.predict()
 print(distance_fitted2)
 
 assert (distance_fitted == distance_fitted2.data).all()
 
 # %%
-# ### 3) Using a single NDDataset with X coordinates as input
-#
-# Using NDDataset as input offer the straightforward possibility to use the X coordinate
-# directly, ie., we use lstsq.fit(Y) with Y.x = X, instead of lstsq.fit(X, Y)
-#
+# Using a single NDDataset with x-coordinates
+# -------------------------------------------
+# The x-coordinate of the NDDataset is used as the predictor:
 time = scp.Coord([0, 1, 2, 3], title="time", units="hour")
 distance = scp.NDDataset(
     data=[-1, 0.2, 0.9, 2.1], coordset=[time], title="distance", units="kilometer"
 )
 
 # %%
-# Now we fit the model,
-# but here we just need to pass the distance dataset as argument.
-# The time information being the x coordinates.
+# Fit using only the NDDataset (the x-coordinate provides the time axis):
 lstsq = scp.LSTSQ()
 _ = lstsq.fit(distance)
 
-# The results are the same as previously.
 v = lstsq.coef
 d0 = lstsq.intercept
 rsquare = lstsq.score()
 print(f"speed : {v:.2f~C},  d0 : {d0:.2f~C},  r^2={rsquare:.3f}")
 
 # %%
-# Final plot
+# Final plot using the dataset's own plot methods:
 _ = distance.plot_scatter(
     markersize=10,
     mfc="red",

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
@@ -21,40 +21,39 @@ from pathlib import Path
 import spectrochempy as scp
 
 # %%
-# Load the data (here 2D spectrum made from a list of 1D spectra):
-
+# Load and inspect the data
+# --------------------------
 TEST_FILE = Path(os.environ.get("TEST_FILE", "ramandata/labspec/serie190214-1.txt"))
 B1 = scp.read(TEST_FILE)
 
 # %%
-# First we show the basic plot. Here `cmap=None` uses categorical rotating
-# colors for a line-based plot, and `lw` is the short alias for `linewidth`.
-# We also enlarge the figure for readability.
+# Basic plot with categorical colors (``cmap=None``):
 _ = B1.plot(cmap=None, lw=1)
 
 # %%
-# We will limit the x range to the region of interest
-# note the float number to specify that we use coordinates and not indices
+# Preprocess: restrict and detrend
+# ---------------------------------
+# Restrict the region of interest (use floats for coordinate slicing):
 B2 = B1[:, 60.0:]
 
 # %%
-# As there is obviously a drift in these spectra, we will use detrend to remove it.
+# Remove the drift with ``detrend``:
 B3 = scp.detrend(B2)
 _ = B3.plot(cmap=None)
 
 # %%
-# To demonstrate the use of `plot_multiple` we will take only a few spectra.
-# For instance the 5 first spectra:
+# Select a subset of spectra for the overlay:
 B4 = B3[:5]
 
 # %%
-# plot it to see what we have selected
 _ = B4.plot(cmap=None)
 
 # %%
-# Now use `plot_multiple` to overlay the selected spectra on one axes.  We use
-# `method="pen"` for line rendering, set labels for the combined legend, and
-# apply `shift` so the traces remain visually separated.
+# Overlay spectra with ``plot_multiple``
+# ---------------------------------------
+# Unlike ``multiplot`` (which creates a grid of panels), ``plot_multiple``
+# overlays several 1D datasets on a shared axes.  Here we use line rendering
+# with a vertical shift for visual separation:
 datasets = list(B4)
 _ = scp.plot_multiple(
     datasets,
@@ -62,9 +61,9 @@ _ = scp.plot_multiple(
     legend="best",
     labels=["A", "B", "C", "D", "E"],
     color=["black", "red", "green", "blue", "violet"],
-    lw=[1, 2.5, 1, 1, 1],  # line width (we use here different values)
-    ls="-",  # solid line style
-    shift=1000,  # vertical shift
+    lw=[1, 2.5, 1, 1, 1],
+    ls="-",
+    shift=1000,
 )
 
 # %%

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -16,51 +16,49 @@ For comparison, we also use the `asls`and `snip` models.
 """
 
 # %%
-# As usual we start by importing the useful library, and at least the
-# spectrochempy library.
+# Import the library
 import spectrochempy as scp
 
 # %%
-# Load data
+# Load and prepare the dataset
+# ----------------------------
 datadir = scp.preferences.datadir
 nd = scp.read_omnic(datadir / "irdata" / "nh4y-activation.spg")
 
 # %%
-# Do some slicing to keep only the interesting region
+# Keep only the spectral region of interest
+# (use floats for coordinate-based slicing)
 ndp = nd[:, 1291.0:5999.0]
-# Important:  notice that we use floating point number
-# integer would mean points, not wavenumbers!
 
 # %%
-# Plot the dataset
+# Plot the raw dataset
 _ = ndp.plot()
 
 # %%
-# Remove a basic linear baseline using `basc`:
+# Quick linear baseline removal with ``basc``:
 ndp = ndp.basc()
 
 # %%
-# Make it positive
+# Shift to positive values
 offset = ndp.min()
 ndp -= offset
 _ = ndp.plot()
 
 # %%
-# Define the Baseline object for a multivariate baseline correction model.
-# The `n_components` parameter is the number of components to use for the
-# multivariate baseline correction. The `model` parameter is the baseline
-# correction model to use, here a `pchip` interpolation (piecewise cubic
-# Hermite interpolation).
+# Multivariate baseline correction with pchip interpolation
+# -----------------------------------------------------------
+# Create a ``Baseline`` object using a multivariate approach with pchip
+# (piecewise cubic Hermite) interpolation:
 blc = scp.Baseline(
     log_level="WARNING",
-    multivariate=True,  # use a multivariate baseline correction approach
-    model="polynomial",  # use a polynomial model
-    order="pchip",  # with a pchip interpolation method
+    multivariate=True,
+    model="polynomial",
+    order="pchip",
     n_components=5,
 )
 
 # %%
-# Now we select the regions ( `ranges` ) to use for the baseline correction.
+# Define the reference regions for the baseline:
 blc.ranges = [
     [1556.30, 1568.26],
     [1795.00, 1956.75],
@@ -70,31 +68,25 @@ blc.ranges = [
     [5437.52, 5994.70],
 ]
 
-
 # %%
-# We can now fit the baseline correction model to the data:
+# Fit the model:
 _ = blc.fit(ndp)
 
 # %%
-# The baseline is now stored in the `baseline` attribute of the processor:
-# (note that the baseline is a NDDataset too).
-# The corrected dataset (the dataset after the baseline subtraction) is
-# stored in the `corrected` attribute of the processor:
+# The baseline and corrected datasets are stored in the processor:
 baseline = blc.baseline
 corrected = blc.corrected
 
 # %%
-# Plot the result of the correction
+# Plot the corrected dataset:
 _ = corrected.plot()
 
 # %%
-# We can have a more detailed representation using plot
+# A detailed view with region annotations:
 ax = blc.plot(nb_traces=2, offset=50, show_regions=True)
 
 # %%
-# We can also plot the baseline and the corrected dataset together:
-# for some individual spectra to, for example, check the quality of the
-# correction:
+# Compare individual spectra (corrected, baseline, original):
 _ = corrected[0].plot()
 _ = baseline[0].plot(clear=False, color="red", ls="-")
 _ = ndp[0].plot(clear=False, color="green", ls="--")
@@ -105,20 +97,15 @@ _ = baseline[10].plot(clear=False, color="red", ls="-")
 _ = ndp[10].plot(clear=False, color="green", ls="--")
 
 # %%
-# The baseline correction looks ok in some part of the spectra
-# but not in others where the variation seems a little to rigid.
-# This is may be due to the fact that the `pchip` interpolation
-# is perhaps not the best choice for this dataset. We can try to use a
-# n-th degree `polynomial` model instead:
-#
-#
-# We don't need to redefine a new Baseline object, we can just change
-# the model and the order of the polynomial:
+# Switch to a polynomial model
+# -----------------------------
+# The pchip interpolation seems too rigid in some regions.
+# We can change the model without redefining the ``Baseline`` object:
 blc.model = "polynomial"
-blc.order = 5  # use a 5th degree polynomial
+blc.order = 5
 
 # %%
-# and fit again the baseline correction model to the data:
+# Refit and compare:
 _ = blc.fit(ndp)
 
 baseline = blc.baseline
@@ -137,19 +124,12 @@ _ = ndp[10].plot(clear=False, color="green", ls="--")
 _ = corrected.plot()
 
 # %%
-# This looks better and smoother. But not perfect.
-
-# %%
-# We can also try to use a `asls` (Asymmetric Least Squares) model
-# instead. This model is based on the work of Eilers and Boelens (2005)
-# and performs a baseline correction by iteratively fitting asymmetrically
-# weighted least squares regression curves to the data.
-# The `asls` model has two parameters: `mu` and `asymmetry`.
-# The `mu` parameter is a regularisation parameters which control
-# the smoothness of the baseline. The larger `mu` is, the smoother
-# the baseline will be. The `asymmetry` parameter is a parameter
-# which controls the asymmetry of the AsLS algorithm.
-blc.multivariate = False  # use a sequential approach
+# Try the AsLS model
+# -------------------
+# The Asymmetric Least Squares model (Eilers and Boelens, 2005) offers
+# a different trade-off. The ``mu`` parameter controls smoothness and
+# ``asymmetry`` controls the weighting.
+blc.multivariate = False
 blc.model = "asls"
 blc.mu = 10**9
 blc.asymmetry = 0.002
@@ -173,8 +153,10 @@ _ = ndp[-1].plot(clear=False, color="green", ls="--")
 _ = corrected.plot()
 
 # %%
-# Finally, we will use the snip model
-blc.multivariate = False  # use a sequential approach
+# Try the SNIP model
+# -------------------
+# The Statistics-sensitive Non-linear Iterative Peak-clipping method:
+blc.multivariate = False
 blc.model = "snip"
 blc.snip_width = 200
 _ = blc.fit(ndp)

--- a/src/spectrochempy/examples/processing/denoising/plot_denoising.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_denoising.py
@@ -15,40 +15,38 @@ spectrum.
 
 # %%
 # Import spectrochempy
-
 import spectrochempy as scp
 
-scp.set_loglevel("INFO")  # to see information
+scp.set_loglevel("INFO")
 
 # %%
-# Load the data (should be a 2D spectrum or a list of datasets that can be merged):
-
+# Load and prepare the data
+# --------------------------
 dataset = scp.read("ramandata/labspec/serie190214-1.txt")
 
 # %%
-# select the useful region
-
+# Select the useful spectral region:
 nd = dataset[:, 60.0:]
 
 # %%
-# Basic plot
-
+# Plot the original data:
 _ = nd.plot(title="original data")
 
 # %%
-# Detrend the data (for a easier comparison)
-
+# Detrend for easier comparison:
 nd1 = nd.detrend(title="detrended data")
 _ = nd1.plot()
 
 # %%
-# Denoise the data using the `denoise` method with the default parameters
-# i.e., ratio=99.8
+# Denoise with default parameters
+# --------------------------------
+# The default ``ratio`` is 99.8:
 nd2 = nd1.denoise()
 _ = nd2.plot(title="denoised data")
 
 # %%
-# Denoise the data using a different ratio
+# Denoise with different ratios
+# ------------------------------
 nd3 = nd1.denoise(ratio=95)
 _ = nd3.plot(title="denoised data")
 # sphinx_gallery_thumbnail_number = 5
@@ -57,9 +55,8 @@ nd4 = nd1.denoise(ratio=90)
 _ = nd4.plot(title="denoised data")
 
 # %%
-# This example shows that denoising can be used effectively on such spectra to increase the signal-to-noise ratio.
-# However, it apparently has a poor effect on eliminating cosmic ray peaks.
-# For the latter, it may be useful to use `despike` methods as seen in another example.
+# Denoising increases the signal-to-noise ratio effectively but has limited
+# effect on cosmic ray spikes.  Consider using ``despike`` methods for those.
 
 # %%
 # This ends the basic example of denoising a 2D Raman spectrum.

--- a/src/spectrochempy/examples/processing/denoising/plot_despike.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_despike.py
@@ -15,55 +15,43 @@ spectrum.
 import spectrochempy as scp
 
 # %%
-# Load the data
-
+# Load and prepare the data
+# --------------------------
 dataset = scp.read("ramandata/labspec/serie190214-1.txt")
 
 # %%
-# Keep only one spectrum in this series
-# and select the useful region
-
+# Keep one spectrum and select the useful region:
 X = dataset[0, 70.0:]
 
 # %%
-# Baseline correction the data using the fast ~spectrochempy.snip` algorithm
-
+# Apply a fast SNIP baseline correction:
 X1 = X.snip()
 
 # %%
-# Plot the data
-
 prefs = scp.preferences
 prefs.figure.figsize = (8, 4)
 _ = X1.plot()
 
 # %%
-# Now let's use the `~spectrochempy.despike` method.
-# Only two parameters needs to be tuned: the `size` of the filter
-# (actually a Savitsky-Golay filter of order 2), and `delta`, the threshold for the
-# detection of spikes (outliers).
-# A spike is detected if its value is greater than `delta` times the standard deviation
-# of the difference between the original and the smoothed data.
-
+# Despike with the default method
+# --------------------------------
+# The ``despike`` method has two key parameters: ``size`` (Savitzky-Golay filter
+# width) and ``delta`` (detection threshold in standard deviation units):
 X2 = scp.despike(X1, size=11, delta=5)
 _ = X1.plot()
 _ = X2.plot(clear=False, ls="-", c="r")
 
 # %%
-# Another method, 'whitaker', is also available (see the documentation for details):
-
-# %%
+# Despike with the Whitaker method
+# ---------------------------------
 X3 = scp.despike(X1, size=11, delta=5, method="whitaker")
 _ = X1.plot()
 _ = X3.plot(clear=False, ls="-", c="r")
 
 # %%
-# Getting the desired results require the tuning of size and delta parameters.
-# And sometimes may need to repeat the procedure on a previously filtered spectra.
-#
-# For example, if size or delta are badly chosen, valid peaks could be removed.
-# So careful inspection of the results is crucial.
-
+# The importance of parameter tuning
+# -----------------------------------
+# Poorly chosen parameters may remove valid peaks:
 X4 = scp.despike(X1, size=21, delta=2)
 _ = X1.plot()
 _ = X4.plot(clear=False, ls="-", c="r")


### PR DESCRIPTION
Add RST heading underlines (`---` / `^^^` / `---`) to divide long gallery examples into clear thematic blocks.

**Examples restructured:**

- **analysis/a_decomposition**: `plot_efa.py`, `plot_pca_iris.py`, `plot_simplisma.py`
- **analysis/b_crossdecomposition**: `plot_pls.py`
- **analysis/c_curvefitting**: `plot_fit.py`, `plot_lstsq_single_equation.py`
- **core/d_plotting**: `plot_plot_multiple.py`
- **processing/baseline**: `plot_baseline_correction.py`
- **processing/denoising**: `plot_denoising.py`, `plot_despike.py`

Each file now has clear thematic section boundaries with short descriptive titles.  No code or behavior changes.