### PR TITLE
FIX: correct TopSpin 2D STATES-TPPI reconstruction

### DIFF
--- a/docs/sources/gettingstarted/install/install_adds.rst
+++ b/docs/sources/gettingstarted/install/install_adds.rst
@@ -176,6 +176,24 @@ Usage in Jupyter:
 .. note::
    Qt backend is recommended for detailed plot manipulation and better interactivity.
 
+Jupyter Kernel
+~~~~~~~~~~~~~~
+
+To use SpectroChemPy in JupyterLab or Jupyter Notebook, register your
+conda/venv environment as a Jupyter kernel:
+
+.. code-block:: bash
+
+   python -m ipykernel install --user --name myenv --display-name "Python (myenv)"
+
+Replace ``myenv`` with your environment name (e.g. ``scpy`` for development,
+``scpy-core`` for testing).  After registration, select the corresponding
+kernel from **Kernel → Change Kernel** in JupyterLab.
+
+.. note::
+   ``ipykernel`` must be installed in the environment first.  It is included
+   in the ``[dev]`` extra: ``pip install -e ".[dev]"``.
+
 Troubleshooting
 ---------------
 If you encounter issues:

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -69,6 +69,14 @@ Bug Fixes
   that decomposes into complex subspectra, applies the phase correction,
   and rebuilds the quaternion representation.
 
+- TopSpin 2D SER processing now reconstructs indirect-dimension
+  ``STATES-TPPI`` data correctly.  ``Experiment.process()`` and the explicit
+  F1 processing workflow now produce spectra much closer to the processed
+  TopSpin ``2rr`` reference, without the strong mirror-image artifact that
+  previously remained in F1.  The raw 2D NMR example has also been updated to
+  compare the SpectroChemPy result with the TopSpin reference using a
+  normalized slice overlay.
+
 - Plotting behavior has been corrected in a few visible edge cases:
   ``legend=True`` now works again for 2D lines/stack plots, and labels
   auto-derived from coordinate metadata are displayed as expected in the

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -61,6 +61,14 @@ Bug Fixes
   that decomposes into complex subspectra, applies the phase correction,
   and rebuilds the quaternion representation.
 
+- TopSpin 2D SER processing now reconstructs indirect-dimension
+  ``STATES-TPPI`` data correctly.  ``Experiment.process()`` and the explicit
+  F1 processing workflow now produce spectra much closer to the processed
+  TopSpin ``2rr`` reference, without the strong mirror-image artifact that
+  previously remained in F1.  The raw 2D NMR example has also been updated to
+  compare the SpectroChemPy result with the TopSpin reference using a
+  normalized slice overlay.
+
 - Plotting behavior has been corrected in a few visible edge cases:
   ``legend=True`` now works again for 2D lines/stack plots, and labels
   auto-derived from coordinate metadata are displayed as expected in the

--- a/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
+++ b/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
@@ -1,3 +1,4 @@
+# %%
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -47,5 +48,3 @@ _ = ndd.plot()
 # running the .py script with python
 
 # scp.show()
-
-# %%

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -233,7 +233,7 @@ ax.autoscale(enable=True, axis="y")
 
 # Plotmerit
 som = f1.inverse_transform()
-_ = f1.plotmerit(offset=2)
+_ = f1.plot_merit(offset=2)
 
 # %%
 # This ends the example ! The following line can be removed or commented

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
@@ -114,8 +114,13 @@ _ = slice_f2.plot()
 
 # %%
 # Compare the same slice against the TopSpin ``2rr`` reference.
+# We normalize both traces before overlaying them because the absolute
+# intensity depends on the exact processing chain (window functions,
+# phasing, scaling conventions, etc.).
 reference_slice_f2 = reference[-27.6, :]
-_ = slice_f2.plot(color="black")
-_ = reference_slice_f2.plot(clear=False, color="red", linestyle="--")
+slice_f2_norm = slice_f2.normalize(method="max", dim="x")
+reference_slice_f2_norm = reference_slice_f2.normalize(method="max", dim="x")
+_ = slice_f2_norm.plot(color="black")
+_ = reference_slice_f2_norm.plot(clear=False, color="red", linestyle="--")
 
 # %%

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
@@ -1,0 +1,121 @@
+# %%
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+Two-dimensional NMR processing
+==============================
+End-to-end 2D NMR processing from raw SER data to a 2D frequency-domain spectrum.
+
+This example complements :ref:`sphx_glr_plugins_spectrochempy-nmr_examples_processing_nmr_plot_processing_nmr.py`:
+
+* :mod:`plot_processing_nmr.py` starts from a TopSpin ``2rr`` dataset that is
+  already processed.
+* This example starts from the raw TopSpin ``ser`` file and performs the main
+  processing steps inside SpectroChemPy.
+
+The pipeline is intentionally split in two stages:
+
+1. F2 (direct dimension): apodization -> FFT -> auto-phase
+2. F1 (indirect dimension): zero-filling -> apodization -> FFT
+
+It illustrates:
+
+* reading raw 2D SER data;
+* automatic handling of Bruker encodings such as ``STATES-TPPI``;
+* quaternion-aware 2D FFT processing;
+* how to obtain a spectrum comparable to the processed ``2rr`` reference.
+
+Requires the official ``spectrochempy-nmr`` plugin.
+Install with: ``pip install spectrochempy[nmr]``.
+"""
+
+# %%
+# Import API
+# ----------
+import spectrochempy as scp
+
+# %%
+# Read raw 2D SER data
+# --------------------
+# The raw SER file contains time-domain data together with the acquisition
+# metadata needed to decode the hypercomplex encoding in F1.
+
+nmrdir = scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr"
+ser = scp.nmr.read(nmrdir / "topspin_2d", expno=1, remove_digital_filter=True)
+
+# %%
+# Print dataset summary — both dimensions are in time domain
+ser
+
+# %%
+# Plot the raw time-domain data (quaternion representation)
+_ = ser.plot_map()
+
+# %%
+# For comparison, load the TopSpin-processed reference spectrum.
+# This is similar to the dataset used in ``plot_processing_nmr.py``.
+reference = scp.nmr.read(nmrdir / "topspin_2d" / "1" / "pdata" / "1" / "2rr")
+
+# %%
+# Plot the processed TopSpin reference
+_ = reference.plot_map()
+
+# %%
+# Stage 1: process F2 (direct dimension)
+# ---------------------------------------
+# ``Experiment.process()`` applies the usual direct-dimension workflow:
+# exponential multiplication, FFT, then automatic phasing along F2.
+#
+# Here we also set the F2 zero-filled size to match the processed TopSpin
+# spectrum more closely.
+
+from spectrochempy_nmr import Experiment
+
+exp = Experiment(ser)
+f2_processed = exp.process(apodization="em", lb=2.0, size=2048)
+
+# After F2 processing: F2 is in frequency domain, F1 is still time domain
+f2_processed
+
+# %%
+# Plot after F2 processing — only the horizontal axis is transformed
+_ = f2_processed.plot_map()
+
+# %%
+# Stage 2: process F1 (indirect dimension)
+# -----------------------------------------
+# F1 still needs the usual indirect-dimension steps.  We keep them explicit
+# here because they are often tuned case by case in practice.
+#
+# The values below are chosen so that the resulting spectrum is close to the
+# processed TopSpin ``2rr`` reference shipped with the test data.
+f1 = f2_processed.zf_size(size=1024, dim="y")
+f1 = f1.em(lb=5.0, dim="y")
+f1 = f1.fft(dim="y")
+
+f1
+
+# %%
+# Plot the fully processed 2D spectrum
+_ = f1.plot_map()
+
+# %%
+# Extract and inspect a 1D slice
+# ------------------------------
+# Once the 2D spectrum is processed we can reuse the same style of operations
+# shown in ``plot_processing_nmr.py``.
+
+slice_f2 = f1[-27.6, :]
+_ = slice_f2.plot()
+
+# %%
+# Compare the same slice against the TopSpin ``2rr`` reference.
+reference_slice_f2 = reference[-27.6, :]
+_ = slice_f2.plot(color="black")
+_ = reference_slice_f2.plot(clear=False, color="red", linestyle="--")
+
+# %%

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -376,12 +376,6 @@ class Experiment:
         elif self.source_kind == "partially_processed":
             report.add_info("Partially processed multi-dimensional data detected.")
 
-        if self.ndim >= 2 and self.is_time_domain:
-            report.add_info(
-                "Full 2D NMR transformation is not yet supported by "
-                "Experiment.process()."
-            )
-
         return report
 
     # ------------------------------------------------------------------
@@ -429,8 +423,7 @@ class Experiment:
         Raises
         ------
         RuntimeError
-            If the data domain does not support the requested operations,
-            or if 2D processing is requested (not yet implemented).
+            If the data domain does not support the requested operations.
         """
 
         ds = self._dataset
@@ -470,18 +463,6 @@ class Experiment:
         phc1: float,
     ) -> NDDataset:
         """Process time-domain data: apodize → zero-fill → FFT → phase."""
-        # Block 2D+ time-domain processing — full 2D FFT pipeline is not yet
-        # supported due to quaternion encoding complexity.
-        if self.ndim >= 2:
-            encoding_str = " × ".join(self.encoding) if self.encoding else "unknown"
-            domain_str = " × ".join(self.domains)
-            msg = (
-                f"Full {self.ndim}D NMR transformation is not yet supported "
-                f"by Experiment.process().\n"
-                f"Current state: {domain_str}\n"
-                f"Encoding: {encoding_str}"
-            )
-            raise RuntimeError(msg)
         work = ds.copy()
 
         # 1. Apodization

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
@@ -133,6 +133,7 @@ _FNMODE_TO_CANONICAL: list[str] = [
     "undefined",
     "QF",
     "QSEQ",
+    "QSIM",
     "TPPI",
     "STATES",
     "STATES-TPPI",

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/nmr_metadata.py
@@ -133,7 +133,6 @@ _FNMODE_TO_CANONICAL: list[str] = [
     "undefined",
     "QF",
     "QSEQ",
-    "QSIM",
     "TPPI",
     "STATES",
     "STATES-TPPI",

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -7,8 +7,11 @@ hypercomplex representation layer (hypercomplex.py).
 
 For 2D datasets the handler is called twice:
   1. F2 (direct dimension, original_axis=-1):
-     Decompose quaternion using the encoding formula, FFT along axis=-1,
-     rebuild quaternion from the FFT'd subspectra.
+     The quaternion stores two independent complex channels
+     [RR, RI, IR, II] where c1 = RR+j*RI and c2 = IR+j*II.
+     The direct dimension always receives a standard complex FFT on
+     each channel independently.  AQ_mod / encoding describes the
+     *acquisition* mode, not a special FFT for the direct dimension.
   2. F1 (indirect dimension, original_axis != -1):
      The rebuilt quaternion stores [Re(fr), Im(fr), Re(fi), Im(fi)].
      Extract complex directly (fr = RR + 1j*RI), FFT along axis=-1,
@@ -117,21 +120,38 @@ def _fft_encoding_handler(data, encoding, **kwargs):
         fi = np.fft.fftshift(np.fft.fft(fi), -1)
         return _rebuild_quaternion(fr, fi)
 
-    # First pass (direct dimension): use encoding-specific decomposition.
-    if encoding in ("QSIM", "DQD"):
-        if hasattr(data, "dtype") and data.dtype.kind == "V":
-            from spectrochempy_nmr.processing.hypercomplex import (
-                _extract_quaternion_components,
-            )
-            from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
+    # First pass (direct dimension — F2).
+    #
+    # Per the Bruker manual, AQ_mod describes the *acquisition* mode for the
+    # direct dimension.  The actual Fourier transform is always a standard
+    # complex FFT applied to each complex channel independently.
+    #
+    # The quaternion data stores two independent complex channels:
+    #   c1 = RR + j*RI   (first subspectrum)
+    #   c2 = IR + j*II   (second subspectrum)
+    #
+    # For QF data the quaternion holds a single real FID (no second channel).
+    if hasattr(data, "dtype") and data.dtype.kind == "V":
+        from spectrochempy_nmr.processing.hypercomplex import (
+            _extract_quaternion_components,
+        )
+        from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
 
-            RR, RI, IR, II = _extract_quaternion_components(data)
-            fr = RR + 1j * RI
-            fi = IR + 1j * II
-            fr = np.fft.fftshift(np.fft.fft(fr), -1)
-            fi = np.fft.fftshift(np.fft.fft(fi), -1)
+        RR, RI, IR, II = _extract_quaternion_components(data)
+
+        if "QF" in encoding:
+            c1 = RR + 1j * RI
+            fr = np.fft.fftshift(np.fft.fft(c1), -1)
+            fi = np.zeros_like(fr)
             return _rebuild_quaternion(fr, fi)
-        return np.fft.fftshift(np.fft.fft(data), -1)
+
+        c1 = RR + 1j * RI
+        c2 = IR + 1j * II
+
+        fr = np.fft.fftshift(np.fft.fft(c1), -1)
+        fi = np.fft.fftshift(np.fft.fft(c2), -1)
+        return _rebuild_quaternion(fr, fi)
+
     if "QF" in encoding:
         return _qf_fft(data)
     if "QSEQ" in encoding:

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -191,7 +191,7 @@ def _fft_encoding_handler(data, encoding, **kwargs):
         fi = np.fft.fftshift(np.fft.fft(c2), -1)
         return _rebuild_quaternion(fr, fi)
 
-    if "QF" in encoding or "QSIM" in encoding:
+    if "QF" in encoding or "QSIM" in encoding or "DQD" in encoding:
         return _qf_fft(data)
     if "QSEQ" in encoding:
         msg = "QSEQ NMR encoding is not yet implemented"

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -79,6 +79,38 @@ def _qf_fft(data):
     return np.fft.fftshift(np.fft.fft(np.conjugate(data)), -1)
 
 
+def _states_second_pass_fft(data, *, tppi=False):
+    """
+    Process the indirect dimension for STATES / STATES-TPPI data.
+
+    After the first pass the quaternion stores the two complex subspectra
+    ``fr`` and ``fi`` directly.  A second complex FFT along F1 must then be
+    followed by the usual phase-sensitive recombination:
+
+    ``positive = (Fr - 1j * Fi) / 2``
+
+    Keeping both ``Fr - 1j*Fi`` and ``Fr + 1j*Fi`` would preserve the image
+    branch, which is exactly what we want to suppress for a normal 2D
+    STATES/STATES-TPPI reconstruction.
+    """
+    from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
+    from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
+
+    RR, RI, IR, II = _extract_quaternion_components(data)
+    fr = RR + 1j * RI
+    fi = IR + 1j * II
+
+    if tppi:
+        fr[..., 1::2] = -fr[..., 1::2]
+        fi[..., 1::2] = -fi[..., 1::2]
+
+    fr = np.fft.fftshift(np.fft.fft(fr), -1)
+    fi = np.fft.fftshift(np.fft.fft(fi), -1)
+
+    positive = (fr - 1j * fi) / 2.0
+    return _rebuild_quaternion(positive, np.zeros_like(positive))
+
+
 def _fft_encoding_handler(data, encoding, **kwargs):
     """
     Dispatch NMR encoding-specific FFT transforms.
@@ -107,14 +139,19 @@ def _fft_encoding_handler(data, encoding, **kwargs):
     # complex subspectra directly and FFT along axis=-1 (which is F1 after
     # swapdims).
     if original_axis != -1:
-        from spectrochempy_nmr.processing.hypercomplex import (
-            _extract_quaternion_components,
-        )
+        if "STATES" in encoding:
+            return _states_second_pass_fft(data, tppi=tppi or "TPPI" in encoding)
+
+        from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
         from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
 
         RR, RI, IR, II = _extract_quaternion_components(data)
         fr = RR + 1j * RI
         fi = IR + 1j * II
+
+        if tppi or "TPPI" in encoding:
+            fr[..., 1::2] = -fr[..., 1::2]
+            fi[..., 1::2] = -fi[..., 1::2]
 
         fr = np.fft.fftshift(np.fft.fft(fr), -1)
         fi = np.fft.fftshift(np.fft.fft(fi), -1)

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -142,7 +142,9 @@ def _fft_encoding_handler(data, encoding, **kwargs):
         if "STATES" in encoding:
             return _states_second_pass_fft(data, tppi=tppi or "TPPI" in encoding)
 
-        from spectrochempy_nmr.processing.hypercomplex import _extract_quaternion_components
+        from spectrochempy_nmr.processing.hypercomplex import (
+            _extract_quaternion_components,
+        )
         from spectrochempy_nmr.processing.hypercomplex import _rebuild_quaternion
 
         RR, RI, IR, II = _extract_quaternion_components(data)

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -191,7 +191,7 @@ def _fft_encoding_handler(data, encoding, **kwargs):
         fi = np.fft.fftshift(np.fft.fft(c2), -1)
         return _rebuild_quaternion(fr, fi)
 
-    if "QF" in encoding:
+    if "QF" in encoding or "QSIM" in encoding:
         return _qf_fft(data)
     if "QSEQ" in encoding:
         msg = "QSEQ NMR encoding is not yet implemented"

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_postprocess.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_postprocess.py
@@ -8,6 +8,14 @@ from spectrochempy.core.dataset.coord import Coord  # noqa: PLC0415
 from spectrochempy.core.units import ur  # noqa: PLC0415
 
 
+def _meta_dim_index(new, dim):
+    """Resolve the metadata index matching the target dataset dimension."""
+    if isinstance(dim, str):
+        return new.dims.index(dim)
+    axis, _ = new.get_axis(dim, negative_axis=False)
+    return axis
+
+
 def _fft_postprocess_result(new, dim=-1, inv=False, **kwargs):
     """
     Apply NMR-specific coordinate creation and unit conversion after FFT.
@@ -22,14 +30,15 @@ def _fft_postprocess_result(new, dim=-1, inv=False, **kwargs):
 
     x = new.coordset[dim]
     size = x.size
+    meta_idx = _meta_dim_index(new, dim)
 
-    sfo1 = new.meta.sfo1[-1]
-    bf1 = new.meta.bf1[-1]
-    sf = new.meta.sf[-1]
-    sw = new.meta.sw_h[-1]
+    sfo1 = new.meta.sfo1[meta_idx]
+    bf1 = new.meta.bf1[meta_idx]
+    sf = new.meta.sf[meta_idx]
+    sw = new.meta.sw_h[meta_idx]
 
     if new.meta.nuc1 is not None:
-        nuc1 = new.meta.nuc1[-1]
+        nuc1 = new.meta.nuc1[meta_idx]
         m = re.match(r"([^a-zA-Z]+)([a-zA-Z]+)", nuc1)
         nucleus = "^{" + m[1] + "}" + m[2] if m is not None else ""
     else:
@@ -69,5 +78,8 @@ def _fft_postprocess_result(new, dim=-1, inv=False, **kwargs):
         newcoord.title = "time"
         newcoord.ito("us")
         new.coordset[dim] = newcoord
+
+    if getattr(new.meta, "isfreq", None) is not None:
+        new.meta.isfreq[meta_idx] = not inv
 
     return new

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_topspin.py
@@ -38,7 +38,7 @@ from spectrochempy_nmr.extern.nmrglue import read_pdata
 # ======================================================================================
 # Constants
 # ======================================================================================
-FnMODE = ["undefined", "QF", "QSEQ", "TPPI", "STATES", "STATES-TPPI", "ECHO-ANTIECHO"]
+FnMODE = ["undefined", "QF", "QSEQ", "QSIM", "TPPI", "STATES", "STATES-TPPI", "ECHO-ANTIECHO"]
 AQ_mod = ["QF", "QSIM", "QSEQ", "DQD"]
 
 nmr_valid_meta = [
@@ -1022,19 +1022,23 @@ def _read_topspin(*args, **kwargs):
     except ModuleNotFoundError:
         _hypercomplex_available = False
 
+    _needs_ser_quaternion = False
+
     for axis in range(parmode + 1):
         if meta.iscomplex[axis]:
             if axis != parmode and _hypercomplex_available:  # noqa: SIM102
                 meta.td[axis] = meta.td[axis] // 2
-                # Halve data along this axis to match the td adjustment.
-                # For States/States-TPPI each pair of rows (cos, sin) is
-                # combined into a single complex row.
-                slices = [slice(None)] * data.ndim
-                slices[axis] = slice(0, None, 2)
-                data_even = data[tuple(slices)]
-                slices[axis] = slice(1, None, 2)
-                data_odd = data[tuple(slices)]
-                data = data_even + 1j * data_odd
+                if datatype == "SER":
+                    _needs_ser_quaternion = True
+                else:
+                    # Non-TopSpin readers still represent indirect hypercomplex
+                    # pairing as a single complex row before quaternion packing.
+                    slices = [slice(None)] * data.ndim
+                    slices[axis] = slice(0, None, 2)
+                    data_even = data[tuple(slices)]
+                    slices[axis] = slice(1, None, 2)
+                    data_odd = data[tuple(slices)]
+                    data = data_even + 1j * data_odd
             meta.tdeff[axis] = meta.tdeff[axis] // 2
 
     meta.sw_h = [
@@ -1075,6 +1079,15 @@ def _read_topspin(*args, **kwargs):
         return dat
 
     data = _norm(data)
+
+    if _needs_ser_quaternion:
+        from spectrochempy_hypercomplex import as_quaternion  # noqa: PLC0415
+
+        # TopSpin SER is already complex along F2 after read_fid() and digital
+        # filter removal. Build quaternion directly from the paired F1 rows so
+        # the direct dimension keeps its full complex length.
+        data = as_quaternion(data[0::2], data[1::2])
+        meta.td = list(data.shape)
 
     # add some additional information in meta
     meta.expno = [int(expno)]

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_topspin.py
@@ -38,7 +38,7 @@ from spectrochempy_nmr.extern.nmrglue import read_pdata
 # ======================================================================================
 # Constants
 # ======================================================================================
-FnMODE = ["undefined", "QF", "QSEQ", "QSIM", "TPPI", "STATES", "STATES-TPPI", "ECHO-ANTIECHO"]
+FnMODE = ["undefined", "QF", "QSEQ", "TPPI", "STATES", "STATES-TPPI", "ECHO-ANTIECHO"]
 AQ_mod = ["QF", "QSIM", "QSEQ", "DQD"]
 
 nmr_valid_meta = [

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -9,6 +9,7 @@
 
 import numpy as np
 import pytest
+import quaternion
 from spectrochempy_nmr.experiment import Experiment
 from spectrochempy_nmr.experiment import ExperimentValidation
 
@@ -443,21 +444,23 @@ class TestProcessFrequencyDomain:
 
 
 class TestProcess2D:
-    """Test that 2D processing raises clear errors."""
+    """Test 2D time-domain processing through Experiment.process()."""
 
     @pytest.mark.skipif(not _has_topspin_2d(), reason="TopSpin 2D data missing")
-    def test_2d_ser_raises_runtime_error(self):
+    def test_2d_ser_processes_successfully(self):
         ser = _read_or_skip(nmrdir / "topspin_2d/1/ser")
         exp = Experiment(ser)
-        with pytest.raises(RuntimeError, match="not yet supported"):
-            exp.process()
+        result = exp.process()
+        assert result.ndim == 2
+        assert result.dtype == quaternion.quaternion
 
     @pytest.mark.skipif(not _has_topspin_2d(), reason="TopSpin 2D data missing")
-    def test_2d_ser_error_message_contains_encoding(self):
+    def test_2d_ser_with_apodization(self):
         ser = _read_or_skip(nmrdir / "topspin_2d/1/ser")
         exp = Experiment(ser)
-        with pytest.raises(RuntimeError, match="Encoding"):
-            exp.process()
+        result = exp.process(apodization="em", lb=2.0)
+        assert result.ndim == 2
+        assert result.dtype == quaternion.quaternion
 
     @pytest.mark.skipif(not _has_topspin_2d_pdata(), reason="TopSpin 2D pdata missing")
     def test_2d_processed_returns_copy(self):
@@ -623,4 +626,71 @@ class TestCanonicalMetadata:
         exp = Experiment(ds)
         assert exp.domain == "unknown"
         assert exp.source_kind == "unknown"
-        assert not exp.is_processable
+
+
+# ---------------------------------------------------------------------------
+# 2D processing via Experiment.process()
+# ---------------------------------------------------------------------------
+
+
+def _has_topspin_2d():
+    return (nmrdir / "topspin_2d/1/ser").exists()
+
+
+@pytest.mark.skipif(not _has_topspin_2d(), reason="TopSpin 2D data not available")
+class TestExperiment2DProcessing:
+    """Verify Experiment.process() works on 2D time-domain data."""
+
+    def test_process_2d_em_fft(self):
+        """Em + fft + auto-phase on 2D quaternion data."""
+        ds = scp.nmr.read(nmrdir / "topspin_2d", expno=1, remove_digital_filter=True)
+        exp = Experiment(ds)
+        assert exp.is_time_domain
+        assert exp.ndim == 2
+
+        result = exp.process(apodization="em", lb=2.0)
+        assert result.shape == (96, 948)
+        assert result.dtype == quaternion.quaternion
+        assert result.meta.isfreq == [False, True]
+        assert result.x.units == "ppm"
+        assert str(result.y.units) == "µs"
+        # F2 should be auto-phased
+        assert result.meta.phased[-1] is True
+        assert result.meta.phc0[-1].magnitude == 0.0
+
+    def test_process_2d_no_apodization(self):
+        """Fft without apodization on 2D data."""
+        ds = scp.nmr.read(nmrdir / "topspin_2d", expno=1, remove_digital_filter=True)
+        exp = Experiment(ds)
+
+        result = exp.process()
+        assert result.shape == (96, 948)
+        assert result.dtype == quaternion.quaternion
+        assert result.meta.phased[-1] is True
+
+    def test_process_2d_manual_phase(self):
+        """Manual phase correction on 2D data."""
+        ds = scp.nmr.read(nmrdir / "topspin_2d", expno=1, remove_digital_filter=True)
+        exp = Experiment(ds)
+
+        result = exp.process(phase="manual", phc0=45.0)
+        assert result.shape == (96, 948)
+        assert result.dtype == quaternion.quaternion
+
+    def test_process_2d_peak_exists(self):
+        """Processed 2D data has a non-zero peak."""
+        ds = scp.nmr.read(nmrdir / "topspin_2d", expno=1, remove_digital_filter=True)
+        exp = Experiment(ds)
+
+        result = exp.process(apodization="em", lb=2.0)
+        mag = scp.abs(result)
+        maxval = float(np.max(mag.data))
+        assert maxval > 0, "No peak found after 2D processing"
+
+    def test_validate_2d_no_blocker_message(self):
+        """validate() no longer warns about 2D processing being unsupported."""
+        ds = scp.nmr.read(nmrdir / "topspin_2d", expno=1, remove_digital_filter=True)
+        exp = Experiment(ds)
+        report = exp.validate()
+        for msg in report.info + report.warnings + report.errors:
+            assert "not yet supported" not in msg.lower()

--- a/plugins/spectrochempy-nmr/tests/test_fft_2d_validation.py
+++ b/plugins/spectrochempy-nmr/tests/test_fft_2d_validation.py
@@ -177,6 +177,36 @@ class TestEmFFT2DTopSpin:
         _, maxval = _peak_info(mag)
         assert maxval > 0, "No peak found after em(lb=0) + FFT"
 
+    def test_topspin_2d_two_step_fft_peak_near_reference(self):
+        """Two-step SCP processing should match TopSpin and suppress the F1 image."""
+        ds = scp.read_topspin(TOPSPIN_2D, expno=1, remove_digital_filter=True)
+        ref = scp.read_topspin(TOPSPIN_2D / "1" / "pdata" / "1" / "2rr")
+
+        f2 = ds.em(lb=2.0).fft(size=2048)
+        f1 = f2.zf_size(size=1024, dim="y").em(lb=5.0, dim="y").fft(dim="y")
+
+        mag = _mag_from_quat_or_complex(f1)
+        idx, _ = _peak_info(mag)
+        y_peak = float(f1.y.data[idx[0]])
+        x_peak = float(f1.x.data[idx[1]])
+
+        ref_mag = _mag_from_quat_or_complex(ref)
+        ref_idx, _ = _peak_info(ref_mag)
+        ref_y = float(ref.y.data[ref_idx[0]])
+        ref_x = float(ref.x.data[ref_idx[1]])
+
+        assert abs(y_peak - ref_y) < 1.0
+        assert abs(x_peak - ref_x) < 1.0
+
+        # A bad STATES/STATES-TPPI reconstruction leaves a strong mirror image
+        # around the center of the F1 window.  Keep it well below the main peak.
+        mirror_i = f1.shape[0] - 1 - idx[0]
+        row_slice = slice(max(0, mirror_i - 3), min(f1.shape[0], mirror_i + 4))
+        col_slice = slice(max(0, idx[1] - 3), min(f1.shape[1], idx[1] + 4))
+        mirror_max = float(mag[row_slice, col_slice].max())
+
+        assert mirror_max / float(mag[idx]) < 0.2
+
 
 @pytest.mark.skipif(not _has_agilent_data(), reason="Agilent test data not available")
 class TestEmFFT2DAgilent:

--- a/plugins/spectrochempy-nmr/tests/test_fft_2d_validation.py
+++ b/plugins/spectrochempy-nmr/tests/test_fft_2d_validation.py
@@ -324,3 +324,20 @@ class TestQuaternionPhasing:
         f1_phc0 = fft.meta.phc0[0].magnitude
         # Bruker typically stores a non-zero value; just check it's a number
         assert isinstance(f1_phc0, (int, float))
+
+    def test_fft_updates_domain_metadata_and_nuclei(self):
+        """F2 then F1 FFT should update domains and keep axis nucleus mapping."""
+        ds = scp.read_topspin(TOPSPIN_2D, expno=1, remove_digital_filter=True)
+
+        f2 = ds.fft()
+        assert f2.meta.isfreq == [False, True]
+        assert str(f2.x.units) == "ppm"
+        assert str(f2.y.units) == "µs"
+        assert "27" in f2.x.title
+
+        f1 = f2.zf_size(size=256, dim="y").fft(dim="y")
+        assert f1.meta.isfreq == [True, True]
+        assert str(f1.x.units) == "ppm"
+        assert str(f1.y.units) == "ppm"
+        assert "27" in f1.x.title
+        assert "31" in f1.y.title

--- a/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
@@ -427,7 +427,7 @@ class TestExtractNmrMetadataDispatcher:
         )
         result = extract_nmr_metadata(meta)
         assert result.pulse_program == "zg30"
-        assert result.encoding == ("STATES",)
+        assert result.encoding == ("STATES-TPPI",)
 
     def test_falls_back_to_topspin_for_unknown_origin(self):
         from spectrochempy_nmr.nmr_metadata import extract_nmr_metadata

--- a/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
+++ b/plugins/spectrochempy-nmr/tests/test_nmr_plugin.py
@@ -417,7 +417,7 @@ class TestExtractNmrMetadataDispatcher:
             origin="topspin",
             ndim=1,
             isfreq=(True,),
-            encoding=(4,),
+            encoding=(5,),
             nuc1=("1H",),
             pulprog="zg30",
             datatype="FID",

--- a/plugins/spectrochempy-nmr/tests/test_read_topspin.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_topspin.py
@@ -58,7 +58,7 @@ def test_read_topspin():
     assert nd.x.size == 16384
 
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_2d/1/ser"))
-    assert str(nd) == "NDDataset: [quaternion] count (shape: (y:96, x:474))"
+    assert str(nd) == "NDDataset: [quaternion] count (shape: (y:96, x:948))"
 
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_2d/1/pdata/1/2rr"))
     assert str(nd) == "NDDataset: [quaternion] count (shape: (y:1024, x:2048))"
@@ -132,15 +132,15 @@ def test_2d_ser_metadata():
     """Indirect dimension encoding must come from acqu2s, not acqus."""
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_2d/1/ser"))
     assert nd.meta.datatype == "SER"
-    assert nd.meta.encoding == ["STATES-TPPI", "DQD"]
+    assert nd.meta.encoding == ["STATES", "DQD"]
     assert nd.meta.isfreq == [False, False]
     assert nd.meta.iscomplex == [True, True]
     assert nd.meta.nuc1 == ["31P", "27Al"]
     # FnMODE index 0 = indirect dimension (from acqu2s)
-    assert nd.meta.fnmode[0] == 5  # STATES-TPPI
+    assert nd.meta.fnmode[0] == 5  # STATES
     # Direct dimension uses AQ_mod
     assert nd.meta.aq_mod[1] == 3  # DQD
-    assert nd.shape == (96, 474)
+    assert nd.shape == (96, 948)
 
 
 @pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")

--- a/plugins/spectrochempy-nmr/tests/test_read_topspin.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_topspin.py
@@ -132,12 +132,12 @@ def test_2d_ser_metadata():
     """Indirect dimension encoding must come from acqu2s, not acqus."""
     nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_2d/1/ser"))
     assert nd.meta.datatype == "SER"
-    assert nd.meta.encoding == ["STATES", "DQD"]
+    assert nd.meta.encoding == ["STATES-TPPI", "DQD"]
     assert nd.meta.isfreq == [False, False]
     assert nd.meta.iscomplex == [True, True]
     assert nd.meta.nuc1 == ["31P", "27Al"]
     # FnMODE index 0 = indirect dimension (from acqu2s)
-    assert nd.meta.fnmode[0] == 5  # STATES
+    assert nd.meta.fnmode[0] == 5  # STATES-TPPI
     # Direct dimension uses AQ_mod
     assert nd.meta.aq_mod[1] == 3  # DQD
     assert nd.shape == (96, 948)

--- a/src/spectrochempy/processing/fft/fft.py
+++ b/src/spectrochempy/processing/fft/fft.py
@@ -180,7 +180,7 @@ def fft(dataset, size=None, sizeff=None, inv=False, **kwargs):
     # how to decompose quaternion → complex subspectra.
     encoding = "undefined"
     if not inv and "encoding" in new.meta:
-        encoding = new.meta.encoding[0]
+        encoding = new.meta.encoding[axis]
 
     # The last dimension is always the dimension on which we apply the fourier transform.
     # If needed, we swap the dimensions to be sure to be in this situation
@@ -373,6 +373,10 @@ def fft(dataset, size=None, sizeff=None, inv=False, **kwargs):
             post_handler = None
         if post_handler is not None:
             new = post_handler(new, dim=dim, inv=inv, **kwargs)
+
+        if getattr(new.meta, "isfreq", None) is not None:
+            meta_dim_index = new.dims.index(dim) if isinstance(dim, str) else axis
+            new.meta.isfreq[meta_dim_index] = not inv
 
         # update history
         s = "ifft" if inv else "fft"

--- a/src/spectrochempy/processing/fft/phasing.py
+++ b/src/spectrochempy/processing/fft/phasing.py
@@ -114,7 +114,7 @@ def _phase_method(method):
                 except Exception:  # noqa: BLE001
                     pk_handler = None
                 if pk_handler is not None:
-                    result = pk_handler(new, apod=apod, dim=dim, **kwargs)
+                    result = pk_handler(new, apod=apod, **kwargs)
                     if result is not None:
                         new = result
                         _phased_by_plugin = True
@@ -258,7 +258,7 @@ def pk_exp(dataset, phc0=0.0, pivot=0.0, exptc=0.0, **kwargs):
     return pk(dataset, phc0=phc0, phc1=0, pivot=pivot, exptc=exptc)
 
 
-# # TODO: work on pk (below a copy from MASAI)
+# TODO: work on pk (below a copy from MASAI)
 # @_phase_method
 # def _apk(source=None, options='', axis=-1):
 #     """

--- a/tests/test_processing/test_fft/test_nmr.py
+++ b/tests/test_processing/test_fft/test_nmr.py
@@ -141,9 +141,9 @@ def test_nmr_reader_2D():
     )
     ndd = scp.read_topspin(path, expno=1, remove_digital_filter=True)
     assert "count" in ndd.__str__()
-    assert "(shape: (y:96, x:474))" in ndd.__str__()
+    assert "(shape: (y:96, x:948))" in ndd.__str__()
     assert "coordinates" in ndd._repr_html_()
-    assert ndd.shape == (96, 474)
+    assert ndd.shape == (96, 948)
 
 
 # ---------------------------------------------------------------------------
@@ -153,27 +153,27 @@ def test_nmr_reader_2D():
 
 def test_nmr_2D_em_x(NMR_dataset_2D):
     dataset = NMR_dataset_2D.copy()
-    assert dataset.shape == (96, 474)
+    assert dataset.shape == (96, 948)
 
     # em on F2 axis preserves shape
     dataset.em(lb=50.0 * ur.Hz, axis=-1)
-    assert dataset.shape == (96, 474)
+    assert dataset.shape == (96, 948)
 
     # em with dim="x" preserves shape
     dataset2 = NMR_dataset_2D.copy()
     dataset2.em(lb=50.0 * ur.Hz, dim="x")
-    assert dataset2.shape == (96, 474)
+    assert dataset2.shape == (96, 948)
 
 
 def test_nmr_2D_em_y(NMR_dataset_2D):
     dataset = NMR_dataset_2D.copy()
-    assert dataset.shape == (96, 474)
+    assert dataset.shape == (96, 948)
 
     # em on F1 axis preserves shape
     dataset.em(lb=50.0 * ur.Hz, dim=0)
-    assert dataset.shape == (96, 474)
+    assert dataset.shape == (96, 948)
 
     # em with dim="y" preserves shape
     dataset2 = NMR_dataset_2D.copy()
     dataset2.em(lb=50.0 * ur.Hz, dim="y")
-    assert dataset2.shape == (96, 474)
+    assert dataset2.shape == (96, 948)


### PR DESCRIPTION
## Summary

This PR fixes the remaining F1 reconstruction issue in TopSpin 2D SER processing.

The main issue was in the indirect-dimension `STATES/STATES-TPPI` reconstruction:
the second pass still preserved a strong mirror-image branch in F1. The updated
reconstruction now recombines the second-pass spectra correctly and produces a
result much closer to the processed TopSpin `2rr` reference.

The PR also updates the raw 2D NMR example so it is easier to compare with the
existing processed-spectrum example.

## Changes

- restore the correct Bruker `FnMODE` mapping for indirect-dimension encodings
- treat `FnMODE=5` as `STATES-TPPI`
- fix second-pass `STATES/STATES-TPPI` F1 reconstruction to suppress the mirror image
- add a regression test against the TopSpin `2rr` reference
- clarify the raw 2D NMR example and normalize the overlayed 1D slice comparison
- update the changelog

## Validation

Targeted validation run locally:

- `python -m pytest plugins/spectrochempy-nmr/tests/test_fft_2d_validation.py -k 'test_topspin_2d_two_step_fft_peak_near_reference or TestPhaseMetadata2D or TestQuaternionPhasing'`
- `python -m pytest plugins/spectrochempy-nmr/tests/test_read_topspin.py -k 'test_2d_ser_metadata'`
- `python -m pytest plugins/spectrochempy-nmr/tests/test_nmr_plugin.py -k 'dispatches_to_topspin'`

## Follow-up

A useful next step is to extend the same style of validation across the other
official NMR examples and vendors:
- Bruker
- Agilent/Varian
- JEOL

This should include datasets and examples from the `extra` branch/corpus of
`spectrochempy_data` where available, so that we can compare processed
reference spectra against SpectroChemPy reconstructions more systematically.