### PR TITLE
FIX: complete explicit NMR apodization contract

### DIFF
--- a/docs/sources/devguide/plugins/api_policy.rst
+++ b/docs/sources/devguide/plugins/api_policy.rst
@@ -48,7 +48,9 @@ For NMR, the high-level scientific API is ``Experiment``::
 
     dataset = scp.nmr.read(path)
     experiment = scp.nmr.Experiment(dataset)
-    spectrum = experiment.process(lb=10.0, phase="manual", phc0=45.0)
+    spectrum = experiment.process(
+        apodization="em", lb=10.0, phase="manual", phc0=45.0
+    )
 
 Low-level NMR operations (apodization, phasing, FFT) already exist as
 ``NDDataset`` methods (``dataset.em(...)``, ``dataset.pk(...)``,

--- a/docs/sources/devguide/plugins/roadmap.rst
+++ b/docs/sources/devguide/plugins/roadmap.rst
@@ -32,7 +32,9 @@ The ``Experiment`` class is the chosen high-level NMR API layer::
 
     dataset = scp.nmr.read(path)
     experiment = scp.nmr.Experiment(dataset)
-    spectrum = experiment.process(lb=10.0, phase="manual", phc0=45.0)
+    spectrum = experiment.process(
+        apodization="em", lb=10.0, phase="manual", phc0=45.0
+    )
 
 Dataset accessors such as ``dataset.nmr.phase(...)`` or
 ``dataset.nmr.apodize(...)`` are **not** part of the planned API. Low-level

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -61,6 +61,13 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``scp.nmr.Experiment.process()`` now forwards the full explicit public
+  apodization contract for the modes it already exposes:
+  ``em(lb=...)``, ``gm(lb=..., gb=...)``, and ``sp(ssb=..., pow=...)``.
+  Incompatible parameter combinations such as ``apodization=\"em\", gb=...``
+  or ``apodization=None, lb=...`` now raise explicit errors instead of being
+  silently ignored.
+
 - `plot()` and `plot_multiple()` no longer crash when `marker=None` or
   `ls=None` is passed explicitly. Both are matplotlib's own standard
   values (no marker, default linestyle), so passing them is legitimate,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -53,6 +53,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- ``scp.nmr.Experiment.process()`` now forwards the full explicit public
+  apodization contract for the modes it already exposes:
+  ``em(lb=...)``, ``gm(lb=..., gb=...)``, and ``sp(ssb=..., pow=...)``.
+  Incompatible parameter combinations such as ``apodization=\"em\", gb=...``
+  or ``apodization=None, lb=...`` now raise explicit errors instead of being
+  silently ignored.
+
 - `plot()` and `plot_multiple()` no longer crash when `marker=None` or
   `ls=None` is passed explicitly. Both are matplotlib's own standard
   values (no marker, default linestyle), so passing them is legitimate,

--- a/plugins/spectrochempy-nmr/README.md
+++ b/plugins/spectrochempy-nmr/README.md
@@ -4,7 +4,7 @@ NMR plugin for SpectroChemPy.
 
 This package is the home for NMR-specific readers and tools that are useful in
 SpectroChemPy but should not live in the core package. It currently provides a
-validated public workflow for 1D NMR data across the supported readers, exposed
+validated public 1D workflow for reading data and processing raw 1D FIDs
 through `scp.nmr.read(...)` and `scp.nmr.Experiment(...)`.
 
 Future NMR readers or processing helpers can be added here without creating a
@@ -37,6 +37,14 @@ dataset = scp.nmr.read("path/to/experiment", expno=1, procno=1)
 experiment = scp.nmr.Experiment(dataset)
 spectrum = experiment.process(apodization="em", lb=2.0, size=32768)
 ```
+
+This explicit processing example does not imply that vendor processing
+parameters are automatically imported and replayed from metadata. That contract
+remains under active characterization.
+
+The current explicit apodization contract covers the public modes already
+exposed by `Experiment.process()`: `em(lb=...)`, `gm(lb=..., gb=...)`, and
+`sp(ssb=..., pow=...)`.
 
 The NMR ppm/frequency unit context is also provided by this plugin:
 

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -14,8 +14,11 @@ Basic 1D NMR processing and inspection with the official
 This example stays within the currently validated public scope of the plugin:
 
 * reading a 1D NMR dataset;
-* processing the FID to a frequency-domain spectrum;
+* processing the FID to a frequency-domain spectrum with explicit
+  SpectroChemPy parameters;
 * inspecting slices, correcting the baseline and picking peaks.
+
+It does not claim replay of vendor processing parameters from metadata.
 """
 
 # %%
@@ -31,24 +34,46 @@ import spectrochempy as scp
 datadir = scp.preferences.datadir
 nmrdir = datadir / "nmrdata"
 
-dataset = scp.nmr.read(nmrdir / "bruker" / "tests" / "nmr" / "topspin_1d" / "1" / "fid")
+fid = scp.nmr.read(nmrdir / "bruker" / "tests" / "nmr" / "topspin_1d" / "1" / "fid")
 
 # %%
-# Process the 1D FID
-# ------------------
-experiment = scp.nmr.Experiment(dataset)
-dataset = experiment.process(apodization="em", lb=2.0, size=16384, phase="metadata")
-
+# Compare two explicit apodization choices
+# ----------------------------------------
+# The source FID is left unchanged. Each processed spectrum comes from its own
+# independent copy so the comparison is purely about the explicit `lb` value.
+low_lb = scp.nmr.Experiment(fid.copy()).process(
+    apodization="em",
+    lb=2.0,
+    size=16384,
+    phase=None,
+)
+high_lb = scp.nmr.Experiment(fid.copy()).process(
+    apodization="em",
+    lb=20.0,
+    size=16384,
+    phase=None,
+)
 
 # %%
-# Analyse the processed 1D spectrum
-# ---------------------------------
-# Print dataset summary
+# Overlay the two processed spectra on the same axes
+# --------------------------------------------------
+ax = low_lb.plot(color="C0", label="LB = 2 Hz")
+high_lb.plot(
+    ax=ax,
+    color="C1",
+    linestyle="--",
+    label="LB = 20 Hz",
+)
+ax.legend()
+
+# %%
+# Continue with the mildly broadened spectrum
+# -------------------------------------------
+#
+# The rest of the example uses `low_lb`, which keeps the resolved multiplets
+# visually useful for peak picking and fitting.
+dataset = low_lb
 dataset
-
-# %%
-# Plot the dataset
-_ = dataset.plot()
 
 # %%
 # Select a region of interest

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -442,7 +442,8 @@ class Experiment:
         ----------
         apodization : str, optional
             Apodization function name (``'em'``, ``'gm'``, ``'sp'``).
-            Only applied to time-domain data.  Ignored for frequency-domain.
+            Only accepted for time-domain data. Frequency-domain datasets
+            reject explicit apodization requests.
         lb : float or Quantity, optional
             Explicit line-broadening parameter for ``'em'`` and Lorentzian
             term for ``'gm'``. If omitted, the selected core apodization
@@ -509,6 +510,13 @@ class Experiment:
                 phc1=phc1,
             )
         if self.is_frequency_domain:
+            self._reject_frequency_domain_apodization_requests(
+                apodization,
+                lb=lb,
+                gb=gb,
+                ssb=ssb,
+                pow=pow,
+            )
             return self._process_frequency_domain(
                 ds,
                 phase=phase,
@@ -518,6 +526,36 @@ class Experiment:
         msg = (
             f"Cannot process data in '{self.domain}' domain. "
             f"Current state: {' × '.join(self.domains)}"
+        )
+        raise RuntimeError(msg)
+
+    def _reject_frequency_domain_apodization_requests(
+        self,
+        apodization: str | None,
+        *,
+        lb: float | Quantity | None,
+        gb: float | Quantity | None,
+        ssb: float | None,
+        pow: float | None,
+    ) -> None:
+        """Reject explicit apodization requests on already transformed spectra."""
+        provided = {
+            "apodization": apodization,
+            "lb": lb,
+            "gb": gb,
+            "ssb": ssb,
+            "pow": pow,
+        }
+        non_null = [name for name, value in provided.items() if value is not None]
+        if not non_null:
+            return
+
+        names = ", ".join(non_null)
+        msg = (
+            "Frequency-domain datasets cannot accept apodization requests in "
+            f"Experiment.process(). Received: {names}. Use apodization only on "
+            "time-domain FIDs, or call process() without apodization arguments "
+            "to preserve the existing frequency-domain workflow."
         )
         raise RuntimeError(msg)
 

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -14,12 +14,23 @@ never references Bruker-specific field names (``nuc1``, ``pulprog``,
 from __future__ import annotations
 
 import re
+from numbers import Real
 from typing import TYPE_CHECKING
 
 import numpy as np
 
+from spectrochempy.core.units import Quantity
+from spectrochempy.core.units import ur
+
 if TYPE_CHECKING:
     from spectrochempy.core.dataset.nddataset import NDDataset
+
+
+_APODIZATION_ALLOWED_PARAMS = {
+    "em": ("lb",),
+    "gm": ("lb", "gb"),
+    "sp": ("ssb", "pow"),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +119,9 @@ class Experiment:
     >>> fid = scp.nmr.read(path)
     >>> experiment = scp.nmr.Experiment(fid)
     >>> experiment.summary()
-    >>> spectrum = experiment.process(lb=10.0, phase="manual", phc0=45.0)
+    >>> spectrum = experiment.process(
+    ...     apodization="em", lb=10.0, phase="manual", phc0=45.0
+    ... )
     """
 
     def __init__(self, dataset):
@@ -407,7 +420,10 @@ class Experiment:
         self,
         *,
         apodization: str | None = None,
-        lb: float = 1.0,
+        lb: float | Quantity | None = None,
+        gb: float | Quantity | None = None,
+        ssb: float | None = None,
+        pow: float | None = None,
         size: int | None = None,
         phase: str | None = None,
         phc0: float = 0.0,
@@ -427,8 +443,21 @@ class Experiment:
         apodization : str, optional
             Apodization function name (``'em'``, ``'gm'``, ``'sp'``).
             Only applied to time-domain data.  Ignored for frequency-domain.
-        lb : float
-            Line broadening in Hz (for ``apodization='em'``).  Default 1.0.
+        lb : float or Quantity, optional
+            Explicit line-broadening parameter for ``'em'`` and Lorentzian
+            term for ``'gm'``. If omitted, the selected core apodization
+            function uses its own default.
+        gb : float or Quantity, optional
+            Explicit Gaussian broadening parameter for ``'gm'``. If omitted,
+            the selected core apodization function uses its own default.
+        ssb : float, optional
+            Explicit sine-bell shift parameter for ``'sp'``. Must be positive
+            when provided. If omitted, the selected core apodization function
+            uses its own default.
+        pow : float, optional
+            Explicit exponent parameter for ``'sp'``. Only ``1`` and ``2`` are
+            accepted by the public API. If omitted, the selected core
+            apodization function uses its own default.
         size : int, optional
             Zero-fill target size.  Only applied to time-domain data.
         phase : str, optional
@@ -451,6 +480,9 @@ class Experiment:
         NotImplementedError
             If the dataset is multi-dimensional and therefore outside the
             current public supported processing scope.
+        ValueError
+            If an apodization parameter combination is incompatible with the
+            selected apodization mode.
         """
 
         ds = self._dataset
@@ -468,6 +500,9 @@ class Experiment:
                 ds,
                 apodization=apodization,
                 lb=lb,
+                gb=gb,
+                ssb=ssb,
+                pow=pow,
                 size=size,
                 phase=phase,
                 phc0=phc0,
@@ -491,7 +526,10 @@ class Experiment:
         ds: NDDataset,
         *,
         apodization: str | None,
-        lb: float,
+        lb: float | Quantity | None,
+        gb: float | Quantity | None,
+        ssb: float | None,
+        pow: float | None,
         size: int | None,
         phase: str | None,
         phc0: float,
@@ -501,8 +539,15 @@ class Experiment:
         work = ds.copy()
 
         # 1. Apodization
+        apodization_kwargs = self._validate_apodization_arguments(
+            apodization,
+            lb=lb,
+            gb=gb,
+            ssb=ssb,
+            pow=pow,
+        )
         if apodization is not None:
-            work = self._apply_apodization(work, apodization, lb=lb)
+            work = self._apply_apodization(work, apodization, **apodization_kwargs)
 
         # 2. Zero-filling / FFT sizing
         if size is not None:
@@ -541,25 +586,153 @@ class Experiment:
 
         return work
 
-    def _apply_apodization(
-        self, ds: NDDataset, func_name: str, *, lb: float
-    ) -> NDDataset:
+    def _validate_apodization_arguments(
+        self,
+        apodization: str | None,
+        *,
+        lb: float | Quantity | None,
+        gb: float | Quantity | None,
+        ssb: float | None,
+        pow: float | None,
+    ) -> dict[str, float | Quantity]:
+        """Validate the explicit public apodization contract."""
+        provided = {
+            "lb": lb,
+            "gb": gb,
+            "ssb": ssb,
+            "pow": pow,
+        }
+        non_null = {
+            name: value for name, value in provided.items() if value is not None
+        }
+
+        if apodization is None:
+            if non_null:
+                names = ", ".join(sorted(non_null))
+                msg = (
+                    "Explicit apodization parameters require an apodization mode. "
+                    f"Received parameters without apodization: {names}."
+                )
+                raise ValueError(msg)
+            return {}
+
+        func_name = apodization.lower()
+        if func_name not in _APODIZATION_ALLOWED_PARAMS:
+            msg = (
+                f"Unknown apodization function: {func_name!r}. Use 'em', 'gm', or 'sp'."
+            )
+            raise ValueError(msg)
+
+        allowed = set(_APODIZATION_ALLOWED_PARAMS[func_name])
+        invalid = sorted(name for name in non_null if name not in allowed)
+        if invalid:
+            names = ", ".join(invalid)
+            msg = (
+                f"Apodization {func_name!r} does not accept parameter(s): {names}. "
+                f"Allowed parameters: {', '.join(_APODIZATION_ALLOWED_PARAMS[func_name])}."
+            )
+            raise ValueError(msg)
+
+        validated: dict[str, float | Quantity] = {}
+        for name in _APODIZATION_ALLOWED_PARAMS[func_name]:
+            value = provided[name]
+            if value is None:
+                continue
+            validated[name] = self._validate_apodization_parameter(
+                func_name, name, value
+            )
+        return validated
+
+    def _validate_apodization_parameter(
+        self,
+        func_name: str,
+        param_name: str,
+        value: float | Quantity,
+    ) -> float | Quantity:
+        """Validate one explicit apodization parameter."""
+        if param_name in {"lb", "gb"}:
+            return self._validate_frequency_like_parameter(func_name, param_name, value)
+        if param_name == "ssb":
+            if isinstance(value, Quantity):
+                msg = f"Parameter 'ssb' for apodization {func_name!r} must be a plain scalar."
+                raise TypeError(msg)
+            if not isinstance(value, Real):
+                msg = f"Parameter 'ssb' for apodization {func_name!r} must be a real scalar."
+                raise TypeError(msg)
+            magnitude = float(value)
+            if not np.isfinite(magnitude):
+                msg = f"Parameter 'ssb' for apodization {func_name!r} must be finite."
+                raise ValueError(msg)
+            if magnitude <= 0.0:
+                msg = "Parameter 'ssb' for apodization 'sp' must be strictly positive."
+                raise ValueError(msg)
+            return magnitude
+        if param_name == "pow":
+            if isinstance(value, Quantity):
+                msg = f"Parameter 'pow' for apodization {func_name!r} must be a plain scalar."
+                raise TypeError(msg)
+            if not isinstance(value, Real):
+                msg = f"Parameter 'pow' for apodization {func_name!r} must be a real scalar."
+                raise TypeError(msg)
+            magnitude = float(value)
+            if not np.isfinite(magnitude):
+                msg = f"Parameter 'pow' for apodization {func_name!r} must be finite."
+                raise ValueError(msg)
+            if magnitude not in (1.0, 2.0):
+                msg = "Parameter 'pow' for apodization 'sp' must be 1 or 2."
+                raise ValueError(msg)
+            return int(magnitude)
+
+        msg = f"Unsupported apodization parameter {param_name!r}."
+        raise ValueError(msg)
+
+    def _validate_frequency_like_parameter(
+        self,
+        func_name: str,
+        param_name: str,
+        value: float | Quantity,
+    ) -> float | Quantity:
+        """Validate frequency-like explicit apodization parameters."""
+        if isinstance(value, Quantity):
+            if value.dimensionality != ur.Hz.dimensionality:
+                msg = (
+                    f"Parameter {param_name!r} for apodization {func_name!r} must "
+                    "have frequency units compatible with Hz."
+                )
+                raise ValueError(msg)
+            magnitude = float(value.magnitude)
+        else:
+            if not isinstance(value, Real):
+                msg = (
+                    f"Parameter {param_name!r} for apodization {func_name!r} must "
+                    "be a real scalar or a Quantity."
+                )
+                raise TypeError(msg)
+            magnitude = float(value)
+
+        if not np.isfinite(magnitude):
+            msg = f"Parameter {param_name!r} for apodization {func_name!r} must be finite."
+            raise ValueError(msg)
+        return value
+
+    def _apply_apodization(self, ds: NDDataset, func_name: str, **kwargs) -> NDDataset:
         """Apply an apodization function by name."""
         func_name = func_name.lower()
-        if func_name == "em":
-            from spectrochempy.processing.fft.apodization import em  # noqa: PLC0415
+        from spectrochempy.processing.fft.apodization import em  # noqa: PLC0415
+        from spectrochempy.processing.fft.apodization import gm  # noqa: PLC0415
+        from spectrochempy.processing.fft.apodization import sp  # noqa: PLC0415
 
-            return em(ds, lb=lb)
-        if func_name == "gm":
-            from spectrochempy.processing.fft.apodization import gm  # noqa: PLC0415
-
-            return gm(ds, lb=lb)
-        if func_name == "sp":
-            from spectrochempy.processing.fft.apodization import sp  # noqa: PLC0415
-
-            return sp(ds)
-        msg = f"Unknown apodization function: {func_name!r}. Use 'em', 'gm', or 'sp'."
-        raise ValueError(msg)
+        apodizers = {
+            "em": em,
+            "gm": gm,
+            "sp": sp,
+        }
+        if func_name not in apodizers:
+            msg = (
+                f"Unknown apodization function: {func_name!r}. Use 'em', 'gm', or 'sp'."
+            )
+            raise ValueError(msg)
+        return apodizers[func_name](ds, **kwargs)
 
     def _apply_phase(
         self, ds: NDDataset, mode: str, *, phc0: float, phc1: float

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -574,6 +574,25 @@ class TestProcessTimeDomain:
         with pytest.raises((TypeError, ValueError), match=match):
             exp.process(**kwargs)
 
+    @pytest.mark.skipif(not _has_topspin_1d_pdata(), reason="TopSpin 1D pdata missing")
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"apodization": "em", "lb": 2.0},
+            {"apodization": "gm", "lb": 2.0, "gb": 1.0},
+            {"apodization": "sp", "ssb": 2.0, "pow": 2},
+        ],
+    )
+    def test_frequency_domain_rejects_explicit_apodization_requests(self, kwargs):
+        spectrum = _read_or_skip(nmrdir / "topspin_1d", expno=1, procno=1)
+        exp = Experiment(spectrum)
+
+        with pytest.raises(
+            RuntimeError,
+            match="Frequency-domain datasets cannot accept apodization requests",
+        ):
+            exp.process(**kwargs)
+
     def test_gm_process_matches_manual_apodize_then_fft_on_synthetic_fid(self):
         ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
         public = Experiment(ds.copy()).process(

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -92,6 +92,23 @@ def _topspin_1d_oracle_metrics(spectrum, ref):
     }
 
 
+def _manual_apodize_then_fft(dataset, apodization, *, size=None, **kwargs):
+    apodizers = {
+        "em": scp.em,
+        "gm": scp.gm,
+        "sp": scp.sp,
+    }
+    work = apodizers[apodization](dataset.copy(), inplace=False, **kwargs)
+    if size is not None:
+        work = work.zf_size(size=size)
+    return work.fft()
+
+
+def _manual_public_process(experiment, dataset, apodization, *, size=None, **kwargs):
+    work = _manual_apodize_then_fft(dataset, apodization, size=size, **kwargs)
+    return experiment._calibrate_1d_spectral_axis(work)
+
+
 def _make_synthetic_vendor_fid(
     *,
     npts=64,
@@ -464,6 +481,218 @@ class TestProcessTimeDomain:
         exp = Experiment(fid)
         _ = exp.process(apodization="em", lb=10.0)
         assert exp.is_time_domain  # Experiment itself is unchanged
+
+    @pytest.mark.skipif(not _has_topspin_1d(), reason="TopSpin 1D data missing")
+    def test_explicit_lb_changes_public_result_and_keeps_inputs_independent(self):
+        fid = _read_or_skip(nmrdir / "topspin_1d/1/fid")
+        source_data = np.asarray(fid.data).copy()
+
+        fid_low = fid.copy()
+        fid_high = fid.copy()
+        assert not np.shares_memory(np.asarray(fid_low.data), np.asarray(fid.data))
+        assert not np.shares_memory(np.asarray(fid_high.data), np.asarray(fid.data))
+        assert not np.shares_memory(np.asarray(fid_low.data), np.asarray(fid_high.data))
+
+        low = Experiment(fid_low).process(
+            apodization="em",
+            lb=2.0,
+            size=16384,
+            phase=None,
+        )
+        high = Experiment(fid_high).process(
+            apodization="em",
+            lb=20000.0,
+            size=16384,
+            phase=None,
+        )
+
+        low_data = np.asarray(low.data)
+        high_data = np.asarray(high.data)
+
+        assert not np.array_equal(low_data, high_data)
+        assert not np.allclose(low_data, high_data)
+        assert np.max(np.abs(low_data - high_data)) > 1.0e5
+        assert np.linalg.norm(low_data - high_data) / np.linalg.norm(low_data) > 0.5
+        assert np.max(np.abs(low_data)) > 1.0e5
+        assert np.max(np.abs(high_data)) < 2.0e4
+
+        np.testing.assert_array_equal(fid.data, source_data)
+        np.testing.assert_array_equal(fid_low.data, source_data)
+        np.testing.assert_array_equal(fid_high.data, source_data)
+
+    @pytest.mark.skipif(not _has_topspin_1d(), reason="TopSpin 1D data missing")
+    def test_public_em_processing_matches_manual_apodize_then_fft(self):
+        from spectrochempy.processing.fft.zero_filling import zf_size
+
+        fid = _read_or_skip(nmrdir / "topspin_1d/1/fid")
+        lb = 20000.0
+        size = 16384
+
+        exp = Experiment(fid.copy())
+        public = exp.process(apodization="em", lb=lb, size=size, phase=None)
+
+        direct_apodized = scp.em(fid.copy(), lb=lb, inplace=False)
+        internal_apodized = exp._apply_apodization(fid.copy(), "em", lb=lb)
+
+        np.testing.assert_allclose(
+            np.asarray(internal_apodized.data),
+            np.asarray(direct_apodized.data),
+            atol=1.0e-12,
+        )
+
+        manual = zf_size(internal_apodized, size=size).fft()
+
+        np.testing.assert_allclose(
+            np.asarray(public.data),
+            np.asarray(manual.data),
+            atol=1.0e-12,
+        )
+        np.testing.assert_allclose(
+            np.asarray(public.x.data),
+            np.asarray(manual.x.data),
+            atol=1.0e-12,
+        )
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"lb": 2.0}, "without apodization"),
+            ({"apodization": "em", "gb": 0.5}, "does not accept parameter"),
+            ({"apodization": "gm", "ssb": 2.0}, "does not accept parameter"),
+            ({"apodization": "sp", "lb": 2.0}, "does not accept parameter"),
+            ({"apodization": "sp", "pow": 3}, "must be 1 or 2"),
+            ({"apodization": "sp", "ssb": 0.0}, "must be strictly positive"),
+            (
+                {"apodization": "gm", "gb": 1.0 * ur.s},
+                "compatible with Hz",
+            ),
+        ],
+    )
+    def test_invalid_apodization_argument_combinations_raise(self, kwargs, match):
+        fid = _read_or_skip(nmrdir / "topspin_1d/1/fid")
+        exp = Experiment(fid)
+        with pytest.raises((TypeError, ValueError), match=match):
+            exp.process(**kwargs)
+
+    def test_gm_process_matches_manual_apodize_then_fft_on_synthetic_fid(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        public = Experiment(ds.copy()).process(
+            apodization="gm",
+            lb=-2.0,
+            gb=4.0,
+            size=128,
+            phase=None,
+        )
+        manual = _manual_public_process(
+            Experiment(ds.copy()),
+            ds,
+            "gm",
+            lb=-2.0,
+            gb=4.0,
+            size=128,
+        )
+
+        np.testing.assert_allclose(public.data, manual.data, atol=1.0e-12)
+        np.testing.assert_allclose(public.x.data, manual.x.data, atol=1.0e-12)
+
+    def test_sp_process_matches_manual_apodize_then_fft_on_synthetic_fid(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        public = Experiment(ds.copy()).process(
+            apodization="sp",
+            ssb=2.0,
+            pow=2,
+            size=128,
+            phase=None,
+        )
+        manual = _manual_public_process(
+            Experiment(ds.copy()),
+            ds,
+            "sp",
+            ssb=2.0,
+            pow=2,
+            size=128,
+        )
+
+        np.testing.assert_allclose(public.data, manual.data, atol=1.0e-12)
+        np.testing.assert_allclose(public.x.data, manual.x.data, atol=1.0e-12)
+
+    def test_gm_parameter_defaults_match_core_defaults_on_synthetic_fid(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        public = Experiment(ds.copy()).process(
+            apodization="gm",
+            size=128,
+            phase=None,
+        )
+        manual = _manual_public_process(Experiment(ds.copy()), ds, "gm", size=128)
+
+        np.testing.assert_allclose(public.data, manual.data, atol=1.0e-12)
+        np.testing.assert_allclose(public.x.data, manual.x.data, atol=1.0e-12)
+
+    def test_sp_parameter_defaults_match_core_defaults_on_synthetic_fid(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        public = Experiment(ds.copy()).process(
+            apodization="sp",
+            size=128,
+            phase=None,
+        )
+        manual = _manual_public_process(Experiment(ds.copy()), ds, "sp", size=128)
+
+        np.testing.assert_allclose(public.data, manual.data, atol=1.0e-12)
+        np.testing.assert_allclose(public.x.data, manual.x.data, atol=1.0e-12)
+
+    @pytest.mark.skipif(not _has_topspin_1d(), reason="TopSpin 1D data missing")
+    def test_real_fid_gm_gb_changes_public_result_without_mutating_source(self):
+        fid = _read_or_skip(nmrdir / "topspin_1d/1/fid")
+        source_data = np.asarray(fid.data).copy()
+
+        low = Experiment(fid.copy()).process(
+            apodization="gm",
+            lb=-2.0,
+            gb=1.0,
+            size=16384,
+            phase=None,
+        )
+        high = Experiment(fid.copy()).process(
+            apodization="gm",
+            lb=-2.0,
+            gb=8.0,
+            size=16384,
+            phase=None,
+        )
+
+        assert not np.allclose(np.asarray(low.data), np.asarray(high.data))
+        np.testing.assert_array_equal(fid.data, source_data)
+
+    @pytest.mark.skipif(not _has_topspin_1d(), reason="TopSpin 1D data missing")
+    def test_real_fid_sp_ssb_and_pow_change_public_result_without_mutating_source(self):
+        fid = _read_or_skip(nmrdir / "topspin_1d/1/fid")
+        source_data = np.asarray(fid.data).copy()
+
+        ssb_low = Experiment(fid.copy()).process(
+            apodization="sp",
+            ssb=1.0,
+            pow=1,
+            size=16384,
+            phase=None,
+        )
+        ssb_high = Experiment(fid.copy()).process(
+            apodization="sp",
+            ssb=4.0,
+            pow=1,
+            size=16384,
+            phase=None,
+        )
+        pow_high = Experiment(fid.copy()).process(
+            apodization="sp",
+            ssb=4.0,
+            pow=2,
+            size=16384,
+            phase=None,
+        )
+
+        assert not np.allclose(np.asarray(ssb_low.data), np.asarray(ssb_high.data))
+        assert not np.allclose(np.asarray(ssb_high.data), np.asarray(pow_high.data))
+        np.testing.assert_array_equal(fid.data, source_data)
 
     @pytest.mark.skipif(not _has_topspin_1d(), reason="TopSpin 1D data missing")
     def test_unknown_apodization_on_real_fid_raises(self):


### PR DESCRIPTION
## Summary

This PR completes the explicit user-facing apodization contract of `scp.nmr.Experiment.process()` for the public 1D NMR workflow.

It now wires the already exposed modes all the way through the public path:

- `em(lb=...)`
- `gm(lb=..., gb=...)`
- `sp(ssb=..., pow=...)`

It also makes incompatible explicit parameter combinations fail loudly instead of being silently ignored.

## What Changed

- Extended `Experiment.process()` to accept explicit `gb`, `ssb`, and `pow` parameters in addition to `lb`.
- Added explicit validation for apodization arguments:
  - rejects apodization parameters when `apodization=None`
  - rejects parameters incompatible with the selected window
  - validates `lb` / `gb` as real scalars or `Quantity` values compatible with `Hz`
  - validates `ssb > 0`
  - validates `pow` in `{1, 2}`
- Completed the `_apply_apodization()` dispatch so the public path actually forwards:
  - `lb` to `em()`
  - `lb` and `gb` to `gm()`
  - `ssb` and `pow` to `sp()`
- Rejects explicit apodization requests on already frequency-domain datasets instead of silently ignoring them.
- Updated the public 1D NMR example to keep a clear variable flow and to avoid presenting vendor-processing replay.
- Narrowed the plugin README and developer docs so they describe the explicit SpectroChemPy processing contract rather than implying vendor-processing replay.
- Added a changelog entry for the public behavior change.

## Why

The recent audit confirmed that the explicit `em(lb=...)` public path already worked numerically, but that the rest of the exposed apodization surface was incomplete:

- `gm` accepted only `lb` publicly even though the numerical core expects `gb` too
- `sp` accepted neither `ssb` nor `pow` publicly
- some explicit parameters could otherwise be ignored silently

This PR fixes that gap without broadening the scope to vendor-processing import or replay.

## Validation

- `pre-commit run --all-files`
- `python -m py_compile` on the modified NMR files
- `pytest plugins/spectrochempy-nmr/tests/test_experiment.py -k 'invalid_apodization_argument_combinations_raise or frequency_domain_rejects_explicit_apodization_requests or gm_process_matches_manual_apodize_then_fft_on_synthetic_fid or sp_process_matches_manual_apodize_then_fft_on_synthetic_fid or real_fid_gm_gb_changes_public_result_without_mutating_source or real_fid_sp_ssb_and_pow_change_public_result_without_mutating_source' -q`
  - result: `14 passed, 72 deselected`
- Added `test_frequency_domain_rejects_explicit_apodization_requests` to lock the frequency-domain rejection rule.
- Confirmed that already frequency-domain spectra reject explicit apodization requests while the existing frequency-domain path remains available when no apodization arguments are supplied.
- Executed `plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py`

## Scope Explicitly Left Out

This PR does **not** implement:

- import of vendor processing parameters from `procs`
- a structured vendor processing-parameter model
- `processing="vendor"`
- TopSpin processing replay
- any broader semantic change to `phase="metadata"`

## Notes

`latest.rst` was regenerated by the repository hook during pre-commit, so the changelog-derived file is included in the branch diff.