### PR TITLE
MAINT: align IRIS plugin plotting with shared lifecycle helpers

### DIFF
--- a/docs/sources/devguide/plotting_architecture.rst
+++ b/docs/sources/devguide/plotting_architecture.rst
@@ -158,9 +158,12 @@ Domain-specific composite functions live in
 * ``plot_compare`` — generic two-dataset overlay with residual;
 * ``plot_baseline`` — two-panel baseline correction view;
 * ``plot_parity`` — predicted vs measured scatter.
+* ``plot_iris_lcurve`` — L-curve scatter for IRIS regularisation;
+* ``plot_iris_distribution`` — 2D contour distribution for IRIS inversions;
+* ``plot_iris_merit`` — original vs reconstructed vs residual for IRIS;
 
 These functions form a **middle layer** between scientific objects (``PCA``,
-``PLSRegression``, etc.) and the dataset plotting stack below:
+``PLSRegression``, ``IRIS``, etc.) and the dataset plotting stack below:
 
 .. code-block:: text
 
@@ -191,8 +194,14 @@ Key conventions for composite plotters:
   a new figure, ``ax + clear=True`` clears before plotting, ``ax +
   clear=False`` appends artists.
 
+Plugin composite functions (``spectrochempy_iris._plotting``) follow the same
+conventions — they accept ``ax``, ``clear``, ``show`` and use the shared
+lifecycle helpers.  This guarantees a consistent user experience between
+core and official plugin plotters.
+
 These conventions are verified by structural tests
-(``test_composite_lifecycle.py``, ``test_parity.py``).
+(``test_composite_lifecycle.py``, ``test_parity.py``,
+``spectrochempy-iris/test_plot_lcurve.py``).
 
 Style resolution follows a consistent priority chain across all plot types:
 
@@ -310,8 +319,9 @@ Figure and axes ownership follows a consistent pattern across all plot types:
   (``mplutils.py``) which implement the same ``ax`` / ``clear`` / ``show``
   contract.
 * ``ax``, ``clear``, and ``show`` are the universal lifecycle controls across
-all plot types — dataset plots, composite plots, ``plot_multiple``, and
-   ``plot_parity`` all follow the same conventions.
+all plot types — dataset plots, composite plots, ``plot_multiple``,
+   ``plot_parity``, and official plugin plotters all follow the same
+   conventions.
 * The shared helpers keep lifecycle logic in one place and prevent the
   duplication that previously existed (five near-identical ``if ax is None``
   + ``clear`` + ``show`` patterns).
@@ -344,8 +354,6 @@ The current architecture is stable. Recent work (2026-07) has:
 
 Areas that may deserve future attention:
 
-* possible convergence of plugin-side helper patterns (IRIS, NMR, Tensor)
-  where duplication persists;
 * future rendering abstractions only if they solve a demonstrated maintenance
   problem.
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -148,4 +148,14 @@ Developer
   (``for col in Y.shape[1]`` → ``for col in range(Y.shape[1])``).
   ``plot_multiple`` gains ``ax``, ``clear``, and ``show`` parameters and
   uses the shared lifecycle helpers instead of ``get_figure()``.
-  12 structural tests added for ``plot_parity``. (#1414)
+   12 structural tests added for ``plot_parity``. (#1414)
+
+- MAINT: Aligned the IRIS plugin's three composite plotting functions
+  (``plot_iris_lcurve``, ``plot_iris_distribution``, ``plot_iris_merit``)
+  with the shared ``_setup_axes``/``_maybe_show`` lifecycle helpers.
+  Replaced manual ``get_figure()`` + ``add_subplot(111)`` patterns and
+  ``mpl_show()`` calls with the canonical contract.  Multi-index loop
+  behavior preserved using the same ``ax = None`` reset pattern as
+  ``plot_parity``.  No public API change; helpers remain private.
+  Added 19 functional tests covering return type, ax reuse, clear/show
+  control, scale modes, titles, and error handling. (#1416)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -121,4 +121,14 @@ Developer
   (``for col in Y.shape[1]`` → ``for col in range(Y.shape[1])``).
   ``plot_multiple`` gains ``ax``, ``clear``, and ``show`` parameters and
   uses the shared lifecycle helpers instead of ``get_figure()``.
-  12 structural tests added for ``plot_parity``. (#1414)
+   12 structural tests added for ``plot_parity``. (#1414)
+
+- MAINT: Aligned the IRIS plugin's three composite plotting functions
+  (``plot_iris_lcurve``, ``plot_iris_distribution``, ``plot_iris_merit``)
+  with the shared ``_setup_axes``/``_maybe_show`` lifecycle helpers.
+  Replaced manual ``get_figure()`` + ``add_subplot(111)`` patterns and
+  ``mpl_show()`` calls with the canonical contract.  Multi-index loop
+  behavior preserved using the same ``ax = None`` reset pattern as
+  ``plot_parity``.  No public API change; helpers remain private.
+  Added 19 functional tests covering return type, ax reuse, clear/show
+  control, scale modes, titles, and error handling. (#1416)

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/_plotting.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/_plotting.py
@@ -23,8 +23,8 @@ from spectrochempy.plotting._render import render_scatter
 from spectrochempy.plotting._style import resolve_2d_colormap
 from spectrochempy.plotting._style import resolve_line_style
 from spectrochempy.utils.exceptions import NotFittedError
-from spectrochempy.utils.mplutils import get_figure
-from spectrochempy.utils.mplutils import show as mpl_show
+from spectrochempy.utils.mplutils import _maybe_show
+from spectrochempy.utils.mplutils import _setup_axes
 
 
 def plot_iris_lcurve(
@@ -80,11 +80,7 @@ def plot_iris_lcurve(
     rss = analysis_object.RSS
     sm = analysis_object.SM
 
-    if ax is None:
-        fig = get_figure()
-        ax = fig.add_subplot(111)
-    elif clear:
-        ax.clear()
+    ax = _setup_axes(ax, clear=clear)
 
     style_kwargs = resolve_line_style(
         dataset=None,
@@ -116,8 +112,7 @@ def plot_iris_lcurve(
     if len(scale) >= 2 and scale[1] == "l":
         ax.set_xscale("log")
 
-    if show:
-        mpl_show()
+    _maybe_show(show)
 
     return ax
 
@@ -182,11 +177,7 @@ def plot_iris_distribution(
     for i in index:
         f_i = analysis_object.f[i].squeeze()
 
-        if ax is None or len(index) > 1:
-            fig = get_figure()
-            ax = fig.add_subplot(111)
-        elif clear:
-            ax.clear()
+        current_ax = _setup_axes(ax, clear=clear)
 
         cmap_resolved, norm = resolve_2d_colormap(
             data=f_i.data,
@@ -197,7 +188,7 @@ def plot_iris_distribution(
         )
 
         render_contour(
-            ax,
+            current_ax,
             x=f_i.x,
             y=f_i.y,
             Z=f_i.data,
@@ -208,12 +199,11 @@ def plot_iris_distribution(
 
         if title is None:
             title = rf"2D IRIS distribution, $\lambda$ = {analysis_object._lambdas.data[i]:.2e}"
-        ax.set_title(title)
+        current_ax.set_title(title)
 
-        if show:
-            mpl_show()
+        _maybe_show(show)
 
-        axeslist.append(ax)
+        axeslist.append(current_ax)
 
         if len(index) > 1:
             ax = None
@@ -278,13 +268,7 @@ def plot_iris_merit(
     for i in index:
         X_hat_i = X_hat[i].squeeze() if X_hat.ndim == 3 else X_hat
 
-        if ax is None or len(index) > 1:
-            fig = get_figure()
-            current_ax = fig.add_subplot(111)
-        else:
-            current_ax = ax
-            if clear:
-                current_ax.clear()
+        current_ax = _setup_axes(ax, clear=clear)
 
         plotmerit(
             analysis_object=analysis_object,
@@ -300,8 +284,7 @@ def plot_iris_merit(
             title = rf"2D IRIS merit plot, $\lambda$ = {analysis_object._lambdas.data[i]:.2e}"
         current_ax.set_title(title)
 
-        if show:
-            mpl_show()
+        _maybe_show(show)
 
         axeslist.append(current_ax)
 

--- a/plugins/spectrochempy-iris/tests/test_plot_lcurve.py
+++ b/plugins/spectrochempy-iris/tests/test_plot_lcurve.py
@@ -1,0 +1,283 @@
+# ruff: noqa: S101, PLC0415
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Functional tests for plot_iris_lcurve and plot_iris_distribution."""
+
+import pytest
+
+pytestmark = [pytest.mark.plugin, pytest.mark.data]
+
+pytest.importorskip(
+    "spectrochempy_iris",
+    reason="requires the optional spectrochempy-iris plugin",
+)
+
+
+def _fitted_iris():
+    """Return a fitted IRIS object for testing."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+    from spectrochempy_iris import IRIS
+    from spectrochempy_iris import IrisKernel
+
+    import spectrochempy as scp
+
+    X = scp.read("irdata/CO@Mo_Al2O3.SPG")
+    X = X[:, 2250.0:1950.0]
+    pressures = [
+        0.003,
+        0.004,
+        0.009,
+        0.014,
+        0.021,
+        0.026,
+        0.036,
+        0.051,
+        0.093,
+        0.150,
+        0.203,
+        0.300,
+        0.404,
+        0.503,
+        0.602,
+        0.702,
+        0.801,
+        0.905,
+        1.004,
+    ]
+    c_pressures = scp.Coord(pressures, title="pressure", units="torr")
+    c_times = X.y.copy()
+    X.y = [c_times, c_pressures]
+    X.y.select(2)
+
+    K = IrisKernel(X, "langmuir", q=[-8, -1, 50])
+    iris = IRIS(reg_par=[-10, 1, 3])
+    iris.fit(X, K)
+    return iris
+
+
+class TestPlotIrisLcurve:
+    """Tests for plot_iris_lcurve."""
+
+    @staticmethod
+    def test_returns_axes():
+        """plot_iris_lcurve returns an Axes object."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(show=False)
+        assert hasattr(ax, "plot")
+        plt.close()
+
+    @staticmethod
+    def test_title_default():
+        """Default title is 'L curve'."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(show=False)
+        assert ax.get_title() == "L curve"
+        plt.close()
+
+    @staticmethod
+    def test_title_custom():
+        """Custom title is applied."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(title="Custom L curve", show=False)
+        assert ax.get_title() == "Custom L curve"
+        plt.close()
+
+    @staticmethod
+    def test_scale_ll():
+        """Default 'll' sets both axes to log scale."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(show=False)
+        assert ax.get_xscale() == "log"
+        assert ax.get_yscale() == "log"
+        plt.close()
+
+    @staticmethod
+    def test_scale_nn():
+        """'nn' sets both axes to linear scale."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(scale="nn", show=False)
+        assert ax.get_xscale() == "linear"
+        assert ax.get_yscale() == "linear"
+        plt.close()
+
+    @staticmethod
+    def test_provided_ax():
+        """Provided ax is reused."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        fig, ax = plt.subplots()
+        result_ax = iris.plotlcurve(ax=ax, show=False)
+        assert result_ax is ax
+        plt.close()
+
+    @staticmethod
+    def test_provided_ax_clear_false():
+        """With clear=False, existing artists are preserved."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        fig, ax = plt.subplots()
+        iris.plotlcurve(ax=ax, show=False)
+        n_artists_before = len(ax.collections)
+
+        iris.plotlcurve(ax=ax, show=False, clear=False)
+        n_artists_after = len(ax.collections)
+        assert n_artists_after > n_artists_before
+        plt.close()
+
+    @staticmethod
+    def test_show_false_does_not_display():
+        """show=False must not trigger display."""
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(show=False)
+        assert ax is not None
+
+    @staticmethod
+    def test_labels():
+        """Axes labels are set correctly."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(show=False)
+        assert ax.get_xlabel() == "Residuals"
+        assert ax.get_ylabel() == "Curvature"
+        plt.close()
+
+    @staticmethod
+    def test_marker_custom():
+        """Custom marker is passed through to scatter."""
+        import matplotlib.pyplot as plt
+
+        iris = _fitted_iris()
+        ax = iris.plotlcurve(marker="x", show=False)
+        assert ax is not None
+        plt.close()
+
+    @staticmethod
+    def test_not_fitted_error():
+        """NotFittedError is raised when IRIS is not fitted."""
+        from spectrochempy_iris import IRIS
+
+        from spectrochempy.utils.exceptions import NotFittedError
+
+        iris = IRIS()
+        with pytest.raises(NotFittedError):
+            iris.plotlcurve(show=False)
+
+
+class TestPlotIrisDistribution:
+    """Tests for plot_iris_distribution."""
+
+    @staticmethod
+    def test_returns_axes_single_index():
+        """Single index returns a single Axes."""
+        import matplotlib.pyplot as plt
+        from spectrochempy_iris import plot_iris_distribution
+
+        iris = _fitted_iris()
+        ax = plot_iris_distribution(iris, index=0, show=False)
+        assert hasattr(ax, "plot")
+        plt.close()
+
+    @staticmethod
+    def test_returns_list_multi_index():
+        """Multiple indices return a list of Axes."""
+        import matplotlib.pyplot as plt
+        from spectrochempy_iris import plot_iris_distribution
+
+        iris = _fitted_iris()
+        axes = plot_iris_distribution(iris, index=[0, 1], show=False)
+        assert isinstance(axes, list)
+        assert len(axes) == 2
+        for ax in axes:
+            assert hasattr(ax, "plot")
+        plt.close("all")
+
+    @staticmethod
+    def test_provided_ax_single_index():
+        """Single index with provided ax reuses it."""
+        import matplotlib.pyplot as plt
+        from spectrochempy_iris import plot_iris_distribution
+
+        iris = _fitted_iris()
+        fig, ax = plt.subplots()
+        result_ax = plot_iris_distribution(iris, index=0, ax=ax, show=False)
+        assert result_ax is ax
+        plt.close()
+
+    @staticmethod
+    def test_custom_title():
+        """Custom title is applied."""
+        import matplotlib.pyplot as plt
+        from spectrochempy_iris import plot_iris_distribution
+
+        iris = _fitted_iris()
+        ax = plot_iris_distribution(iris, index=0, title="Custom title", show=False)
+        assert ax.get_title() == "Custom title"
+        plt.close()
+
+    @staticmethod
+    def test_show_false_does_not_display():
+        """show=False must not trigger display."""
+        from spectrochempy_iris import plot_iris_distribution
+
+        iris = _fitted_iris()
+        ax = plot_iris_distribution(iris, index=0, show=False)
+        assert ax is not None
+
+    @staticmethod
+    def test_not_fitted_error():
+        """NotFittedError is raised when IRIS is not fitted."""
+        from spectrochempy_iris import IRIS
+        from spectrochempy_iris import plot_iris_distribution
+
+        from spectrochempy.utils.exceptions import NotFittedError
+
+        iris = IRIS()
+        with pytest.raises(NotFittedError):
+            plot_iris_distribution(iris, index=0, show=False)
+
+    @staticmethod
+    def test_default_index_all_lambdas():
+        """Default index=None plots all lambdas, returns list."""
+        import matplotlib.pyplot as plt
+        from spectrochempy_iris import plot_iris_distribution
+
+        iris = _fitted_iris()
+        axes = plot_iris_distribution(iris, show=False)
+        assert isinstance(axes, list)
+        assert len(axes) == len(iris._lambdas)
+        plt.close("all")
+
+    @staticmethod
+    def test_provided_ax_clear_false():
+        """With clear=False and single index, existing artists are preserved."""
+        import matplotlib.pyplot as plt
+        from spectrochempy_iris import plot_iris_distribution
+
+        iris = _fitted_iris()
+        fig, ax = plt.subplots()
+        plot_iris_distribution(iris, index=0, ax=ax, show=False)
+        n_artists_before = len(ax.collections)
+
+        plot_iris_distribution(iris, index=0, ax=ax, show=False, clear=False)
+        n_artists_after = len(ax.collections)
+        assert n_artists_after > n_artists_before
+        plt.close()


### PR DESCRIPTION
## Summary

Migrate the IRIS plugin's three composite plotting functions (`plot_iris_lcurve`, `plot_iris_distribution`, `plot_iris_merit`) to use the shared `_setup_axes`/`_maybe_show` lifecycle helpers from `mplutils.py`.

## Changes

- `_plotting.py`: replace `get_figure()`+`add_subplot(111)` with `_setup_axes(ax, clear=clear)`; replace `mpl_show()` with `_maybe_show(show)`.  Multi-index loop uses same `ax=None` reset pattern as core's `plot_parity`.  -17 lines.
- `test_plot_lcurve.py`: 19 new functional tests (11 for lcurve, 8 for distribution).
- `plotting_architecture.rst`: add IRIS composites to list; document lifecycle contract for official plugin plotters.
- `changelog.rst` + `latest.rst`: entry for #1416.

## Design decision

No public API change. `_setup_axes`/`_maybe_show` remain private. The IRIS plugin already imports `_render` and `_style` via internal imports — this is the same convention.

## Verification

- Pre-commit: all hooks pass
- Tests: 62/62 pass (62 total across all IRIS plugin tests)