### PR TITLE
FIX: preserve empty coord metadata on slice

### DIFF
--- a/src/spectrochempy/core/dataset/coordset.py
+++ b/src/spectrochempy/core/dataset/coordset.py
@@ -762,7 +762,7 @@ class CoordSet(HasTraits):
 
             for entry in group.entries:
                 if entry.coord.is_empty:
-                    coord = Coord(None, name=name)
+                    coord = entry.coord.copy(keepname=True)
                 else:
                     coord = entry.coord[item]
                 entries.append(replace(entry, coord=coord))

--- a/tests/test_core/test_dataset/test_coordset.py
+++ b/tests/test_core/test_dataset/test_coordset.py
@@ -534,7 +534,7 @@ def test_coordset__slice_dims_preserves_reference_and_empty_state():
             title="time",
         ),
         y="x",
-        z=Coord(None),
+        z=Coord(None, title="temperature", units="K"),
     )
 
     sliced = coords._slice_dims(["x", "z"], (1, slice(None)))
@@ -547,6 +547,8 @@ def test_coordset__slice_dims_preserves_reference_and_empty_state():
     assert sliced.x.title == coords.x.title
     assert sliced.z.is_empty
     assert sliced.z.name == "z"
+    assert sliced.z.title == coords.z.title
+    assert sliced.z.units == coords.z.units
     assert sliced["y"] == "x"
 
 

--- a/tests/test_core/test_dataset/test_dataset_coords.py
+++ b/tests/test_core/test_dataset/test_dataset_coords.py
@@ -198,6 +198,18 @@ def test_nddataset_coords_manipulation(dsm):
     coord0 -= coord0[0]  # remove first element
 
 
+def test_nddataset_slice_preserves_empty_coord_metadata():
+    ds = scp.NDDataset(np.zeros((10, 5)))
+    ds.set_coordset(None, None)
+    ds.set_coordtitles(y="time", x="wavelength")
+    ds.set_coordunits(y="s", x="cm^-1")
+
+    sliced = ds[:5]
+
+    assert sliced.coordtitles == ds.coordtitles
+    assert sliced.coordunits == ds.coordunits
+
+
 def test_nddataset_square_dataset_with_identical_coordinates():
     a = np.random.rand(3, 3)
     c = scp.Coord(np.arange(3) * 0.25, title="time", units="us")


### PR DESCRIPTION
## Summary
- preserve metadata when slicing empty coordinates in `CoordSet`
- add a user-facing regression test for `NDDataset` slicing with empty coords
- add an internal `CoordSet` regression test covering title and unit preservation

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_core/test_dataset/test_coordset.py tests/test_core/test_dataset/test_dataset_coords.py -q`