### PR TITLE
DOC: clarify MASAI reference code as future apk() candidate

### DIFF
--- a/src/spectrochempy/processing/fft/phasing.py
+++ b/src/spectrochempy/processing/fft/phasing.py
@@ -258,7 +258,9 @@ def pk_exp(dataset, phc0=0.0, pivot=0.0, exptc=0.0, **kwargs):
     return pk(dataset, phc0=phc0, phc1=0, pivot=pivot, exptc=exptc)
 
 
-# # TODO: work on pk (below a copy from MASAI)
+# Reference: MASAI auto-phase algorithms (negmin + entropy minimization).
+# To be reworked into a proper apk() function when needed.
+# See roadmap/current-roadmap.md for status.
 # @_phase_method
 # def _apk(source=None, options='', axis=-1):
 #     """


### PR DESCRIPTION
## Summary

Clarifies the commented-out MASAI auto-phase code in `phasing.py` as reference material for a future `apk()` function, rather than dead code to be deleted.

### Context

The MASAI code (lines 261-692) contains sophisticated auto-phase algorithms:
- **negmin**: negative area minimization
- **entropy**: spectral entropy minimization
- Combined `negmin+entropy` mode

These are the same algorithms used in TopSpin's `apk` command. The code uses the old API (argparse, globals, FitParameters, DataFrame) and cannot be used as-is, but the algorithms are valuable reference material.

### Change

Replaced the `# TODO: work on pk` comment with a clear reference note explaining the code's purpose and roadmap status.
