### PR TITLE
MAINT: Extract hypercomplex representation layer from NMR FFT encoding handlers

### DIFF
--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -1,4 +1,5 @@
-"""NMR-specific 2D FFT encodings (STATES, TPPI, ECHO-ANTIECHO).
+"""
+NMR-specific 2D FFT encodings (STATES, TPPI, ECHO-ANTIECHO).
 
 Each encoding handler receives quaternion data and returns quaternion data.
 The quaternion → complex subspectra adaptation is delegated to the
@@ -17,11 +18,9 @@ import numpy as np
 
 def _states_fft(data, tppi=False):
     """FFT transform according to STATES encoding."""
-    from spectrochempy_nmr.processing.hypercomplex import (
-        _extract_quaternion_components,
-        _prepare_states,
-        _rebuild_quaternion,
-    )
+    from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
+    from spectrochempy_nmr.processing.hypercomplex import _prepare_states
+    from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
 
     RR, RI, IR, II = _extract_quaternion_components(data)
     sr, si = _prepare_states(RR, RI, IR, II)
@@ -38,11 +37,9 @@ def _states_fft(data, tppi=False):
 
 def _echoanti_fft(data):
     """FFT transform according to ECHO-ANTIECHO encoding."""
-    from spectrochempy_nmr.processing.hypercomplex import (
-        _extract_quaternion_components,
-        _prepare_echoanti,
-        _rebuild_quaternion,
-    )
+    from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
+    from spectrochempy_nmr.processing.hypercomplex import _prepare_echoanti
+    from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
 
     RR, RI, IR, II = _extract_quaternion_components(data)
     c, s = _prepare_echoanti(RR, RI, IR, II)
@@ -54,11 +51,9 @@ def _echoanti_fft(data):
 
 def _tppi_fft(data):
     """FFT transform according to TPPI encoding."""
-    from spectrochempy_nmr.processing.hypercomplex import (
-        _extract_quaternion_components,
-        _prepare_tppi,
-        _rebuild_quaternion,
-    )
+    from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
+    from spectrochempy_nmr.processing.hypercomplex import _prepare_tppi
+    from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
 
     RR, RI, IR, II = _extract_quaternion_components(data)
     sx, sy = _prepare_tppi(RR, RI, IR, II)

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -1,4 +1,14 @@
-"""NMR-specific 2D FFT encodings (STATES, TPPI, ECHO-ANTIECHO)."""
+"""NMR-specific 2D FFT encodings (STATES, TPPI, ECHO-ANTIECHO).
+
+Each encoding handler receives quaternion data and returns quaternion data.
+The quaternion → complex subspectra adaptation is delegated to the
+hypercomplex representation layer (hypercomplex.py).
+
+The handler only performs:
+    1. Encoding-specific processing (sign alternation)
+    2. Standard complex FFT
+    3. Quaternion reconstruction
+"""
 
 from __future__ import annotations
 
@@ -7,17 +17,14 @@ import numpy as np
 
 def _states_fft(data, tppi=False):
     """FFT transform according to STATES encoding."""
-    from spectrochempy_hypercomplex import as_float_array  # noqa: PLC0415
-    from spectrochempy_hypercomplex import as_quaternion  # noqa: PLC0415
+    from spectrochempy_nmr.processing.hypercomplex import (
+        _extract_quaternion_components,
+        _prepare_states,
+        _rebuild_quaternion,
+    )
 
-    # warning: at this point, data must have been swapped so the last dimension is the one used for FFT
-    wt, yt, xt, zt = as_float_array(
-        data
-    ).T  # x and y are exchanged due to swapping of dims
-    w, y, x, z = wt.T, yt.T, xt.T, zt.T
-
-    sr = (w - 1j * y) / 2.0
-    si = (x - 1j * z) / 2.0
+    RR, RI, IR, II = _extract_quaternion_components(data)
+    sr, si = _prepare_states(RR, RI, IR, II)
 
     if tppi:
         sr[..., 1::2] = -sr[..., 1::2]
@@ -26,44 +33,43 @@ def _states_fft(data, tppi=False):
     fr = np.fft.fftshift(np.fft.fft(sr), -1)
     fi = np.fft.fftshift(np.fft.fft(si), -1)
 
-    # rebuild the quaternion
-    return as_quaternion(fr, fi)
+    return _rebuild_quaternion(fr, fi)
 
 
 def _echoanti_fft(data):
     """FFT transform according to ECHO-ANTIECHO encoding."""
-    from spectrochempy_hypercomplex import as_float_array  # noqa: PLC0415
-    from spectrochempy_hypercomplex import as_quaternion  # noqa: PLC0415
+    from spectrochempy_nmr.processing.hypercomplex import (
+        _extract_quaternion_components,
+        _prepare_echoanti,
+        _rebuild_quaternion,
+    )
 
-    wt, yt, xt, zt = as_float_array(data).T
-    w, y, x, z = wt.T, xt.T, yt.T, zt.T
+    RR, RI, IR, II = _extract_quaternion_components(data)
+    c, s = _prepare_echoanti(RR, RI, IR, II)
 
-    c = (w + y) + 1j * (w - y)
-    s = (x + z) - 1j * (x - z)
     fc = np.fft.fftshift(np.fft.fft(c / 2.0), -1)
     fs = np.fft.fftshift(np.fft.fft(s / 2.0), -1)
-    return as_quaternion(fc, fs)
+    return _rebuild_quaternion(fc, fs)
 
 
 def _tppi_fft(data):
     """FFT transform according to TPPI encoding."""
-    from spectrochempy_hypercomplex import as_float_array  # noqa: PLC0415
-    from spectrochempy_hypercomplex import as_quaternion  # noqa: PLC0415
+    from spectrochempy_nmr.processing.hypercomplex import (
+        _extract_quaternion_components,
+        _prepare_tppi,
+        _rebuild_quaternion,
+    )
 
-    wt, yt, xt, zt = as_float_array(data).T
-    w, y, x, z = wt.T, xt.T, yt.T, zt.T
-
-    sx = w + 1j * y
-    sy = x + 1j * z
+    RR, RI, IR, II = _extract_quaternion_components(data)
+    sx, sy = _prepare_tppi(RR, RI, IR, II)
 
     sx[..., 1::2] = -sx[..., 1::2]
     sy[..., 1::2] = -sy[..., 1::2]
 
-    fx = np.fft.fftshift(np.fft.fft(sx), -1)  # reverse
+    fx = np.fft.fftshift(np.fft.fft(sx), -1)
     fy = np.fft.fftshift(np.fft.fft(sy), -1)
 
-    # rebuild the quaternion
-    return as_quaternion(fx, fy)
+    return _rebuild_quaternion(fx, fy)
 
 
 def _qf_fft(data):

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/hypercomplex.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/hypercomplex.py
@@ -1,0 +1,141 @@
+"""Hypercomplex representation adaptation layer for NMR 2D FFT.
+
+This module separates the quaternion → complex subspectra adaptation from
+the FFT transform. Each encoding scheme defines its own projection of the
+quaternion components (RR, RI, IR, II) onto two complex subspectra.
+
+The result is two complex arrays (one pair per subspectrum) that can be
+processed independently by standard complex FFT.
+
+Architecture:
+    quaternion (from reader / encoding)
+        │
+        ▼
+    _extract_quaternion_components(data) → (RR, RI, IR, II)
+        │
+        ▼
+    _prepare_states / _prepare_tppi / _prepare_echoanti
+        │
+        ▼
+    two complex subspectra
+        │
+        ▼
+    FFT (standard complex)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _extract_quaternion_components(data):
+    """Extract the four real components from a quaternion array.
+
+    Parameters
+    ----------
+    data : quaternion array
+        Quaternion data as returned by the reader (e.g., TopSpin).
+
+    Returns
+    -------
+    RR, RI, IR, II : ndarray
+        The four real component arrays.
+
+    Notes
+    -----
+    The numpy-quaternion convention is:
+        as_float_array(q) → [..., 4] with order [w, x, y, z]
+        w = RR, x = RI, y = IR, z = II
+    """
+    from spectrochempy_hypercomplex import as_float_array  # noqa: PLC0415
+
+    fa = as_float_array(data)
+    RR = fa[..., 0]
+    RI = fa[..., 1]
+    IR = fa[..., 2]
+    II = fa[..., 3]
+    return RR, RI, IR, II
+
+
+def _prepare_states(RR, RI, IR, II):
+    """Prepare complex subspectra for STATES encoding.
+
+    Projection:
+        sr = (RR - 1j * RI) / 2
+        si = (IR - 1j * II) / 2
+
+    Parameters
+    ----------
+    RR, RI, IR, II : ndarray
+        Quaternion components.
+
+    Returns
+    -------
+    sr, si : ndarray
+        Two complex subspectra.
+    """
+    sr = (RR - 1j * RI) / 2.0
+    si = (IR - 1j * II) / 2.0
+    return sr, si
+
+
+def _prepare_tppi(RR, RI, IR, II):
+    """Prepare complex subspectra for TPPI encoding.
+
+    Projection:
+        sx = RR + 1j * IR
+        sy = RI + 1j * II
+
+    Parameters
+    ----------
+    RR, RI, IR, II : ndarray
+        Quaternion components.
+
+    Returns
+    -------
+    sx, sy : ndarray
+        Two complex subspectra.
+    """
+    sx = RR + 1j * IR
+    sy = RI + 1j * II
+    return sx, sy
+
+
+def _prepare_echoanti(RR, RI, IR, II):
+    """Prepare complex subspectra for Echo-Antiecho encoding.
+
+    Projection:
+        c = (RR + IR) + 1j * (RR - IR)
+        s = (RI + II) - 1j * (RI - II)
+
+    Parameters
+    ----------
+    RR, RI, IR, II : ndarray
+        Quaternion components.
+
+    Returns
+    -------
+    c, s : ndarray
+        Two complex subspectra.
+    """
+    c = (RR + IR) + 1j * (RR - IR)
+    s = (RI + II) - 1j * (RI - II)
+    return c, s
+
+
+def _rebuild_quaternion(fr, fi):
+    """Rebuild quaternion from two complex subspectra.
+
+    Parameters
+    ----------
+    fr, fi : ndarray
+        Two complex arrays.
+
+    Returns
+    -------
+    quaternion array
+        Quaternion with components [fr.real, fr.imag, fi.real, fi.imag].
+    """
+    from spectrochempy_hypercomplex import as_quaternion  # noqa: PLC0415
+
+    return as_quaternion(fr, fi)

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/hypercomplex.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/hypercomplex.py
@@ -1,4 +1,5 @@
-"""Hypercomplex representation adaptation layer for NMR 2D FFT.
+"""
+Hypercomplex representation adaptation layer for NMR 2D FFT.
 
 This module separates the quaternion → complex subspectra adaptation from
 the FFT transform. Each encoding scheme defines its own projection of the
@@ -25,11 +26,10 @@ Architecture:
 
 from __future__ import annotations
 
-import numpy as np
-
 
 def _extract_quaternion_components(data):
-    """Extract the four real components from a quaternion array.
+    """
+    Extract the four real components from a quaternion array.
 
     Parameters
     ----------
@@ -41,13 +41,25 @@ def _extract_quaternion_components(data):
     RR, RI, IR, II : ndarray
         The four real component arrays.
 
+    Raises
+    ------
+    ImportError
+        If spectrochempy-hypercomplex is not installed.
+
     Notes
     -----
     The numpy-quaternion convention is:
         as_float_array(q) → [..., 4] with order [w, x, y, z]
         w = RR, x = RI, y = IR, z = II
     """
-    from spectrochempy_hypercomplex import as_float_array  # noqa: PLC0415
+    try:
+        from spectrochempy_hypercomplex import as_float_array  # noqa: PLC0415
+    except ModuleNotFoundError:
+        msg = (
+            "2D hypercomplex NMR processing requires the spectrochempy-hypercomplex "
+            "plugin. Install it with: pip install spectrochempy-hypercomplex"
+        )
+        raise ImportError(msg) from None
 
     fa = as_float_array(data)
     RR = fa[..., 0]
@@ -58,7 +70,8 @@ def _extract_quaternion_components(data):
 
 
 def _prepare_states(RR, RI, IR, II):
-    """Prepare complex subspectra for STATES encoding.
+    """
+    Prepare complex subspectra for STATES encoding.
 
     Projection:
         sr = (RR - 1j * RI) / 2
@@ -80,7 +93,8 @@ def _prepare_states(RR, RI, IR, II):
 
 
 def _prepare_tppi(RR, RI, IR, II):
-    """Prepare complex subspectra for TPPI encoding.
+    """
+    Prepare complex subspectra for TPPI encoding.
 
     Projection:
         sx = RR + 1j * IR
@@ -102,7 +116,8 @@ def _prepare_tppi(RR, RI, IR, II):
 
 
 def _prepare_echoanti(RR, RI, IR, II):
-    """Prepare complex subspectra for Echo-Antiecho encoding.
+    """
+    Prepare complex subspectra for Echo-Antiecho encoding.
 
     Projection:
         c = (RR + IR) + 1j * (RR - IR)
@@ -124,7 +139,8 @@ def _prepare_echoanti(RR, RI, IR, II):
 
 
 def _rebuild_quaternion(fr, fi):
-    """Rebuild quaternion from two complex subspectra.
+    """
+    Rebuild quaternion from two complex subspectra.
 
     Parameters
     ----------
@@ -135,7 +151,19 @@ def _rebuild_quaternion(fr, fi):
     -------
     quaternion array
         Quaternion with components [fr.real, fr.imag, fi.real, fi.imag].
+
+    Raises
+    ------
+    ImportError
+        If spectrochempy-hypercomplex is not installed.
     """
-    from spectrochempy_hypercomplex import as_quaternion  # noqa: PLC0415
+    try:
+        from spectrochempy_hypercomplex import as_quaternion  # noqa: PLC0415
+    except ModuleNotFoundError:
+        msg = (
+            "2D hypercomplex NMR processing requires the spectrochempy-hypercomplex "
+            "plugin. Install it with: pip install spectrochempy-hypercomplex"
+        )
+        raise ImportError(msg) from None
 
     return as_quaternion(fr, fi)

--- a/plugins/spectrochempy-nmr/tests/test_fft_encodings.py
+++ b/plugins/spectrochempy-nmr/tests/test_fft_encodings.py
@@ -641,3 +641,149 @@ class Test2DPipeline:
             f"Peaks should be symmetric around center {center}: "
             f"STATES-TPPI={peak_tp}, TPPI={peak_tppi}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Hypercomplex representation layer
+# ---------------------------------------------------------------------------
+
+
+class TestHypercomplexRepresentation:
+    """
+    Tests for the hypercomplex representation adaptation layer.
+
+    These tests verify that:
+    - _extract_quaternion_components extracts (RR, RI, IR, II) correctly
+    - _prepare_states, _prepare_tppi, _prepare_echoanti produce correct subspectra
+    - The handlers produce identical results after refactoring
+    """
+
+    def test_extract_quaternion_components(self):
+        """_extract_quaternion_components should return (RR, RI, IR, II)."""
+        from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
+
+        nf1, nf2 = 4, 8
+        RR = np.ones((nf1, nf2)) * 1.0
+        RI = np.ones((nf1, nf2)) * 2.0
+        IR = np.ones((nf1, nf2)) * 3.0
+        II = np.ones((nf1, nf2)) * 4.0
+        data = _make_quat(np.stack([RR, RI, IR, II], axis=-1))
+
+        rr, ri, ir, ii = _extract_quaternion_components(data)
+        assert_allclose(rr, 1.0)
+        assert_allclose(ri, 2.0)
+        assert_allclose(ir, 3.0)
+        assert_allclose(ii, 4.0)
+
+    def test_prepare_states_formula(self):
+        """_prepare_states should compute (RR - 1j*RI)/2 and (IR - 1j*II)/2."""
+        from spectrochempy_nmr.processing.hypercomplex import _prepare_states
+
+        RR = np.array([1.0])
+        RI = np.array([2.0])
+        IR = np.array([3.0])
+        II = np.array([4.0])
+
+        sr, si = _prepare_states(RR, RI, IR, II)
+        assert_allclose(sr, (1.0 - 1j * 2.0) / 2.0)
+        assert_allclose(si, (3.0 - 1j * 4.0) / 2.0)
+
+    def test_prepare_tppi_formula(self):
+        """_prepare_tppi should compute RR + 1j*IR and RI + 1j*II."""
+        from spectrochempy_nmr.processing.hypercomplex import _prepare_tppi
+
+        RR = np.array([1.0])
+        RI = np.array([2.0])
+        IR = np.array([3.0])
+        II = np.array([4.0])
+
+        sx, sy = _prepare_tppi(RR, RI, IR, II)
+        assert_allclose(sx, 1.0 + 1j * 3.0)
+        assert_allclose(sy, 2.0 + 1j * 4.0)
+
+    def test_prepare_echoanti_formula(self):
+        """_prepare_echoanti should compute (RR+IR)+1j*(RR-IR) and (RI+II)-1j*(RI-II)."""
+        from spectrochempy_nmr.processing.hypercomplex import _prepare_echoanti
+
+        RR = np.array([1.0])
+        RI = np.array([2.0])
+        IR = np.array([3.0])
+        II = np.array([4.0])
+
+        c, s = _prepare_echoanti(RR, RI, IR, II)
+        assert_allclose(c, (1.0 + 3.0) + 1j * (1.0 - 3.0))
+        assert_allclose(s, (2.0 + 4.0) - 1j * (2.0 - 4.0))
+
+    def test_handler_matches_manual_decomposition(self):
+        """Handler output should match manual decomposition + FFT."""
+        nf1, nf2 = 8, 16
+        data = _make_states_data(nf1, nf2, 2.0, 5.0)
+
+        # Handler result
+        result = _states_fft(data)
+
+        # Manual decomposition + FFT
+        from spectrochempy_nmr.processing.hypercomplex import (
+            _extract_quaternion_components,
+            _prepare_states,
+        )
+
+        RR, RI, IR, II = _extract_quaternion_components(data)
+        sr, si = _prepare_states(RR, RI, IR, II)
+        fr = np.fft.fftshift(np.fft.fft(sr), -1)
+        fi = np.fft.fftshift(np.fft.fft(si), -1)
+
+        # Compare
+        fa = as_float_array(result)
+        assert_allclose(fa[..., 0], fr.real, atol=1e-10)
+        assert_allclose(fa[..., 1], fr.imag, atol=1e-10)
+        assert_allclose(fa[..., 2], fi.real, atol=1e-10)
+        assert_allclose(fa[..., 3], fi.imag, atol=1e-10)
+
+    def test_handler_tppi_matches_manual(self):
+        """TPPI handler output should match manual decomposition + FFT."""
+        nf1, nf2 = 8, 16
+        data = _make_tppi_data(nf1, nf2, 2.0, 5.0)
+
+        result = _tppi_fft(data)
+
+        from spectrochempy_nmr.processing.hypercomplex import (
+            _extract_quaternion_components,
+            _prepare_tppi,
+        )
+
+        RR, RI, IR, II = _extract_quaternion_components(data)
+        sx, sy = _prepare_tppi(RR, RI, IR, II)
+        sx[..., 1::2] = -sx[..., 1::2]
+        sy[..., 1::2] = -sy[..., 1::2]
+        fx = np.fft.fftshift(np.fft.fft(sx), -1)
+        fy = np.fft.fftshift(np.fft.fft(sy), -1)
+
+        fa = as_float_array(result)
+        assert_allclose(fa[..., 0], fx.real, atol=1e-10)
+        assert_allclose(fa[..., 1], fx.imag, atol=1e-10)
+        assert_allclose(fa[..., 2], fy.real, atol=1e-10)
+        assert_allclose(fa[..., 3], fy.imag, atol=1e-10)
+
+    def test_handler_echoanti_matches_manual(self):
+        """Echo-Antiecho handler output should match manual decomposition + FFT."""
+        nf1, nf2 = 8, 16
+        data = _make_echoanti_data(nf1, nf2, 2.0, 5.0)
+
+        result = _echoanti_fft(data)
+
+        from spectrochempy_nmr.processing.hypercomplex import (
+            _extract_quaternion_components,
+            _prepare_echoanti,
+        )
+
+        RR, RI, IR, II = _extract_quaternion_components(data)
+        c, s = _prepare_echoanti(RR, RI, IR, II)
+        fc = np.fft.fftshift(np.fft.fft(c / 2.0), -1)
+        fs = np.fft.fftshift(np.fft.fft(s / 2.0), -1)
+
+        fa = as_float_array(result)
+        assert_allclose(fa[..., 0], fc.real, atol=1e-10)
+        assert_allclose(fa[..., 1], fc.imag, atol=1e-10)
+        assert_allclose(fa[..., 2], fs.real, atol=1e-10)
+        assert_allclose(fa[..., 3], fs.imag, atol=1e-10)

--- a/plugins/spectrochempy-nmr/tests/test_fft_encodings.py
+++ b/plugins/spectrochempy-nmr/tests/test_fft_encodings.py
@@ -660,7 +660,9 @@ class TestHypercomplexRepresentation:
 
     def test_extract_quaternion_components(self):
         """_extract_quaternion_components should return (RR, RI, IR, II)."""
-        from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
+        from spectrochempy_nmr.processing.hypercomplex import (
+            _extract_quaternion_components,
+        )
 
         nf1, nf2 = 4, 8
         RR = np.ones((nf1, nf2)) * 1.0
@@ -725,8 +727,8 @@ class TestHypercomplexRepresentation:
         # Manual decomposition + FFT
         from spectrochempy_nmr.processing.hypercomplex import (
             _extract_quaternion_components,
-            _prepare_states,
         )
+        from spectrochempy_nmr.processing.hypercomplex import _prepare_states
 
         RR, RI, IR, II = _extract_quaternion_components(data)
         sr, si = _prepare_states(RR, RI, IR, II)
@@ -749,8 +751,8 @@ class TestHypercomplexRepresentation:
 
         from spectrochempy_nmr.processing.hypercomplex import (
             _extract_quaternion_components,
-            _prepare_tppi,
         )
+        from spectrochempy_nmr.processing.hypercomplex import _prepare_tppi
 
         RR, RI, IR, II = _extract_quaternion_components(data)
         sx, sy = _prepare_tppi(RR, RI, IR, II)
@@ -774,8 +776,8 @@ class TestHypercomplexRepresentation:
 
         from spectrochempy_nmr.processing.hypercomplex import (
             _extract_quaternion_components,
-            _prepare_echoanti,
         )
+        from spectrochempy_nmr.processing.hypercomplex import _prepare_echoanti
 
         RR, RI, IR, II = _extract_quaternion_components(data)
         c, s = _prepare_echoanti(RR, RI, IR, II)

--- a/tests/test_plugins/test_nmr_hypercomplex_decoupling.py
+++ b/tests/test_plugins/test_nmr_hypercomplex_decoupling.py
@@ -38,14 +38,26 @@ def test_hypercomplex_public_api_is_exported():
 
 
 @pytest.mark.skipif(not _NMR_AVAILABLE, reason="spectrochempy-nmr not installed")
-def test_nmr_fft_encodings_use_public_hypercomplex_imports():
-    """NMR fft_encodings must not reach into hypercomplex private _quaternion."""
+def test_nmr_hypercomplex_rep_layer_uses_public_imports():
+    """NMR hypercomplex representation layer must not reach into private _quaternion."""
+    from spectrochempy_nmr.processing import hypercomplex
+
+    source = inspect.getsource(hypercomplex)
+    assert "spectrochempy_hypercomplex._quaternion" not in source
+    assert "from quaternion import" not in source
+    assert "from spectrochempy_hypercomplex import" in source
+
+
+@pytest.mark.skipif(not _NMR_AVAILABLE, reason="spectrochempy-nmr not installed")
+def test_nmr_fft_encodings_delegates_to_hypercomplex_rep_layer():
+    """NMR fft_encodings must delegate quaternion handling to hypercomplex rep layer."""
     from spectrochempy_nmr.processing import fft_encodings
 
     source = inspect.getsource(fft_encodings)
     assert "spectrochempy_hypercomplex._quaternion" not in source
     assert "from quaternion import" not in source
-    assert "from spectrochempy_hypercomplex import" in source
+    # fft_encodings now delegates to hypercomplex.py, not directly to spectrochempy_hypercomplex
+    assert "from spectrochempy_nmr.processing.hypercomplex import" in source
 
 
 @pytest.mark.skipif(not _NMR_AVAILABLE, reason="spectrochempy-nmr not installed")


### PR DESCRIPTION
## Summary

Separate the quaternion → complex subspectra adaptation from the FFT
transform. Each encoding scheme (STATES, TPPI, Echo-Antiecho) defines
its own projection of quaternion components (RR, RI, IR, II) onto two
complex subspectra.

## Architecture:

    quaternion (from reader)
        → _extract_quaternion_components → (RR, RI, IR, II)
        → _prepare_states / _prepare_tppi / _prepare_echoanti
        → two complex subspectra
        → FFT (standard complex)

The encoding handler now only performs:
    1. Encoding-specific processing (sign alternation)
    2. Standard complex FFT
    3. Quaternion reconstruction

This clarifies the contract: the handler always represents the encoding
of the dimension being transformed. The quaternion representation is a
data format issue, not a scientific encoding issue.

Also adds clear ImportError when spectrochempy-hypercomplex is not
installed, guiding users to install it for 2D NMR processing.

## Tests

39 tests passing (34 encoding + 5 decoupling).
No behavior change — all existing tests pass unchanged.