### PR TITLE
FIX: stabilize vendor-independent 1D NMR processing

### DIFF
--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -521,9 +521,7 @@ class Experiment:
             work = self._apply_phase(work, phase, phc0=phc0, phc1=phc1)
 
         # 5. Calibrate the final spectral axis using canonical NMR metadata.
-        work = self._calibrate_1d_spectral_axis(work)
-
-        return work
+        return self._calibrate_1d_spectral_axis(work)
 
     def _process_frequency_domain(
         self,

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -13,6 +13,7 @@ never references Bruker-specific field names (``nuc1``, ``pulprog``,
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -519,6 +520,9 @@ class Experiment:
         if phase is not None:
             work = self._apply_phase(work, phase, phc0=phc0, phc1=phc1)
 
+        # 5. Calibrate the final spectral axis using canonical NMR metadata.
+        work = self._calibrate_1d_spectral_axis(work)
+
         return work
 
     def _process_frequency_domain(
@@ -600,6 +604,44 @@ class Experiment:
         if self.ndim >= 2 and "ECHO-ANTIECHO" in encoding:
             return self._apply_phase(ds, "manual", phc0=-90.0, phc1=0.0)
         return ds
+
+    def _calibrate_1d_spectral_axis(self, ds: NDDataset) -> NDDataset:
+        """
+        Normalize the final 1D frequency axis to ppm when possible.
+
+        Some readers preserve enough information for ``fft()`` to create a
+        frequency-domain axis in Hz but not to complete the final ppm
+        calibration automatically.  The canonical NMR metadata already carries
+        the spectrometer frequency and nucleus information, so finalize the
+        public 1D output here in a vendor-independent way.
+        """
+        if ds.ndim != 1:
+            return ds
+
+        coord = ds.coord(0)
+        if str(coord.units) == "ppm":
+            return ds
+
+        sfo = self._nmr_meta.spectrometer_freq_mhz
+        nuclei = self._nmr_meta.nuclei
+        if not sfo or sfo[0] is None:
+            return ds
+
+        work = ds.copy()
+        work.meta.readonly = False
+        coord = work.coord(0)
+        from spectrochempy.core.units import ur  # noqa: PLC0415
+
+        coord.meta["acquisition_frequency"] = float(sfo[0]) * ur.MHz
+        coord.ito("ppm")
+
+        if nuclei and nuclei[0]:
+            nucleus = str(nuclei[0])
+            match = re.match(r"([^a-zA-Z]+)([a-zA-Z]+)", nucleus)
+            nucleus_label = rf"$^{{{match[1]}}}{match[2]}$" if match else nucleus
+            coord.title = rf"$\delta\ {nucleus_label}$"
+
+        return work
 
     # ------------------------------------------------------------------
     # Summary and representation

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py
@@ -155,6 +155,15 @@ def _fft_encoding_handler(data, encoding, **kwargs):
     tppi = kwargs.get("tppi", False)
     original_axis = kwargs.get("original_axis", -1)
 
+    if encoding is None or str(encoding).strip().lower() in {"", "none", "unknown"}:
+        # For 1D complex direct-dimension data, the vendor-independent fallback
+        # is a standard complex FFT.  This keeps the public 1D pipeline robust
+        # even if a reader leaves the direct encoding unspecified.
+        if hasattr(data, "dtype") and data.dtype.kind != "V":
+            return _qf_fft(data)
+        msg = "NMR encoding metadata is missing for hypercomplex/quaternion data"
+        raise NotImplementedError(msg)
+
     # Second pass (indirect dimension): the quaternion was rebuilt from
     # [Re(fr), Im(fr), Re(fi), Im(fi)] by the first pass.  Extract the
     # complex subspectra directly and FFT along axis=-1 (which is F1 after

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_jeol.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_jeol.py
@@ -97,18 +97,31 @@ def read_jeol(*paths, **kwargs):
 # ======================================================================================
 
 
-# Mapping from JEOL axis_type strings to SpectroChemPy encoding + iscomplex
-_JEOL_AXIS_TYPE_MAP = {
-    "real": ("QF", False),
-    "tppi": ("TPPI", True),
-    "complex": ("STATES", True),
-    "real_complex": ("STATES-TPPI", True),
-}
+def _jeol_axis_type_to_encoding(axis_type_str, *, axis: int, ndim: int):
+    """
+    Map a JEOL ``data_axis_type`` string to a canonical encoding.
 
+    JEOL uses axis-type labels such as ``complex`` and ``real_complex`` for
+    both 1D and 2D data.  In 1D those values describe direct-dimension complex
+    quadrature and should therefore be normalized to a vendor-independent
+    direct encoding (``QSIM``), not to 2D indirect encodings such as
+    ``STATES``.
+    """
+    axis_type = str(axis_type_str).lower()
 
-def _jeol_axis_type_to_encoding(axis_type_str):
-    """Map a JEOL data_axis_type string to (encoding, iscomplex)."""
-    return _JEOL_AXIS_TYPE_MAP.get(axis_type_str, ("unknown", False))
+    if axis_type == "real":
+        return "QF", False
+    if axis_type == "tppi":
+        return "TPPI", True
+    if axis_type == "complex":
+        if ndim == 1 or axis == ndim - 1:
+            return "QSIM", True
+        return "STATES", True
+    if axis_type == "real_complex":
+        if ndim == 1 or axis == ndim - 1:
+            return "QSIM", True
+        return "STATES-TPPI", True
+    return "unknown", False
 
 
 @_importer_method
@@ -183,7 +196,7 @@ def _read_jdf(*args, **kwargs):
         # Encoding and iscomplex from axis_type
         axis_type = header.get("data_axis_type", [None] * 8)[i]
         if axis_type is not None:
-            enc, ic = _jeol_axis_type_to_encoding(axis_type)
+            enc, ic = _jeol_axis_type_to_encoding(axis_type, axis=i, ndim=ndim)
             meta.encoding[i] = enc
             meta.iscomplex[i] = ic
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_tecmag.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_tecmag.py
@@ -171,7 +171,7 @@ def _read_tnt(*args, **kwargs):
         # Nucleus name (strip null bytes and padding)
         nuc_raw = dic["nuclei"][i]
         if isinstance(nuc_raw, bytes):
-            nuc = nuc_raw.decode("latin1").rstrip("\x00").strip()
+            nuc = nuc_raw.decode("latin1").split("\x00", 1)[0].strip()
             nuc = re.sub(r"[^a-zA-Z0-9]+$", "", nuc)
         else:
             nuc = str(nuc_raw)
@@ -184,6 +184,10 @@ def _read_tnt(*args, **kwargs):
 
         # Data is always complex in .tnt
         meta.iscomplex[i] = True
+
+        # TecMag 1D data uses a direct complex quadrature acquisition.
+        if ndim == 1:
+            meta.encoding[i] = "QSIM"
 
     # Spectral width in Hz with units
     meta.sw_h = [None] * ndim
@@ -228,6 +232,18 @@ def _read_tnt(*args, **kwargs):
         sw_hz = meta.sw_h[axis]
         freq_mhz = meta.sfrq[axis]
         nuc = meta.nucleus[axis]
+
+        if not meta.isfreq[axis]:
+            if sw_hz is not None and float(sw_hz.magnitude) > 0:
+                dw = (1.0 / sw_hz).to("us")
+                coordpoints = np.arange(size)
+                coord = Coord(coordpoints * dw, title=f"F{axis + 1} acquisition time")
+            else:
+                coord = Coord(np.arange(size), title=f"F{axis + 1} acquisition time")
+
+            if freq_mhz is not None:
+                coord.meta["acquisition_frequency"] = freq_mhz * ur.MHz
+            return coord
 
         if sw_hz is not None and freq_mhz is not None and size > 1:
             sizem = max(size - 1, 1)

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -18,6 +18,8 @@ from spectrochempy.core.dataset.nddataset import NDDataset
 DATADIR = scp.preferences.datadir
 NMRDATA = DATADIR / "nmrdata"
 nmrdir = NMRDATA / "bruker" / "tests" / "nmr"
+EXTRA_DATADIR = scp.preferences.datadir.parent / "testdata-extra"
+EXTRA_NMR = EXTRA_DATADIR / "testdata" / "nmrdata"
 
 
 def _require_path(path):
@@ -389,6 +391,39 @@ class TestProcessTimeDomain:
         exp = Experiment(fid)
         with pytest.raises(ValueError, match="Unknown phase mode"):
             exp.process(phase="bad_mode")
+
+    @pytest.mark.skipif(
+        not (EXTRA_NMR / "agilent" / "agilent_1d" / "fid").exists(),
+        reason="Agilent 1D data missing",
+    )
+    def test_agilent_1d_pipeline_calibrates_to_ppm(self):
+        fid = _read_or_skip(EXTRA_NMR / "agilent" / "agilent_1d" / "fid")
+        exp = Experiment(fid)
+        spectrum = exp.process()
+        assert exp.encoding == ("QSIM",)
+        assert str(spectrum.coord(0).units) == "ppm"
+
+    @pytest.mark.skipif(
+        not (EXTRA_NMR / "jeol" / "1H.jdf").exists(),
+        reason="JEOL 1D data missing",
+    )
+    def test_jeol_1d_pipeline_uses_direct_complex_encoding(self):
+        fid = _read_or_skip(EXTRA_NMR / "jeol" / "1H.jdf")
+        exp = Experiment(fid)
+        assert exp.encoding == ("QSIM",)
+        spectrum = exp.process()
+        assert str(spectrum.coord(0).units) == "ppm"
+
+    @pytest.mark.skipif(
+        not (EXTRA_NMR / "tecmag" / "LiCl_ref1.tnt").exists(),
+        reason="TecMag 1D data missing",
+    )
+    def test_tecmag_1d_pipeline_uses_direct_complex_encoding(self):
+        fid = _read_or_skip(EXTRA_NMR / "tecmag" / "LiCl_ref1.tnt")
+        exp = Experiment(fid)
+        assert exp.encoding == ("QSIM",)
+        spectrum = exp.process()
+        assert str(spectrum.coord(0).units) == "ppm"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/spectrochempy-nmr/tests/test_read_jeol.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_jeol.py
@@ -160,6 +160,10 @@ class TestReadJeol:
         ds = _read_jeol_or_skip(str(JEOL_DIR / "1H.jdf"))
         assert np.issubdtype(ds.data.dtype, np.complexfloating)
 
+    def test_1d_encoding_is_direct_complex(self):
+        ds = _read_jeol_or_skip(str(JEOL_DIR / "1H.jdf"))
+        assert ds.meta.encoding == ["QSIM"]
+
     def test_1d_has_coords(self):
         ds = _read_jeol_or_skip(str(JEOL_DIR / "1H.jdf"))
         assert ds.x is not None

--- a/plugins/spectrochempy-nmr/tests/test_read_tecmag.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_tecmag.py
@@ -103,6 +103,11 @@ class TestTecMagReader:
         dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
         assert dataset.meta.nucleus[0] is not None
         assert "Li" in dataset.meta.nucleus[0]
+        assert "\x00" not in dataset.meta.nucleus[0]
+
+    def test_read_tecmag_metadata_encoding(self):
+        dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))
+        assert dataset.meta.encoding == ["QSIM"]
 
     def test_read_tecmag_metadata_origin(self):
         dataset = _read_tecmag_or_skip(str(TECMAG_DIR / "LiCl_ref1.tnt"))


### PR DESCRIPTION
## Summary

This PR stabilizes the public 1D NMR processing pipeline across the currently supported vendor readers, without reintroducing any 2D workflow.

## What Changed

- normalize JEOL 1D direct complex data to a direct-dimension encoding (`QSIM`) instead of routing it through 2D-style `STATES`
- normalize TecMag 1D raw data to a direct-complex encoding and clean malformed nucleus strings
- build a true acquisition-time axis for TecMag raw 1D FIDs instead of a premature frequency-domain axis
- make the FFT encoding dispatch robust when a reader leaves 1D complex encoding metadata unspecified
- add a final vendor-independent 1D spectral-axis calibration step in `scp.nmr.Experiment.process()` so raw 1D processing ends on a calibrated `ppm` axis when metadata allows it
- add targeted regression tests for JEOL, TecMag, and multi-vendor 1D `Experiment.process()` behavior

## Why

The recent public recentering on validated 1D NMR made two remaining scientific issues more visible:

- some JEOL 1D data still inherited an encoding path conceptually tied to indirect 2D quadrature
- TecMag 1D processing could still fail because encoding metadata remained unset

Both issues showed that the 1D public path still depended on assumptions inherited from the older 2D-oriented code paths. This PR makes the 1D route more genuinely vendor-independent:

```text
vendor reader
-> time-domain complex 1D NDDataset
-> normalized NMR metadata
-> Experiment
-> time-domain preprocessing
-> direct FFT
-> phase
-> Hz/ppm calibration
-> 1D spectrum
```

## Validation

- `/Users/christian/micromamba/envs/scpy-core/bin/python -m py_compile plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_jeol.py plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_tecmag.py plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_encodings.py plugins/spectrochempy-nmr/tests/test_experiment.py plugins/spectrochempy-nmr/tests/test_read_jeol.py plugins/spectrochempy-nmr/tests/test_read_tecmag.py`
- `/Users/christian/micromamba/envs/scpy-core/bin/python -m pytest plugins/spectrochempy-nmr/tests/test_read_tecmag.py plugins/spectrochempy-nmr/tests/test_experiment.py -k 'tecmag or agilent_1d_pipeline or jeol_1d_pipeline'`
- `/Users/christian/micromamba/envs/scpy-core/bin/python -m pytest plugins/spectrochempy-nmr/tests/test_read_jeol.py plugins/spectrochempy-nmr/tests/test_experiment.py -k 'encoding_is_direct_complex or jeol_1d_pipeline'`

## Notes

This PR is intentionally limited to the public 1D route. It does not reintroduce any 2D API claim and does not begin the separate 2D reimplementation campaign.