### PR TITLE
DOC: restructure 17 gallery examples with thematic RST sections

### DIFF
--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
@@ -22,8 +22,8 @@ directly with the SpectroChemPy API:
 import spectrochempy as scp
 
 # %%
-# Build a shared time axis and three simple concentration profiles with
-# ``scp.exp(...)``.
+# Build profiles with analytical expressions
+# -------------------------------------------
 time = scp.linspace(0.0, 1.0, 200)
 
 c1 = scp.exp(-0.5 * ((time - 0.25) / 0.10) ** 2)
@@ -31,7 +31,7 @@ c2 = 0.8 * scp.exp(-0.5 * ((time - 0.55) / 0.12) ** 2)
 c3 = 0.6 * scp.exp(-0.5 * ((time - 0.82) / 0.08) ** 2)
 
 # %%
-# Assemble the 1D profiles as columns of a concentration matrix.
+# Assemble as columns of a concentration matrix:
 profiles = scp.stack([c1, c2, c3], axis=1)
 profiles.x.title = "time"
 profiles.y = scp.Coord(labels=["c1", "c2", "c3"], title="species")
@@ -43,8 +43,8 @@ ax = profiles.T.plot()
 ax.legend()
 
 # %%
-# The same workflow can also use the built-in Gaussian line-shape helper when
-# that reads more naturally for the problem at hand.
+# Use built-in Gaussian line-shape helper
+# -----------------------------------------
 profiles_gaussian = scp.stack(
     [
         scp.gaussian(time, ampl=1.0, pos=0.25, width=0.235, normalized=False),

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
@@ -31,15 +31,12 @@ def _tracked_peak_position(spec):
 
 
 # %%
-# Load a time-resolved IR dataset and express the acquisition axis in minutes.
-
+# Load and focus on the carbonyl region
+# ---------------------------------------
 dataset = scp.read("irdata/CO@Mo_Al2O3.SPG")
 dataset.y -= dataset.y.data[0]
 dataset.y.title = "time"
 dataset.y = dataset.y.to("minutes")
-
-# %%
-# Focus on the carbonyl region.
 
 region = dataset[:, 2300.0:1900.0]
 prefs = scp.preferences
@@ -49,16 +46,15 @@ prefs.colorbar = True
 _ = region.plot()
 
 # %%
-# Peak finding can use spacing constraints directly in coordinate units when
-# the spectral axis is linear.
-
+# Find peaks with coordinate-aware constraints
+# ---------------------------------------------
 last = region[-1]
 peaks, properties = last.find_peaks(distance="5 cm^-1", prominence=0.02)
 peaks.x.values
 
 # %%
-# Plot the detected maxima on top of the last spectrum.
-
+# Visualize detected peaks
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
 ax = last.plot_pen()
 markers = peaks + 0.015
 _ = markers.plot_scatter(
@@ -83,16 +79,13 @@ for x, y in zip(
     )
 
 # %%
-# The optional properties dictionary can be useful to inspect how the peaks
-# were selected.
-
+# Inspect the properties dictionary:
 sorted(properties)
 
 # %%
-# The same logic can be applied to each spectrum of the time series. Here we
-# follow one band in a restricted region so each spectrum contributes one peak
-# position.
-
+# Track a band across the time series
+# ------------------------------------
+# Follow one band in a restricted region:
 tracked_region = region[:, 2220.0:2180.0]
 positions = [_tracked_peak_position(spec) for spec in tracked_region]
 

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
@@ -15,8 +15,8 @@ trapezoidal and Simpson integration on a sequence of IR spectra.
 import spectrochempy as scp
 
 # %%
-# Load a stacked IR dataset and restrict the analysis to the band of interest.
-
+# Load and prepare the dataset
+# -----------------------------
 dataset = scp.read_omnic("irdata/nh4y-activation.spg")
 band = dataset[:20, 1250.0:1800.0]
 band.y -= band.y[0]
@@ -30,8 +30,8 @@ prefs.colorbar = True
 _ = band.plot()
 
 # %%
-# Fit a polynomial baseline on three reference regions.
-
+# Fit a polynomial baseline
+# --------------------------
 blc = scp.Baseline(model="polynomial", order=3)
 blc.ranges = (
     [1740.0, 1800.0],
@@ -44,8 +44,8 @@ corrected = blc.corrected
 _ = corrected.plot()
 
 # %%
-# Integrate each spectrum over the full selected region.
-
+# Compare integration methods
+# ----------------------------
 trapz_area = corrected.trapezoid(dim="x")
 simpson_area = corrected.simpson(dim="x")
 
@@ -58,8 +58,7 @@ _ = scp.plot_multiple(
 )
 
 # %%
-# For this dataset both numerical methods are very close.
-
+# For this dataset both numerical methods are very close:
 relative_difference = (trapz_area - simpson_area) * 100.0 / simpson_area
 relative_difference.title = "relative difference"
 relative_difference.units = "percent"

--- a/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
@@ -15,8 +15,8 @@ coordinate-aware slicing on an infrared time series.
 import spectrochempy as scp
 
 # %%
-# Load an IR dataset and express the acquisition axis in minutes.
-
+# Load and inspect the dataset
+# -----------------------------
 dataset = scp.read_omnic(
     "irdata/CO@Mo_Al2O3.SPG",
     description="CO adsorption, difference spectra",
@@ -25,15 +25,14 @@ dataset.y = (dataset.y - dataset[0].y).to("minute")
 print(dataset)
 
 # %%
-# Plot the full dataset once for context.
-
 prefs = scp.preferences
 prefs.figure.figsize = (7, 4)
 _ = dataset.plot()
 
 # %%
-# Standard integer slices work as expected on both dimensions.
-
+# Integer-based slicing
+# ----------------------
+# Standard integer slices work as expected on both dimensions:
 first_four = dataset[:4]
 every_other_point = dataset[:, ::2]
 
@@ -41,21 +40,21 @@ print(first_four.shape)
 print(every_other_point.shape)
 
 # %%
-# Coordinate-aware slicing is often more convenient for spectroscopy work.
-# Using floats slices directly on axis coordinates instead of integer indices.
-
+# Coordinate-aware slicing
+# -------------------------
+# Using floats slices directly on axis coordinates instead of integer indices:
 carbonyl_region = dataset[:, 2300.0:1900.0]
 _ = carbonyl_region.plot()
 
 # %%
-# The same applies to the time axis.
-
+# The same applies to the time axis:
 window = dataset[80.0:180.0, 2300.0:1900.0]
 _ = window.plot()
 
 # %%
-# A single float selects the closest spectrum on that axis.
-
+# Selecting the closest spectrum
+# -------------------------------
+# A single float selects the nearest spectrum on that axis:
 selected = dataset[60.0]
 selected.y
 

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
@@ -16,15 +16,15 @@ Here we load an experimental SPG file (OMNIC) and plot it.
 import spectrochempy as scp
 
 # %%
-# Loading and stacked plot of the original
-
+# Load and display the dataset
+# -----------------------------
 datadir = scp.preferences.datadir
 dataset = scp.read_omnic(datadir / "irdata" / "nh4y-activation.spg")
 _ = dataset.plot_stack(style="paper")
 
 # %%
-# change the unit of y-axis, the y origin as well as the title of the axis
-
+# Adjust axis metadata
+# ---------------------
 dataset.y.to("hour")
 dataset.y -= dataset.y[0]
 dataset.y.title = "acquisition time"

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
@@ -13,7 +13,8 @@ Here we load an experimental Bruker OPUS files and plot it.
 """
 
 # %%
-
+# Read and display OPUS files
+# ----------------------------
 import spectrochempy as scp
 
 Z = scp.read_opus(
@@ -22,8 +23,6 @@ Z = scp.read_opus(
 Z
 
 # %%
-# plot it
-
 _ = Z.plot()
 
 # %%

--- a/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
@@ -11,21 +11,20 @@ Here we load experimental LABSPEC spectra and plot them.
 import spectrochempy as scp
 
 # %%
-# Define the folder where are the spectra:
+# Read and plot a single file
+# ----------------------------
 datadir = scp.preferences.datadir
 ramandir = datadir / "ramandata/labspec"
-
-# %%
-# Read some data:
 A = scp.read_labspec("Activation.txt", directory=ramandir)
 A
 
 # %%
-# Now plot them:
 _ = A.plot()
 
 # %%
-# As it is a 2D dataset, we can plot it as an image:
+# Explore with different plot types
+# ----------------------------------
+# As a 2D dataset, we can display it as an image:
 _ = A.plot_image()
 
 # %%
@@ -33,7 +32,8 @@ _ = A.plot_image()
 _ = A.plot_map()
 
 # %%
-# We can also read the content of a folder, and merge all spectra:
+# Read and merge multiple files
+# ------------------------------
 B = scp.read_labspec(ramandir / "subdir")
 _ = B.plot()
 

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -13,46 +13,35 @@ See https://github.com/alchem0x2A/py-wdf-reader/blob/master/examples
 """
 
 # %%
-# First we need to import the spectrochempy API package
+# Import the package
 import spectrochempy as scp
 
 # %%
-# **Import dataset from local files**
-# Read Raman data recorded in WiRe format (``.wdf`` extension).
-# We just pass the file name as parameter.
-
-# %%
-# First read a single spectrum (measurement type : single)
-dataset = scp.read_wire("ramandata/wire/sp.wdf")  # or read_wdf (or read)
+# Read a single spectrum
+# ----------------------
+dataset = scp.read_wire("ramandata/wire/sp.wdf")
 _ = dataset.plot()
 
 # %%
-# Now read a series of spectra (measurement type : series) from a Z-depth scan.
+# Read a depth series
+# --------------------
 dataset = scp.read_wdf("ramandata/wire/depth.wdf")
 _ = dataset.plot(method="image")
 
 # %%
-# In this example, the diverging colormap is triggered because the dataset
-# contains a few negative values. If the smaller lobe is larger than
-# `diverging_margin` (default 5%) of the total range, i.e. if the following
-# condition is satisfied:
-# `min(abs(vmin), abs(vmax)) / (vmax - vmin) > margin`
-# then a diverging colormap is used.
-#
-# To avoid this behavior, you can explicitly enforce a sequential colormap,
-# for example "viridis":
-
+# Handle diverging colormaps
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^
+# A diverging colormap is triggered when negative values are present.
+# Enforce a sequential colormap explicitly:
 _ = dataset.plot_image(cmap="cividis")
 
 # %%
-# Alternatively, you can increase the `diverging_margin` that determines when the
-# diverging colormap is applied. Then the default sequential colormap
-# (`viridis`) will be used:
-
+# Alternatively, adjust ``diverging_margin`` to keep the default colormap:
 _ = dataset.plot(method="image", diverging_margin=0.1)
 
 # %%
-# filter blank spectra
+# Filter blank spectra
+# --------------------
 import numpy as np
 
 keep_rows = np.where(dataset.data.mean(axis=1) > 0)[0]
@@ -60,16 +49,16 @@ dataset = dataset[keep_rows]
 _ = dataset.plot_image()
 
 # %%
-# extract a line scan data from a StreamLine HR measurement
+# Read line scan and grid scan data
+# ----------------------------------
+# Line scan from a StreamLine HR measurement:
 dataset = scp.read("ramandata/wire/line.wdf")
 _ = dataset.plot_image()
 
 # %%
-# finally extract grid scan data from a StreamLine HR measurement
+# Grid scan data:
 dataset = scp.read_wdf("ramandata/wire/mapping.wdf")
-# plot the dataset as an image (summing all wavenumbers)
 _ = dataset.sum(dim=2).plot_image(equal_aspect=True)
-# plot the image taken at 1529cm-1
 _ = dataset[..., 1529.0].plot_image(equal_aspect=True)
 
 

--- a/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
@@ -7,29 +7,28 @@ This example shows reading of 'Galactic Industries’ SPC data file format. (``.
 """
 
 # %%
-# First we need to import the spectrochempy API package
+# Import the package
 import spectrochempy as scp
 
 # %%
-# The SPC format is a proprietary format from Galactic Industries. It is used for
-# storing spectroscopic data. The SPC format is a binary file format that can store
-# multiple spectra in a single file. The SPC format is widely used in the field of
-# spectroscopy and is supported by many spectroscopic software packages.
-
-# %%
-# Reading single file
+# Read a single spectrum file
+# ----------------------------
 ex1 = scp.read_spc("galacticdata/BENZENE.SPC")
 _ = ex1.plot()
 ex1
 
 # %%
-# reading SPC file with multiple subfiles with same x coordinates (they are merged by default)
+# Read merged subfiles
+# --------------------
+# When subfiles share the same x-coordinates, they are merged automatically:
 ex2 = scp.read_spc("galacticdata/CONTOUR.SPC")
 _ = ex2.plot()
 ex2
 
 # %%
-# Reading SPC file with multiple subfiles with different x coordinates (they are not merged)
+# Read subfiles with different x-coordinates
+# -------------------------------------------
+# Subfiles with distinct x-coordinates are returned as a list:
 ex3 = scp.read_spc("galacticdata/DRUG_SAMPLE_PEAKS.SPC")
 for nd in ex3:
     _ = nd.plot_bar(width=0.1, clear=False)

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
@@ -18,8 +18,8 @@ from pathlib import Path
 import spectrochempy as scp
 
 # %%
-# Load a 2D IR dataset and prepare a cleaner spectral window for display.
-
+# Load and prepare the dataset
+# -----------------------------
 TEST_FILE = Path(os.environ.get("TEST_FILE", "irdata/nh4y-activation.spg"))
 dataset = scp.read(TEST_FILE)
 dataset = dataset[:, 4000.0:650.0]
@@ -32,22 +32,22 @@ prefs = scp.preferences
 prefs.figure.figsize = (7, 4)
 
 # %%
-# A single spectrum is naturally shown as a line plot.
-
+# Single-spectrum line plot
+# --------------------------
 single = dataset[0]
 _ = single.plot()
 
 # %%
-# For the full 2D dataset, explicit methods make the intended representation
-# very clear.
-
+# 2D dataset plots
+# -----------------
+# Explicit methods make the intended representation clear:
 _ = dataset.plot_lines()
 _ = dataset.plot_image(colorbar=True)
 _ = dataset.plot_contour(colorbar=True)
 
 # %%
-# Plot-specific options still apply in the same way.
-
+# Customize plot options
+# -----------------------
 _ = dataset.plot_image(
     cmap="plasma",
     xlim=(2000, 1300),

--- a/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
@@ -24,52 +24,48 @@ import numpy as np
 import spectrochempy as scp
 
 # %%
-# The location of the spectrochempy_data can be found in preferences.
-
+# Locate and load a dataset
+# --------------------------
 datadir = scp.preferences.datadir
 TEST_FILE = Path(
     os.environ.get("TEST_FILE", datadir / "irdata" / "nh4y-activation.spg")
 )
-
-# %%
-# Let's read one dataset (in ``.spg`` OMNIC format).
-
 dataset = scp.read(TEST_FILE)
 
 # %%
-# First use the default plotting entry point and default style.
-
+# Default plot and style
+# -----------------------
 ax = dataset[0].plot()
 
 # %%
-# Apply a different style to this single plot only.
-
+# Per-call style changes
+# -----------------------
+# Apply a style to this single plot only:
 ax = dataset[0].plot(style="classic")
 
 # %%
-# Style selection is local to the previous call, so the default style is used
-# again here.
+# The style change is local — the default style is used again here:
 ax = dataset[0].plot()
 
 # %%
-# ``plot_multiple()`` overlays several 1D datasets on one shared axes.
+# Overlay with ``plot_multiple``
+# -------------------------------
 dataset = dataset[:, ::100]
 
 sample_indices = np.linspace(0, dataset.shape[0] - 1, 5, dtype=int)
 datasets = [dataset[index] for index in sample_indices]
 labels = [f"sample {index}" for index in sample_indices]
 
-# Use ``method="scatter"`` when the visual intent is marker-based.
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")
 
 # %%
-# As above, the style change applies only to this call.
+# The style change applies only to this call:
 _ = scp.plot_multiple(
     method="scatter", style="sans", datasets=datasets, labels=labels, legend="best"
 )
 
 # %%
-# The default style is used again on the next call.
+# The default style is used again on the next call:
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")
 
 # %%

--- a/src/spectrochempy/examples/core/d_plotting/plot_styles.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_styles.py
@@ -17,8 +17,8 @@ from pathlib import Path
 import spectrochempy as scp
 
 # %%
-# Load an IR dataset and inspect the available styles.
-
+# Inspect available styles
+# -------------------------
 dataset = scp.read("irdata/nh4y-activation.spg")[0]
 
 styles_dir = Path(scp.preferences.stylesheets)
@@ -26,18 +26,18 @@ available_styles = sorted(f.stem for f in styles_dir.glob("*.mplstyle"))
 print(available_styles[:8])
 
 # %%
-# Apply a style to one plot only.
-
+# Apply a style to one plot only
+# -------------------------------
 _ = dataset.plot(style="grayscale")
 
 # %%
-# Styles combine naturally with ordinary plot options.
-
+# Combine style with plot options
+# --------------------------------
 _ = dataset.plot(style="grayscale", xlim=(1800, 1500), grid=True)
 
 # %%
-# Session-level defaults can also be changed through preferences.
-
+# Change defaults via preferences
+# --------------------------------
 original_style = scp.preferences.style
 scp.preferences.style = "ggplot"
 _ = dataset.plot()

--- a/src/spectrochempy/examples/core/e_project/plot_project.py
+++ b/src/spectrochempy/examples/core/e_project/plot_project.py
@@ -17,14 +17,12 @@ In this example, we create a Project from scratch
 import spectrochempy as scp
 
 # %%
-# Let's assume we have three subprojects to group in a single project.
-
+# Create a project with subprojects
+# ----------------------------------
 proj = scp.Project(
-    # subprojects
     scp.Project(name="P350", label=r"$\mathrm{M_P}\,(623\,K)$"),
     scp.Project(name="A350", label=r"$\mathrm{M_A}\,(623\,K)$"),
     scp.Project(name="B350", label=r"$\mathrm{M_B}\,(623\,K)$"),
-    # attributes
     name="project_1",
     label="main project",
 )
@@ -32,10 +30,9 @@ proj = scp.Project(
 proj.projects_names
 
 # %%
-# Add for example two datasets to the `A350` subproject.
-
-# %%
-# Create two datasets
+# Add datasets to a subproject
+# -----------------------------
+# Create two datasets:
 ir = scp.NDDataset([1.1, 2.2, 3.3], coords=[[1, 2, 3]])
 ir
 
@@ -44,25 +41,23 @@ tg = scp.NDDataset([1, 3, 4], coords=[[1, 2, 3]])
 tg
 
 # %%
-# Add the datasets to the subproject
+# Add them to the ``A350`` subproject:
 proj.A350["IR"] = ir
 proj.A350["TG"] = tg
 
 # %%
-# Members of the project or attributes are easily accessed:
-
+# Access project members
+# -----------------------
 print(proj.A350)
 print(proj)
 print(proj.A350.label)
 print(proj.A350.TG)
 
 # %%
-# Save this project
-
+# Save and reload
+# ----------------
 proj.save()
 
 # %%
-# RELOAD the project from disk as newproj
-
 newproj = scp.Project.load("project_1", allow_unsafe_legacy=True)
 newproj

--- a/src/spectrochempy/examples/processing/filtering/plot_filter.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_filter.py
@@ -14,25 +14,18 @@ In this example, we use the `Filter` processor to smooth a Raman spectrum.
 import spectrochempy as scp
 
 # %%
-# First, we import a sample raman spectrum and plot it:
-
-# use the generic read function.
-# Note that read_labspec would be equivalent for this file format.
-
+# Load and plot the spectrum
+# ---------------------------
 X = scp.read("ramandata/labspec/SMC1-Initial_RT.txt")
 prefs = scp.preferences
 prefs.figure.figsize = (8, 4)
 _ = X.plot()
 
 # %%
-# here `Filter` processor is used to apply a Savitzky-Golay filter to the
-# spectrum.
+# Savitzky-Golay filtering
+# -------------------------
+filter = scp.Filter(method="savgol", size=5, order=0)
 
-filter = scp.Filter(
-    method="savgol", size=5, order=0
-)  # default is size=5, order=2, deriv=0
-
-# plot the result
 Xm = filter(X)
 _ = X.plot(color="b", label="original")
 ax = Xm.plot(clear=False, color="r", ls="-", lw=1.5, label="SG filter")
@@ -43,12 +36,9 @@ ax.legend(loc="best", fontsize=10)
 ax.set_title("Savitzky-Golay filter (size=7, order=2)")
 
 # %%
-# As good alternative to the Savitzky-Golay filter want can choose to use the
-# Whittaker-Eilers smoother
-
+# Whittaker-Eilers smoothing
+# ---------------------------
 filter = scp.Filter(method="whittaker", order=2, lamb=1.5)
-Xm = filter(X)
-# plot the result
 Xm = filter(X)
 _ = X.plot(color="b", label="original")
 ax = Xm.plot(clear=False, color="r", ls="-", lw=1.5, label="WE filter")

--- a/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
@@ -15,9 +15,8 @@ noise reduction and signal distortion on a Raman spectrum.
 import spectrochempy as scp
 
 # %%
-# Load a Raman spectrum, focus on the low-wavenumber region, and add synthetic
-# noise to make the smoothing effect easier to see.
-
+# Prepare a noisy spectrum
+# -------------------------
 dataset = scp.read("ramandata/labspec/SMC1-Initial_RT.txt")
 region = dataset[:, :400.0]
 region += 200 * scp.random(region.shape)
@@ -28,14 +27,13 @@ prefs.figure.figsize = (8, 4)
 _ = region.plot()
 
 # %%
-# Apply the default moving-average smoothing with several window sizes.
-
+# Moving-average smoothing
+# -------------------------
 smoothed = {size: region.smooth(size) for size in (3, 7, 11)}
 
 # %%
 # Compare the results. Larger windows remove more noise but can also flatten
-# narrow features.
-
+# narrow features:
 for size, smoothed_region in smoothed.items():
     _ = scp.plot_compare(
         region,
@@ -44,9 +42,8 @@ for size, smoothed_region in smoothed.items():
     )
 
 # %%
-# Savitzky-Golay smoothing offers another trade-off between denoising and peak
-# shape preservation.
-
+# Savitzky-Golay smoothing
+# -------------------------
 sg = scp.Filter(method="savgol", size=7, order=2)(region)
 _ = scp.plot_compare(region, sg, title="Savitzky-Golay smoothing (size=7, order=2)")
 

--- a/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
@@ -15,8 +15,8 @@ masking a saturated region, transposing the dataset, and converting axis units.
 import spectrochempy as scp
 
 # %%
-# Load a stacked IR dataset and convert the acquisition axis to hours.
-
+# Load and inspect the dataset
+# -----------------------------
 dataset = scp.read_omnic("irdata/nh4y-activation.spg")
 dataset.y -= dataset.y[0]
 dataset.y.title = "time"
@@ -28,25 +28,25 @@ prefs.colorbar = True
 _ = dataset.plot()
 
 # %%
-# Mask the saturated region around 1100 cm^-1.
-
+# Mask a saturated region
+# ------------------------
 dataset[:, 1290.0:890.0] = scp.MASKED
 _ = dataset.plot_stack()
 
 # %%
-# The mask is then respected by subsequent operations such as reductions.
-
+# The mask is respected by subsequent operations such as reductions:
 dataset.max()
 
 # %%
-# Transposition exchanges the dataset axes while preserving the data and mask.
-
+# Transpose the dataset
+# ----------------------
+# Transposition exchanges axes while preserving data and mask:
 transposed = dataset.T
 _ = transposed.plot()
 
 # %%
-# Compatible unit conversions can be applied to coordinates in place.
-
+# Convert coordinate units
+# -------------------------
 dataset.y.ito("hours")
 _ = dataset.plot()
 

--- a/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
@@ -17,42 +17,41 @@ Standard Normal Variate (SNV), and Multiplicative Scatter Correction (MSC).
 import spectrochempy as scp
 
 # %%
-# Load a stacked IR dataset and select a single spectral region.
-
+# Load the dataset
+# -----------------
 dataset = scp.read_omnic("irdata/nh4y-activation.spg")
 region = dataset[:, 4000.0:2000.0]
 
 # %%
-# **Normalization** scales each spectrum.  The default is ``method='max'``.
-
+# Normalization
+# --------------
+# Scales each spectrum.  The default is ``method='max'``:
 norm = region.normalize(method="max", dim="x")
 _ = norm.plot(title="Max-normalized")
 
 # %%
-# **Mean-centering** subtracts the mean along a chosen dimension.
-# Here we center each spectrum individually (``dim='x'``).
-
+# Mean-centering
+# ---------------
+# Subtracts the mean along a chosen dimension:
 centered = region.center(dim="x")
 _ = centered.plot(title="Mean-centered per spectrum")
 
 # %%
-# **Autoscaling** mean-centers and divides by the standard deviation.
-# This is the classic z-score used before PCA or PLS.
-
+# Autoscaling
+# ------------
+# Mean-centers and divides by the standard deviation (z-score):
 scaled = region.autoscale(dim="x")
 _ = scaled.plot(title="Autoscaled (z-score) per spectrum")
 
 # %%
-# **Standard Normal Variate (SNV)** is a convenience wrapper that autoscales
-# each spectrum individually.  It is equivalent to ``autoscale(dim='x')``.
-
+# SNV and MSC
+# ------------
+# Standard Normal Variate (SNV) — equivalent to ``autoscale(dim='x')``:
 snv = region.snv()
 _ = snv.plot(title="SNV corrected")
 
 # %%
-# **Multiplicative Scatter Correction (MSC)** removes multiplicative and
-# additive scatter by regressing each spectrum against a mean reference.
-
+# Multiplicative Scatter Correction (MSC):
 msc = region.msc()
 _ = msc.plot(title="MSC corrected")
 


### PR DESCRIPTION
Add RST heading underlines to all remaining flat gallery examples.

**Examples restructured (17 files):**

- **analysis/a_decomposition**: `plot_synthetic_profiles`
- **analysis/d_peak_analysis**: `plot_peak_finding`, `plot_peak_integration`
- **core/a_nddataset**: `plot_d_slicing`
- **core/c_importer**: `plot_read_IR_from_omnic`, `plot_read_IR_from_opus`, `plot_read_raman_from_labspec`, `plot_read_renishaw`, `plot_read_spc`
- **core/d_plotting**: `plot_plot_types`, `plot_plotting`, `plot_styles`
- **core/e_project**: `plot_project`
- **processing/filtering**: `plot_filter`, `plot_smoothing_window_size`
- **processing/transformations**: `plot_masking_transpose_units`, `plot_preprocessing`

No code or behavior changes.