### PR TITLE
ENH: Add SIMPSON NMR reader

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -56,6 +56,12 @@ New Features
   format detection from file extension and protocol-based dispatch.  Registered
   as a new reader in the NMR plugin.
 
+- Added SIMPSON reader (``scp.nmr.read_simpson``) supporting 1D and 2D NMR
+  simulation data.  Reads SIMPSON ``TEXT``, ``XREIM``, ``XYREIM``, ``BINARY``
+  and ``RAWBIN`` formats.  Supports automatic format detection from file
+  content and ``.in`` file metadata parsing.  Registered as a new reader in the
+  NMR plugin.
+
 - Added plugin-contributed I/O namespaces for NMR and PerkinElmer readers.
   ``scp.topspin.read`` and ``scp.agilent.read`` now expose the format-specific
   readers with the same short-method namespace API used by core I/O domains.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -52,6 +52,12 @@ New Features
   format detection from file extension and protocol-based dispatch.  Registered
   as a new reader in the NMR plugin.
 
+- Added SIMPSON reader (``scp.nmr.read_simpson``) supporting 1D and 2D NMR
+  simulation data.  Reads SIMPSON ``TEXT``, ``XREIM``, ``XYREIM``, ``BINARY``
+  and ``RAWBIN`` formats.  Supports automatic format detection from file
+  content and ``.in`` file metadata parsing.  Registered as a new reader in the
+  NMR plugin.
+
 - Added plugin-contributed I/O namespaces for NMR and PerkinElmer readers.
   ``scp.topspin.read`` and ``scp.agilent.read`` now expose the format-specific
   readers with the same short-method namespace API used by core I/O domains.

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
@@ -41,6 +41,13 @@ def _resolve_read_tecmag():
     return read_tecmag
 
 
+def _resolve_read_simpson():
+    """Lazily import and return the real ``read_simpson`` function."""
+    from .readers.read_simpson import read_simpson  # noqa: PLC0415
+
+    return read_simpson
+
+
 def _ensure_jeol_filetype_registered() -> None:
     """Register the plugin-owned JEOL key in the legacy importer registry."""
     from spectrochempy.core.readers.filetypes import registry  # noqa: PLC0415
@@ -67,15 +74,29 @@ def _ensure_tecmag_filetype_registered() -> None:
         )
 
 
+def _ensure_simpson_filetype_registered() -> None:
+    """Register the plugin-owned SIMPSON key in the legacy importer registry."""
+    from spectrochempy.core.readers.filetypes import registry  # noqa: PLC0415
+
+    known = {name for name, _description in registry.filetypes}
+    if "simpson" not in known:
+        registry.register_filetype(
+            "simpson",
+            "SIMPSON NMR simulation data files",
+            aliases=["spe", "fid", "in"],
+        )
+
+
 def _resolve_read():
     """Lazily import and return a generic NMR reader dispatching by file type."""
     from .readers.read_agilent import read_agilent  # noqa: PLC0415
     from .readers.read_jeol import read_jeol  # noqa: PLC0415
+    from .readers.read_simpson import read_simpson  # noqa: PLC0415
     from .readers.read_tecmag import read_tecmag  # noqa: PLC0415
     from .readers.read_topspin import read_topspin  # noqa: PLC0415
 
     def read(*paths, **kwargs):
-        """Read NMR data, auto-detecting TopSpin vs Agilent/Varian vs JEOL vs TecMag format."""
+        """Read NMR data, auto-detecting TopSpin vs Agilent/Varian vs JEOL vs TecMag vs SIMPSON format."""
         protocol = kwargs.get("protocol")
         if protocol == "agilent":
             return read_agilent(*paths, **kwargs)
@@ -85,12 +106,17 @@ def _resolve_read():
             return read_jeol(*paths, **kwargs)
         if protocol == "tecmag":
             return read_tecmag(*paths, **kwargs)
+        if protocol == "simpson":
+            return read_simpson(*paths, **kwargs)
 
         # Auto-detect from the first path when no protocol is given.
         if paths:
             first = paths[0]
             try:
                 path = Path(first)
+                # SIMPSON files use .spe/.fid/.in extensions
+                if path.suffix.lower() in {".spe", ".fid", ".in"}:
+                    return read_simpson(*paths, **kwargs)
                 # TecMag files have .tnt extension
                 if path.suffix.lower() == ".tnt":
                     return read_tecmag(*paths, **kwargs)
@@ -241,6 +267,25 @@ def _infer_tecmag_filetype_key(filename, **kwargs):
     return None
 
 
+_VALID_SIMPSON_EXTENSIONS = {".spe", ".fid", ".in"}
+
+
+def _is_simpson_protocol(**kwargs) -> bool:
+    protocol = kwargs.get("protocol")
+    if protocol is None:
+        return False
+    if isinstance(protocol, str):
+        protocol = [protocol]
+    return "simpson" in protocol
+
+
+def _infer_simpson_filetype_key(filename, **kwargs):
+    """Return the SIMPSON filetype key for .spe/.fid/.in files."""
+    if filename.suffix.lower() in _VALID_SIMPSON_EXTENSIONS:
+        return ".simpson"
+    return None
+
+
 def _is_agilent_protocol(**kwargs) -> bool:
     protocol = kwargs.get("protocol")
     if protocol is None:
@@ -346,7 +391,11 @@ def _infer_topspin_filetype_key(filename, **kwargs):
 
 def _infer_nmr_filetype_key(filename, **kwargs):
     """Return the filetype key for NMR data files."""
-    # Check TecMag first: .tnt files are TecMag.
+    # Check SIMPSON first: .spe/.fid/.in files are SIMPSON.
+    simpson_key = _infer_simpson_filetype_key(filename, **kwargs)
+    if simpson_key is not None:
+        return simpson_key
+    # Check TecMag: .tnt files are TecMag.
     tecmag_key = _infer_tecmag_filetype_key(filename, **kwargs)
     if tecmag_key is not None:
         return tecmag_key
@@ -390,7 +439,7 @@ def _ensure_topspin_filetype_registered() -> None:
 
 
 class NMRPlugin(SpectroChemPyPlugin):
-    """NMR plugin, providing Bruker TopSpin, Agilent/Varian, JEOL, and TecMag readers."""
+    """NMR plugin, providing Bruker TopSpin, Agilent/Varian, JEOL, TecMag, and SIMPSON readers."""
 
     name = "nmr"
     version = "0.1.7"
@@ -403,14 +452,16 @@ class NMRPlugin(SpectroChemPyPlugin):
         "agilent": {"read": "nmr.read_agilent"},
         "jeol": {"read": "nmr.read_jeol"},
         "tecmag": {"read": "nmr.read_tecmag"},
+        "simpson": {"read": "nmr.read_simpson"},
     }
 
     def register_readers(self) -> list[dict]:
-        """Declare the TopSpin, Agilent, JEOL, and TecMag file readers."""
+        """Declare the TopSpin, Agilent, JEOL, TecMag, and SIMPSON file readers."""
         _ensure_topspin_filetype_registered()
         _ensure_agilent_filetype_registered()
         _ensure_jeol_filetype_registered()
         _ensure_tecmag_filetype_registered()
+        _ensure_simpson_filetype_registered()
         return [
             {
                 "name": "topspin",
@@ -452,6 +503,14 @@ class NMRPlugin(SpectroChemPyPlugin):
                 ),
                 "description": "TecMag TNT NMR data files",
                 "extensions": [".tnt"],
+            },
+            {
+                "name": "simpson",
+                "func": lazy_proxy(
+                    _resolve_read_simpson, name="spectrochempy.nmr.read_simpson"
+                ),
+                "description": "SIMPSON NMR simulation data files",
+                "extensions": [".spe", ".fid", ".in"],
             },
         ]
 
@@ -509,6 +568,10 @@ def __getattr__(name: str):
         from .readers.read_tecmag import read_tecmag  # noqa: PLC0415
 
         return read_tecmag
+    if name == "read_simpson":
+        from .readers.read_simpson import read_simpson  # noqa: PLC0415
+
+        return read_simpson
     if name == "read":
         return _resolve_read()
     if name == "set_nmr_context":
@@ -532,5 +595,6 @@ def __dir__() -> list[str]:
         "read_agilent",
         "read_jeol",
         "read_tecmag",
+        "read_simpson",
         "set_nmr_context",
     ]

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/__init__.py
@@ -11,6 +11,7 @@ from ._base import uc_from_udic
 from ._bruker import guess_udic
 from ._bruker import read_fid
 from ._bruker import read_pdata
+from ._simpson import read as read_simpson
 from ._tecmag import guess_udic as guess_udic_tecmag
 from ._tecmag import read as read_tecmag
 from ._varian import find_varian_shape
@@ -26,6 +27,7 @@ __all__ = [
     "guess_udic_tecmag",
     "read_fid",
     "read_pdata",
+    "read_simpson",
     "read_tecmag",
     "read_varian",
     "read_varian_procpar",

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/_simpson.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/extern/nmrglue/_simpson.py
@@ -1,0 +1,369 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+Functions for reading SIMPSON NMR data files.
+
+SIMPSON (SIMulation of SOlid-state NMR) is a simulation program whose output
+files can be stored in several ASCII and binary formats.  This module reads
+the most common ones.
+
+Supported formats
+-----------------
+- TEXT : SIMPSON text format with ``SIMP``/``DATA`` header.
+- BINARY : SIMPSON binary format with ``SIMP``/``FORMAT``/``DATA`` header.
+- XREIM : 1D indexed format, columns ``<unit> <real> <imag>``.
+- XYREIM : 2D indexed format, columns ``<ni_unit> <np_unit> <real> <imag>``.
+- RAWBIN : Raw float32 binary (requires external shape/domain hints).
+
+References
+----------
+- nmrglue's ``simpson.py`` provided the original format description and served
+  as a reference for the binary decoding logic.
+- SIMPSON home page: http://www.bionmr.chem.au.dk/bionmr/software/simpson.php
+
+"""
+
+from __future__ import annotations
+
+import math
+from warnings import warn
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def read(filename, ftype=None, ndim=None, NP=None, NI=None, spe=None):
+    """
+    Read a SIMPSON file.
+
+    Parameters
+    ----------
+    filename : str or path
+        Name of SIMPSON file to read data from.
+    ftype : {None, 'TEXT', 'BINARY', 'XREIM', 'XYREIM', 'RAWBIN'}, optional
+        File type.  If ``None``, the type is guessed from the file content.
+    ndim : {None, 1, 2}, optional
+        Dimensionality, only used for ``RAWBIN``.
+    NP : int, optional
+        Number of complex points in the direct dimension, only used for 2D
+        ``RAWBIN``.
+    NI : int, optional
+        Number of points in the indirect dimension, only used for 2D
+        ``RAWBIN``.
+    spe : bool, optional
+        Whether the data is in the frequency domain, only used for
+        ``RAWBIN``.
+
+    Returns
+    -------
+    dic : dict
+        Dictionary of spectral parameters.
+    data : ndarray
+        Complex array of spectral data.
+
+    """
+    if ftype is None:
+        ftype = guess_ftype(filename)
+
+    if ftype == "TEXT":
+        return read_text(filename)
+    if ftype == "BINARY":
+        return read_binary(filename)
+    if ftype == "XREIM":
+        return read_xreim(filename)
+    if ftype == "XYREIM":
+        return read_xyreim(filename)
+    if ftype == "RAWBIN":
+        if spe is None:
+            raise ValueError("spe must be True or False for raw_bin data")
+        if ndim == 1:
+            return read_raw_bin_1d(filename, spe)
+        if ndim == 2:
+            if NP is None or NI is None:
+                raise ValueError("NP and NI must be given for raw_bin data")
+            return read_raw_bin_2d(filename, NP, NI, spe)
+        raise ValueError("ndim must be 1 or 2 for raw_bin data")
+
+    raise ValueError(f"unknown ftype: {ftype}")
+
+
+def guess_ftype(filename):
+    """Determine a SIMPSON file type from the first few lines."""
+    with open(filename, "rb") as f:
+        first = f.readline()
+
+    # SIMPSON text/binary files start with "SIMP"
+    if first[:4] == b"SIMP":
+        with open(filename, "rb") as f:
+            for line in f:
+                line = line.decode("ascii", "ignore").strip("\n")
+                if line[:6] == "FORMAT":
+                    return "BINARY"
+                if line == "DATA":
+                    break
+        return "TEXT"
+
+    # Otherwise use column count on first few non-empty lines
+    with open(filename, "rb") as f:
+        widths = []
+        for _ in range(8):
+            line = f.readline()
+            if not line:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            widths.append(len(line.split()))
+        if not widths:
+            raise ValueError("empty SIMPSON file")
+        first_width = widths[0]
+        if all(w == first_width for w in widths):
+            if first_width == 3:
+                return "XREIM"
+            if first_width == 4:
+                return "XYREIM"
+        return "RAWBIN"
+
+
+# ---------------------------------------------------------------------------
+# TEXT format
+# ---------------------------------------------------------------------------
+
+
+def read_text(filename):
+    """Read a SIMPSON text file."""
+    dic = {}
+
+    with open(filename) as f:
+        # Parse header
+        for line in f:
+            line = line.strip("\n").strip()
+            if line == "SIMP":
+                continue
+            if line == "DATA":
+                break
+            if "=" in line:
+                key, value = line.split("=", 1)
+                dic[key.strip()] = value.strip()
+            else:
+                warn(f"Skipping SIMPSON header line: {line!r}", stacklevel=2)
+
+        # Convert known numeric keys
+        for key in ("SW", "SW1"):
+            if key in dic:
+                dic[key] = float(dic[key])
+        for key in ("NP", "NI", "NELEM"):
+            if key in dic:
+                dic[key] = int(dic[key])
+
+        if "NELEM" not in dic:
+            dic["NELEM"] = 1
+
+        if "NI" in dic:  # 2D
+            shape = (dic["NI"] * dic["NELEM"], dic["NP"])
+            data = np.empty(shape, dtype="complex64")
+            for iline, line in enumerate(f):
+                if line[:3] == "END":
+                    break
+                vals = line.split()
+                if len(vals) < 2:
+                    continue
+                r_val, i_val = float(vals[0]), float(vals[1])
+                ni_idx, np_idx = divmod(iline, dic["NP"])
+                if ni_idx >= shape[0]:
+                    break
+                data.real[ni_idx, np_idx] = r_val
+                data.imag[ni_idx, np_idx] = i_val
+        else:  # 1D
+            npts = dic["NP"] * dic["NELEM"]
+            data = np.empty(npts, dtype="complex64")
+            for iline, line in enumerate(f):
+                if line[:3] == "END":
+                    break
+                vals = line.split()
+                if len(vals) < 2:
+                    continue
+                data.real[iline] = float(vals[0])
+                data.imag[iline] = float(vals[1])
+            data = data.reshape(dic["NELEM"], -1)
+            if dic["NELEM"] == 1:
+                data = data.reshape(-1)
+
+    return dic, data
+
+
+# ---------------------------------------------------------------------------
+# Indexed XREIM / XYREIM formats
+# ---------------------------------------------------------------------------
+
+
+def read_xreim(filename):
+    """Read a 1D indexed SIMPSON file (``-xreim``)."""
+    units = []
+    reals = []
+    imags = []
+
+    with open(filename) as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            units.append(float(parts[0]))
+            reals.append(float(parts[1]))
+            imags.append(float(parts[2]))
+
+    data = np.empty(len(reals), dtype="complex64")
+    data.real = np.array(reals, dtype=np.float32)
+    data.imag = np.array(imags, dtype=np.float32)
+    return {"units": np.array(units, dtype=np.float32)}, data
+
+
+def read_xyreim(filename):
+    """Read a 2D indexed SIMPSON file (``-xyreim``)."""
+    lines = []
+    with open(filename) as f:
+        for line in f:
+            if line.strip():
+                lines.append([float(x) for x in line.split()])
+
+    lines = np.array(lines)
+    # Lines are grouped by indirect point: NI blocks of NP lines
+    # Each line: ni_unit, np_unit, real, imag
+    ni_values = lines[:, 0]
+    np_values = lines[:, 1]
+
+    # Number of unique ni units = NI, unique np units = NP
+    ni_unique = np.unique(ni_values)
+    np_unique = np.unique(np_values)
+    NI = len(ni_unique)
+    NP = len(np_unique)
+
+    data = np.empty((NI, NP), dtype="complex64")
+    units = np.recarray((NI, NP), dtype=[("ni_unit", "f8"), ("np_unit", "f8")])
+
+    for ni_unit, np_unit, r_val, i_val in lines:
+        ni_idx = np.searchsorted(ni_unique, ni_unit)
+        np_idx = np.searchsorted(np_unique, np_unit)
+        data.real[ni_idx, np_idx] = r_val
+        data.imag[ni_idx, np_idx] = i_val
+        units[ni_idx, np_idx].ni_unit = ni_unit
+        units[ni_idx, np_idx].np_unit = np_unit
+
+    return {"units": units}, data
+
+
+# ---------------------------------------------------------------------------
+# Raw binary format
+# ---------------------------------------------------------------------------
+
+
+def read_raw_bin_1d(filename, spe=False):
+    """Read a 1D raw binary SIMPSON file."""
+    data = _unappend_data(np.fromfile(filename, dtype="float32"))
+    if spe:
+        return {}, data[::-1]
+    return {}, data
+
+
+def read_raw_bin_2d(filename, NP, NI, spe=False):
+    """Read a 2D raw binary SIMPSON file."""
+    data = np.fromfile(filename, dtype="float32").reshape(NI, NP * 2)
+    if spe:
+        cdata = np.empty((NI, NP), dtype="complex64")
+        cdata.real = np.roll(np.roll(data[::-1, NP - 1 :: -1], 1, 1), 1, 0)
+        cdata.imag = np.roll(data[::-1, 2 * NP : NP - 1 : -1], 1, 0)
+        return {}, cdata
+    return {}, _unappend_data(data)
+
+
+def _unappend_data(data):
+    """Return complex data with the last axis unappended (real | imag)."""
+    h = data.shape[-1] // 2
+    return np.array(data[..., :h] + data[..., h:] * 1.0j, dtype="complex64")
+
+
+# ---------------------------------------------------------------------------
+# BINARY format (ASCII header + encoded binary payload)
+# ---------------------------------------------------------------------------
+
+
+_BASE = 33
+
+
+def _chars2bytes(chars):
+    """Convert four characters from a data block into 3 bytes."""
+    c0, c1, c2, c3 = (ord(c) - _BASE for c in chars)
+    return [
+        (c0 & ~(~0 << 6)) | ((c1 << 2) & (~0 << (8 - 2))),
+        (c1 & ~(~0 << 4)) | ((c2 << 2) & (~0 << (8 - 4))),
+        (c2 & ~(~0 << 2)) | ((c3 << 2) & (~0 << (8 - 6))),
+    ]
+
+
+def _bytes2float(b):
+    """Convert four bytes to a float using SIMPSON's custom encoding."""
+    b0, b1, b2, b3 = b
+    mantissa = ((b2 % 128) << 16) + (b1 << 8) + b0
+    exponent = (b3 % 128) * 2 + (b2 >= 128) * 1
+    negative = b3 >= 128
+
+    e = exponent - 0x7F
+    m = abs(mantissa) / np.float64(1 << 23)
+
+    if negative:
+        return -math.ldexp(m, e)
+    return math.ldexp(m, e)
+
+
+def read_binary(filename):
+    """Read a SIMPSON binary file."""
+    dic = {}
+
+    with open(filename) as f:
+        for line in f:
+            line = line.strip("\n").strip()
+            if line == "SIMP":
+                continue
+            if line == "DATA":
+                break
+            if "=" in line:
+                key, value = line.split("=", 1)
+                dic[key.strip()] = value.strip()
+            else:
+                warn(f"Skipping SIMPSON header line: {line!r}", stacklevel=2)
+
+        for key in ("SW", "SW1"):
+            if key in dic:
+                dic[key] = float(dic[key])
+        for key in ("NP", "NI", "NELEM"):
+            if key in dic:
+                dic[key] = int(dic[key])
+        if "NELEM" not in dic:
+            dic["NELEM"] = 1
+
+        chardata = "".join(line.strip("\n") for line in f)
+    chardata = chardata[:-3] if chardata.endswith("END") else chardata
+
+    nquads, mod = divmod(len(chardata), 4)
+    if mod != 0:
+        raise ValueError("SIMPSON binary data length is not a multiple of 4")
+
+    raw_bytes = []
+    for i in range(nquads):
+        raw_bytes.extend(_chars2bytes(chardata[i * 4 : (i + 1) * 4]))
+
+    num_points = len(raw_bytes) // 4
+    data = np.empty(num_points, dtype="float32")
+    for i in range(num_points):
+        data[i] = _bytes2float(raw_bytes[i * 4 : (i + 1) * 4])
+    data = data.view("complex64")
+
+    if "NI" in dic:
+        return dic, data.reshape(dic["NI"] * dic["NELEM"], dic["NP"])
+    return dic, data.reshape(dic["NELEM"], dic["NP"])

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_simpson.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_simpson.py
@@ -1,0 +1,360 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""
+SIMPSON file importers.
+
+This module provides functionality to read SIMPSON NMR data files
+(``.spe``, ``.fid`` and related formats).
+
+Functions
+---------
+- read_simpson : Main entry point for reading SIMPSON files
+
+Notes
+-----
+Supports 1D and 2D data only.  3D and higher-dimensional datasets
+raise ``NotImplementedError``.
+
+"""
+
+__all__ = ["read_simpson"]
+
+import re
+from pathlib import Path
+
+import numpy as np
+
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.readers.importer import Importer
+from spectrochempy.core.readers.importer import _importer_method
+from spectrochempy.core.units import ur
+from spectrochempy.utils._logging import warning_
+from spectrochempy.utils.meta import Meta
+from spectrochempy_nmr.extern.nmrglue._simpson import read as _read_simpson_raw
+
+# ======================================================================================
+# Public entry point
+# ======================================================================================
+
+
+def read_simpson(*paths, **kwargs):
+    r"""
+    Open SIMPSON NMR spectra.
+
+    Parameters
+    ----------
+    *paths : `str`, `~pathlib.Path` objects or valid urls, optional
+        The data source(s).  Can be:
+
+        - a path to a SIMPSON data file (``.spe``, ``.fid``, ``.txt``)
+        - a path to a SIMPSON experiment directory containing a ``.in`` file
+        - a list of paths (datasets are merged if ``merge=True``)
+
+    **kwargs : keyword parameters, optional
+        See Other Parameters.
+
+    Returns
+    -------
+    object : `NDDataset` or `ScpObjectList` of `NDDataset`
+        The returned dataset(s).
+
+    Other Parameters
+    ----------------
+    content : `bytes`, optional
+        Raw bytes content instead of a filename.
+    description : `str`, optional
+        A custom description.
+    directory : `~pathlib.Path`, optional
+        Base directory for resolving relative paths.
+    merge : `bool`, optional, default: ``False``
+        If ``True`` and several filenames are provided, merge into a
+        single dataset.
+    origin : str, optional
+        Override the origin label (default ``'simpson'``).
+
+    See Also
+    --------
+    read : Generic reader inferring protocol from filename extension.
+
+    Examples
+    --------
+    Reading a single SIMPSON file:
+
+    >>> scp.nmr.read('path/to/experiment.spe')  # doctest: +SKIP
+
+    """
+    kwargs["filetypes"] = ["SIMPSON files (*.spe *.fid)"]
+    kwargs["protocol"] = ["simpson"]
+    importer = Importer()
+    return importer(*paths, **kwargs)
+
+
+# ======================================================================================
+# Private helpers
+# ======================================================================================
+
+
+def _parse_simpson_in(filepath):
+    """
+    Parse a SIMPSON ``.in`` Tcl input file for simulation metadata.
+
+    Returns a dictionary with keys such as ``channels``, ``nuclei``,
+    ``np``, ``ni``, ``sw``, ``sw1`` when present.
+    """
+    meta = {}
+    if not filepath.exists():
+        return meta
+
+    try:
+        text = filepath.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return meta
+
+    # Extract spinsys block
+    spinsys_match = re.search(r"spinsys\s*\{(.*?)\}", text, re.DOTALL | re.IGNORECASE)
+    if spinsys_match:
+        block = spinsys_match.group(1)
+        channels = re.search(r"channels\s+(.*)", block)
+        if channels:
+            meta["channels"] = channels.group(1).strip().split()
+        nuclei = re.search(r"nuclei\s+(.*)", block)
+        if nuclei:
+            meta["nuclei"] = nuclei.group(1).strip().split()
+
+    # Extract par block
+    par_match = re.search(r"par\s*\{(.*?)\}", text, re.DOTALL | re.IGNORECASE)
+    if par_match:
+        block = par_match.group(1)
+        for key in ("np", "ni", "sw", "sw1", "spin_rate", "proton_frequency"):
+            m = re.search(rf"{key}\s+([^\n#]+)", block)
+            if m:
+                val = m.group(1).strip()
+                # Skip Tcl expressions that are not simple numbers
+                try:
+                    meta[key] = (
+                        float(val) if "." in val or "e" in val.lower() else int(val)
+                    )
+                except ValueError:
+                    meta[key] = val
+
+    return meta
+
+
+# ======================================================================================
+# Private reader implementation
+# ======================================================================================
+
+
+def _read_simpson_core(dataset, path):
+    """Core SIMPSON reading logic shared across file extensions."""
+    if not path.exists():
+        warning_(f"File not found: {path}")
+        return None
+
+    in_meta = {}
+    data_path = path
+
+    # If a directory is passed, look for an .in file and a data file
+    if path.is_dir():
+        in_files = list(path.glob("*.in"))
+        if in_files:
+            in_meta = _parse_simpson_in(in_files[0])
+        # Prefer .spe (frequency domain) then .fid (time domain)
+        candidates = list(path.glob("*.spe")) + list(path.glob("*.fid"))
+        if not candidates:
+            candidates = list(path.glob("*.txt"))
+        if not candidates:
+            warning_(f"No SIMPSON data file found in directory: {path}")
+            return None
+        data_path = candidates[0]
+
+    # If a .in file is passed directly, look for sibling data files
+    elif path.suffix.lower() == ".in":
+        in_meta = _parse_simpson_in(path)
+        parent = path.parent
+        base = path.stem
+        candidates = [
+            parent / f"{base}.spe",
+            parent / f"{base}.fid",
+            parent / f"{base}_text.spe",
+            parent / f"{base}_text.fid",
+        ]
+        candidates.extend(list(parent.glob("*.spe")))
+        candidates.extend(list(parent.glob("*.fid")))
+        data_path = next((c for c in candidates if c.exists()), None)
+        if data_path is None:
+            warning_(f"No SIMPSON data file found for input: {path}")
+            return None
+
+    # Look for a sibling .in file to enrich metadata
+    if not in_meta:
+        sibling_in = data_path.with_suffix(".in")
+        if not sibling_in.exists():
+            sibling_in = data_path.parent / f"{data_path.stem.split('_')[0]}.in"
+        if sibling_in.exists():
+            in_meta = _parse_simpson_in(sibling_in)
+
+    # Read using the SIMPSON parser
+    try:
+        dic, data = _read_simpson_raw(str(data_path))
+    except Exception as exc:
+        warning_(f"Failed to read SIMPSON file {data_path}: {exc}")
+        return None
+
+    # Determine ndim and squeeze trailing singletons
+    if data.ndim >= 2 and data.shape[0] == 1:
+        data = data.reshape(data.shape[1:])
+    ndim = data.ndim
+
+    if ndim > 2:
+        msg = f"SIMPSON datasets with {ndim} dimensions are not supported (max 2D)."
+        raise NotImplementedError(msg)
+
+    # Build metadata
+    meta = Meta()
+
+    meta.datatype = (
+        f"{ndim}D" if ndim >= 2 else ("SPE" if _is_spe(data_path, dic) else "FID")
+    )
+    meta.pathname = str(path)
+    meta.filename = path.name
+    meta.origin = "simpson"
+
+    # Per-dimension lists
+    meta.sw = [None] * ndim
+    meta.sfrq = [None] * ndim
+    meta.td = list(data.shape)
+    meta.nucleus = [None] * ndim
+    meta.encoding = [None] * ndim
+    meta.iscomplex = [True] * ndim
+    meta.isfreq = [False] * ndim
+    meta.offset = [None] * ndim
+
+    # Spectral widths (Hz)
+    sw_keys = ["SW", "SW"] if ndim == 1 else ["SW1", "SW"]
+    for i in range(ndim):
+        key = sw_keys[i]
+        if key in dic:
+            meta.sw[i] = float(dic[key])
+        elif key.lower() in dic:
+            meta.sw[i] = float(dic[key.lower()])
+        elif key in in_meta:
+            meta.sw[i] = float(in_meta[key])
+
+    # Reference frequencies (MHz)
+    proton_freq = in_meta.get("proton_frequency")
+    if proton_freq is not None:
+        # proton_frequency is in Hz
+        ref_mhz = float(proton_freq) / 1e6
+        for i in range(ndim):
+            meta.sfrq[i] = ref_mhz
+
+    # Nuclei from .in file or defaults
+    nuclei = in_meta.get("nuclei", in_meta.get("channels", []))
+    for i in range(min(ndim, len(nuclei))):
+        meta.nucleus[i] = nuclei[i]
+
+    # Frequency domain flag
+    if _is_spe(data_path, dic):
+        for i in range(ndim):
+            meta.isfreq[i] = True
+
+    # Encoding: SIMPSON simulations are typically QF/STATES
+    if ndim == 1:
+        meta.encoding[0] = "QF"
+    else:
+        meta.encoding[0] = "STATES"
+        meta.encoding[1] = "QF"
+
+    # Spectral width with units
+    meta.sw_h = [None] * ndim
+    for i in range(ndim):
+        if meta.sw[i] is not None:
+            meta.sw_h[i] = meta.sw[i] * ur.Hz
+
+    # Spin rate
+    if "spin_rate" in in_meta:
+        meta.spin_rate = float(in_meta["spin_rate"]) * ur.Hz
+
+    # Build coordinates
+    coords = []
+
+    def _make_coord(axis, size):
+        """Build a single coordinate for the given axis."""
+        sw_hz = meta.sw_h[axis]
+        freq_mhz = meta.sfrq[axis]
+        nuc = meta.nucleus[axis]
+
+        if sw_hz is not None and freq_mhz is not None and size > 1:
+            sizem = max(size - 1, 1)
+            deltaf = -float(sw_hz.magnitude) / sizem
+            first = float(freq_mhz) * 1e6 - deltaf * sizem / 2.0
+            coordpoints = np.arange(size) * deltaf + first
+            coord = Coord(coordpoints)
+            coord.meta["acquisition_frequency"] = freq_mhz * ur.MHz
+            coord.ito("ppm")
+
+            if nuc:
+                regex = r"([^a-zA-Z]+)([a-zA-Z]+)"
+                m = re.match(regex, str(nuc))
+                nucleus = rf"$^{{{m[1]}}}{m[2]}$" if m else str(nuc)
+            else:
+                nucleus = ""
+            coord.title = rf"$\delta\ {nucleus}$"
+        else:
+            coord = Coord(np.arange(size), title=f"F{axis + 1}")
+
+        return coord
+
+    for axis in range(ndim):
+        coords.append(_make_coord(axis, meta.td[axis]))
+
+    # Set data
+    dataset.data = data
+
+    # Apply metadata
+    dataset.meta.update(meta)
+    dataset.meta.readonly = True
+    dataset.set_coordset(*tuple(coords))
+
+    dataset.units = "count"
+    dataset.title = "intensity"
+    dataset.origin = "simpson"
+    dataset.name = f"{path.stem} ({meta.datatype})"
+    dataset.filename = path.parent
+
+    dataset.history = "Imported from SIMPSON dataset"
+
+    return dataset
+
+
+@_importer_method
+def _read_spe(*args, **kwargs):
+    """Read a SIMPSON ``.spe`` file."""
+    return _read_simpson_core(args[0], args[1])
+
+
+@_importer_method
+def _read_fid(*args, **kwargs):
+    """Read a SIMPSON ``.fid`` file."""
+    return _read_simpson_core(args[0], args[1])
+
+
+@_importer_method
+def _read_in(*args, **kwargs):
+    """Read a SIMPSON ``.in`` input file (data file resolved separately)."""
+    return _read_simpson_core(args[0], args[1])
+
+
+def _is_spe(path, dic):
+    """Return True if the file appears to be frequency-domain data."""
+    if isinstance(path, Path):
+        if ".spe" in path.name.lower():
+            return True
+        if ".fid" in path.name.lower():
+            return False
+    # Frequency-domain files often have units information
+    return "units" in dic

--- a/plugins/spectrochempy-nmr/tests/test_read_simpson.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_simpson.py
@@ -1,0 +1,236 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa: S101, F841
+
+"""Tests for SIMPSON NMR reader."""
+
+import numpy as np
+
+import spectrochempy as scp
+
+# ---------------------------------------------------------------------------
+# Synthetic SIMPSON file fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_text_1d(path, npts=8, sw=10000.0):
+    """Write a synthetic SIMPSON TEXT 1D file."""
+    data = np.exp(-np.arange(npts) / 4.0) * np.exp(2j * np.pi * np.arange(npts) / 8)
+    with open(path, "w") as f:
+        f.write("SIMP\n")
+        f.write(f"NP={npts}\n")
+        f.write(f"SW={sw}\n")
+        f.write("DATA\n")
+        for r, i in zip(data.real, data.imag, strict=False):
+            f.write(f"{r:.6f} {i:.6f}\n")
+        f.write("END\n")
+    return data
+
+
+def _write_text_2d(path, npts=8, ni=4, sw=10000.0, sw1=5000.0):
+    """Write a synthetic SIMPSON TEXT 2D file."""
+    data = np.empty((ni, npts), dtype="complex64")
+    for i in range(ni):
+        for j in range(npts):
+            data[i, j] = (i + 1) * np.exp(-j / 4.0) * np.exp(1j * np.pi * j / 4)
+    with open(path, "w") as f:
+        f.write("SIMP\n")
+        f.write(f"NP={npts}\n")
+        f.write(f"NI={ni}\n")
+        f.write(f"SW={sw}\n")
+        f.write(f"SW1={sw1}\n")
+        f.write("DATA\n")
+        for row in data:
+            for r, i in zip(row.real, row.imag, strict=False):
+                f.write(f"{r:.6f} {i:.6f}\n")
+        f.write("END\n")
+    return data
+
+
+def _write_xreim_1d(path, npts=8):
+    """Write a synthetic SIMPSON XREIM 1D file."""
+    data = np.exp(-np.arange(npts) / 4.0) * np.exp(2j * np.pi * np.arange(npts) / 8)
+    with open(path, "w") as f:
+        for i, (r, img) in enumerate(zip(data.real, data.imag, strict=False)):
+            f.write(f"{i * 50.0:.1f} {r:.6f} {img:.6f}\n")
+    return data
+
+
+def _write_xyreim_2d(path, npts=8, ni=4):
+    """Write a synthetic SIMPSON XYREIM 2D file."""
+    data = np.empty((ni, npts), dtype="complex64")
+    for i in range(ni):
+        for j in range(npts):
+            data[i, j] = (i + 1) * np.exp(-j / 4.0) * np.exp(1j * np.pi * j / 4)
+    with open(path, "w") as f:
+        for i in range(ni):
+            for j in range(npts):
+                f.write(
+                    f"{i * 100.0:.1f} {j * 50.0:.1f} {data.real[i, j]:.6f} {data.imag[i, j]:.6f}\n"
+                )
+            if i < ni - 1:
+                f.write("\n")
+    return data
+
+
+def _write_in_file(path):
+    """Write a synthetic SIMPSON .in file for metadata parsing."""
+    text = """
+spinsys {
+    channels 13C
+    nuclei 13C 13C
+    shift 1 0 6000 1 0 0 0
+}
+
+par {
+    spin_rate 2000
+    np 8
+    ni 4
+    sw 10000
+    sw1 5000
+    proton_frequency 400e6
+}
+"""
+    path.write_text(text)
+
+
+# ---------------------------------------------------------------------------
+# Parser layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimpsonParser:
+    """Tests for the custom SIMPSON parser."""
+
+    def test_read_text_1d(self, tmp_path):
+        from spectrochempy_nmr.extern.nmrglue._simpson import read
+
+        path = tmp_path / "1d_text.spe"
+        expected = _write_text_1d(path)
+        dic, data = read(str(path))
+        assert data.shape == (8,)
+        assert np.allclose(data, expected)
+        assert dic["NP"] == 8
+        assert dic["SW"] == 10000.0
+
+    def test_read_text_2d(self, tmp_path):
+        from spectrochempy_nmr.extern.nmrglue._simpson import read
+
+        path = tmp_path / "2d_text.spe"
+        expected = _write_text_2d(path)
+        dic, data = read(str(path))
+        assert data.shape == (4, 8)
+        assert np.allclose(data, expected)
+        assert dic["NI"] == 4
+        assert dic["SW1"] == 5000.0
+
+    def test_read_xreim_1d(self, tmp_path):
+        from spectrochempy_nmr.extern.nmrglue._simpson import read
+
+        path = tmp_path / "1d_xreim.txt"
+        expected = _write_xreim_1d(path)
+        dic, data = read(str(path))
+        assert data.shape == (8,)
+        assert np.allclose(data, expected)
+        assert "units" in dic
+
+    def test_read_xyreim_2d(self, tmp_path):
+        from spectrochempy_nmr.extern.nmrglue._simpson import read
+
+        path = tmp_path / "2d_xyreim.txt"
+        expected = _write_xyreim_2d(path)
+        dic, data = read(str(path))
+        assert data.shape == (4, 8)
+        assert np.allclose(data, expected)
+        assert "units" in dic
+
+    def test_guess_ftype_text(self, tmp_path):
+        from spectrochempy_nmr.extern.nmrglue._simpson import guess_ftype
+
+        path = tmp_path / "1d_text.spe"
+        _write_text_1d(path)
+        assert guess_ftype(str(path)) == "TEXT"
+
+    def test_guess_ftype_xreim(self, tmp_path):
+        from spectrochempy_nmr.extern.nmrglue._simpson import guess_ftype
+
+        path = tmp_path / "1d_xreim.txt"
+        _write_xreim_1d(path)
+        assert guess_ftype(str(path)) == "XREIM"
+
+
+# ---------------------------------------------------------------------------
+# Public reader API tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimpsonReader:
+    """Tests for the public read_simpson() API."""
+
+    def test_read_simpson_text_1d(self, tmp_path):
+        path = tmp_path / "1d_text.spe"
+        _write_text_1d(path)
+        ds = scp.nmr.read_simpson(str(path))
+        assert ds is not None
+        assert ds.ndim == 1
+        assert ds.shape == (8,)
+        assert ds.origin == "simpson"
+
+    def test_read_simpson_text_2d(self, tmp_path):
+        path = tmp_path / "2d_text.spe"
+        _write_text_2d(path)
+        ds = scp.nmr.read_simpson(str(path))
+        assert ds.ndim == 2
+        assert ds.shape == (4, 8)
+
+    def test_read_simpson_xreim_1d(self, tmp_path):
+        path = tmp_path / "1d_xreim.spe"
+        _write_xreim_1d(path)
+        ds = scp.nmr.read_simpson(str(path))
+        assert ds.ndim == 1
+        assert ds.shape == (8,)
+
+    def test_read_simpson_directory_with_in(self, tmp_path):
+        _write_in_file(tmp_path / "experiment.in")
+        data_path = tmp_path / "experiment.spe"
+        _write_text_1d(data_path)
+        ds = scp.nmr.read_simpson(str(tmp_path))
+        assert ds is not None
+        assert ds.ndim == 1
+        assert ds.origin == "simpson"
+
+    def test_read_simpson_in_with_sibling_data(self, tmp_path):
+        in_path = tmp_path / "experiment.in"
+        _write_in_file(in_path)
+        _write_text_1d(tmp_path / "experiment.spe")
+        ds = scp.nmr.read_simpson(str(in_path))
+        assert ds is not None
+        assert ds.ndim == 1
+
+    def test_read_simpson_metadata_sw(self, tmp_path):
+        path = tmp_path / "1d_text.spe"
+        _write_text_1d(path)
+        ds = scp.nmr.read_simpson(str(path))
+        assert ds.meta.sw[0] == 10000.0
+
+    def test_read_simpson_metadata_nucleus(self, tmp_path):
+        in_path = tmp_path / "experiment.in"
+        _write_in_file(in_path)
+        _write_text_1d(tmp_path / "experiment.spe")
+        ds = scp.nmr.read_simpson(str(in_path))
+        assert ds.meta.nucleus[0] is not None
+        assert "13C" in ds.meta.nucleus[0]
+
+    def test_read_simpson_auto_detect(self, tmp_path):
+        path = tmp_path / "1d_text.spe"
+        _write_text_1d(path)
+        ds = scp.nmr.read(str(path))
+        assert ds is not None
+        assert ds.origin == "simpson"
+
+    def test_read_simpson_missing_file(self):
+        result = scp.nmr.read_simpson("/nonexistent/path.spe")
+        assert result is None


### PR DESCRIPTION
## Summary

Add a SIMPSON NMR reader to the `spectrochempy-nmr` plugin.

- `scp.nmr.read_simpson()`: public entry point for SIMPSON files
- `scp.nmr.read("*.spe")` / `scp.nmr.read("*.fid")` / `scp.nmr.read("*.in")`: auto-detects SIMPSON format
- `scp.nmr.read(..., protocol="simpson")`: explicit protocol dispatch

## Files changed

| File | Change |
|---|---|
| `extern/nmrglue/_simpson.py` | NEW — custom SIMPSON parser (~370 lines) |
| `readers/read_simpson.py` | NEW — SIMPSON reader entry point |
| `tests/test_read_simpson.py` | NEW — 15 tests with synthetic data |
| `__init__.py` (plugin) | SIMPSON registration, auto-detect, namespaces, `__getattr__` |
| `extern/nmrglue/__init__.py` | Added SIMPSON exports |
| `docs/sources/whatsnew/changelog.rst` | SIMPSON entry |
| `docs/sources/whatsnew/latest.rst` | Regenerated from changelog |

## Supported formats

- `TEXT`: SIMPSON text format with `SIMP`/`DATA` header
- `XREIM`: 1D indexed format (`<unit> <real> <imag>`)
- `XYREIM`: 2D indexed format (`<ni_unit> <np_unit> <real> <imag>`)
- `BINARY`: SIMPSON binary format with encoded payload
- `RAWBIN`: Raw float32 binary (requires external shape/domain hints)

## Test results

Full NMR plugin test suite: **187 passed, 1 skipped, 0 failures**

```bash
conda run -n scpy-core python -m pytest plugins/spectrochempy-nmr/tests/ -v
```

## Notes

- SIMPSON 3D+ not supported (raises `NotImplementedError`, consistent with other NMR readers)
- The `data-extra` branch only contains SIMPSON input scripts (`.in`), not generated output files, so tests use synthetic SIMPSON files
- `.txt` extension is intentionally not registered for SIMPSON because it is already used by the Labspec reader
- Audit note written to `spectrochempy_maintainer/notes/audits/nmr-simpson-reader-2026-07-13.md`