### PR TITLE
CI: add narrow safe-docs PR bypass

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@
 - [ ] The new API methods have been included in a section of `docs/sources/reference/index.rst`.
 - [ ] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
 - [ ] Changelog entry is present (or label `no-changelog` is applied).
+- [ ] If this PR changes only safe maintainer/policy docs, the label `safe-docs-no-ci` has been applied; otherwise it has not.
 - [ ] If you are a new contributor, you have added your name (affiliation and ORCID
       if you have one) in the `zenodo.json` in the field contributors field. _Be careful
       not to break the json format (check the content of the file with the

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -37,23 +37,67 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify-pr-bypass:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.eval.outputs.skip }}
+      reason: ${{ steps.eval.outputs.reason }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Evaluate safe-docs CI bypass
+        id: eval
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          LABELS_JSON: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '[]' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          labels = json.loads(os.environ["LABELS_JSON"])
+          cmd = [
+              sys.executable,
+              ".github/workflows/scripts/evaluate_pr_bypass.py",
+              "--base",
+              os.environ.get("BASE_SHA", ""),
+              "--head",
+              os.environ["HEAD_SHA"],
+          ]
+          for label in labels:
+              cmd.extend(["--label", label])
+          raise SystemExit(subprocess.run(cmd, check=False).returncode)
+          PY
+
   build_and_publish_documentation:
+    needs: [classify-pr-bypass]
     # Only run scheduled jobs on main repository.
     # For pull_request events, skip if the PR is from the same repository
     # (push events on the branch already trigger the workflow), except for
     # documentation branches where the PR itself should still exercise the
     # docs build and preview path.
     if: >
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name != 'pull_request' || needs.classify-pr-bypass.outputs.skip != 'true') &&
       (
-        github.repository == 'spectrochempy/spectrochempy' &&
+        github.event_name == 'workflow_dispatch' ||
         (
-          github.event_name == 'schedule' ||
-          github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name != github.repository ||
-          startsWith(github.event.pull_request.head.ref, 'docs/') ||
-          startsWith(github.event.pull_request.head.ref, 'doc/') ||
-          startsWith(github.event.pull_request.head.ref, 'codex/doc-')
+          github.repository == 'spectrochempy/spectrochempy' &&
+          (
+            github.event_name == 'schedule' ||
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name != github.repository ||
+            startsWith(github.event.pull_request.head.ref, 'docs/') ||
+            startsWith(github.event.pull_request.head.ref, 'doc/') ||
+            startsWith(github.event.pull_request.head.ref, 'codex/doc-')
+          )
         )
       )
 

--- a/.github/workflows/scripts/evaluate_pr_bypass.py
+++ b/.github/workflows/scripts/evaluate_pr_bypass.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Evaluate whether a PR can safely bypass heavyweight CI jobs."""
 
+# ruff: noqa: S603, S607, T201
+
 from __future__ import annotations
 
 import argparse
@@ -18,9 +20,7 @@ SAFE_EXACT = {
     ".github/PULL_REQUEST_TEMPLATE.md",
 }
 
-SAFE_PREFIXES = (
-    "maintainers/",
-)
+SAFE_PREFIXES = ("maintainers/",)
 
 UNSAFE_PREFIXES = (
     "docs/",

--- a/.github/workflows/scripts/evaluate_pr_bypass.py
+++ b/.github/workflows/scripts/evaluate_pr_bypass.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Evaluate whether a PR can safely bypass heavyweight CI jobs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SAFE_DOCS_LABEL = "safe-docs-no-ci"
+
+SAFE_EXACT = {
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+}
+
+SAFE_PREFIXES = (
+    "maintainers/",
+)
+
+UNSAFE_PREFIXES = (
+    "docs/",
+    "examples/",
+    "src/",
+    "tests/",
+    "plugins/",
+    ".github/workflows/",
+)
+
+
+def _run_git(args: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _is_zero_sha(value: str) -> bool:
+    return bool(value) and set(value) == {"0"}
+
+
+def changed_files(base: str | None, head: str | None) -> list[str]:
+    """Return changed files between two refs, using conservative fallbacks."""
+    if not head:
+        head = "HEAD"
+
+    if base and not _is_zero_sha(base):
+        for separator in ("...", ".."):
+            try:
+                return _run_git(["diff", "--name-only", f"{base}{separator}{head}"])
+            except subprocess.CalledProcessError:
+                continue
+
+    try:
+        return _run_git(["diff", "--name-only", "HEAD~1..HEAD"])
+    except subprocess.CalledProcessError:
+        return []
+
+
+def is_safe_docs_only(files: list[str]) -> bool:
+    if not files:
+        return False
+    for path in files:
+        if any(path.startswith(prefix) for prefix in UNSAFE_PREFIXES):
+            return False
+        if path in SAFE_EXACT:
+            continue
+        if any(path.startswith(prefix) for prefix in SAFE_PREFIXES):
+            if path.endswith(".md"):
+                continue
+            return False
+        if path.endswith(".md"):
+            continue
+        return False
+    return True
+
+
+def write_github_output(*, should_skip: bool, reason: str) -> None:
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if not output_file:
+        return
+    with Path(output_file).open("a", encoding="utf-8") as stream:
+        stream.write(f"skip={'true' if should_skip else 'false'}\n")
+        stream.write(f"reason={reason}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    parser.add_argument("--label", action="append", default=[])
+    args = parser.parse_args()
+
+    files = changed_files(args.base, args.head)
+    labels = set(args.label)
+    has_label = SAFE_DOCS_LABEL in labels
+    safe_only = is_safe_docs_only(files)
+    should_skip = has_label and safe_only
+
+    if not has_label:
+        reason = f"label '{SAFE_DOCS_LABEL}' not present"
+    elif not safe_only:
+        reason = "changed files are not limited to safe documentation/policy paths"
+    else:
+        reason = "safe documentation/policy-only PR explicitly labeled for CI bypass"
+
+    print("Changed files:")
+    for path in files:
+        print(f"  - {path}")
+    if not files:
+        print("  none")
+    print(f"Labels: {sorted(labels)}")
+    print(f"Safe docs only: {safe_only}")
+    print(f"Skip heavyweight CI: {should_skip}")
+    print(f"Reason: {reason}")
+
+    write_github_output(should_skip=should_skip, reason=reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -37,14 +37,55 @@ permissions:
   statuses: write  # Required for updating commit statuses
 
 jobs:
+  classify-pr-bypass:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.eval.outputs.skip }}
+      reason: ${{ steps.eval.outputs.reason }}
+    steps:
+      - name: Checkout spectrochempy repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Evaluate safe-docs CI bypass
+        id: eval
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          LABELS_JSON: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '[]' }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          labels = json.loads(os.environ["LABELS_JSON"])
+          cmd = [
+              sys.executable,
+              ".github/workflows/scripts/evaluate_pr_bypass.py",
+              "--base",
+              os.environ.get("BASE_SHA", ""),
+              "--head",
+              os.environ["HEAD_SHA"],
+          ]
+          for label in labels:
+              cmd.extend(["--label", label])
+          raise SystemExit(subprocess.run(cmd, check=False).returncode)
+          PY
+
   test-package:
+    needs: [classify-pr-bypass]
     # Skip tests for releases and limit scheduled runs to main repository
     if: |
       (github.event_name == 'schedule'
        && github.repository == 'spectrochempy/spectrochempy'
        && !startsWith(github.ref, 'refs/release/')) || (
        github.event_name != 'schedule'
-       && !startsWith(github.ref, 'refs/release/'))
+       && !startsWith(github.ref, 'refs/release/')
+       && (github.event_name != 'pull_request' || needs.classify-pr-bypass.outputs.skip != 'true'))
 
     name: ${{ matrix.check_name }}
 
@@ -121,6 +162,8 @@ jobs:
           echo "os: ${{ matrix.os }}"
           echo "core_only: ${{ matrix.core_only }}"
           echo "plugins: ${{ matrix.plugins }}"
+          echo "safe-docs-no-ci bypass: ${{ needs.classify-pr-bypass.outputs.skip || 'false' }}"
+          echo "bypass reason: ${{ needs.classify-pr-bypass.outputs.reason || 'not applicable' }}"
 
       - name: Initialize CI diagnostics
         if: ${{ !(env.ACT && matrix.pythonVersion == '3.14') }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,66 @@ risks, and next steps.  For multi-PR projects, maintain dedicated files in
 `spectrochempy_maintainer/notes/audits/` and update them before considering a
 task complete.
 
+## Maintainer repository hygiene
+
+When writing into `spectrochempy_maintainer` during work on `spectrochempy`,
+prefer updating an existing active document over creating a new one.
+
+Before creating a new note, verify whether the same topic already has:
+
+* an active audit in `spectrochempy_maintainer/notes/audits/`;
+* a maintained roadmap entry in `spectrochempy_maintainer/roadmap/`;
+* a maintained contract in `spectrochempy_maintainer/rfcs/`;
+* a maintained architecture note in `spectrochempy_maintainer/architecture/`.
+
+Do not create a new document when extending the existing one would preserve
+clarity.
+
+For any active topic, keep a single obvious entry point:
+
+* roadmap for current priority and campaign state;
+* RFC for the normative contract or decision;
+* architecture note for the maintained current model;
+* audit for evidence, implementation notes, and unresolved questions.
+
+Audits in `spectrochempy_maintainer/notes/audits/` must contain only:
+
+* active investigations;
+* ongoing campaign logs;
+* unresolved implementation/design notes.
+
+Move a note to `spectrochempy_maintainer/archive/audits/` once it becomes
+primarily:
+
+* a validation log;
+* a post-merge confirmation;
+* an implementation history record;
+* evidence already absorbed by code and maintained documents.
+
+When promoting knowledge from an audit or proposal into
+`spectrochempy_maintainer/rfcs/`, `architecture/`, or `roadmap/`:
+
+* rewrite the durable content instead of copying it;
+* update the source note with a clear status and link to the maintained
+  destination;
+* archive the source note when it no longer carries an open decision.
+
+Keep `spectrochempy_maintainer/roadmap/current-roadmap.md` short.  It should
+contain only:
+
+* active priorities;
+* near-term follow-up;
+* pointers to deeper documents.
+
+Deferred or backlog material belongs in a separate governance note, not in the
+main current roadmap.
+
+At the end of the session, explicitly decide for every maintainer note touched:
+
+* still active;
+* promoted to maintained reference;
+* archived as historical context.
+
 ---
 
 # Architecture Documentation Lifecycle
@@ -379,6 +439,34 @@ gh pr edit <PR_NUMBER> --add-label no-changelog
 ```
 
 The label must be applied before the workflow runs, or CI will fail.
+
+## Safe-docs CI bypass
+
+For PRs that modify only non-executable maintainer or policy documentation,
+maintainers may apply the label ``safe-docs-no-ci`` to bypass the heavyweight
+test and docs workflows.
+
+This label is intentionally narrow.  It is valid only when the changed files
+are limited to safe documentation/policy paths such as:
+
+* `AGENTS.md`;
+* root-level `*.md`;
+* `maintainers/**/*.md`;
+* `CONTRIBUTING.md`;
+* the PR template and similar non-executable repository-policy documents.
+
+Do **not** use ``safe-docs-no-ci`` for:
+
+* `docs/` changes, even when the files are non-Python;
+* `examples/` changes;
+* gallery/example/tutorial updates;
+* plugin Markdown such as `plugins/**/README.md`;
+* code changes hidden inside a documentation PR;
+* any change that can affect executable documentation, packaging, plugins, or
+  runtime behavior.
+
+The CI bypass is enforced conservatively: the label alone is not sufficient if
+the changed files are outside the approved safe-documentation scope.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,20 @@ The same workflow verifies that `docs/sources/whatsnew/changelog.rst` has
 been modified.  If the PR genuinely does not need a changelog entry (e.g.
 pure CI or internal tooling change), add the label **`no-changelog`**.
 
+For PRs that change only safe maintainer-policy or governance Markdown
+documents (`AGENTS.md`, root `*.md`, `maintainers/**/*.md`, PR templates, and
+similar non-executable repository-policy files), maintainers may add the label
+**`safe-docs-no-ci`** to bypass the heavyweight test and docs workflows.
+
+This label must **not** be used for:
+
+* `docs/` changes, even when the files are non-Python;
+* `examples/` changes;
+* plugin Markdown such as `plugins/**/README.md`;
+* code changes hidden inside a documentation PR;
+* any change that can affect executable documentation, packaging, or runtime
+  behavior.
+
 See `docs/sources/devguide/contributing.rst` for the full PR workflow.
 
 The PR description should begin with:


### PR DESCRIPTION
Summary:
- add a conservative `safe-docs-no-ci` label mechanism for PRs that touch only non-executable maintainer/policy Markdown
- gate both the heavyweight test workflow and docs workflow behind the same changed-file classifier
- document the label in contributor guidance, the PR template, and agent rules

Out of scope:
- bypassing CI for `docs/`, `examples/`, plugin README files, or any executable documentation surface
- changing changelog policy beyond existing labels
- publishing local-only `.opencode/rules.md` changes in this PR, since that file is not tracked in the repository

Notes:
- the bypass is label-driven but still refuses PRs whose changed files fall outside the approved safe-documentation scope
- `AGENTS.md` was updated in the repository; `.opencode/rules.md` was updated locally only
