### PR TITLE
ENH: reconstruct write_matlab() minimal exchange payloads in read_matlab()

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -154,6 +154,12 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- Added comprehensive regression coverage for the `write_matlab()` /
+  `read_matlab()` minimal exchange payload: non-default dimension names, a
+  true 1D round trip, an empty-coordinate edge case, and adversarial cases
+  where a file shares the right variable names but the wrong structure.
+  (#1270)
+
 - The NMR test suite has been modernized and made substantially more reliable:
   skipped legacy FFT tests were reactivated, visual-only tests were replaced
   with numerical assertions, and targeted plugin tests now check observable

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -31,6 +31,11 @@ New Features
   criteria.
 .. Add here new public features (do not delete this comment)
 
+- `read_matlab()` now reconstructs `NDDataset` objects from the minimal
+  MATLAB exchange payload written by `write_matlab()`, restoring the
+  dataset's name, title, units, description, dimension names, and
+  coordinates (values, units, and titles). (#1270)
+
 - NMR support has been significantly expanded.  SpectroChemPy now provides
   ``scp.nmr.Experiment`` as a state-aware NMR scientific model, alongside new
   official readers for Agilent/Varian, JEOL JDF, TecMag TNT, and SIMPSON
@@ -53,6 +58,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
+
+- `read_matlab()` no longer crashes on `.mat` files containing a plain MATLAB
+  cell-array variable. It previously raised an unguarded `TypeError` (surfaced
+  only as a swallowed `UserWarning`, with the function silently returning
+  `None`), or, for files with other variables alongside the cell array, an
+  `AttributeError` in the dataset-merging step. Such variables are now safely
+  skipped with a warning. (#1270)
 
 - NMR reader and processing reliability has improved substantially.  TopSpin
   metadata handling is more robust, ``scp.nmr.Experiment`` now correctly

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -127,6 +127,12 @@ Deprecations
 Developer
 ~~~~~~~~~
 
+- Added comprehensive regression coverage for the `write_matlab()` /
+  `read_matlab()` minimal exchange payload: non-default dimension names, a
+  true 1D round trip, an empty-coordinate edge case, and adversarial cases
+  where a file shares the right variable names but the wrong structure.
+  (#1270)
+
 - The NMR test suite has been modernized and made substantially more reliable:
   skipped legacy FFT tests were reactivated, visual-only tests were replaced
   with numerical assertions, and targeted plugin tests now check observable

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,11 @@ New Features
   columns have been removed because they did not map clearly to the stopping
   criteria.
 
+- `read_matlab()` now reconstructs `NDDataset` objects from the minimal
+  MATLAB exchange payload written by `write_matlab()`, restoring the
+  dataset's name, title, units, description, dimension names, and
+  coordinates (values, units, and titles). (#1270)
+
 - NMR support has been significantly expanded.  SpectroChemPy now provides
   ``scp.nmr.Experiment`` as a state-aware NMR scientific model, alongside new
   official readers for Agilent/Varian, JEOL JDF, TecMag TNT, and SIMPSON
@@ -45,6 +50,13 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
+
+- `read_matlab()` no longer crashes on `.mat` files containing a plain MATLAB
+  cell-array variable. It previously raised an unguarded `TypeError` (surfaced
+  only as a swallowed `UserWarning`, with the function silently returning
+  `None`), or, for files with other variables alongside the cell array, an
+  `AttributeError` in the dataset-merging step. Such variables are now safely
+  skipped with a warning. (#1270)
 
 - NMR reader and processing reliability has improved substantially.  TopSpin
   metadata handling is more robust, ``scp.nmr.Experiment`` now correctly

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -203,6 +203,10 @@ read_mat = read_matlab
 # --------------------------------------------------------------------------------------
 # Private methods
 # --------------------------------------------------------------------------------------
+# The fields write_matlab() always emits, regardless of whether the dataset
+# has units, a description, or any coordinates set. `units` and
+# `description` are conditional on the writer side, so they are
+# deliberately not part of this required set.
 _SCP_EXCHANGE_REQUIRED_KEYS = {
     "data",
     "dims",
@@ -215,6 +219,7 @@ _SCP_EXCHANGE_REQUIRED_KEYS = {
 
 
 def _unwrap_str(value):
+    """Unwrap a scalar MATLAB char-array/cell entry back to a plain str."""
     if hasattr(value, "item"):
         value = value.item()
     if isinstance(value, bytes):
@@ -223,6 +228,15 @@ def _unwrap_str(value):
 
 
 def _is_matlab_struct_or_empty(value):
+    """
+    Check that `value` is a MATLAB struct, or the empty-dict placeholder.
+
+    write_matlab() writes `{}` for coords/coord_units/coord_titles when a
+    dataset has no coordinates on a given dimension. scipy round-trips an
+    empty dict as a bare ``array([[None]], dtype=object)`` rather than as a
+    structured array, so that specific shape has to be accepted here too,
+    not just genuine structs with named fields.
+    """
     if not isinstance(value, np.ndarray):
         return False
     if value.dtype.names is not None:
@@ -231,6 +245,16 @@ def _is_matlab_struct_or_empty(value):
 
 
 def _is_scp_matlab_exchange_payload(dic):
+    """
+    Check that `dic` matches the structure written by write_matlab().
+
+    Presence of the always-emitted keys alone is not a safe enough signal:
+    an unrelated third-party `.mat` file could coincidentally define
+    variables with the same names. Each field is also checked against the
+    shape/dtype `write_matlab()` actually produces, so any mismatch falls
+    back to the generic per-variable import path instead of being
+    incorrectly treated as a SpectroChemPy exchange payload.
+    """
     if not dic.keys() >= _SCP_EXCHANGE_REQUIRED_KEYS:
         return False
 
@@ -241,7 +265,15 @@ def _is_scp_matlab_exchange_payload(dic):
     dims_raw = dic.get("dims")
     if not isinstance(dims_raw, np.ndarray) or dims_raw.dtype.kind != "O":
         return False
-    if dims_raw.size != data.ndim:
+    if dims_raw.size != data.ndim and not (
+        dims_raw.size == 1 and data.ndim == 2 and data.shape[0] == 1
+    ):
+        # scipy.io.loadmat() always reads MATLAB arrays back as at least 2D,
+        # so a truly 1D NDDataset (one dimension name, written as a plain
+        # 1D array) comes back as a (1, n) row vector: dims.size == 1 but
+        # data.ndim == 2. That specific shape is a legitimate exchange
+        # payload, not a mismatch, so it is accepted here alongside the
+        # ordinary dims.size == data.ndim case.
         return False
 
     for key in ("coords", "coord_units", "coord_titles"):
@@ -257,9 +289,17 @@ def _is_scp_matlab_exchange_payload(dic):
 
 
 def _read_scp_matlab_exchange(dic, filename):
+    """Reconstruct the NDDataset written by write_matlab()'s minimal exchange payload."""
     dims = [_unwrap_str(d) for d in np.asarray(dic["dims"]).ravel()]
 
-    dataset = NDDataset(np.asarray(dic["data"]), dims=dims)
+    data = np.asarray(dic["data"])
+    if len(dims) == 1 and data.ndim == 2 and data.shape[0] == 1:
+        # Undo scipy.io.loadmat()'s forced promotion of a true 1D array to
+        # a (1, n) row vector, so the reconstructed dataset's ndim actually
+        # matches the single dimension name that was written.
+        data = data.reshape(-1)
+
+    dataset = NDDataset(data, dims=dims)
 
     name = _unwrap_str(dic["name"][0])
     title = _unwrap_str(dic["title"][0])
@@ -352,11 +392,15 @@ def _read_mat(*args, **kwargs):
             datasets.append(dataset)
 
         else:
-            # There is no safe generic NDDataset reconstruction for this,
-            # and returning a non-NDDataset placeholder here breaks merge_datasets() downstream,
-            # so this variable is skipped.
+            # Unrecognized structured/object data (e.g. a plain MATLAB cell
+            # array, or a struct that doesn't match the DSO signature).
+            # There is no safe generic NDDataset reconstruction for this, and
+            # returning a non-NDDataset placeholder here breaks
+            # merge_datasets() downstream, so this variable is skipped.
             warning_(
-                f"The mat file contains a variable named '{name}' with unsupported data type '{data.dtype}', which will not be converted to NDDataset"
+                f"The mat file contains a variable named '{name}' with "
+                f"unsupported data type '{data.dtype}', which will not be "
+                "converted to NDDataset",
             )
             continue
 

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -151,16 +151,17 @@ def read_matlab(*paths, **kwargs):
     ``.filter_by_shape()``.
 
     If the file matches the minimal exchange payload written by
-    :func:`spectrochempy.write_matlab` (i.e. it contains exactly the
-    ``data``, ``dims``, ``coords``, ``coord_units``, and ``coord_titles``
-    variables), a single `NDDataset` is reconstructed directly from those
-    fields instead of going through the generic per-variable import: values,
-    dimension names, coordinates (values, units, titles), name, title,
-    units, and description are all restored. Masked values are not
-    reconstructed, since the exchange payload stores them as plain ``NaN``
-    with no separate mask array; they come back unmasked. Any other `.mat`
-    file, including ones that only partially overlap this key set, is read
-    through the generic path described above.
+    :func:`spectrochempy.write_matlab` (i.e. it contains the ``data``,
+    ``dims``, ``coords``, ``coord_units``, ``coord_titles``, ``name``, and
+    ``title`` variables with the expected shapes and dtypes), a single
+    `NDDataset` is reconstructed directly from those fields instead of going
+    through the generic per-variable import: values, dimension names,
+    coordinates (values, units, titles), name, title, units, and description
+    are all restored. Masked values are not reconstructed, since the
+    exchange payload stores them as plain ``NaN`` with no separate mask
+    array; they come back unmasked. Any other `.mat` file, including ones
+    that only partially match this structure, is read through the generic
+    path described above.
 
     Examples
     --------
@@ -202,11 +203,10 @@ read_mat = read_matlab
 # --------------------------------------------------------------------------------------
 # Private methods
 # --------------------------------------------------------------------------------------
-_SCP_EXCHANGE_SIGNATURE = {"data", "dims", "coords", "coord_units", "coord_titles"}
+_SCP_EXCHANGE_REQUIRED_KEYS = {"data", "dims", "coords", "coord_units", "coord_titles", "name", "title"}
 
 
 def _unwrap_str(value):
-    """Unwrap a scalar MATLAB char-array/cell entry back to a plain str."""
     if hasattr(value, "item"):
         value = value.item()
     if isinstance(value, bytes):
@@ -214,14 +214,47 @@ def _unwrap_str(value):
     return str(value)
 
 
-def _read_scp_matlab_exchange(dic, filename):
-    """Reconstruct the NDDataset written by write_matlab()'s minimal exchange payload."""
-    dataset = NDDataset(np.asarray(dic["data"]))
+def _is_matlab_struct_or_empty(value):
+    if not isinstance(value, np.ndarray):
+        return False
+    if value.dtype.names is not None:
+        return True
+    return value.dtype.kind == "O" and value.size == 1 and value.ravel()[0] is None
 
+
+def _is_scp_matlab_exchange_payload(dic):
+    if not dic.keys() >= _SCP_EXCHANGE_REQUIRED_KEYS:
+        return False
+
+    data = dic.get("data")
+    if not isinstance(data, np.ndarray) or data.dtype.kind not in "biuf":
+        return False
+
+    dims_raw = dic.get("dims")
+    if not isinstance(dims_raw, np.ndarray) or dims_raw.dtype.kind != "O":
+        return False
+    if dims_raw.size != data.ndim:
+        return False
+
+    for key in ("coords", "coord_units", "coord_titles"):
+        if not _is_matlab_struct_or_empty(dic.get(key)):
+            return False
+
+    for key in ("name", "title"):
+        value = dic.get(key)
+        if not isinstance(value, np.ndarray) or value.dtype.kind != "U":
+            return False
+
+    return True
+
+
+def _read_scp_matlab_exchange(dic, filename):
     dims = [_unwrap_str(d) for d in np.asarray(dic["dims"]).ravel()]
 
-    name = _unwrap_str(dic["name"][0]) if "name" in dic else ""
-    title = _unwrap_str(dic["title"][0]) if "title" in dic else ""
+    dataset = NDDataset(np.asarray(dic["data"]), dims=dims)
+
+    name = _unwrap_str(dic["name"][0])
+    title = _unwrap_str(dic["title"][0])
     if name:
         dataset.name = name
     if title:
@@ -231,21 +264,20 @@ def _read_scp_matlab_exchange(dic, filename):
     if "description" in dic:
         dataset.description = _unwrap_str(dic["description"][0])
 
-    coords_struct = dic.get("coords")
-    units_struct = dic.get("coord_units")
-    titles_struct = dic.get("coord_titles")
+    coords_struct = dic["coords"]
+    units_struct = dic["coord_units"]
+    titles_struct = dic["coord_titles"]
     coord_kwargs = {}
-    if coords_struct is not None and coords_struct.dtype.names:
-        for dim in dims:
-            if dim not in coords_struct.dtype.names:
-                continue
-            cdata = np.asarray(coords_struct[dim][0, 0]).ravel()
-            coord = Coord(data=cdata)
-            if units_struct is not None and dim in (units_struct.dtype.names or ()):
-                coord.units = _unwrap_str(units_struct[dim][0, 0])
-            if titles_struct is not None and dim in (titles_struct.dtype.names or ()):
-                coord.title = _unwrap_str(titles_struct[dim][0, 0])
-            coord_kwargs[dim] = coord
+    for dim in dims:
+        if coords_struct.dtype.names is None or dim not in coords_struct.dtype.names:
+            continue
+        cdata = np.asarray(coords_struct[dim][0, 0]).ravel()
+        coord = Coord(data=cdata)
+        if units_struct.dtype.names is not None and dim in units_struct.dtype.names:
+            coord.units = _unwrap_str(units_struct[dim][0, 0])
+        if titles_struct.dtype.names is not None and dim in titles_struct.dtype.names:
+            coord.title = _unwrap_str(titles_struct[dim][0, 0])
+        coord_kwargs[dim] = coord
     if coord_kwargs:
         dataset.set_coordset(**coord_kwargs)
 
@@ -263,9 +295,9 @@ def _read_mat(*args, **kwargs):
 
     dic = sio.loadmat(fid)
 
-    if _SCP_EXCHANGE_SIGNATURE <= dic.keys():
+    if _is_scp_matlab_exchange_payload(dic):
         return [_read_scp_matlab_exchange(dic, filename)]
-    
+
     datasets = []
     for name, data in dic.items():
         dataset = NDDataset()
@@ -304,7 +336,7 @@ def _read_mat(*args, **kwargs):
             )
             continue
 
-       elif data.dtype.names is not None and all(
+        elif data.dtype.names is not None and all(
             name_ in data.dtype.names for name_ in ["moddate", "axisscale", "imagesize"]
         ):
             # this is probably a DSO object
@@ -312,11 +344,11 @@ def _read_mat(*args, **kwargs):
             datasets.append(dataset)
 
         else:
+            # There is no safe generic NDDataset reconstruction for this,
+            # and returning a non-NDDataset placeholder here breaks merge_datasets() downstream,
+            # so this variable is skipped.
             warning_(
-                f"The mat file contains a variable named '{name}' with "
-                f"unsupported data type '{data.dtype}', which will not be "
-                "converted to NDDataset",
-            )
+                f"The mat file contains a variable named '{name}' with unsupported data type '{data.dtype}', which will not be converted to NDDataset")
             continue
 
     return datasets

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -150,6 +150,18 @@ def read_matlab(*paths, **kwargs):
     ``.select_largest()``, ``.select_by_name()``, ``.filter_by_ndim()``, or
     ``.filter_by_shape()``.
 
+    If the file matches the minimal exchange payload written by
+    :func:`spectrochempy.write_matlab` (i.e. it contains exactly the
+    ``data``, ``dims``, ``coords``, ``coord_units``, and ``coord_titles``
+    variables), a single `NDDataset` is reconstructed directly from those
+    fields instead of going through the generic per-variable import: values,
+    dimension names, coordinates (values, units, titles), name, title,
+    units, and description are all restored. Masked values are not
+    reconstructed, since the exchange payload stores them as plain ``NaN``
+    with no separate mask array; they come back unmasked. Any other `.mat`
+    file, including ones that only partially overlap this key set, is read
+    through the generic path described above.
+
     Examples
     --------
     Reading a single Matlab file
@@ -190,6 +202,59 @@ read_mat = read_matlab
 # --------------------------------------------------------------------------------------
 # Private methods
 # --------------------------------------------------------------------------------------
+_SCP_EXCHANGE_SIGNATURE = {"data", "dims", "coords", "coord_units", "coord_titles"}
+
+
+def _unwrap_str(value):
+    """Unwrap a scalar MATLAB char-array/cell entry back to a plain str."""
+    if hasattr(value, "item"):
+        value = value.item()
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "ignore")
+    return str(value)
+
+
+def _read_scp_matlab_exchange(dic, filename):
+    """Reconstruct the NDDataset written by write_matlab()'s minimal exchange payload."""
+    dataset = NDDataset(np.asarray(dic["data"]))
+
+    dims = [_unwrap_str(d) for d in np.asarray(dic["dims"]).ravel()]
+
+    name = _unwrap_str(dic["name"][0]) if "name" in dic else ""
+    title = _unwrap_str(dic["title"][0]) if "title" in dic else ""
+    if name:
+        dataset.name = name
+    if title:
+        dataset.title = title
+    if "units" in dic:
+        dataset.units = _unwrap_str(dic["units"][0])
+    if "description" in dic:
+        dataset.description = _unwrap_str(dic["description"][0])
+
+    coords_struct = dic.get("coords")
+    units_struct = dic.get("coord_units")
+    titles_struct = dic.get("coord_titles")
+    coord_kwargs = {}
+    if coords_struct is not None and coords_struct.dtype.names:
+        for dim in dims:
+            if dim not in coords_struct.dtype.names:
+                continue
+            cdata = np.asarray(coords_struct[dim][0, 0]).ravel()
+            coord = Coord(data=cdata)
+            if units_struct is not None and dim in (units_struct.dtype.names or ()):
+                coord.units = _unwrap_str(units_struct[dim][0, 0])
+            if titles_struct is not None and dim in (titles_struct.dtype.names or ()):
+                coord.title = _unwrap_str(titles_struct[dim][0, 0])
+            coord_kwargs[dim] = coord
+    if coord_kwargs:
+        dataset.set_coordset(**coord_kwargs)
+
+    dataset.filename = filename
+    dataset.origin = "spectrochempy"
+    dataset.history = "Reconstructed from SpectroChemPy MATLAB exchange payload"
+    return dataset
+
+
 @_importer_method
 def _read_mat(*args, **kwargs):
     _, filename = args
@@ -198,6 +263,9 @@ def _read_mat(*args, **kwargs):
 
     dic = sio.loadmat(fid)
 
+    if _SCP_EXCHANGE_SIGNATURE <= dic.keys():
+        return [_read_scp_matlab_exchange(dic, filename)]
+    
     datasets = []
     for name, data in dic.items():
         dataset = NDDataset()
@@ -236,7 +304,7 @@ def _read_mat(*args, **kwargs):
             )
             continue
 
-        elif all(
+       elif data.dtype.names is not None and all(
             name_ in data.dtype.names for name_ in ["moddate", "axisscale", "imagesize"]
         ):
             # this is probably a DSO object
@@ -244,9 +312,12 @@ def _read_mat(*args, **kwargs):
             datasets.append(dataset)
 
         else:
-            warning_(f"unsupported data type : {data.dtype}")
-            # TODO: implement DSO reader
-            datasets.append([name, data])
+            warning_(
+                f"The mat file contains a variable named '{name}' with "
+                f"unsupported data type '{data.dtype}', which will not be "
+                "converted to NDDataset",
+            )
+            continue
 
     return datasets
 

--- a/src/spectrochempy/core/readers/read_matlab.py
+++ b/src/spectrochempy/core/readers/read_matlab.py
@@ -203,7 +203,15 @@ read_mat = read_matlab
 # --------------------------------------------------------------------------------------
 # Private methods
 # --------------------------------------------------------------------------------------
-_SCP_EXCHANGE_REQUIRED_KEYS = {"data", "dims", "coords", "coord_units", "coord_titles", "name", "title"}
+_SCP_EXCHANGE_REQUIRED_KEYS = {
+    "data",
+    "dims",
+    "coords",
+    "coord_units",
+    "coord_titles",
+    "name",
+    "title",
+}
 
 
 def _unwrap_str(value):
@@ -348,7 +356,8 @@ def _read_mat(*args, **kwargs):
             # and returning a non-NDDataset placeholder here breaks merge_datasets() downstream,
             # so this variable is skipped.
             warning_(
-                f"The mat file contains a variable named '{name}' with unsupported data type '{data.dtype}', which will not be converted to NDDataset")
+                f"The mat file contains a variable named '{name}' with unsupported data type '{data.dtype}', which will not be converted to NDDataset"
+            )
             continue
 
     return datasets

--- a/tests/test_core/test_readers/test_read_matlab.py
+++ b/tests/test_core/test_readers/test_read_matlab.py
@@ -34,12 +34,6 @@ def test_read_matlab(matlabdata):
 
 
 def test_read_matlab_multiple_variables(tmp_path):
-    # read_matlab() imports each numeric variable of a .mat file as its own
-    # NDDataset, named after the MATLAB variable, and skips non-numeric and
-    # MATLAB-internal (``__header__``/``__version__``/``__globals__``)
-    # variables (#1142). Distinct shapes are used so the importer keeps the
-    # arrays as separate datasets rather than stacking same-shape arrays into
-    # a single one.
     path = tmp_path / "multi.mat"
     savemat(
         path,
@@ -62,8 +56,6 @@ def test_read_matlab_multiple_variables(tmp_path):
     assert shapes["alpha"] == (1, 5)
     assert shapes["beta"] == (1, 7)
 
-    # the non-numeric (string) variable and the MATLAB internals are not
-    # returned as datasets
     assert "label" not in names
     assert not any(ds.name.startswith("__") for ds in datasets)
 
@@ -106,9 +98,6 @@ def test_read_matlab_single_2d_array_preserves_values_without_materialized_coord
 
 
 def test_read_matlab_same_shape_arrays_are_stacked(tmp_path):
-    # same-shape numeric arrays are stacked by the importer into a single
-    # NDDataset (the documented merge behaviour), so two (1, n) arrays come
-    # back as one (2, n) dataset (#1142).
     path = tmp_path / "stack.mat"
     savemat(
         path,

--- a/tests/test_core/test_readers/test_read_matlab.py
+++ b/tests/test_core/test_readers/test_read_matlab.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from scipy.io import savemat
 
-from spectrochempy import NDDataset, read_matlab
+from spectrochempy import Coord, NDDataset, read_matlab
 from spectrochempy import preferences as prefs
 
 MATLABDATA = prefs.datadir / "matlabdata"
@@ -126,3 +126,165 @@ def test_read_matlab_three_dimensional_array_preserves_shape_and_values(tmp_path
     assert np.array_equal(dataset.data, values)
     assert dataset.origin == "matlab"
     assert dataset.coordset is None
+
+
+def test_read_matlab_reconstructs_write_matlab_exchange_payload(tmp_path):
+    x = Coord(np.linspace(4000.0, 1000.0, 6), units="cm^-1", title="wavenumber")
+    y = Coord(np.array([0.0, 10.0]), units="s", title="time")
+    original = NDDataset(np.random.rand(2, 6), coordset=[y, x])
+    original.name = "myspectrum"
+    original.title = "absorbance"
+    original.units = "absorbance"
+    original.description = "round trip check"
+
+    path = tmp_path / "exchange.mat"
+    original.write_matlab(path)
+
+    result = read_matlab(path)
+
+    assert isinstance(result, NDDataset)
+    assert result.name == "myspectrum"
+    assert result.title == "absorbance"
+    assert str(result.units) == str(original.units)
+    assert result.description == "round trip check"
+    assert result.dims == original.dims
+    assert result.shape == original.shape
+    assert np.allclose(result.data, original.data)
+
+    assert result.coordset is not None
+    assert np.allclose(result.coord("x").data, x.data)
+    assert str(result.coord("x").units) == str(x.units)
+    assert result.coord("x").title == "wavenumber"
+    assert np.allclose(result.coord("y").data, y.data)
+    assert str(result.coord("y").units) == str(y.units)
+    assert result.coord("y").title == "time"
+
+
+def test_read_matlab_exchange_payload_without_coordinates(tmp_path):
+    original = NDDataset(np.arange(10.0).reshape(2, 5))
+    original.name = "plain"
+    original.title = "raw signal"
+
+    path = tmp_path / "exchange_no_coords.mat"
+    original.write_matlab(path)
+
+    result = read_matlab(path)
+
+    assert isinstance(result, NDDataset)
+    assert result.name == "plain"
+    assert result.title == "raw signal"
+    assert result.shape == (2, 5)
+    assert np.allclose(result.data, original.data)
+
+
+def test_read_matlab_does_not_crash_on_plain_cell_array_variable(tmp_path):
+    path = tmp_path / "generic_with_cell.mat"
+    savemat(
+        path,
+        {
+            "signal": np.linspace(0.0, 1.0, 5).reshape(1, 5),
+            "channel_names": np.array(["ch1", "ch2"], dtype=object),
+        },
+    )
+
+    result = read_matlab(path)
+
+    assert isinstance(result, NDDataset)
+    assert result.name == "signal"
+    assert result.shape == (1, 5)
+
+
+def test_read_matlab_partial_exchange_keys_use_generic_path(tmp_path):
+    path = tmp_path / "partial_signature.mat"
+    savemat(
+        path,
+        {
+            "data": np.linspace(0.0, 1.0, 5).reshape(1, 5),
+            "dims": np.array(["x"], dtype=object),
+            "coords": {"x": np.arange(5.0)},
+        },
+    )
+
+    result = read_matlab(path)
+
+    assert isinstance(result, NDDataset)
+    assert result.name == "data"
+    assert result.shape == (1, 5)
+
+
+def test_read_matlab_exchange_payload_restores_non_default_dimension_names(tmp_path):
+    q = Coord(np.linspace(4000.0, 1000.0, 6), units="cm^-1", title="wavenumber")
+    v = Coord(np.array([0.0, 10.0]), units="s", title="time")
+    original = NDDataset(np.random.rand(2, 6), dims=["v", "q"], coordset=[v, q])
+    original.name = "myspectrum"
+
+    path = tmp_path / "nondefault_dims.mat"
+    original.write_matlab(path)
+
+    result = read_matlab(path)
+
+    assert isinstance(result, NDDataset)
+    assert result.dims == ["v", "q"]
+    assert result.shape == original.shape
+    assert np.allclose(result.data, original.data)
+    assert np.allclose(result.coord("q").data, q.data)
+    assert result.coord("q").title == "wavenumber"
+    assert np.allclose(result.coord("v").data, v.data)
+    assert result.coord("v").title == "time"
+
+
+def test_read_matlab_exchange_detection_rejects_wrong_field_structure(tmp_path):
+    path = tmp_path / "wrong_structure.mat"
+    savemat(
+        path,
+        {
+            "data": np.linspace(0.0, 1.0, 5).reshape(1, 5),
+            "dims": np.array(["x"], dtype=object),
+            "coords": np.array([1, 2, 3]),
+            "coord_units": np.array([1, 2, 3]),
+            "coord_titles": np.array([1, 2, 3]),
+            "name": "somefile",
+            "title": "sometitle",
+        },
+    )
+
+    result = read_matlab(path)
+
+    names = {ds.name for ds in result} if isinstance(result, list) else {result.name}
+    assert "somefile" not in names
+
+
+def test_read_matlab_exchange_detection_rejects_dims_length_mismatch(tmp_path):
+    path = tmp_path / "dims_mismatch.mat"
+    savemat(
+        path,
+        {
+            "data": np.linspace(0.0, 1.0, 10).reshape(2, 5),
+            "dims": np.array(["x"], dtype=object),
+            "coords": {"x": np.arange(5.0)},
+            "coord_units": {"x": "s"},
+            "coord_titles": {"x": "time"},
+            "name": "mismatched",
+            "title": "t",
+        },
+    )
+
+    result = read_matlab(path)
+
+    assert getattr(result, "name", None) != "mismatched"
+
+
+def test_read_matlab_exchange_payload_without_coordinates_round_trips_via_writer(
+    tmp_path,
+):
+    original = NDDataset(np.arange(6.0).reshape(1, 6))
+    original.name = "no_coords"
+
+    path = tmp_path / "no_coords_exchange.mat"
+    original.write_matlab(path)
+
+    result = read_matlab(path)
+
+    assert isinstance(result, NDDataset)
+    assert result.name == "no_coords"
+    assert np.allclose(result.data, original.data)

--- a/tests/test_core/test_readers/test_read_matlab.py
+++ b/tests/test_core/test_readers/test_read_matlab.py
@@ -34,6 +34,12 @@ def test_read_matlab(matlabdata):
 
 
 def test_read_matlab_multiple_variables(tmp_path):
+    # read_matlab() imports each numeric variable of a .mat file as its own
+    # NDDataset, named after the MATLAB variable, and skips non-numeric and
+    # MATLAB-internal (``__header__``/``__version__``/``__globals__``)
+    # variables (#1142). Distinct shapes are used so the importer keeps the
+    # arrays as separate datasets rather than stacking same-shape arrays into
+    # a single one.
     path = tmp_path / "multi.mat"
     savemat(
         path,
@@ -56,6 +62,8 @@ def test_read_matlab_multiple_variables(tmp_path):
     assert shapes["alpha"] == (1, 5)
     assert shapes["beta"] == (1, 7)
 
+    # the non-numeric (string) variable and the MATLAB internals are not
+    # returned as datasets
     assert "label" not in names
     assert not any(ds.name.startswith("__") for ds in datasets)
 
@@ -98,6 +106,9 @@ def test_read_matlab_single_2d_array_preserves_values_without_materialized_coord
 
 
 def test_read_matlab_same_shape_arrays_are_stacked(tmp_path):
+    # same-shape numeric arrays are stacked by the importer into a single
+    # NDDataset (the documented merge behaviour), so two (1, n) arrays come
+    # back as one (2, n) dataset (#1142).
     path = tmp_path / "stack.mat"
     savemat(
         path,
@@ -128,7 +139,14 @@ def test_read_matlab_three_dimensional_array_preserves_shape_and_values(tmp_path
     assert dataset.coordset is None
 
 
+# --------------------------------------------------------------------------------------
+# #1270 - reconstruction of write_matlab() minimal exchange payloads
+# --------------------------------------------------------------------------------------
 def test_read_matlab_reconstructs_write_matlab_exchange_payload(tmp_path):
+    # Full round trip: a dataset written with write_matlab() must come back
+    # from read_matlab() as a single NDDataset with its data, name, title,
+    # units, description, and both coordinates (values, units, titles)
+    # intact (#1270).
     x = Coord(np.linspace(4000.0, 1000.0, 6), units="cm^-1", title="wavenumber")
     y = Coord(np.array([0.0, 10.0]), units="s", title="time")
     original = NDDataset(np.random.rand(2, 6), coordset=[y, x])
@@ -161,6 +179,9 @@ def test_read_matlab_reconstructs_write_matlab_exchange_payload(tmp_path):
 
 
 def test_read_matlab_exchange_payload_without_coordinates(tmp_path):
+    # A dataset written without explicit coordinates should still round-trip
+    # its values, name, title, units, and description; the reconstructed
+    # dataset simply has no coordset (#1270).
     original = NDDataset(np.arange(10.0).reshape(2, 5))
     original.name = "plain"
     original.title = "raw signal"
@@ -178,6 +199,16 @@ def test_read_matlab_exchange_payload_without_coordinates(tmp_path):
 
 
 def test_read_matlab_does_not_crash_on_plain_cell_array_variable(tmp_path):
+    # Regression test (#1270): before the fix, any .mat file containing a
+    # plain MATLAB cell array (a numpy object array with dtype.names is
+    # None) crashed read_matlab() entirely -- first with an unguarded
+    # TypeError in the DSO-signature check (surfaced only as a UserWarning,
+    # with the function silently returning None), and, once that guard is
+    # added, with an AttributeError in merge_datasets() because the
+    # unrecognized variable was appended as a raw [name, data] list instead
+    # of being skipped. Neither should happen: the numeric variable must
+    # still come back as a valid NDDataset, and the cell array must simply
+    # be skipped with a warning.
     path = tmp_path / "generic_with_cell.mat"
     savemat(
         path,
@@ -195,6 +226,11 @@ def test_read_matlab_does_not_crash_on_plain_cell_array_variable(tmp_path):
 
 
 def test_read_matlab_partial_exchange_keys_use_generic_path(tmp_path):
+    # Safety net for the signature-based detection (#1270): a file that only
+    # partially overlaps write_matlab()'s key set (here, missing name,
+    # title, coord_units, and coord_titles) must not be mistaken for an
+    # exchange payload. It falls back to the generic per-variable import
+    # path instead of being incorrectly reconstructed.
     path = tmp_path / "partial_signature.mat"
     savemat(
         path,
@@ -213,6 +249,13 @@ def test_read_matlab_partial_exchange_keys_use_generic_path(tmp_path):
 
 
 def test_read_matlab_exchange_payload_restores_non_default_dimension_names(tmp_path):
+    # Regression test (#1270): dimension names read from the `dims` field
+    # must actually be applied to the reconstructed NDDataset, not just
+    # used internally to look up coordinates. A dataset using SpectroChemPy's
+    # default dimension names (`y`, `x`) would pass even if the stored names
+    # were silently ignored, since a freshly constructed NDDataset defaults
+    # to those names anyway -- so this uses non-default names (`v`, `q`) to
+    # actually exercise the restoration.
     q = Coord(np.linspace(4000.0, 1000.0, 6), units="cm^-1", title="wavenumber")
     v = Coord(np.array([0.0, 10.0]), units="s", title="time")
     original = NDDataset(np.random.rand(2, 6), dims=["v", "q"], coordset=[v, q])
@@ -234,6 +277,12 @@ def test_read_matlab_exchange_payload_restores_non_default_dimension_names(tmp_p
 
 
 def test_read_matlab_exchange_detection_rejects_wrong_field_structure(tmp_path):
+    # Regression test (#1270): having all the right variable names is not
+    # enough to be treated as a write_matlab() exchange payload -- the
+    # fields must also have the expected structure. Here `coords`,
+    # `coord_units`, and `coord_titles` are plain numeric arrays instead of
+    # MATLAB structs, so this must fall back to the generic per-variable
+    # import path (and must not crash) rather than being misreconstructed.
     path = tmp_path / "wrong_structure.mat"
     savemat(
         path,
@@ -255,6 +304,11 @@ def test_read_matlab_exchange_detection_rejects_wrong_field_structure(tmp_path):
 
 
 def test_read_matlab_exchange_detection_rejects_dims_length_mismatch(tmp_path):
+    # Regression test (#1270): the number of names in `dims` must match the
+    # number of dimensions in `data`. A mismatch (here, one dimension name
+    # for 2D data) indicates the file does not actually match the
+    # write_matlab() contract, so it must fall back to the generic
+    # per-variable import path instead of being misreconstructed.
     path = tmp_path / "dims_mismatch.mat"
     savemat(
         path,
@@ -277,6 +331,13 @@ def test_read_matlab_exchange_detection_rejects_dims_length_mismatch(tmp_path):
 def test_read_matlab_exchange_payload_without_coordinates_round_trips_via_writer(
     tmp_path,
 ):
+    # Edge case uncovered while tightening the detection in
+    # _is_scp_matlab_exchange_payload (#1270): when a dataset has no
+    # coordinates at all, write_matlab() writes empty {} dicts for
+    # coords/coord_units/coord_titles. scipy round-trips an empty dict as a
+    # bare `array([[None]], dtype=object)` rather than a structured array,
+    # which must still be recognized as a valid (empty) exchange payload
+    # rather than rejected as malformed.
     original = NDDataset(np.arange(6.0).reshape(1, 6))
     original.name = "no_coords"
 
@@ -288,3 +349,65 @@ def test_read_matlab_exchange_payload_without_coordinates_round_trips_via_writer
     assert isinstance(result, NDDataset)
     assert result.name == "no_coords"
     assert np.allclose(result.data, original.data)
+
+
+def test_read_matlab_exchange_payload_true_1d_round_trip(tmp_path):
+    # Regression test (#1270): scipy.io.loadmat() always reads MATLAB
+    # arrays back as at least 2D, so a genuinely 1D NDDataset (ndim == 1,
+    # a single dimension name) is written by write_matlab() with one dims
+    # entry, but its `data` variable comes back from loadmat() as a
+    # (1, n) row vector -- dims.size == 1 while data.ndim == 2. Without
+    # accounting for this, the payload is wrongly rejected as malformed
+    # and falls back to the generic per-variable import path, which loses
+    # the dataset's name, title, units, and description, and returns a
+    # 2D (y:1, x:n) dataset instead of a true 1D one.
+    x = Coord(np.linspace(0.0, 9.0, 10), units="s", title="time")
+    original = NDDataset(np.arange(10.0), coordset=[x])
+    original.name = "trueoned"
+    original.title = "signal"
+    original.units = "V"
+    original.description = "a genuinely 1D dataset"
+
+    path = tmp_path / "true_1d_exchange.mat"
+    original.write_matlab(path)
+
+    result = read_matlab(path)
+
+    assert isinstance(result, NDDataset)
+    assert result.ndim == 1
+    assert result.shape == (10,)
+    assert result.dims == ["x"]
+    assert result.name == "trueoned"
+    assert result.title == "signal"
+    assert str(result.units) == str(original.units)
+    assert result.description == "a genuinely 1D dataset"
+    assert np.allclose(result.data, original.data)
+    assert np.allclose(result.coord("x").data, x.data)
+    assert result.coord("x").title == "time"
+
+
+def test_read_matlab_exchange_detection_still_rejects_genuine_dims_mismatch_for_2d(
+    tmp_path,
+):
+    # Safety net alongside the true-1D fix above: the (1, n) row-vector
+    # allowance must only apply when data actually collapses to a single
+    # row. A genuinely 2D array (more than one row) with too few dims
+    # names is still a real mismatch and must still fall back to the
+    # generic path, not be swept in by the same exception.
+    path = tmp_path / "genuine_2d_mismatch.mat"
+    savemat(
+        path,
+        {
+            "data": np.linspace(0.0, 1.0, 10).reshape(2, 5),
+            "dims": np.array(["x"], dtype=object),
+            "coords": {"x": np.arange(5.0)},
+            "coord_units": {"x": "s"},
+            "coord_titles": {"x": "time"},
+            "name": "mismatched",
+            "title": "t",
+        },
+    )
+
+    result = read_matlab(path)
+
+    assert getattr(result, "name", None) != "mismatched"

--- a/zenodo.json
+++ b/zenodo.json
@@ -31,6 +31,11 @@
     {
       "type": "Other",
       "name": "Gao, Vincent"
+    },
+    {
+      "type": "Other",
+      "orcid": "0009-0008-0898-4557",
+      "name": "Alifino Revaza, Revian"
     }
   ],
   "creators": [


### PR DESCRIPTION
## Summary

Addresses #1270. `write_matlab()` writes a minimal exchange payload (`data`, `dims`, `coords`, `coord_units`, `coord_titles`, `name`, `title`, `units`, `description`), but `read_matlab()` has no path that reconstructs it. Checked what actually happens when you feed it back in:

```python
elif all(
    name_ in data.dtype.names for name_ in ["moddate", "axisscale", "imagesize"]
):
```

`write_matlab()`'s `dims` field is a plain MATLAB cell array. `loadmat()` gives that back as an object array with `dtype.names == None`, so `"moddate" in data.dtype.names` raises `TypeError: argument of type 'NoneType' is not iterable`. That gets caught somewhere upstream and shows up only as a `UserWarning`, and `read_matlab()` returns `None`. This isn't specific to files SpectroChemPy itself writes. Any `.mat` file with an ordinary MATLAB cell-array variable hits the same crash.

Patching just that line still doesn't give a working round trip: `dims`, `coords`, `coord_units`, and `coord_titles` then fall into the catch-all branch, which appends raw `[name, data]` list entries instead of `NDDataset`s. `merge_datasets()` calls `.shape` on every item in that list and raises `AttributeError: 'list' object has no attribute 'shape'`.

This PR fixes the crash and adds a narrow, signature-gated path that reconstructs the payload when the exact key set `write_matlab()` writes ispresent. Anything that doesn't match that signature goes through the existing generic/DSO logic, unchanged.

## Scope Suggestions

Everything the issue listed under "Possible scope" is covered:

* dataset values from `data` are restored.
* dimension names from `dims` are restored and used to key the coordinate reconstruction.
* simple coordinates from `coords` are restored (values only, per dim).
* dataset title and units are restored.
* coordinate titles and units are restored, per dim.
* description is restored.

## Non-goals Confirmation

Checked each one against what the PR actually does:

* No full MATLAB round-trip fidelity claim: correct, this only reconstructs the fields `write_matlab()` itself writes.
* No mask reconstruction: `write_matlab()` fills masked values with `NaN` and writes no boolean mask array, so guessing a mask back from `NaN` would be wrong (an unmasked dataset can legitimately contain `NaN` too). Masked values come back as plain, unmasked `NaN`. Not listed explicitly in the issue's non-goals, but follows the same "no round-trip fidelity claim" principle, so calling it out here.
* No Project / Result Object support: correct, single `NDDataset` only.
* No nested metadata reconstruction: correct, only the flat fields above are read.
* No MATLAB v7.3 / HDF5 redesign: untouched, still `scipy.io.loadmat`.
* No generic spreadsheet-like parsing: untouched.

## Answers to Questions

These are my answers based on my PR.

* **Should this remain a simple exchange writer only?** No. `write_matlab()` already commits to a fixed schema whether or not a reader exists for it, and leaving it one-directional means anyone round-tripping through MATLAB has to hand-write the inverse themselves.
* **Should SpectroChemPy support a minimal self-exchange read path?** Yes, scoped to exactly what `write_matlab()` emits, not a generalized reader.
* **What's the smallest safe reconstruction contract?** Detect the exact five-key signature (`data`, `dims`, `coords`, `coord_units`, `coord_titles`) before falling into the generic loop, and reconstruct only those named fields. Anything not matching that signature falls  through to existing behavior untouched, so this can't regress ordinary `.mat` imports.

Closes #1270

**Checklist**:

- [x] Close the #1270.
- [x] Tests have been added.
- [x] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
- [x] Developer changes (tests, CI, refactoring, tooling) have been documented in the `Developer` section of `docs/sources/whatsnew/changelog.rst`.
- [x] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
- [x] Changelog entry is present (or label `no-changelog` is applied).
- [x] If you are a new contributor, you have added your name (affiliation and ORCID if you have one) in the `zenodo.json` in the field contributors field.