### PR TITLE
CI: replace BOT_TOKEN with GitHub App for plugin releases

### DIFF
--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -51,11 +51,18 @@ jobs:
     if: github.repository == 'spectrochempy/spectrochempy'
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Ensure running from master
         run: |
@@ -226,7 +233,7 @@ jobs:
             --notes "Release of ${{ inputs.plugin_name }} v${{ inputs.version }}." \
             --verify-tag
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Unset "Latest" flag for plugin release
         # Reserve the "Latest" badge on the repository front page for core
@@ -240,4 +247,4 @@ jobs:
             --repo "${{ github.repository }}" \
             --latest=false
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/maintainers/emergency-recovery.md
+++ b/maintainers/emergency-recovery.md
@@ -56,22 +56,18 @@ remote: - Changes must be made through a pull request.
 
 Le `GITHUB_TOKEN` automatique ne peut pas contourner les règles de
 protection de la branche `master`. Le workflow **Release an official plugin** (`release_plugin.yml`)
-   utilise `secrets.BOT_TOKEN` (un PAT personnel) pour le checkout, ce qui
+   utilise la GitHub App `spectrochempy-releaser` pour le checkout, ce qui
 permet de pusher.
 
-Si ce secret est expiré ou a été révoqué, le push est rejeté.
+Si l'app n'est plus installée ou si la clé privée a changé, le push est rejeté.
 
 ### Résolution
 
-1. Créer un nouveau **classic PAT** sur
-   [github.com/settings/tokens](https://github.com/settings/tokens) avec le
-   scope `repo`
-2. Mettre à jour le secret `BOT_TOKEN` dans
-   [Settings → Secrets → Actions](https://github.com/spectrochempy/spectrochempy/settings/secrets/actions)
+1. Vérifier que la GitHub App `spectrochempy-releaser` est toujours installée
+   sur le repo (Settings → GitHub Apps → Installed GitHub Apps)
+2. Vérifier que les secrets `RELEASER_APP_PRIVATE_KEY` et la variable
+   `RELEASER_APP_ID` sont à jour
 3. Relancer le workflow
-
-> **Note** : Les PAT arrivent à expiration après 3 mois. Ajouter un rappel
-> calendaire pour le renouvellement.
 
 ---
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -13,7 +13,11 @@ du dépôt `spectrochempy/spectrochempy` :
 | Secret | Usage |
 |--------|-------|
 | `ANACONDA_API_TOKEN` | Publication sur Anaconda.org (compte `spectrocat`) — core + plugins |
-| `BOT_TOKEN` | PAT personnel utilisé pour contourner la protection de branche lors des releases de plugins (expire tous les 3 mois — penser à le renouveler et mettre à jour le secret) |
+| `RELEASER_APP_PRIVATE_KEY` | Clé privée de la GitHub App `spectrochempy-releaser` (pour contourner la protection de branche lors des releases de plugins) |
+
+| Variable | Usage |
+|----------|-------|
+| `RELEASER_APP_ID` | App ID de la GitHub App `spectrochempy-releaser` |
 
 > **Note PyPI** : le package **core** (`spectrochempy`) et les **plugins**
 > utilisent tous [Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
@@ -434,7 +438,7 @@ confirm_zenodo_disabled: true   # ← doit être coché
      détecte qu'aucun changement n'est nécessaire et **saute les étapes
      de commit et de push** — le tag et la Release sont créés depuis le
      HEAD existant
-   - Pousse le commit sur `master` (via `BOT_TOKEN`) uniquement si un
+   - Pousse le commit sur `master` (via la GitHub App) uniquement si un
      bump de version a eu lieu
    - Crée le tag `spectrochempy-XXX-vX.Y.Z`
    - Crée une Release GitHub
@@ -576,9 +580,9 @@ entrées sont incorrectes car :
 
 ### Avant toute release
 
-- [ ] Vérifier que les secrets GitHub nécessaires sont valides et non expirés :
+- [ ] Vérifier que les secrets GitHub nécessaires sont valides :
       - Core : `ANACONDA_API_TOKEN` (Trusted Publishing PyPI ne nécessite pas de token secret)
-      - Plugins : `ANACONDA_API_TOKEN`, `BOT_TOKEN` (Trusted Publishing PyPI ne nécessite pas de token secret)
+      - Plugins : `ANACONDA_API_TOKEN`, `RELEASER_APP_PRIVATE_KEY` + `RELEASER_APP_ID` (Trusted Publishing PyPI ne nécessite pas de token secret)
 - [ ] Vérifier l'état des services externes (Zenodo, PyPI, Anaconda.org)
 - [ ] Lancer les tests CI sur la branche cible
 - [ ] Vérifier que le Colab smoke test passe (`install_on_colab.yml`)
@@ -605,7 +609,7 @@ entrées sont incorrectes car :
 
 ### Release des plugins
 
-- [ ] Vérifier que `BOT_TOKEN` est valide (expire tous les 3 mois)
+- [ ] Vérifier que la GitHub App `spectrochempy-releaser` est installée sur le repo
 - [ ] Désactiver l'intégration GitHub → Zenodo
 - [ ] Lancer **Release an official plugin** avec `confirm_zenodo_disabled=true`
 - [ ] Vérifier que le workflow termine sans erreur (commit sauté si version déjà à jour)


### PR DESCRIPTION
Replace the personal PAT (BOT_TOKEN) with a dedicated GitHub App (spectrochempy-releaser) for pushing version bumps and creating releases in release_plugin.yml. This allows the release workflow to bypass branch protection without requiring a personal account token.

- Add actions/create-github-app-token@v2 step
- Use app token for checkout, push, and gh CLI operations
- Update maintainers docs to reference new secrets/variables

