### PR TITLE
FIX: dispatch NMR metadata extraction by vendor origin

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -94,6 +94,10 @@ Bug Fixes
   Nucleus-string parsing and missing ``use_list`` files are handled gracefully.
   Dead comments and uncertain TODOs removed. (#1420, #1424)
 
+- ``scp.nmr.Experiment`` now correctly classifies non-Bruker datasets
+  (JEOL, TecMag, SIMPSON).  Previously, metadata extraction was hardcoded
+  to Bruker field names, causing silent misclassification of other formats.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -86,6 +86,10 @@ Bug Fixes
   Nucleus-string parsing and missing ``use_list`` files are handled gracefully.
   Dead comments and uncertain TODOs removed. (#1420, #1424)
 
+- ``scp.nmr.Experiment`` now correctly classifies non-Bruker datasets
+  (JEOL, TecMag, SIMPSON).  Previously, metadata extraction was hardcoded
+  to Bruker field names, causing silent misclassification of other formats.
+
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -168,15 +168,15 @@ class Experiment:
         Build a classification dict from canonical NMR metadata.
 
         All vendor-specific extraction happens in
-        :func:`spectrochempy_nmr.nmr_metadata.extract_topspin_metadata`.
+        :func:`spectrochempy_nmr.nmr_metadata.extract_nmr_metadata`.
         This method consumes only the resulting
         :class:`~spectrochempy_nmr.nmr_metadata.NMRMetadata` fields.
         """
         from .nmr_metadata import NMRMetadata  # noqa: PLC0415
-        from .nmr_metadata import extract_topspin_metadata  # noqa: PLC0415
+        from .nmr_metadata import extract_nmr_metadata  # noqa: PLC0415
 
         meta = self._meta()
-        nmr_meta: NMRMetadata = extract_topspin_metadata(meta)
+        nmr_meta: NMRMetadata = extract_nmr_metadata(meta)
 
         # Fallback: when metadata is empty, infer basic shape from the
         # dataset itself.  This handles non-NMR or metadata-less datasets.

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
@@ -344,3 +344,346 @@ def extract_agilent_metadata(meta) -> NMRMetadata:
         spectral_width_hz=sw_hz,
         spectrometer_freq_mhz=sfo_mhz,
     )
+
+
+# ---------------------------------------------------------------------------
+# JEOL extraction
+# ---------------------------------------------------------------------------
+
+_JEOL_ENCODING_MAP = {
+    "QF": "QF",
+    "QSIM": "QSIM",
+    "QSEQ": "QSEQ",
+    "TPPI": "TPPI",
+    "STATES": "STATES",
+    "STATES-TPPI": "STATES-TPPI",
+    "ECHO-ANTIECHO": "ECHO-ANTIECHO",
+}
+
+
+def extract_jeol_metadata(meta) -> NMRMetadata:
+    """
+    Extract :class:`NMRMetadata` from a JEOL metadata object.
+
+    Parameters
+    ----------
+    meta : Meta or None
+        The ``dataset.meta`` object produced by the JEOL reader.
+
+    Returns
+    -------
+    NMRMetadata
+        Canonical NMR metadata.
+    """
+    if meta is None or len(meta) == 0:
+        return NMRMetadata(ndim=0, domains=())
+
+    # --- dimensionality ---
+    td = getattr(meta, "td", None)
+    ndim = len(td) if td is not None else 0
+
+    # --- domains ---
+    isfreq = getattr(meta, "isfreq", None)
+    if isfreq is not None:
+        domains = tuple("frequency" if f else "time" for f in isfreq)
+    else:
+        domains = tuple("unknown" for _ in range(ndim))
+
+    # --- encoding ---
+    raw_enc = getattr(meta, "encoding", None)
+    encoding = None
+    if raw_enc is not None:
+        encoding = tuple(_JEOL_ENCODING_MAP.get(str(e), str(e)) for e in raw_enc)
+
+    # --- nuclei ---
+    raw_nuc = getattr(meta, "nucleus", None)
+    nuclei = None
+    if raw_nuc is not None:
+        nuclei = tuple(n if n else None for n in raw_nuc)
+
+    # --- pulse program ---
+    pulse_program = getattr(meta, "experiment", None)
+
+    # --- datatype ---
+    datatype = getattr(meta, "datatype", None)
+
+    # --- iscomplex ---
+    raw_ic = getattr(meta, "iscomplex", None)
+    iscomplex = tuple(raw_ic) if raw_ic else None
+
+    # --- spectral width (Hz) ---
+    raw_sw = getattr(meta, "sw_h", None)
+    sw_hz = None
+    if raw_sw is not None:
+        sw_hz = tuple(
+            float(v.magnitude) if hasattr(v, "magnitude") else (float(v) if v else None)
+            for v in raw_sw
+        )
+
+    # --- spectrometer frequency (MHz) ---
+    raw_sfo = getattr(meta, "sfrq", None)
+    sfo_mhz = None
+    if raw_sfo is not None:
+        sfo_mhz = tuple(
+            float(v.magnitude) if hasattr(v, "magnitude") else (float(v) if v else None)
+            for v in raw_sfo
+        )
+
+    # --- source kind ---
+    source_kind = infer_source_kind(ndim, domains, datatype)
+
+    return NMRMetadata(
+        ndim=ndim,
+        domains=domains,
+        encoding=encoding,
+        nuclei=nuclei,
+        pulse_program=pulse_program,
+        source_kind=source_kind,
+        datatype=datatype,
+        iscomplex=iscomplex,
+        spectral_width_hz=sw_hz,
+        spectrometer_freq_mhz=sfo_mhz,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TecMag extraction
+# ---------------------------------------------------------------------------
+
+_TECMAG_ENCODING_MAP = {
+    "QF": "QF",
+    "QSIM": "QSIM",
+    "QSEQ": "QSEQ",
+    "TPPI": "TPPI",
+    "STATES": "STATES",
+    "STATES-TPPI": "STATES-TPPI",
+    "ECHO-ANTIECHO": "ECHO-ANTIECHO",
+}
+
+
+def extract_tecmag_metadata(meta) -> NMRMetadata:
+    """
+    Extract :class:`NMRMetadata` from a TecMag metadata object.
+
+    Parameters
+    ----------
+    meta : Meta or None
+        The ``dataset.meta`` object produced by the TecMag reader.
+
+    Returns
+    -------
+    NMRMetadata
+        Canonical NMR metadata.
+    """
+    if meta is None or len(meta) == 0:
+        return NMRMetadata(ndim=0, domains=())
+
+    # --- dimensionality ---
+    td = getattr(meta, "td", None)
+    ndim = len(td) if td is not None else 0
+
+    # --- domains ---
+    isfreq = getattr(meta, "isfreq", None)
+    if isfreq is not None:
+        domains = tuple("frequency" if f else "time" for f in isfreq)
+    else:
+        domains = tuple("unknown" for _ in range(ndim))
+
+    # --- encoding ---
+    raw_enc = getattr(meta, "encoding", None)
+    encoding = None
+    if raw_enc is not None:
+        encoding = tuple(_TECMAG_ENCODING_MAP.get(str(e), str(e)) for e in raw_enc)
+
+    # --- nuclei ---
+    raw_nuc = getattr(meta, "nucleus", None)
+    nuclei = None
+    if raw_nuc is not None:
+        nuclei = tuple(n if n else None for n in raw_nuc)
+
+    # --- pulse program ---
+    pulse_program = getattr(meta, "experiment", None)
+
+    # --- datatype ---
+    datatype = getattr(meta, "datatype", None)
+
+    # --- iscomplex ---
+    raw_ic = getattr(meta, "iscomplex", None)
+    iscomplex = tuple(raw_ic) if raw_ic else None
+
+    # --- spectral width (Hz) ---
+    raw_sw = getattr(meta, "sw_h", None)
+    sw_hz = None
+    if raw_sw is not None:
+        sw_hz = tuple(
+            float(v.magnitude) if hasattr(v, "magnitude") else (float(v) if v else None)
+            for v in raw_sw
+        )
+
+    # --- spectrometer frequency (MHz) ---
+    raw_sfo = getattr(meta, "sfrq", None)
+    sfo_mhz = None
+    if raw_sfo is not None:
+        sfo_mhz = tuple(
+            float(v.magnitude) if hasattr(v, "magnitude") else (float(v) if v else None)
+            for v in raw_sfo
+        )
+
+    # --- source kind ---
+    source_kind = infer_source_kind(ndim, domains, datatype)
+
+    return NMRMetadata(
+        ndim=ndim,
+        domains=domains,
+        encoding=encoding,
+        nuclei=nuclei,
+        pulse_program=pulse_program,
+        source_kind=source_kind,
+        datatype=datatype,
+        iscomplex=iscomplex,
+        spectral_width_hz=sw_hz,
+        spectrometer_freq_mhz=sfo_mhz,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SIMPSON extraction
+# ---------------------------------------------------------------------------
+
+_SIMPSON_ENCODING_MAP = {
+    "QF": "QF",
+    "QSIM": "QSIM",
+    "QSEQ": "QSEQ",
+    "TPPI": "TPPI",
+    "STATES": "STATES",
+    "STATES-TPPI": "STATES-TPPI",
+    "ECHO-ANTIECHO": "ECHO-ANTIECHO",
+}
+
+
+def extract_simpson_metadata(meta) -> NMRMetadata:
+    """
+    Extract :class:`NMRMetadata` from a SIMPSON metadata object.
+
+    Parameters
+    ----------
+    meta : Meta or None
+        The ``dataset.meta`` object produced by the SIMPSON reader.
+
+    Returns
+    -------
+    NMRMetadata
+        Canonical NMR metadata.
+    """
+    if meta is None or len(meta) == 0:
+        return NMRMetadata(ndim=0, domains=())
+
+    # --- dimensionality ---
+    td = getattr(meta, "td", None)
+    ndim = len(td) if td is not None else 0
+
+    # --- domains ---
+    isfreq = getattr(meta, "isfreq", None)
+    if isfreq is not None:
+        domains = tuple("frequency" if f else "time" for f in isfreq)
+    else:
+        domains = tuple("unknown" for _ in range(ndim))
+
+    # --- encoding ---
+    raw_enc = getattr(meta, "encoding", None)
+    encoding = None
+    if raw_enc is not None:
+        encoding = tuple(_SIMPSON_ENCODING_MAP.get(str(e), str(e)) for e in raw_enc)
+
+    # --- nuclei ---
+    raw_nuc = getattr(meta, "nucleus", None)
+    nuclei = None
+    if raw_nuc is not None:
+        nuclei = tuple(n if n else None for n in raw_nuc)
+
+    # --- pulse program ---
+    # SIMPSON has no pulse program concept; leave as None
+    pulse_program = None
+
+    # --- datatype ---
+    datatype = getattr(meta, "datatype", None)
+
+    # --- iscomplex ---
+    raw_ic = getattr(meta, "iscomplex", None)
+    iscomplex = tuple(raw_ic) if raw_ic else None
+
+    # --- spectral width (Hz) ---
+    raw_sw = getattr(meta, "sw_h", None)
+    sw_hz = None
+    if raw_sw is not None:
+        sw_hz = tuple(
+            float(v.magnitude) if hasattr(v, "magnitude") else (float(v) if v else None)
+            for v in raw_sw
+        )
+
+    # --- spectrometer frequency (MHz) ---
+    raw_sfo = getattr(meta, "sfrq", None)
+    sfo_mhz = None
+    if raw_sfo is not None:
+        sfo_mhz = tuple(
+            float(v.magnitude) if hasattr(v, "magnitude") else (float(v) if v else None)
+            for v in raw_sfo
+        )
+
+    # --- source kind ---
+    source_kind = infer_source_kind(ndim, domains, datatype)
+
+    return NMRMetadata(
+        ndim=ndim,
+        domains=domains,
+        encoding=encoding,
+        nuclei=nuclei,
+        pulse_program=pulse_program,
+        source_kind=source_kind,
+        datatype=datatype,
+        iscomplex=iscomplex,
+        spectral_width_hz=sw_hz,
+        spectrometer_freq_mhz=sfo_mhz,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vendor-neutral dispatcher
+# ---------------------------------------------------------------------------
+
+_EXTRACTORS = {
+    "topspin": extract_topspin_metadata,
+    "agilent": extract_agilent_metadata,
+    "jeol": extract_jeol_metadata,
+    "tecmag": extract_tecmag_metadata,
+    "simpson": extract_simpson_metadata,
+}
+
+
+def extract_nmr_metadata(meta) -> NMRMetadata:
+    """
+    Extract :class:`NMRMetadata` from any supported NMR metadata object.
+
+    Dispatches to the correct vendor-specific extractor based on
+    ``meta.origin``.
+
+    Parameters
+    ----------
+    meta : Meta or None
+        The ``dataset.meta`` object produced by any supported reader.
+
+    Returns
+    -------
+    NMRMetadata
+        Canonical NMR metadata.
+    """
+    if meta is None or len(meta) == 0:
+        return NMRMetadata(ndim=0, domains=())
+
+    origin = getattr(meta, "origin", None)
+    extractor = _EXTRACTORS.get(origin)
+    if extractor is not None:
+        return extractor(meta)
+
+    # Fallback: try TopSpin extraction (most common format)
+    return extract_topspin_metadata(meta)

--- a/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
@@ -235,3 +235,221 @@ def test_nmr_reader_is_not_dataset_accessor_namespace(monkeypatch):
     dataset = scp.NDDataset([1, 2, 3])
     assert not hasattr(dataset, "nmr")
     assert not hasattr(dataset, "read_topspin")
+
+
+# ---------------------------------------------------------------------------
+# Cross-vendor metadata extraction
+# ---------------------------------------------------------------------------
+
+
+class _MockMeta:
+    """Minimal metadata mock for testing extractors."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __len__(self):
+        return 1
+
+
+class TestExtractJeolMetadata:
+    """Tests for extract_jeol_metadata."""
+
+    def test_1d_dataset(self):
+        from spectrochempy_nmr.nmr_metadata import extract_jeol_metadata
+
+        meta = _MockMeta(
+            td=("1024",),
+            isfreq=(True,),
+            encoding=("QF",),
+            nucleus=("1H",),
+            experiment="EXPERIMENT_1D",
+            datatype="FID",
+            iscomplex=(True,),
+            sw_h=(5000.0,),
+            sfrq=(400.0,),
+        )
+        result = extract_jeol_metadata(meta)
+        assert result.ndim == 1
+        assert result.domains == ("frequency",)
+        assert result.encoding == ("QF",)
+        assert result.nuclei == ("1H",)
+        assert result.pulse_program == "EXPERIMENT_1D"
+        assert result.source_kind == "processed_1d"
+
+    def test_none_meta(self):
+        from spectrochempy_nmr.nmr_metadata import extract_jeol_metadata
+
+        result = extract_jeol_metadata(None)
+        assert result.ndim == 0
+        assert result.domains == ()
+
+    def test_empty_meta(self):
+        from spectrochempy_nmr.nmr_metadata import extract_jeol_metadata
+
+        meta = _MockMeta()
+        result = extract_jeol_metadata(meta)
+        assert result.ndim == 0
+        assert result.domains == ()
+
+
+class TestExtractTecMagMetadata:
+    """Tests for extract_tecmag_metadata."""
+
+    def test_1d_dataset(self):
+        from spectrochempy_nmr.nmr_metadata import extract_tecmag_metadata
+
+        meta = _MockMeta(
+            td=("2048",),
+            isfreq=(False,),
+            encoding=("QSIM",),
+            nucleus=("13C",),
+            experiment="CPMG",
+            iscomplex=(True,),
+            sw_h=(10000.0,),
+            sfrq=(100.0,),
+        )
+        result = extract_tecmag_metadata(meta)
+        assert result.ndim == 1
+        assert result.domains == ("time",)
+        assert result.encoding == ("QSIM",)
+        assert result.nuclei == ("13C",)
+        assert result.pulse_program == "CPMG"
+        assert result.source_kind == "fid"
+
+    def test_none_meta(self):
+        from spectrochempy_nmr.nmr_metadata import extract_tecmag_metadata
+
+        result = extract_tecmag_metadata(None)
+        assert result.ndim == 0
+
+
+class TestExtractSimpsonMetadata:
+    """Tests for extract_simpson_metadata."""
+
+    def test_2d_dataset(self):
+        from spectrochempy_nmr.nmr_metadata import extract_simpson_metadata
+
+        meta = _MockMeta(
+            td=(256, 256),
+            isfreq=(True, True),
+            encoding=("States", "States"),
+            nucleus=("1H", "13C"),
+            iscomplex=(True, True),
+            sw_h=(5000.0, 10000.0),
+            sfrq=(400.0, 100.0),
+        )
+        result = extract_simpson_metadata(meta)
+        assert result.ndim == 2
+        assert result.domains == ("frequency", "frequency")
+        assert result.pulse_program is None
+        assert result.source_kind == "processed_2d"
+
+    def test_none_meta(self):
+        from spectrochempy_nmr.nmr_metadata import extract_simpson_metadata
+
+        result = extract_simpson_metadata(None)
+        assert result.ndim == 0
+
+
+class TestExtractNmrMetadataDispatcher:
+    """Tests for the vendor-neutral extract_nmr_metadata dispatcher."""
+
+    def test_dispatches_to_jeol(self):
+        from spectrochempy_nmr.nmr_metadata import extract_nmr_metadata
+
+        meta = _MockMeta(
+            origin="jeol",
+            td=("1024",),
+            isfreq=(True,),
+            encoding=("QF",),
+            nucleus=("1H",),
+            experiment="EXPERIMENT_1D",
+            datatype="FID",
+            iscomplex=(True,),
+            sw_h=(5000.0,),
+            sfrq=(400.0,),
+        )
+        result = extract_nmr_metadata(meta)
+        assert result.nuclei == ("1H",)
+        assert result.pulse_program == "EXPERIMENT_1D"
+
+    def test_dispatches_to_tecmag(self):
+        from spectrochempy_nmr.nmr_metadata import extract_nmr_metadata
+
+        meta = _MockMeta(
+            origin="tecmag",
+            td=("2048",),
+            isfreq=(False,),
+            encoding=("QSIM",),
+            nucleus=("13C",),
+            experiment="CPMG",
+            iscomplex=(True,),
+            sw_h=(10000.0,),
+            sfrq=(100.0,),
+        )
+        result = extract_nmr_metadata(meta)
+        assert result.nuclei == ("13C",)
+        assert result.pulse_program == "CPMG"
+
+    def test_dispatches_to_simpson(self):
+        from spectrochempy_nmr.nmr_metadata import extract_nmr_metadata
+
+        meta = _MockMeta(
+            origin="simpson",
+            td=(256, 256),
+            isfreq=(True, True),
+            encoding=("States", "States"),
+            nucleus=("1H", "13C"),
+            iscomplex=(True, True),
+            sw_h=(5000.0, 10000.0),
+            sfrq=(400.0, 100.0),
+        )
+        result = extract_nmr_metadata(meta)
+        assert result.pulse_program is None
+        assert result.source_kind == "processed_2d"
+
+    def test_dispatches_to_topspin(self):
+        from spectrochempy_nmr.nmr_metadata import extract_nmr_metadata
+
+        meta = _MockMeta(
+            origin="topspin",
+            ndim=1,
+            isfreq=(True,),
+            encoding=(4,),
+            nuc1=("1H",),
+            pulprog="zg30",
+            datatype="FID",
+            iscomplex=(False,),
+            sw_h=(5000.0,),
+            sfo1=(400.0,),
+        )
+        result = extract_nmr_metadata(meta)
+        assert result.pulse_program == "zg30"
+        assert result.encoding == ("STATES",)
+
+    def test_falls_back_to_topspin_for_unknown_origin(self):
+        from spectrochempy_nmr.nmr_metadata import extract_nmr_metadata
+
+        meta = _MockMeta(
+            origin="unknown_vendor",
+            ndim=1,
+            isfreq=(True,),
+            encoding=(4,),
+            nuc1=("1H",),
+            pulprog="hsqc",
+            iscomplex=(False,),
+            sw_h=(5000.0,),
+            sfo1=(400.0,),
+        )
+        result = extract_nmr_metadata(meta)
+        assert result.nuclei == ("1H",)
+        assert result.pulse_program == "hsqc"
+
+    def test_none_meta(self):
+        from spectrochempy_nmr.nmr_metadata import extract_nmr_metadata
+
+        result = extract_nmr_metadata(None)
+        assert result.ndim == 0
+        assert result.domains == ()


### PR DESCRIPTION
## Summary

Fixes `Experiment._classify()` to dispatch vendor-specific metadata extraction based on `meta.origin` instead of always calling `extract_topspin_metadata()`. This resolves silent misclassification of JEOL, TecMag, and SIMPSON datasets.

## Changes

- **`nmr_metadata.py`** — Added `extract_jeol_metadata()`, `extract_tecmag_metadata()`, `extract_simpson_metadata()` and a vendor-neutral `extract_nmr_metadata()` dispatcher (+343 lines)
- **`experiment.py`** — Updated `_classify()` to use `extract_nmr_metadata()` (+3 lines, -3 lines)
- **`test_nmr_plugin.py`** — Added 13 unit tests across 4 test classes (+218 lines)
- **`changelog.rst`** / **`latest.rst`** — Bug-fix entry (+7 lines)

## Metadata Field Mappings

| Canonical Field | Bruker | JEOL | TecMag | SIMPSON |
|-----------------|--------|------|--------|---------|
| `nuclei` | `nuc1` | `nucleus` | `nucleus` | `nucleus` |
| `spectrometer_freq_mhz` | `sfo1` | `sfrq` | `sfrq` | `sfrq` |
| `pulse_program` | `pulprog` | `experiment` | `experiment` | N/A |
| `encoding` | int `FnMODE` | string | string | string |

## Test Results

All 13 new tests pass:
- `TestExtractJeolMetadata` (3 tests)
- `TestExtractTecMagMetadata` (2 tests)
- `TestExtractSimpsonMetadata` (2 tests)
- `TestExtractNmrMetadataDispatcher` (6 tests)

## Validation

```bash
PYTHONPATH=src:plugins/spectrochempy-nmr/src python -m pytest plugins/spectrochempy-nmr/tests/test_nmr_plugin.py -v -k TestExtract
```

## Remaining Risks

- The `td` field in JEOL/TecMag/SIMPSON extractors is accessed as a single string value, but may need tuple handling for multi-dimensional data — real-world datasets needed to verify.
- Unknown-origin fallback defaults to TopSpin extraction; may need reconsideration for non-NMR datasets.
