### PR TITLE
FIX: accept squeezable singleton 2D Coord inputs

### DIFF
--- a/src/spectrochempy/core/dataset/coord.py
+++ b/src/spectrochempy/core/dataset/coord.py
@@ -249,7 +249,11 @@ class Coord(NDMath, NDArray):
 
         # check if data is 1D
         if self.has_data and len(self.shape) > 1:
-            raise ValueError("Only one 1D arrays can be used to define coordinates")
+            squeezed = np.squeeze(self._data)
+            if squeezed.ndim == 1:
+                self._data = squeezed
+            else:
+                raise ValueError("Only one 1D arrays can be used to define coordinates")
 
         # linearize the data if possible or at least round it
         # to the number of significant digits

--- a/tests/test_core/test_dataset/test_coord_behavior.py
+++ b/tests/test_core/test_dataset/test_coord_behavior.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.units import DimensionalityError
 from spectrochempy.core.units import ur
 from spectrochempy.utils.testing import assert_array_equal
@@ -34,6 +35,28 @@ class TestCoordConstruction:
         c = Coord(np.array([10.0, 20.0, 30.0]))
         assert c.size == 3
         assert np.issubdtype(c.dtype, np.floating)
+
+    def test_from_singleton_row_array(self):
+        c = Coord(np.array([[1.0, 2.0, 3.0]]))
+        assert c.shape == (3,)
+        assert_array_equal(c.data, np.array([1.0, 2.0, 3.0]))
+
+    def test_from_singleton_column_array(self):
+        c = Coord(np.array([[1.0], [2.0], [3.0]]))
+        assert c.shape == (3,)
+        assert_array_equal(c.data, np.array([1.0, 2.0, 3.0]))
+
+    def test_from_singleton_row_nddataset(self):
+        c = Coord(NDDataset(np.array([[1.0, 2.0, 3.0]])))
+        assert c.shape == (3,)
+        assert_array_equal(c.data, np.array([1.0, 2.0, 3.0]))
+
+    def test_from_true_2d_array_raises(self):
+        with pytest.raises(
+            ValueError,
+            match="Only one 1D arrays can be used to define coordinates",
+        ):
+            Coord(np.array([[1.0, 2.0], [3.0, 4.0]]))
 
     def test_from_linspace(self):
         c = Coord(np.linspace(0, 10, 11))


### PR DESCRIPTION
## Summary
- accept singleton row or column 2D inputs when they squeeze cleanly to 1D in `Coord`
- keep rejecting true multidimensional coordinate payloads
- add focused regression coverage for ndarray and `NDDataset` construction paths

## Validation
- `PYTHONPATH=/private/tmp/spectrochempy-issue-1437/src micromamba run -n scpy-core python -m pytest /private/tmp/spectrochempy-issue-1437/tests/test_core/test_dataset/test_coord_behavior.py -q`