### PR TITLE
ENH: expose plugin reader namespaces and add generic scp.nmr.read dispatcher

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -174,24 +174,26 @@ case, helper methods such as ``datasets.names``,
 ``datasets.select_largest(ndim=2)``, and ``datasets.select_by_name("spectra")``
 make it easier to pick the dataset you want while staying in the public API.
 
+The NMR readers ``read_topspin`` and ``read_agilent`` require the
+``spectrochempy-nmr`` plugin to be installed. The PerkinElmer reader
+``read_perkinelmer`` requires the ``spectrochempy-perkinelmer`` plugin.
+
 .. autosummary::
     :nosignatures:
     :toctree: generated/
 
     load
     read
+    read_agilent
     read_csv
     read_ddr
     read_dir
     read_hdr
     read_jcamp
     read_labspec
-    read_wire
-    read_wdf
-    read_mat
-    read_matlab
     read_omnic
     read_opus
+    read_perkinelmer
     read_quadera
     read_sdr
     read_soc
@@ -199,6 +201,11 @@ make it easier to pick the dataset you want while staying in the public API.
     read_spc
     read_spg
     read_srs
+    read_topspin
+    read_wire
+    read_wdf
+    read_mat
+    read_matlab
     NDDataset.from_xarray
     NDDataset.from_netcdf
     load_iris

--- a/docs/sources/reference/plugins.rst
+++ b/docs/sources/reference/plugins.rst
@@ -17,6 +17,8 @@ NMR plugin
     :toctree: generated/
 
     spectrochempy.nmr.read
+    spectrochempy.nmr.read_topspin
+    spectrochempy.nmr.read_agilent
     spectrochempy.nmr.Experiment
 
 PerkinElmer plugin
@@ -27,6 +29,7 @@ PerkinElmer plugin
     :toctree: generated/
 
     spectrochempy.perkinelmer.read
+    spectrochempy.perkinelmer.read_perkinelmer
 
 Carroucell plugin
 =================

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -46,6 +46,14 @@ New Features
   vendored NMRGlue code.  Includes ``extract_agilent_metadata`` for canonical
   metadata extraction.  Registered as a new reader in the NMR plugin.
 
+- Added plugin-contributed I/O namespaces for NMR and PerkinElmer readers.
+  ``scp.topspin.read`` and ``scp.agilent.read`` now expose the format-specific
+  readers with the same short-method namespace API used by core I/O domains.
+  ``scp.nmr.read`` is a generic dispatcher that auto-detects TopSpin and
+  Agilent/Varian formats (or uses ``protocol=``).  Root-level aliases
+  ``scp.read_topspin``, ``scp.read_agilent`` and ``scp.read_perkinelmer``
+  remain available as compatibility shims.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -42,6 +42,14 @@ New Features
   vendored NMRGlue code.  Includes ``extract_agilent_metadata`` for canonical
   metadata extraction.  Registered as a new reader in the NMR plugin.
 
+- Added plugin-contributed I/O namespaces for NMR and PerkinElmer readers.
+  ``scp.topspin.read`` and ``scp.agilent.read`` now expose the format-specific
+  readers with the same short-method namespace API used by core I/O domains.
+  ``scp.nmr.read`` is a generic dispatcher that auto-detects TopSpin and
+  Agilent/Varian formats (or uses ``protocol=``).  Root-level aliases
+  ``scp.read_topspin``, ``scp.read_agilent`` and ``scp.read_perkinelmer``
+  remain available as compatibility shims.
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
+from pathlib import Path
 
 from spectrochempy.api.plugins import CORE_PLUGIN_API_VERSION
 from spectrochempy.api.plugins import PluginCapability
@@ -24,6 +25,44 @@ def _resolve_read_agilent():
     from .readers.read_agilent import read_agilent  # noqa: PLC0415
 
     return read_agilent
+
+
+def _resolve_read():
+    """Lazily import and return a generic NMR reader dispatching by file type."""
+    from .readers.read_agilent import read_agilent  # noqa: PLC0415
+    from .readers.read_topspin import read_topspin  # noqa: PLC0415
+
+    def read(*paths, **kwargs):
+        """Read NMR data, auto-detecting TopSpin vs Agilent/Varian format."""
+        protocol = kwargs.get("protocol")
+        if protocol == "agilent":
+            return read_agilent(*paths, **kwargs)
+        if protocol == "topspin":
+            return read_topspin(*paths, **kwargs)
+
+        # Auto-detect from the first path when no protocol is given.
+        if paths:
+            first = paths[0]
+            try:
+                path = Path(first)
+                if path.is_dir():
+                    # An Agilent directory contains fid + procpar.
+                    if (path / "fid").exists() and (path / "procpar").exists():
+                        return read_agilent(*paths, **kwargs)
+                    return read_topspin(*paths, **kwargs)
+                if (
+                    path.name == "fid"
+                    and path.parent.exists()
+                    and (path.parent / "procpar").exists()
+                ):
+                    return read_agilent(*paths, **kwargs)
+            except (TypeError, ValueError):
+                pass
+
+        # Default to TopSpin for backward compatibility.
+        return read_topspin(*paths, **kwargs)
+
+    return read
 
 
 def _resolve_set_nmr_context():
@@ -253,7 +292,7 @@ def _ensure_topspin_filetype_registered() -> None:
 
 
 class NMRPlugin(SpectroChemPyPlugin):
-    """NMR plugin, currently providing the Bruker TopSpin reader."""
+    """NMR plugin, providing Bruker TopSpin and Agilent/Varian readers."""
 
     name = "nmr"
     version = "0.1.7"
@@ -261,6 +300,10 @@ class NMRPlugin(SpectroChemPyPlugin):
     spectrochempy_min_version = "0.9.0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [PluginCapability.READER]
+    io_namespaces = {
+        "topspin": {"read": "nmr.read_topspin"},
+        "agilent": {"read": "nmr.read_agilent"},
+    }
 
     def register_readers(self) -> list[dict]:
         """Declare the TopSpin and Agilent file readers."""
@@ -332,7 +375,7 @@ class NMRPlugin(SpectroChemPyPlugin):
 
 
 def __getattr__(name: str):
-    if name in ("read_topspin", "read"):
+    if name == "read_topspin":
         from .readers.read_topspin import read_topspin  # noqa: PLC0415
 
         return read_topspin
@@ -340,6 +383,8 @@ def __getattr__(name: str):
         from .readers.read_agilent import read_agilent  # noqa: PLC0415
 
         return read_agilent
+    if name == "read":
+        return _resolve_read()
     if name == "set_nmr_context":
         from .units import set_nmr_context  # noqa: PLC0415
 

--- a/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
@@ -13,6 +13,7 @@ import spectrochempy.plugins.manager as manager_module
 from spectrochempy.api.plugins import PluginCapability
 from spectrochempy.api.plugins import PluginState
 from spectrochempy.api.plugins import check_plugin_compatibility
+from spectrochempy.core.io_namespaces import _is_io_namespace
 from spectrochempy.plugins.deps import MissingPluginError
 from spectrochempy.plugins.manager import ENTRY_POINT_GROUP
 from spectrochempy.plugins.manager import PluginManager
@@ -155,20 +156,25 @@ def test_package_namespace_exposes_topspin_reader(monkeypatch):
 
 
 def test_package_namespace_exposes_short_read_alias(monkeypatch):
-    """scp.nmr.read is a short alias for scp.nmr.read_topspin."""
+    """scp.nmr.read is a generic dispatcher for all NMR readers."""
     _require_reader_dependencies()
 
     pm, _registry = _isolate_scp_plugins(monkeypatch, scp)
     pm.register(NMRPlugin())
 
-    short_reader = scp.nmr.read
-    long_reader = scp.nmr.read_topspin
+    generic_reader = scp.nmr.read
+    topspin_reader = scp.nmr.read_topspin
+    agilent_reader = scp.nmr.read_agilent
 
-    assert callable(short_reader)
-    # Both names must resolve to the same underlying reader.  They may be
-    # different objects (module attribute vs registry proxy) so we check
-    # functional equivalence rather than identity.
-    assert short_reader.__name__ == long_reader.__name__ == "read_topspin"
+    assert callable(generic_reader)
+    assert generic_reader.__name__ == "read"
+    # The generic dispatcher delegates to the format-specific readers based on
+    # the ``protocol`` keyword or directory contents, so we only verify that
+    # the namespaced format readers remain directly accessible.
+    assert callable(topspin_reader)
+    assert callable(agilent_reader)
+    assert topspin_reader.__name__ == "read_topspin"
+    assert agilent_reader.__name__ == "read_agilent"
 
 
 def test_top_level_stub_is_actionable_without_registered_nmr(monkeypatch):
@@ -185,8 +191,8 @@ def test_top_level_stub_is_actionable_without_registered_nmr(monkeypatch):
     assert "pip install spectrochempy[nmr]" in message
 
 
-def test_read_topspin_no_deprecation_warning():
-    """scp.read_topspin and scp.nmr.read_topspin do not emit DeprecationWarning."""
+def test_read_topspin_root_alias_works():
+    """scp.read_topspin remains a working alias with no DeprecationWarning."""
     _require_reader_dependencies()
 
     with warnings.catch_warnings(record=True) as captured:
@@ -195,13 +201,28 @@ def test_read_topspin_no_deprecation_warning():
         rt_ns = scp.nmr.read_topspin
 
     assert callable(rt)
+    assert callable(rt_ns)
     assert rt is rt_ns
     deprecation_warnings = [
         w for w in captured if issubclass(w.category, DeprecationWarning)
     ]
-    assert (
-        deprecation_warnings == []
-    ), f"Expected no DeprecationWarning from read_topspin, got: {deprecation_warnings}"
+    assert deprecation_warnings == [], deprecation_warnings
+
+
+def test_io_namespace_topspin_and_agilent(monkeypatch):
+    """scp.topspin.read and scp.agilent.read expose the namespaced readers."""
+    _require_reader_dependencies()
+
+    pm, _registry = _isolate_scp_plugins(monkeypatch, scp)
+    pm.register(NMRPlugin())
+
+    assert _is_io_namespace("topspin")
+    assert _is_io_namespace("agilent")
+
+    assert callable(scp.topspin.read)
+    assert callable(scp.agilent.read)
+    assert scp.topspin.read is scp.nmr.read_topspin
+    assert scp.agilent.read is scp.nmr.read_agilent
 
 
 def test_nmr_reader_is_not_dataset_accessor_namespace(monkeypatch):

--- a/plugins/spectrochempy-perkinelmer/tests/test_perkinelmer_plugin.py
+++ b/plugins/spectrochempy-perkinelmer/tests/test_perkinelmer_plugin.py
@@ -2,6 +2,7 @@
 
 """Tests for the spectrochempy-perkinelmer plugin."""
 
+import warnings
 
 import numpy as np
 import pytest
@@ -82,7 +83,7 @@ def test_sp_parser_invalid_signature() -> None:
 def test_plugin_metadata() -> None:
     plugin = PerkinElmerPlugin()
     assert plugin.name == "perkinelmer"
-    assert plugin.version == "0.1.0"
+    assert plugin.version == "0.1.2"
     assert plugin.description
     assert PluginCapability.READER in plugin.capabilities
 
@@ -416,6 +417,21 @@ def test_top_level_stub_without_plugin(monkeypatch) -> None:
         stub("missing")
 
     assert "spectrochempy-perkinelmer" in str(excinfo.value)
+
+
+def test_read_perkinelmer_root_alias_works() -> None:
+    """scp.read_perkinelmer remains a working alias with no DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", DeprecationWarning)
+        rt = scp.read_perkinelmer
+        rt_ns = scp.perkinelmer.read_perkinelmer
+
+    assert callable(rt)
+    assert callable(rt_ns)
+    deprecation_warnings = [
+        w for w in captured if issubclass(w.category, DeprecationWarning)
+    ]
+    assert deprecation_warnings == [], deprecation_warnings
 
 
 # ------------------------------------------------------------------------------

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -170,7 +170,7 @@ def _plugin_root_export(name, namespace_cls):
         if export["deprecated"] and name not in _EMITTED_PLUGIN_ROOT_WARNINGS:
             warnings.warn(
                 f"scp.{name} is deprecated since SpectroChemPy 0.9.0 "
-                f"and will be removed in 0.11.0. "
+                f"and will be removed in 0.12.0. "
                 f"Use {export['replacement']} instead.",
                 DeprecationWarning,
                 stacklevel=3,
@@ -212,16 +212,17 @@ def __getattr__(name):
         ):
             return sys.modules[module_key]
 
-    # Handle core I/O namespaces (e.g., scp.jcamp, scp.csv)
+    # Ensure external plugins are discovered before resolving I/O namespaces
+    # or plugin-provided functions so that plugin-contributed namespaces
+    # (e.g. scp.topspin, scp.agilent) are registered alongside core ones.
+    plugin_manager.discover()
+
+    # Handle I/O namespaces (core + plugin-contributed)
     from spectrochempy.core.io_namespaces import _IONamespace
     from spectrochempy.core.io_namespaces import _is_io_namespace
 
     if _is_io_namespace(name):
         return _IONamespace(name)
-
-    # Ensure external plugins are discovered (before lazy imports so
-    # plugin-provided functions take precedence over core stubs)
-    plugin_manager.discover()
 
     from spectrochempy.plugins.namespace import has_namespace
 

--- a/src/spectrochempy/core/io_namespaces.py
+++ b/src/spectrochempy/core/io_namespaces.py
@@ -31,6 +31,41 @@ _CORE_IO_NAMESPACES: dict[str, tuple[str | None, str | None]] = {
     "labspec": ("read_labspec", None),
 }
 
+# Plugin-contributed I/O namespaces.
+#
+# Plugins register namespaces such as ``topspin`` or ``agilent`` that map
+# ``scp.<domain>.read()`` to a dotted attribute path on the ``spectrochempy``
+# package (for example ``nmr.read_topspin``).  This keeps the core package
+# decoupled from plugin-specific reader names while exposing the same
+# namespace-style API as core I/O domains.
+_PLUGIN_IO_NAMESPACES: dict[str, tuple[str | None, str | None]] = {}
+
+
+def register_io_namespace(
+    name: str,
+    read_path: str | None = None,
+    write_path: str | None = None,
+) -> None:
+    """
+    Register a plugin-contributed I/O namespace.
+
+    Parameters
+    ----------
+    name : str
+        Namespace name exposed as ``scp.<name>``.
+    read_path : str or None
+        Dotted attribute path resolving to the read function, relative to
+        the ``spectrochempy`` package (for example ``nmr.read_topspin``).
+    write_path : str or None
+        Dotted attribute path resolving to the write function, if any.
+    """
+    _PLUGIN_IO_NAMESPACES[name] = (read_path, write_path)
+
+
+def unregister_io_namespace(name: str) -> None:
+    """Remove a plugin-contributed I/O namespace (mainly for tests)."""
+    _PLUGIN_IO_NAMESPACES.pop(name, None)
+
 
 def _resolve_func(func_name: str) -> Any:
     """Lazy-resolve a top-level function by name."""
@@ -39,40 +74,62 @@ def _resolve_func(func_name: str) -> Any:
     return getattr(scp, func_name)
 
 
+def _resolve_attr(attr_path: str) -> Any:
+    """Lazy-resolve a dotted attribute path relative to ``spectrochempy``."""
+    import spectrochempy as scp
+
+    obj: Any = scp
+    for part in attr_path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
 class _IONamespace:
     """
     Lightweight namespace for core I/O operations.
 
     Instances are returned for names such as ``scp.jcamp`` and delegate
     ``read()`` / ``write()`` to the existing public ``read_*`` / ``write_*``
-    functions.
+    functions (core namespaces) or to plugin namespaced APIs
+    (plugin-contributed namespaces).
     """
 
     def __init__(self, name: str) -> None:
         self._name = name
-        self._read_name, self._write_name = _CORE_IO_NAMESPACES[name]
+        if name in _CORE_IO_NAMESPACES:
+            self._read_ref, self._write_ref = _CORE_IO_NAMESPACES[name]
+            self._plugin = False
+        else:
+            self._read_ref, self._write_ref = _PLUGIN_IO_NAMESPACES[name]
+            self._plugin = True
 
     def __dir__(self) -> list[str]:
-        names = ["read"] if self._read_name else []
-        if self._write_name:
+        names = []
+        if self._read_ref:
+            names.append("read")
+        if self._write_ref:
             names.append("write")
         return names
 
     def __getattr__(self, name: str) -> Any:
-        if name == "read" and self._read_name:
-            return _resolve_func(self._read_name)
-        if name == "write" and self._write_name:
-            return _resolve_func(self._write_name)
+        if name == "read" and self._read_ref:
+            if self._plugin:
+                return _resolve_attr(self._read_ref)
+            return _resolve_func(self._read_ref)
+        if name == "write" and self._write_ref:
+            if self._plugin:
+                return _resolve_attr(self._write_ref)
+            return _resolve_func(self._write_ref)
         raise AttributeError(f"namespace '{self._name}' has no attribute '{name}'")
 
     def __repr__(self) -> str:
         ops = []
-        if self._read_name:
+        if self._read_ref:
             ops.append("read")
-        if self._write_name:
+        if self._write_ref:
             ops.append("write")
         return f"<IONamespace '{self._name}' ({', '.join(ops)})>"
 
 
 def _is_io_namespace(name: str) -> bool:
-    return name in _CORE_IO_NAMESPACES
+    return name in _CORE_IO_NAMESPACES or name in _PLUGIN_IO_NAMESPACES

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -14,6 +14,7 @@ import pluggy
 
 from spectrochempy.api.plugins.validation import check_plugin_requires
 from spectrochempy.api.plugins.validation import validate_plugin_compatibility
+from spectrochempy.core.io_namespaces import register_io_namespace
 from spectrochempy.plugins.hooks import SpectroChemPyHookSpec
 from spectrochempy.plugins.lifecycle import PluginDescriptor
 from spectrochempy.plugins.lifecycle import PluginState
@@ -154,6 +155,14 @@ class PluginManager:
         self._pm.register(plugin, name)
         self.registry.register_plugin(name, plugin)
         self._plugin_states[name] = PluginState.ACTIVE
+
+        # --- Register plugin-contributed I/O namespaces ---
+        io_namespaces = getattr(plugin, "io_namespaces", None)
+        if io_namespaces:
+            for ns_name, ns_spec in io_namespaces.items():
+                read_path = ns_spec.get("read")
+                write_path = ns_spec.get("write")
+                register_io_namespace(ns_name, read_path, write_path)
 
     # ------------------------------------------------------------------
     # Declarative hook collection


### PR DESCRIPTION
## Summary

This PR exposes the documented namespace-style API for plugin-provided readers and adds a generic NMR dispatcher.

## New API

- `scp.topspin.read(...)` maps to `scp.nmr.read_topspin(...)`
- `scp.agilent.read(...)` maps to `scp.nmr.read_agilent(...)`
- `scp.nmr.read(...)` auto-detects TopSpin vs Agilent/Varian format
- `scp.perkinelmer.read(...)` already worked and is kept unchanged

Root-level aliases `scp.read_topspin`, `scp.read_agilent`, `scp.read_perkinelmer` remain available as compatibility shims, per `api-conventions.md`.

## Core changes

- `core/io_namespaces.py`: plugin-contributed I/O namespace registry.
- `src/spectrochempy/__init__.py`: discover plugins before resolving I/O namespaces.
- `src/spectrochempy/plugins/manager.py`: register plugin-declared `io_namespaces` after activation.
- NMR plugin: generic `read()` dispatcher + `io_namespaces` for `topspin`/`agilent`.

## Validation

```bash
conda run -n scpy-core python -m pytest \
  plugins/spectrochempy-nmr/tests \
  plugins/spectrochempy-perkinelmer/tests \
  tests/test_plugins -q
```

Result: **396 passed, 7 skipped**

Pre-commit: all hooks passed.

## Changelog

Entry added to `docs/sources/whatsnew/changelog.rst` (New Features).
