### PR TITLE
FIX: guard against non-string marker/ls values in plot1d.py

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -59,6 +59,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- `plot()` and `plot_multiple()` no longer crash when `marker=None` or
+  `ls=None` is passed explicitly. Both are matplotlib's own standard
+  values (no marker, default linestyle), so passing them is legitimate,
+  not invalid input. (#1462)
+
 - 2D ``plot_map()``/``plot()`` now keep a readable layout for datasets whose
   X and Y axes share units but span very different numeric ranges.  Explicit
   ``figsize=...`` overrides are also now honored reliably when a plotting call

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -51,6 +51,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- `plot()` and `plot_multiple()` no longer crash when `marker=None` or
+  `ls=None` is passed explicitly. Both are matplotlib's own standard
+  values (no marker, default linestyle), so passing them is legitimate,
+  not invalid input. (#1462)
+
 - 2D ``plot_map()``/``plot()`` now keep a readable layout for datasets whose
   X and Y axes share units but span very different numeric ranges.  Explicit
   ``figsize=...`` overrides are also now honored reliably when a plotting call

--- a/src/spectrochempy/plotting/plot1d.py
+++ b/src/spectrochempy/plotting/plot1d.py
@@ -351,12 +351,16 @@ def plot_1D(dataset, method=None, **kwargs):
         if scatter and not pen:
             effective_linestyle = "None"
         elif pen:
-            effective_linestyle = ls if ls.upper() != "AUTO" else "-"
+            effective_linestyle = (
+                "-" if isinstance(ls, str) and ls.upper() == "AUTO" else ls
+            )
         else:
             effective_linestyle = "None"
 
         # Determine effective marker
-        effective_marker = marker if marker.upper() != "AUTO" else None
+        effective_marker = (
+            None if isinstance(marker, str) and marker.upper() == "AUTO" else marker
+        )
 
         if bar:
             # bar only

--- a/tests/test_plotting/test_contract_plot1d.py
+++ b/tests/test_plotting/test_contract_plot1d.py
@@ -54,6 +54,34 @@ def test_plot1d_with_marker(synthetic_1d):
     assert ax is not None
 
 
+def test_plot1d_with_marker_none_does_not_crash(synthetic_1d):
+    """
+    marker=None is matplotlib's own idiom for "no marker" and must not crash.
+
+    Regression test: `effective_marker = marker if marker.upper() != "AUTO"
+    else None` called `.upper()` unconditionally, so passing `marker=None`
+    (a legitimate, matplotlib-standard value, not just an unsupported edge
+    case) raised `AttributeError: 'NoneType' object has no attribute
+    'upper'` instead of simply plotting without a marker.
+    """
+    ax = synthetic_1d.plot(marker=None, show=False)
+    assert ax is not None
+    assert ax.lines[0].get_marker() in (None, "None")
+
+
+def test_plot1d_with_linestyle_none_does_not_crash(synthetic_1d):
+    """
+    ls=None is matplotlib's own idiom for the default linestyle and must
+    not crash.
+
+    Regression test: the same unguarded `.upper()` pattern as the marker
+    case above also existed for `ls` in the `pen=True` branch.
+    """
+    ax = synthetic_1d.plot(pen=True, ls=None, show=False)
+    assert ax is not None
+    assert ax.lines[0].get_linestyle() == "-"
+
+
 def test_plot1d_with_label(synthetic_1d):
     """Test plot1d with label."""
     ax = synthetic_1d.plot(label="test label", show=False)


### PR DESCRIPTION
## Summary

This PR fixes a crash in `plot1d.py` when `marker=None` or `ls=None` is passed to a plot call. Both are matplotlib values (no marker, default linestyle), not invalid input, but the code called `.upper()` on them without checking the type first, since it assumed the only values ever passed would be strings like `"AUTO"` or an actual marker or linestyle character.

The same function already guards `color` and `lw` against this exact situation with an `isinstance` check before calling `.upper()`. `marker` and `ls` were just missing that same guard, a few lines above where the correct version already exists.

This PR brings them in line with the pattern already used right below them, rather than introducing a new one.

Closes #1459 

## What Changed

- guard `ls` and `marker` in `plot_1D()` with the same `isinstance(x, str)` check already used for `color` and `lw`
- add a regression test confirming `marker=None` no longer crashes and correctly results in no marker
- add a regression test confirming `ls=None` no longer crashes and correctly falls back to the default solid line
- add a changelog entry under Bug Fixes