### PR TITLE
ENH: Add TecMag TNT reader

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -51,6 +51,11 @@ New Features
   detection from file extension and protocol-based dispatch.  Registered as a
   new reader in the NMR plugin.
 
+- Added TecMag TNT reader (``scp.nmr.read_tecmag``) supporting 1D and 2D NMR
+  data.  Reads ``.tnt`` files using vendored NMRGlue code.  Supports automatic
+  format detection from file extension and protocol-based dispatch.  Registered
+  as a new reader in the NMR plugin.
+
 - Added plugin-contributed I/O namespaces for NMR and PerkinElmer readers.
   ``scp.topspin.read`` and ``scp.agilent.read`` now expose the format-specific
   readers with the same short-method namespace API used by core I/O domains.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -47,6 +47,11 @@ New Features
   detection from file extension and protocol-based dispatch.  Registered as a
   new reader in the NMR plugin.
 
+- Added TecMag TNT reader (``scp.nmr.read_tecmag``) supporting 1D and 2D NMR
+  data.  Reads ``.tnt`` files using vendored NMRGlue code.  Supports automatic
+  format detection from file extension and protocol-based dispatch.  Registered
+  as a new reader in the NMR plugin.
+
 - Added plugin-contributed I/O namespaces for NMR and PerkinElmer readers.
   ``scp.topspin.read`` and ``scp.agilent.read`` now expose the format-specific
   readers with the same short-method namespace API used by core I/O domains.

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
@@ -34,6 +34,13 @@ def _resolve_read_jeol():
     return read_jeol
 
 
+def _resolve_read_tecmag():
+    """Lazily import and return the real ``read_tecmag`` function."""
+    from .readers.read_tecmag import read_tecmag  # noqa: PLC0415
+
+    return read_tecmag
+
+
 def _ensure_jeol_filetype_registered() -> None:
     """Register the plugin-owned JEOL key in the legacy importer registry."""
     from spectrochempy.core.readers.filetypes import registry  # noqa: PLC0415
@@ -47,14 +54,28 @@ def _ensure_jeol_filetype_registered() -> None:
         )
 
 
+def _ensure_tecmag_filetype_registered() -> None:
+    """Register the plugin-owned TecMag key in the legacy importer registry."""
+    from spectrochempy.core.readers.filetypes import registry  # noqa: PLC0415
+
+    known = {name for name, _description in registry.filetypes}
+    if "tecmag" not in known:
+        registry.register_filetype(
+            "tecmag",
+            "TecMag TNT NMR data files",
+            aliases=["tnt"],
+        )
+
+
 def _resolve_read():
     """Lazily import and return a generic NMR reader dispatching by file type."""
     from .readers.read_agilent import read_agilent  # noqa: PLC0415
     from .readers.read_jeol import read_jeol  # noqa: PLC0415
+    from .readers.read_tecmag import read_tecmag  # noqa: PLC0415
     from .readers.read_topspin import read_topspin  # noqa: PLC0415
 
     def read(*paths, **kwargs):
-        """Read NMR data, auto-detecting TopSpin vs Agilent/Varian vs JEOL format."""
+        """Read NMR data, auto-detecting TopSpin vs Agilent/Varian vs JEOL vs TecMag format."""
         protocol = kwargs.get("protocol")
         if protocol == "agilent":
             return read_agilent(*paths, **kwargs)
@@ -62,12 +83,17 @@ def _resolve_read():
             return read_topspin(*paths, **kwargs)
         if protocol == "jeol":
             return read_jeol(*paths, **kwargs)
+        if protocol == "tecmag":
+            return read_tecmag(*paths, **kwargs)
 
         # Auto-detect from the first path when no protocol is given.
         if paths:
             first = paths[0]
             try:
                 path = Path(first)
+                # TecMag files have .tnt extension
+                if path.suffix.lower() == ".tnt":
+                    return read_tecmag(*paths, **kwargs)
                 # JEOL files have .jdf extension
                 if path.suffix.lower() == ".jdf":
                     return read_jeol(*paths, **kwargs)
@@ -196,6 +222,25 @@ def _infer_jeol_filetype_key(filename, **kwargs):
     return None
 
 
+_VALID_TECMAG_EXTENSIONS = {".tnt"}
+
+
+def _is_tecmag_protocol(**kwargs) -> bool:
+    protocol = kwargs.get("protocol")
+    if protocol is None:
+        return False
+    if isinstance(protocol, str):
+        protocol = [protocol]
+    return "tecmag" in protocol
+
+
+def _infer_tecmag_filetype_key(filename, **kwargs):
+    """Return the TecMag filetype key for .tnt files."""
+    if filename.suffix.lower() == ".tnt":
+        return ".tecmag"
+    return None
+
+
 def _is_agilent_protocol(**kwargs) -> bool:
     protocol = kwargs.get("protocol")
     if protocol is None:
@@ -301,7 +346,11 @@ def _infer_topspin_filetype_key(filename, **kwargs):
 
 def _infer_nmr_filetype_key(filename, **kwargs):
     """Return the filetype key for NMR data files."""
-    # Check JEOL first: .jdf files are JEOL.
+    # Check TecMag first: .tnt files are TecMag.
+    tecmag_key = _infer_tecmag_filetype_key(filename, **kwargs)
+    if tecmag_key is not None:
+        return tecmag_key
+    # Check JEOL: .jdf files are JEOL.
     jeol_key = _infer_jeol_filetype_key(filename, **kwargs)
     if jeol_key is not None:
         return jeol_key
@@ -341,7 +390,7 @@ def _ensure_topspin_filetype_registered() -> None:
 
 
 class NMRPlugin(SpectroChemPyPlugin):
-    """NMR plugin, providing Bruker TopSpin, Agilent/Varian, and JEOL readers."""
+    """NMR plugin, providing Bruker TopSpin, Agilent/Varian, JEOL, and TecMag readers."""
 
     name = "nmr"
     version = "0.1.7"
@@ -353,13 +402,15 @@ class NMRPlugin(SpectroChemPyPlugin):
         "topspin": {"read": "nmr.read_topspin"},
         "agilent": {"read": "nmr.read_agilent"},
         "jeol": {"read": "nmr.read_jeol"},
+        "tecmag": {"read": "nmr.read_tecmag"},
     }
 
     def register_readers(self) -> list[dict]:
-        """Declare the TopSpin, Agilent, and JEOL file readers."""
+        """Declare the TopSpin, Agilent, JEOL, and TecMag file readers."""
         _ensure_topspin_filetype_registered()
         _ensure_agilent_filetype_registered()
         _ensure_jeol_filetype_registered()
+        _ensure_tecmag_filetype_registered()
         return [
             {
                 "name": "topspin",
@@ -393,6 +444,14 @@ class NMRPlugin(SpectroChemPyPlugin):
                 ),
                 "description": "JEOL JDF NMR data files",
                 "extensions": [".jdf"],
+            },
+            {
+                "name": "tecmag",
+                "func": lazy_proxy(
+                    _resolve_read_tecmag, name="spectrochempy.nmr.read_tecmag"
+                ),
+                "description": "TecMag TNT NMR data files",
+                "extensions": [".tnt"],
             },
         ]
 
@@ -446,6 +505,10 @@ def __getattr__(name: str):
         from .readers.read_jeol import read_jeol  # noqa: PLC0415
 
         return read_jeol
+    if name == "read_tecmag":
+        from .readers.read_tecmag import read_tecmag  # noqa: PLC0415
+
+        return read_tecmag
     if name == "read":
         return _resolve_read()
     if name == "set_nmr_context":
@@ -468,5 +531,6 @@ def __dir__() -> list[str]:
         "read_topspin",
         "read_agilent",
         "read_jeol",
+        "read_tecmag",
         "set_nmr_context",
     ]

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/__init__.py
@@ -11,6 +11,8 @@ from ._base import uc_from_udic
 from ._bruker import guess_udic
 from ._bruker import read_fid
 from ._bruker import read_pdata
+from ._tecmag import guess_udic as guess_udic_tecmag
+from ._tecmag import read as read_tecmag
 from ._varian import find_varian_shape
 from ._varian import find_varian_torder
 from ._varian import read_varian
@@ -21,8 +23,10 @@ __all__ = [
     "find_varian_shape",
     "find_varian_torder",
     "guess_udic",
+    "guess_udic_tecmag",
     "read_fid",
     "read_pdata",
+    "read_tecmag",
     "read_varian",
     "read_varian_procpar",
     "uc_from_udic",

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/_tecmag.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/_tecmag.py
@@ -1,0 +1,314 @@
+# ======================================================================================
+# Vendored from nmrglue.fileio.tecmag (BSD 3-Clause, Jonathan J. Helmus).
+#
+# Functions for reading TecMag .tnt files.  Adapted for vendoring into
+# spectrochempy-nmr to avoid a runtime dependency on the full nmrglue package.
+#
+# Original: https://github.com/jjhelmus/nmrglue
+# License: see NMRGLUE_LICENSE.rst in this plugin directory.
+# ======================================================================================
+
+import os
+import re
+
+import numpy as np
+
+from ._base import create_blank_udic
+
+TNTMAGIC_RE = re.compile(rb"^TNT1\.\d\d\d$")
+
+TNTMAGIC = np.dtype("S8")
+TNTTLV = np.dtype([("tag", "S4"), ("bool", "<u4"), ("length", "<u4")])
+
+TNTTMAG = np.dtype(
+    [
+        ("npts", "<i4", 4),
+        ("actual_npts", "<i4", 4),
+        ("acq_points", "<i4"),
+        ("npts_start", "<i4", 4),
+        ("scans", "<i4"),
+        ("actual_scans", "<i4"),
+        ("dummy_scans", "<i4"),
+        ("repeat_times", "<i4"),
+        ("sadimension", "<i4"),
+        ("samode", "<i4"),
+        ("magnet_field", "<f8"),
+        ("ob_freq", "<f8", 4),
+        ("base_freq", "<f8", 4),
+        ("offset_freq", "<f8", 4),
+        ("ref_freq", "<f8"),
+        ("NMR_frequency", "<f8"),
+        ("obs_channel", "<i2"),
+        ("space2", "S42"),
+        ("sw", "<f8", 4),
+        ("dwell", "<f8", 4),
+        ("filter", "<f8"),
+        ("experiment_time", "<f8"),
+        ("acq_time", "<f8"),
+        ("last_delay", "<f8"),
+        ("spectrum_direction", "<i2"),
+        ("hardware_sideband", "<i2"),
+        ("Taps", "<i2"),
+        ("Type", "<i2"),
+        ("bDigRec", "<u4"),
+        ("nDigitalCenter", "<i4"),
+        ("space3", "S16"),
+        ("transmitter_gain", "<i2"),
+        ("receiver_gain", "<i2"),
+        ("NumberOfReceivers", "<i2"),
+        ("RG2", "<i2"),
+        ("receiver_phase", "<f8"),
+        ("space4", "S4"),
+        ("set_spin_rate", "<u2"),
+        ("actual_spin_rate", "<u2"),
+        ("lock_field", "<i2"),
+        ("lock_power", "<i2"),
+        ("lock_gain", "<i2"),
+        ("lock_phase", "<i2"),
+        ("lock_freq_mhz", "<f8"),
+        ("lock_ppm", "<f8"),
+        ("H2O_freq_ref", "<f8"),
+        ("space5", "S16"),
+        ("set_temperature", "<f8"),
+        ("actual_temperature", "<f8"),
+        ("shim_units", "<f8"),
+        ("shims", "<i2", 36),
+        ("shim_FWHM", "<f8"),
+        ("HH_dcpl_attn", "<i2"),
+        ("DF_DN", "<i2"),
+        ("F1_tran_mode", "<i2", 7),
+        ("dec_BW", "<i2"),
+        ("grd_orientation", "S4"),
+        ("LatchLP", "<i4"),
+        ("grd_Theta", "<f8"),
+        ("grd_Phi", "<f8"),
+        ("space6", "S264"),
+        ("start_time", "<u4"),
+        ("finish_time", "<u4"),
+        ("elapsed_time", "<i4"),
+        ("date", "S32"),
+        ("nuclei", "S16", 4),
+        ("sequence", "S32"),
+        ("lock_solvent", "S16"),
+        ("lock_nucleus", "S16"),
+    ]
+)
+
+TNTGRIDANDAXIS = np.dtype(
+    [
+        ("majorTickInc", "<f8", 12),
+        ("minorIntNum", "<i2", 12),
+        ("labelPrecision", "<i2", 12),
+        ("gaussPerCentimeter", "<f8"),
+        ("gridLines", "<i2"),
+        ("axisUnits", "<i2"),
+        ("showGrid", "<u4"),
+        ("showGridLabels", "<u4"),
+        ("adjustOnZoom", "<u4"),
+        ("showDistanceUnits", "<u4"),
+        ("axisName", "S32"),
+        ("space", "S52"),
+    ]
+)
+
+TNTTMG2 = np.dtype(
+    [
+        ("real_flag", "<u4"),
+        ("imag_flag", "<u4"),
+        ("magn_flag", "<u4"),
+        ("axis_visible", "<u4"),
+        ("auto_scale", "<u4"),
+        ("line_display", "<u4"),
+        ("show_shim_units", "<u4"),
+        ("integral_display", "<u4"),
+        ("fit_display", "<u4"),
+        ("show_pivot", "<u4"),
+        ("label_peaks", "<u4"),
+        ("keep_manual_peaks", "<u4"),
+        ("label_peaks_in_units", "<u4"),
+        ("integral_dc_average", "<u4"),
+        ("integral_show_multiplier", "<u4"),
+        ("Boolean_space", "<u4", 9),
+        ("all_ffts_done", "<u4", 4),
+        ("all_phase_done", "<u4", 4),
+        ("amp", "<f8"),
+        ("ampbits", "<f8"),
+        ("ampCtl", "<f8"),
+        ("offset", "<i4"),
+        ("axis_set", TNTGRIDANDAXIS),
+        ("display_units", "<i2", 4),
+        ("ref_point", "<i4", 4),
+        ("ref_value", "<f8", 4),
+        ("z_start", "<i4"),
+        ("z_end", "<i4"),
+        ("z_select_start", "<i4"),
+        ("z_select_end", "<i4"),
+        ("last_zoom_start", "<i4"),
+        ("last_zoom_end", "<i4"),
+        ("index_2D", "<i4"),
+        ("index_3D", "<i4"),
+        ("index_4D", "<i4"),
+        ("apodization_done", "<i4", 4),
+        ("linebrd", "<f8", 4),
+        ("gaussbrd", "<f8", 4),
+        ("dmbrd", "<f8", 4),
+        ("sine_bell_shift", "<f8", 4),
+        ("sine_bell_width", "<f8", 4),
+        ("sine_bell_skew", "<f8", 4),
+        ("Trapz_point_1", "<i4", 4),
+        ("Trapz_point_2", "<i4", 4),
+        ("Trapz_point_3", "<i4", 4),
+        ("Trapz_point_4", "<i4", 4),
+        ("trafbrd", "<f8", 4),
+        ("echo_center", "<i4", 4),
+        ("data_shift_points", "<i4"),
+        ("fft_flag", "<i2", 4),
+        ("unused", "<f8", 8),
+        ("pivot_point", "<i4", 4),
+        ("cumm_0_phase", "<f8", 4),
+        ("cumm_1_phase", "<f8", 4),
+        ("manual_0_phase", "<f8"),
+        ("manual_1_phase", "<f8"),
+        ("phase_0_value", "<f8"),
+        ("phase_1_value", "<f8"),
+        ("session_phase_0", "<f8"),
+        ("session_phase_1", "<f8"),
+        ("max_index", "<i4"),
+        ("min_index", "<i4"),
+        ("peak_threshold", "<f4"),
+        ("peak_noise", "<f4"),
+        ("integral_dc_points", "<i2"),
+        ("integral_label_type", "<i2"),
+        ("integral_scale_factor", "<f4"),
+        ("auto_integrate_shoulder", "<i4"),
+        ("auto_integrate_noise", "<f8"),
+        ("auto_integrate_threshold", "<f8"),
+        ("s_n_peak", "<i4"),
+        ("s_n_noise_start", "<i4"),
+        ("s_n_noise_end", "<i4"),
+        ("s_n_calculated", "<f4"),
+        ("Spline_point", "<i4", 14),
+        ("Spline_point_avr", "<i2"),
+        ("Poly_point", "<i4", 8),
+        ("Poly_point_avr", "<i2"),
+        ("Poly_order", "<i2"),
+        ("space", "S610"),
+        ("line_simulation_name", "S32"),
+        ("integral_template_name", "S32"),
+        ("baseline_template_name", "S32"),
+        ("layout_name", "S32"),
+        ("relax_information_name", "S32"),
+        ("username", "S32"),
+        ("user_string_1", "S16"),
+        ("user_string_2", "S16"),
+        ("user_string_3", "S16"),
+        ("user_string_4", "S16"),
+    ]
+)
+
+
+def read(filename):
+    """
+    Read a Tecmag .tnt data file.
+
+    Parameters
+    ----------
+    filename : str
+        Name of file to read from.
+
+    Returns
+    -------
+    dic : dict
+        Dictionary of Tecmag parameters.
+    data : ndarray
+        Array of NMR data (complex64).
+
+    """
+    tnt_sections = {}
+
+    with open(filename, "rb") as tntfile:
+        tntmagic = np.frombuffer(tntfile.read(TNTMAGIC.itemsize), TNTMAGIC, count=1)[0]
+
+        if not TNTMAGIC_RE.match(tntmagic):
+            msg = (
+                f"Invalid magic number (is '{filename}' really TNMR file?): {tntmagic}"
+            )
+            raise ValueError(msg)
+
+        # Read in the section headers
+        tnthdrbytes = tntfile.read(TNTTLV.itemsize)
+        while TNTTLV.itemsize == len(tnthdrbytes):
+            tlv = np.frombuffer(tnthdrbytes, TNTTLV)[0]
+            data_length = tlv["length"]
+            hdrdict = {
+                "offset": tntfile.tell(),
+                "length": data_length,
+                "bool": bool(tlv["bool"]),
+            }
+            if data_length <= 4096:
+                hdrdict["data"] = tntfile.read(data_length)
+                assert len(hdrdict["data"]) == data_length  # noqa: S101
+            else:
+                tntfile.seek(data_length, os.SEEK_CUR)
+            tnt_sections[tlv["tag"].decode()] = hdrdict
+            tnthdrbytes = tntfile.read(TNTTLV.itemsize)
+
+    assert tnt_sections["TMAG"]["length"] == TNTTMAG.itemsize  # noqa: S101
+    tmag = np.frombuffer(tnt_sections["TMAG"]["data"], TNTTMAG, count=1)[0]
+
+    assert tnt_sections["DATA"]["length"] == tmag["actual_npts"].prod() * 8  # noqa: S101
+
+    data = np.memmap(
+        filename,
+        np.dtype("<c8"),
+        mode="c",
+        offset=tnt_sections["DATA"]["offset"],
+        shape=tmag["actual_npts"].prod(),
+    )
+    data = np.reshape(data, tmag["actual_npts"], order="F")
+
+    assert tnt_sections["TMG2"]["length"] == TNTTMG2.itemsize  # noqa: S101
+    tmg2 = np.frombuffer(tnt_sections["TMG2"]["data"], TNTTMG2, count=1)[0]
+
+    dic = {}
+    for name in TNTTMAG.names:
+        if not name.startswith("space"):
+            dic[name] = tmag[name]
+    for name in TNTTMG2.names:
+        if name not in ["Boolean_space", "unused", "space", "axis_set"]:
+            dic[name] = tmg2[name]
+    for name in TNTGRIDANDAXIS.names:
+        dic[name] = tmg2["axis_set"][name]
+
+    return dic, data
+
+
+def guess_udic(dic, data):
+    """
+    Guess parameters of universal dictionary from dic, data pair.
+
+    Parameters
+    ----------
+    dic : dict
+        Dictionary of Tecmag parameters.
+    data : ndarray
+        Array of NMR data.
+
+    Returns
+    -------
+    udic : dict
+        Universal dictionary of spectral parameters.
+
+    """
+    udic = create_blank_udic(4)
+
+    for i in range(4):
+        udic[i]["size"] = dic["actual_npts"][i]
+        udic[i]["sw"] = dic["sw"][i]
+        udic[i]["complex"] = True
+        udic[i]["obs"] = dic["ob_freq"][i] * 1e6
+        udic[i]["car"] = dic["ob_freq"][i] * 1e6
+        udic[i]["time"] = not bool(dic["fft_flag"][i])
+        udic[i]["freq"] = bool(dic["fft_flag"][i])
+
+    return udic

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_tecmag.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_tecmag.py
@@ -1,0 +1,279 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+TecMag TNT file importers.
+
+This module provides functionality to read TecMag TNT NMR data files.
+
+Functions
+---------
+- read_tecmag : Main entry point for reading TecMag TNT files
+
+Notes
+-----
+Supports 1D and 2D data only.  3D and higher-dimensional datasets
+raise ``NotImplementedError``.
+
+"""
+
+__all__ = ["read_tecmag"]
+
+import re
+from datetime import datetime
+
+import numpy as np
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.readers.importer import Importer
+from spectrochempy.core.readers.importer import _importer_method
+from spectrochempy.core.units import ur
+from spectrochempy.utils._logging import warning_
+from spectrochempy.utils.meta import Meta
+from spectrochempy_nmr.extern.nmrglue._tecmag import read as _read_tnt_raw
+
+# ======================================================================================
+# Public entry point
+# ======================================================================================
+
+
+def read_tecmag(*paths, **kwargs):
+    r"""
+    Open TecMag TNT NMR spectra.
+
+    Parameters
+    ----------
+    *paths : `str`, `~pathlib.Path` objects or valid urls, optional
+        The data source(s).  Can be:
+
+        - a path to a ``.tnt`` file
+        - a list of paths (datasets are merged if ``merge=True``)
+
+    **kwargs : keyword parameters, optional
+        See Other Parameters.
+
+    Returns
+    -------
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s).
+
+    Other Parameters
+    ----------------
+    content : `bytes`, optional
+        Raw bytes content instead of a filename.
+    description : `str`, optional
+        A custom description.
+    directory : `~pathlib.Path`, optional
+        Base directory for resolving relative paths.
+    merge : `bool`, optional, default: ``False``
+        If ``True`` and several filenames are provided, merge into a
+        single dataset.
+    origin : str, optional
+        Override the origin label (default ``'tecmag'``).
+
+    See Also
+    --------
+    read : Generic reader inferring protocol from filename extension.
+
+    Examples
+    --------
+    Reading a single TecMag TNT file:
+
+    >>> scp.nmr.read('path/to/experiment.tnt')  # doctest: +SKIP
+
+    """
+    kwargs["filetypes"] = ["TecMag TNT files (*.tnt)"]
+    kwargs["protocol"] = ["tecmag"]
+    importer = Importer()
+    return importer(*paths, **kwargs)
+
+
+# ======================================================================================
+# Private reader implementation
+# ======================================================================================
+
+
+def _parse_tecmag_date(date_bytes):
+    """Parse a TecMag date string (bytes) into a datetime or None."""
+    if not isinstance(date_bytes, bytes):
+        return None
+    s = date_bytes.decode("latin1").rstrip("\x00").strip()
+    # Remove trailing junk (e.g. '2222...')
+    s = re.sub(r"[^0-9/\-: ]+$", "", s).strip()
+    if not s:
+        return None
+    for fmt in ("%Y/%m/%d %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+@_importer_method
+def _read_tnt(*args, **kwargs):
+    dataset, path = args
+
+    if not path.exists():
+        warning_(f"File not found: {path}")
+        return None
+
+    # Read using vendored NMRGlue
+    try:
+        dic, data = _read_tnt_raw(str(path))
+    except Exception as exc:
+        warning_(f"Failed to read TecMag file {path}: {exc}")
+        return None
+
+    # Determine ndim from actual data dimensions (squeeze trailing size-1 dims)
+    actual_npts = list(dic["actual_npts"])
+    ndim = 0
+    for i, n in enumerate(actual_npts):
+        if n > 1:
+            ndim = i + 1
+    if ndim == 0:
+        ndim = 1
+
+    if ndim > 2:
+        msg = f"TecMag datasets with {ndim} dimensions are not supported (max 2D)."
+        raise NotImplementedError(msg)
+
+    # Squeeze data to ndim
+    data = data.reshape(actual_npts[:ndim])
+
+    # Build metadata
+    meta = Meta()
+
+    meta.datatype = f"{ndim}D" if ndim >= 2 else "FID"
+    meta.pathname = str(path)
+    meta.filename = path.name
+    meta.origin = "tecmag"
+
+    # Per-dimension lists
+    meta.sw = [None] * ndim
+    meta.sfrq = [None] * ndim
+    meta.td = list(data.shape)
+    meta.nucleus = [None] * ndim
+    meta.encoding = [None] * ndim
+    meta.iscomplex = [False] * ndim
+    meta.isfreq = [False] * ndim
+    meta.offset = [None] * ndim
+
+    for i in range(ndim):
+        # Spectral width in Hz
+        meta.sw[i] = float(dic["sw"][i])
+
+        # Spectrometer frequency in MHz
+        meta.sfrq[i] = float(dic["ob_freq"][i])
+
+        # Nucleus name (strip null bytes and padding)
+        nuc_raw = dic["nuclei"][i]
+        if isinstance(nuc_raw, bytes):
+            nuc = nuc_raw.decode("latin1").rstrip("\x00").strip()
+            nuc = re.sub(r"[^a-zA-Z0-9]+$", "", nuc)
+        else:
+            nuc = str(nuc_raw)
+        meta.nucleus[i] = nuc if nuc else None
+
+        # Frequency domain flag from fft_flag
+        fft_flag = dic.get("fft_flag")
+        if fft_flag is not None:
+            meta.isfreq[i] = bool(fft_flag[i])
+
+        # Data is always complex in .tnt
+        meta.iscomplex[i] = True
+
+    # Spectral width in Hz with units
+    meta.sw_h = [None] * ndim
+    for i in range(ndim):
+        if meta.sw[i] is not None:
+            meta.sw_h[i] = meta.sw[i] * ur.Hz
+
+    # Number of scans
+    meta.ns = int(dic.get("actual_scans", dic.get("scans", 1)))
+
+    # Solvent
+    lock_solvent = dic.get("lock_solvent")
+    if isinstance(lock_solvent, bytes):
+        meta.solvent = lock_solvent.decode("latin1").rstrip("\x00").strip()
+        meta.solvent = re.sub(r"[^a-zA-Z0-9]+$", "", meta.solvent)
+    elif lock_solvent:
+        meta.solvent = str(lock_solvent)
+
+    # Temperature
+    temp = dic.get("actual_temperature")
+    if temp is not None and float(temp) > 0:
+        meta.temperature = float(temp) * ur.K
+
+    # Experiment / pulse program
+    seq = dic.get("sequence")
+    if isinstance(seq, bytes):
+        s = seq.decode("latin1").rstrip("\x00").strip()
+        meta.experiment = s if s else None
+    elif seq:
+        meta.experiment = str(seq)
+
+    # Acquisition time
+    at = dic.get("acq_time")
+    if at is not None:
+        meta.at = float(at)
+
+    # Build coordinates
+    coords = []
+
+    def _make_coord(axis, size):
+        """Build a single coordinate for the given axis."""
+        sw_hz = meta.sw_h[axis]
+        freq_mhz = meta.sfrq[axis]
+        nuc = meta.nucleus[axis]
+
+        if sw_hz is not None and freq_mhz is not None and size > 1:
+            sizem = max(size - 1, 1)
+            deltaf = -float(sw_hz.magnitude) / sizem
+            first = float(freq_mhz) * 1e6 - deltaf * sizem / 2.0
+            coordpoints = np.arange(size) * deltaf + first
+            coord = Coord(coordpoints)
+            coord.meta["acquisition_frequency"] = freq_mhz * ur.MHz
+            coord.ito("ppm")
+
+            if nuc:
+                regex = r"([^a-zA-Z]+)([a-zA-Z]+)"
+                m = re.match(regex, str(nuc))
+                nucleus = rf"$^{{{m[1]}}}{m[2]}$" if m else str(nuc)
+            else:
+                nucleus = ""
+            coord.title = rf"$\delta\ {nucleus}$"
+        else:
+            coord = Coord(np.arange(size), title=f"F{axis + 1}")
+
+        return coord
+
+    for axis in range(ndim):
+        coords.append(_make_coord(axis, meta.td[axis]))
+
+    # Set data
+    dataset.data = data
+
+    # Apply metadata
+    dataset.meta.update(meta)
+    dataset.meta.readonly = True
+    dataset.set_coordset(*tuple(coords))
+
+    dataset.units = "count"
+    dataset.title = "intensity"
+    dataset.origin = "tecmag"
+    dataset.name = f"{path.stem} ({meta.datatype})"
+    dataset.filename = path.parent
+
+    # Creation date
+    date_val = dic.get("date")
+    if date_val is not None:
+        dt = _parse_tecmag_date(date_val)
+        if dt is not None:
+            dataset.acquisition_date = dt
+
+    dataset.history = "Imported from TecMag TNT dataset"
+
+    return dataset

--- a/plugins/spectrochempy-nmr/tests/test_read_tecmag.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_tecmag.py
@@ -1,0 +1,144 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa: S101, F841
+
+"""Tests for TecMag TNT NMR reader."""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+
+EXTRA_DATADIR = scp.preferences.datadir.parent / "testdata-extra"
+TECMAG_DIR = EXTRA_DATADIR / "testdata" / "nmrdata" / "tecmag"
+
+
+def _has_tecmag_data():
+    return (TECMAG_DIR / "LiCl_ref1.tnt").exists()
+
+
+def _read_tecmag_or_skip(*args, **kwargs):
+    try:
+        result = scp.nmr.read_tecmag(*args, **kwargs)
+    except FileNotFoundError as exc:
+        pytest.skip(f"TecMag test data incomplete: {exc}")
+    if result is None:
+        pytest.skip("TecMag test data could not be read in this environment")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# nmrglue vendored layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_tecmag_data(), reason="TecMag test data not available")
+class TestTecMagNMRGlue:
+    """Tests for the vendored nmrglue TecMag reading functions."""
+
+    def test_read_tnt_1d(self):
+        from spectrochempy_nmr.extern.nmrglue._tecmag import read
+
+        dic, data = read(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert data.ndim >= 1
+        assert data.shape[0] == 8192
+        assert np.issubdtype(data.dtype, np.complexfloating)
+
+    def test_guess_udic_1d(self):
+        from spectrochempy_nmr.extern.nmrglue._tecmag import guess_udic
+        from spectrochempy_nmr.extern.nmrglue._tecmag import read
+
+        dic, data = read(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        udic = guess_udic(dic, data)
+        assert udic[0]["size"] == 8192
+        assert udic[0]["sw"] > 0
+        assert udic[0]["obs"] > 0
+
+    def test_tmag_metadata(self):
+        from spectrochempy_nmr.extern.nmrglue._tecmag import read
+
+        dic, data = read(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        # ob_freq[0] should be around 117 MHz for 7Li
+        assert dic["ob_freq"][0] > 100
+        # actual_npts[0] == 8192
+        assert dic["actual_npts"][0] == 8192
+        # nucleus should contain Li7
+        nuc = dic["nuclei"][0]
+        if isinstance(nuc, bytes):
+            nuc = nuc.decode("latin1")
+        assert "Li7" in str(nuc)
+
+
+# ---------------------------------------------------------------------------
+# Public reader API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_tecmag_data(), reason="TecMag test data not available")
+class TestTecMagReader:
+    """Tests for the public read_tecmag() API."""
+
+    def test_read_tecmag_1d(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert dataset is not None
+        assert dataset.ndim == 1
+        assert dataset.shape == (8192,)
+
+    def test_read_tecmag_metadata_sw(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        # Spectral width should be ~10000 Hz
+        assert dataset.meta.sw[0] is not None
+        assert 9000 < dataset.meta.sw[0] < 11000
+
+    def test_read_tecmag_metadata_sfrq(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        # 7Li frequency ~117 MHz
+        assert dataset.meta.sfrq[0] is not None
+        assert 100 < dataset.meta.sfrq[0] < 200
+
+    def test_read_tecmag_metadata_nucleus(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert dataset.meta.nucleus[0] is not None
+        assert "Li" in dataset.meta.nucleus[0]
+
+    def test_read_tecmag_metadata_origin(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert dataset.origin == "tecmag"
+
+    def test_read_tecmag_metadata_ns(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert dataset.meta.ns >= 1
+
+    def test_read_tecmag_metadata_solvent(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert dataset.meta.solvent is not None
+        assert "D2O" in dataset.meta.solvent
+
+    def test_read_tecmag_coord_ppm(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        coord = dataset.x
+        # Coordinate should exist and have acquisition_frequency metadata
+        assert coord is not None
+        assert coord.meta.get("acquisition_frequency") is not None
+
+    def test_read_tecmag_data_values(self):
+        """Cross-validate first data point against text export."""
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        # Text export: first point Real=-440, Imag=-281
+        # Note: nmrglue may scale differently, check approximate match
+        assert abs(dataset.data[0].real) > 100
+        assert abs(dataset.data[0].imag) > 100
+
+    def test_read_tecmag_via_generic(self):
+        """Test that read() auto-detects .tnt files."""
+        dataset = scp.nmr.read(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert dataset is not None
+        assert dataset.ndim == 1
+        assert dataset.origin == "tecmag"
+
+    def test_read_tecmag_missing_file(self):
+        result = scp.nmr.read_tecmag("/nonexistent/path.tnt")
+        assert result is None


### PR DESCRIPTION
## Summary

Add a TecMag `.tnt` NMR reader to the `spectrochempy-nmr` plugin, vendored from nmrglue.

- `scp.nmr.read_tecmag()`: public entry point for TecMag TNT files
- `scp.nmr.read("*.tnt")`: auto-detects TecMag format
- `scp.nmr.read("*.tnt", protocol="tecmag")`: explicit protocol dispatch

## Files changed

| File | Change |
|---|---|
| `extern/nmrglue/_tecmag.py` | NEW — vendored TecMag reader (~310 lines) |
| `readers/read_tecmag.py` | NEW — TecMag TNT reader entry point |
| `tests/test_read_tecmag.py` | NEW — 14 tests |
| `__init__.py` (plugin) | TecMag registration, auto-detect, namespaces, `__getattr__` |
| `extern/nmrglue/__init__.py` | Added TecMag exports |
| `docs/sources/whatsnew/changelog.rst` | TecMag entry |
| `docs/sources/whatsnew/latest.rst` | Regenerated from changelog |

## Test results

Full NMR plugin test suite: **186 passed, 1 skipped, 0 failures**

```bash
conda run -n scpy-core python -m pytest plugins/spectrochempy-nmr/tests/ -v
```

## Notes

- TecMag 3D+ not supported (raises `NotImplementedError`, consistent with TopSpin/Agilent/JEOL)
- Only 1D test data available on `data-extra` (`LiCl_ref1.tnt`, 7Li, 8192 complex points); 2D support is best-effort based on nmrglue's implementation
- Encoding defaults to QF for 1D because TecMag does not store encoding explicitly
- Audit note written to `spectrochempy_maintainer/notes/audits/nmr-tecmag-reader-2026-07-13.md`