### PR TITLE
FIX: handle zero-width apodization without ZeroDivisionError

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -62,6 +62,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fixed ``ZeroDivisionError`` when calling ``em(lb=0)`` or
+  ``em(lb=0.0 * ur.Hz)``.  A zero-width exponential apodization is now
+  treated as a no-op (returns the data unchanged) instead of crashing
+  in the unit-conversion wrapper.
+
 - Display legend in 2D lines/stack plots when ``legend=True`` is passed as a
   plotting keyword argument. Previously the ``legend`` kwarg was silently
   ignored by the 2D plot backend, so lines rendered with auto-populated labels

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -54,6 +54,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed ``ZeroDivisionError`` when calling ``em(lb=0)`` or
+  ``em(lb=0.0 * ur.Hz)``.  A zero-width exponential apodization is now
+  treated as a no-op (returns the data unchanged) instead of crashing
+  in the unit-conversion wrapper.
+
 - Display legend in 2D lines/stack plots when ``legend=True`` is passed as a
   plotting keyword argument. Previously the ``legend`` kwarg was silently
   ignored by the 2D plot backend, so lines rendered with auto-populated labels

--- a/src/spectrochempy/processing/fft/apodization.py
+++ b/src/spectrochempy/processing/fft/apodization.py
@@ -86,12 +86,15 @@ def _apodize_method(**units):
                         par *= Quantity(1.0, default_units)
 
                     apod[key] = par
-                    if par.dimensionality == 1 / dunits.dimensionality:
+                    if par.magnitude == 0:
+                        kwargs[key] = 0.0
+                    elif par.dimensionality == 1 / dunits.dimensionality:
                         kwargs[key] = 1.0 / (1.0 / par).to(dunits)
                     else:
                         kwargs[key] = par.to(dunits)
 
-                    kwargs[key] = kwargs[key].magnitude
+                    if hasattr(kwargs[key], "magnitude"):
+                        kwargs[key] = kwargs[key].magnitude
 
                 # Call to the apodize function
                 # ----------------------------

--- a/tests/test_processing/test_fft/test_nmr.py
+++ b/tests/test_processing/test_fft/test_nmr.py
@@ -58,6 +58,13 @@ def test_nmr_1D_em(NMR_dataset_1D):
     dataset2.em(lb=100.0 * ur.Hz, inplace=True)
     assert not np.array_equal(dataset2.data, original2)
 
+    # em with lb=0 is a no-op (no broadening applied)
+    dataset3 = NMR_dataset_1D.copy()
+    dataset3 /= dataset3.real.data.max()
+    original3 = dataset3.data.copy()
+    arr3 = dataset3.em(lb=0.0 * ur.Hz)
+    assert_array_equal(arr3.data, original3)
+
 
 def test_nmr_1D_gm(NMR_dataset_1D):
     dataset = NMR_dataset_1D.copy()


### PR DESCRIPTION
Fix ``ZeroDivisionError`` in the apodization unit-conversion wrapper when
the broadening parameter is zero (``em(lb=0)``, ``em(lb=0.0 * ur.Hz)``).
A zero-width exponential apodization is mathematically a no-op
(exp(0·x) = 1); the wrapper now skips unit conversion for zero-valued
parameters instead of dividing by zero.