### PR TITLE
ENH: add download_extra_testdata() and rename extract_topspin_metadata

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -36,6 +36,11 @@ New Features
   already-transformed data.  This is the first step toward a simplified NMR
   processing workflow.
 
+- Added ``download_extra_testdata()`` to ``spectrochempy.application.testdata``
+  for fetching extra NMR datasets (agilent, jeol, bruker_3d, simpson, tecmag)
+  from the ``data-extra`` branch of the ``spectrochempy_data`` repository.
+  Extra data is cloned into ``~/.spectrochempy/testdata-extra/``. (:pr:`1418`)
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -32,6 +32,11 @@ New Features
   already-transformed data.  This is the first step toward a simplified NMR
   processing workflow.
 
+- Added ``download_extra_testdata()`` to ``spectrochempy.application.testdata``
+  for fetching extra NMR datasets (agilent, jeol, bruker_3d, simpson, tecmag)
+  from the ``data-extra`` branch of the ``spectrochempy_data`` repository.
+  Extra data is cloned into ``~/.spectrochempy/testdata-extra/``. (:pr:`1418`)
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -168,15 +168,15 @@ class Experiment:
         Build a classification dict from canonical NMR metadata.
 
         All vendor-specific extraction happens in
-        :func:`spectrochempy_nmr.nmr_metadata.extract_nmr_metadataBruker`.
+        :func:`spectrochempy_nmr.nmr_metadata.extract_topspin_metadata`.
         This method consumes only the resulting
         :class:`~spectrochempy_nmr.nmr_metadata.NMRMetadata` fields.
         """
         from .nmr_metadata import NMRMetadata  # noqa: PLC0415
-        from .nmr_metadata import extract_nmr_metadataBruker  # noqa: PLC0415
+        from .nmr_metadata import extract_topspin_metadata  # noqa: PLC0415
 
         meta = self._meta()
-        nmr_meta: NMRMetadata = extract_nmr_metadataBruker(meta)
+        nmr_meta: NMRMetadata = extract_topspin_metadata(meta)
 
         # Fallback: when metadata is empty, infer basic shape from the
         # dataset itself.  This handles non-NMR or metadata-less datasets.

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
@@ -154,9 +154,9 @@ def _resolve_encoding(raw_encoding: list) -> tuple[str, ...]:
     return tuple(resolved)
 
 
-def extract_nmr_metadataBruker(meta) -> NMRMetadata:
+def extract_topspin_metadata(meta) -> NMRMetadata:
     """
-    Extract :class:`NMRMetadata` from a Bruker/TopSpin metadata object.
+    Extract :class:`NMRMetadata` from a TopSpin metadata object.
 
     Parameters
     ----------

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -572,7 +572,7 @@ class TestCanonicalMetadata:
         """Experiment classifies data from a non-TopSpin reader."""
         # The canonical extraction layer can consume metadata that contains
         # no Bruker-specific keys — the mock has only the fields that
-        # extract_nmr_metadataBruker reads via getattr.
+        # extract_topspin_metadata reads via getattr.
         import numpy as np
         from spectrochempy_nmr.nmr_metadata import NMRMetadata
 

--- a/src/spectrochempy/application/testdata.py
+++ b/src/spectrochempy/application/testdata.py
@@ -133,7 +133,8 @@ def download_full_testdata_directory(datadir, force=False):
 
 
 def download_extra_testdata(datadir=None, force=False):
-    """Download extra test data from the ``data-extra`` branch.
+    """
+    Download extra test data from the ``data-extra`` branch.
 
     Extra datasets (agilent, jeol, bruker_3d, simpson, tecmag) are stored on a
     separate branch to keep the main download lightweight.
@@ -179,7 +180,7 @@ def download_extra_testdata(datadir=None, force=False):
         str(datadir),
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
     if result.returncode != 0:
         msg = f"git clone failed (exit {result.returncode}):\n{result.stderr}"
         raise RuntimeError(msg)

--- a/src/spectrochempy/application/testdata.py
+++ b/src/spectrochempy/application/testdata.py
@@ -11,6 +11,9 @@ from pathlib import Path
 # Testdata
 # --------------------------------------------------------------------------------------
 _TESTDATA_CACHE_MARKER = "spectrochempy-testdata-v1\n"
+_TESTDATA_EXTRA_CACHE_MARKER = "spectrochempy-testdata-extra-v1\n"
+_EXTRA_REPO_URL = "https://github.com/spectrochempy/spectrochempy_data.git"
+_EXTRA_BRANCH = "data-extra"
 
 
 def download_full_testdata_directory(datadir, force=False):
@@ -127,3 +130,66 @@ def download_full_testdata_directory(datadir, force=False):
     # unless force=True is explicitly passed.
     # ------------------------------------------------------------------
     downloaded.write_text(_TESTDATA_CACHE_MARKER, encoding="utf8")
+
+
+def download_extra_testdata(datadir=None, force=False):
+    """Download extra test data from the ``data-extra`` branch.
+
+    Extra datasets (agilent, jeol, bruker_3d, simpson, tecmag) are stored on a
+    separate branch to keep the main download lightweight.
+
+    Parameters
+    ----------
+    datadir : Path or str, optional
+        Target directory.  Defaults to ``~/.spectrochempy/testdata-extra/``.
+    force : bool, optional
+        If True, force re-download even if already downloaded.
+    """
+    import shutil
+    import subprocess
+
+    if datadir is None:
+        datadir = Path.home() / ".spectrochempy" / "testdata-extra"
+    else:
+        datadir = Path(datadir)
+
+    marker = datadir / "__downloaded_extra__"
+    if (
+        marker.exists()
+        and marker.read_text(encoding="utf8") == _TESTDATA_EXTRA_CACHE_MARKER
+        and not force
+    ):
+        return datadir
+
+    # Remove partial clone if marker is missing
+    if not marker.exists() and datadir.exists() and any(datadir.iterdir()):
+        shutil.rmtree(datadir)
+
+    datadir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "git",
+        "clone",
+        "--branch",
+        _EXTRA_BRANCH,
+        "--depth",
+        "1",
+        "--single-branch",
+        _EXTRA_REPO_URL,
+        str(datadir),
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        msg = f"git clone failed (exit {result.returncode}):\n{result.stderr}"
+        raise RuntimeError(msg)
+
+    # Remove .git directory — we only need the data files
+    git_dir = datadir / ".git"
+    if git_dir.exists():
+        shutil.rmtree(git_dir)
+
+    # Mark download as completed
+    marker.write_text(_TESTDATA_EXTRA_CACHE_MARKER, encoding="utf8")
+
+    return datadir


### PR DESCRIPTION
## Summary

- Add `download_extra_testdata()` to `spectrochempy.application.testdata` for fetching extra NMR datasets from the `data-extra` branch of `spectrochempy_data`
- Rename `extract_nmr_metadataBruker` to `extract_topspin_metadata` (naming by format, not manufacturer)

## Changes

### `src/spectrochempy/application/testdata.py`

- Added `download_extra_testdata()` function that clones the `data-extra` branch via shallow git clone
- Idempotent (skips if already downloaded)
- Stores data in `~/.spectrochempy/testdata-extra/`

### `plugins/spectrochempy-nmr/`

- `experiment.py`: import and call renamed to `extract_topspin_metadata`
- `nmr_metadata.py`: function renamed from `extract_nmr_metadataBruker` to `extract_topspin_metadata`
- `tests/test_experiment.py`: comment updated

## Related

- spectrochempy_data `data-extra` branch: https://github.com/spectrochempy/spectrochempy_data/tree/data-extra
