### PR TITLE
FIX: keep 2D plots readable when equal-aspect defaults are too strict

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -59,6 +59,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- 2D ``plot_map()``/``plot()`` now keep a readable layout for datasets whose
+  X and Y axes share units but span very different numeric ranges.  Explicit
+  ``figsize=...`` overrides are also now honored reliably when a plotting call
+  reuses an existing figure with ``clear=False``.
+
 - `read_matlab()` no longer crashes on `.mat` files containing a plain MATLAB
   cell-array variable. It previously raised an unguarded `TypeError` (surfaced
   only as a swallowed `UserWarning`, with the function silently returning

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -51,6 +51,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- 2D ``plot_map()``/``plot()`` now keep a readable layout for datasets whose
+  X and Y axes share units but span very different numeric ranges.  Explicit
+  ``figsize=...`` overrides are also now honored reliably when a plotting call
+  reuses an existing figure with ``clear=False``.
+
 - `read_matlab()` no longer crashes on `.mat` files containing a plain MATLAB
   cell-array variable. It previously raised an unguarded `TypeError` (surfaced
   only as a swallowed `UserWarning`, with the function silently returning

--- a/src/spectrochempy/core/dataset/nddataset.py
+++ b/src/spectrochempy/core/dataset/nddataset.py
@@ -2265,6 +2265,9 @@ class NDDataset(NDMath, NDIO, NDComplexArray):
             if plt.get_fignums():
                 # Existing figures - use the current one
                 fig = plt.gcf()
+                requested_figsize = kwargs.get("figsize")
+                if requested_figsize is not None:
+                    fig.set_size_inches(*requested_figsize)
             else:
                 # No existing figures - create a new one
                 fig = get_figure(

--- a/src/spectrochempy/plotting/plot2d.py
+++ b/src/spectrochempy/plotting/plot2d.py
@@ -77,6 +77,42 @@ def _can_enforce_equal_aspect(dataset):
     return units_x == units_y
 
 
+def _has_reasonable_equal_aspect_ratio(dataset, *, min_ratio=0.5, max_ratio=2.0):
+    """
+    Return True when equal aspect is unlikely to collapse the plotting area.
+
+    Datasets can legitimately share the same units on both axes while still
+    spanning very different numeric ranges, for example raw 2D NMR time-domain
+    SER data. For those cases, forcing ``ax.set_aspect('equal')`` shrinks the
+    axes into a thin horizontal or vertical strip. We therefore keep the strict
+    equal-aspect default only when the X/Y numeric ranges are of comparable
+    magnitude.
+    """
+    if dataset is None or len(dataset.dims) < 2:
+        return False
+
+    dimx, dimy = dataset.dims[-1], dataset.dims[-2]
+    coord_x = getattr(dataset, dimx, None)
+    coord_y = getattr(dataset, dimy, None)
+
+    if coord_x is None or coord_y is None:
+        return False
+
+    try:
+        xdata = coord_x.data
+        ydata = coord_y.data
+        x_range = float(np.nanmax(xdata) - np.nanmin(xdata))
+        y_range = float(np.nanmax(ydata) - np.nanmin(ydata))
+    except Exception:
+        return False
+
+    if x_range <= 0 or y_range <= 0:
+        return False
+
+    ratio = y_range / x_range
+    return min_ratio <= ratio <= max_ratio
+
+
 def _apply_x_axis_policy(ax, coord, default_xlim, kwargs):
     """
     Apply X axis policy (limits, reversal) for both 2D and 3D plots.
@@ -1992,11 +2028,18 @@ def plot_2D(dataset, method=None, **kwargs):
 
         # Handle equal_aspect for 2D plots (contour, contourf, image, map)
         # Hierarchy: explicit kwarg > preference > default (False)
+        equal_aspect_explicit = "equal_aspect" in kwargs
         equal_aspect = kwargs.get("equal_aspect", prefs.image_equal_aspect)
 
         if equal_aspect and method in ["contour", "contourf", "image", "map"]:
             if _can_enforce_equal_aspect(new):
-                ax.set_aspect("equal", adjustable="box")
+                if equal_aspect_explicit or _has_reasonable_equal_aspect_ratio(new):
+                    ax.set_aspect("equal", adjustable="box")
+                else:
+                    info_(
+                        "equal_aspect preference ignored: X/Y ranges are too "
+                        "different for a readable default layout."
+                    )
             else:
                 info_(
                     "equal_aspect=True ignored: X and Y units are incompatible or missing."

--- a/tests/test_plotting/test_contract_plot2d.py
+++ b/tests/test_plotting/test_contract_plot2d.py
@@ -147,3 +147,41 @@ def test_plot2d_nc_and_calpha_aliases_still_work():
     assert contour_sets
     assert len(contour_sets[0].levels) == 4
     assert contour_sets[0].get_alpha() == pytest.approx(0.25)
+
+
+def test_plot2d_clear_false_honors_requested_figsize(synthetic_2d):
+    """A reused figure should still adopt an explicit figsize override."""
+    ax1 = synthetic_2d.plot(method="map", show=False, clear=False, figsize=(12, 6))
+    assert tuple(ax1.figure.get_size_inches()) == pytest.approx((12, 6))
+
+    ax2 = synthetic_2d.plot(method="map", show=False, clear=False, figsize=(4, 10))
+    assert ax2.figure is ax1.figure
+    assert tuple(ax2.figure.get_size_inches()) == pytest.approx((4, 10))
+
+
+def test_plot2d_default_equal_aspect_does_not_collapse_extreme_same_unit_ranges():
+    """Implicit equal_aspect should not squash 2D plots with extreme X/Y ratios."""
+    import spectrochempy as scp
+
+    x = scp.Coord(np.linspace(0.0, 74048.0, 446), units="us")
+    y = scp.Coord(np.linspace(0.0, 6096.0, 128), units="us")
+    data = np.random.rand(128, 446)
+    dataset = scp.NDDataset(data, coords=[y, x], units="dimensionless")
+
+    ax = dataset.plot(method="map", show=False, figsize=(10, 10))
+
+    assert ax.get_aspect() == "auto"
+
+
+def test_plot2d_default_equal_aspect_does_not_collapse_moderately_anisotropic_ppm_map():
+    """Implicit equal_aspect should stay readable for anisotropic ppm windows."""
+    import spectrochempy as scp
+
+    x = scp.Coord(np.linspace(-1.3, 10.7, 1024), units="ppm")
+    y = scp.Coord(np.linspace(0.0, 60.0, 372), units="ppm")
+    data = np.random.rand(372, 1024)
+    dataset = scp.NDDataset(data, coords=[y, x], units="dimensionless")
+
+    ax = dataset.plot(method="map", show=False)
+
+    assert ax.get_aspect() == "auto"


### PR DESCRIPTION
## Summary

- honor explicit `figsize=` overrides when a 2D plotting call reuses an existing figure with `clear=False`
- avoid forcing implicit equal-aspect layout for 2D datasets whose X and Y axes share units but span very different numeric ranges
- add regression tests for both behaviors and document the user-visible fix in the changelog

## Out of scope

- no broader redesign of 2D plotting defaults
- no changes to explicit `equal_aspect=True` behavior
- no NMR processing changes in this PR

## Root cause

Two separate plotting issues combined here:

1. reused figures ignored a new `figsize=` request because the existing figure size was kept unchanged;
2. the default equal-aspect path treated matching axis units as sufficient, even when the numeric X/Y ranges were so different that Matplotlib collapsed the axes into a thin strip.

## Validation

- `pre-commit run --all-files`
- `MPLBACKEND=Agg MPLCONFIGDIR=/tmp/spectrochempy-mplconfig /Users/christian/micromamba/envs/scpy-core/bin/python -m pytest tests/test_plotting/test_contract_plot2d.py -k 'clear_false_honors_requested_figsize or default_equal_aspect' -q`
