### PR TITLE
ENH: preserve TopSpin vendor processing profile without replay

### DIFF
--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -35,6 +35,27 @@ resolution, processed-data defaults, acquisition metadata, and NMR unit
 contexts. Core SpectroChemPy remains responsible for generic datasets, units,
 plotting, and ordinary FFT operations.
 
+TopSpin Processing Profile
+==========================
+
+TopSpin datasets may expose a descriptive vendor processing profile in
+``dataset.meta.nmr_processing``:
+
+.. code-block:: python
+
+    dataset = scp.nmr.read("path/to/fid")
+    profile = dataset.meta.nmr_processing["vendor_profile"]
+
+This profile records values read from the vendor ``procs`` file. It is
+descriptive only:
+
+- it is not applied automatically when reading a raw FID;
+- it is not replayed automatically by ``scp.nmr.Experiment(...).process()``;
+- it does not establish the exact historical processing sequence of an already
+  processed vendor spectrum such as TopSpin ``1r``;
+- SpectroChemPy-owned ``requested`` / ``applied`` processing traces are handled
+  separately and are not yet part of this metadata.
+
 Compatibility aliases
 =====================
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -31,6 +31,12 @@ New Features
   criteria.
 .. Add here new public features (do not delete this comment)
 
+- TopSpin datasets now preserve a descriptive vendor processing profile in
+  ``dataset.meta.nmr_processing``. The profile records the vendor ``procs``
+  values with stable provenance, but it is not applied automatically to raw
+  FIDs, does not replay vendor processing, and does not yet expose any
+  SpectroChemPy ``requested`` / ``applied`` processing trace.
+
 - `read_matlab()` now reconstructs `NDDataset` objects from the minimal
   MATLAB exchange payload written by `write_matlab()`, restoring the
   dataset's name, title, units, description, dimension names, and

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,12 @@ New Features
   columns have been removed because they did not map clearly to the stopping
   criteria.
 
+- TopSpin datasets now preserve a descriptive vendor processing profile in
+  ``dataset.meta.nmr_processing``. The profile records the vendor ``procs``
+  values with stable provenance, but it is not applied automatically to raw
+  FIDs, does not replay vendor processing, and does not yet expose any
+  SpectroChemPy ``requested`` / ``applied`` processing trace.
+
 - `read_matlab()` now reconstructs `NDDataset` objects from the minimal
   MATLAB exchange payload written by `write_matlab()`, restoring the
   dataset's name, title, units, description, dimension names, and

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_topspin.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/readers/read_topspin.py
@@ -40,6 +40,11 @@ from spectrochempy_nmr.extern.nmrglue import read_pdata
 # ======================================================================================
 FnMODE = ["undefined", "QF", "QSEQ", "TPPI", "STATES", "STATES-TPPI", "ECHO-ANTIECHO"]
 AQ_mod = ["QF", "QSIM", "QSEQ", "DQD"]
+_TOPSPIN_VENDOR_PARAMETER_UNITS = {
+    "LB": ur.Hz,
+    "PHC0": ur.deg,
+    "PHC1": ur.deg,
+}
 
 nmr_valid_meta = [
     # ACQU
@@ -796,6 +801,62 @@ def _get_files(path, typ="acqu"):
     return files
 
 
+def _convert_topspin_vendor_parameter_value(key, value):
+    unit = _TOPSPIN_VENDOR_PARAMETER_UNITS.get(key)
+    if unit is None:
+        return value
+
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, list | tuple):
+        if all(
+            isinstance(item, int | float) and not isinstance(item, bool)
+            for item in value
+        ):
+            return np.array(value) * unit
+        return value
+
+    if isinstance(value, np.ndarray):
+        if np.issubdtype(value.dtype, np.number) and not np.issubdtype(
+            value.dtype, np.bool_
+        ):
+            return value * unit
+        return value
+
+    if isinstance(value, int | float):
+        return value * unit
+
+    return value
+
+
+def _build_topspin_nmr_processing(dic):
+    nmr_processing = {
+        "observed_state": {
+            "processing_history": "not_established",
+        },
+    }
+
+    procs = dic.get("procs")
+    if not procs:
+        return nmr_processing
+
+    parameters = {}
+    for key, value in procs.items():
+        if key.startswith("_"):
+            continue
+        parameters[key] = _convert_topspin_vendor_parameter_value(key, value)
+
+    nmr_processing["vendor_profile"] = {
+        "vendor": "bruker",
+        # Use a JSON-stable sequence here so save/load preserves the exact shape.
+        "source_files": ["procs"],
+        "parameters": parameters,
+    }
+
+    return nmr_processing
+
+
 @_importer_method
 def _read_topspin(*args, **kwargs):
     dataset, path = args
@@ -1110,6 +1171,7 @@ def _read_topspin(*args, **kwargs):
 
     # and the metadata (and make them readonly)
     meta.datatype = datatype
+    meta.nmr_processing = _build_topspin_nmr_processing(dic)
     meta.pathname = str(path)
 
     # add two parameters needed for phasing

--- a/plugins/spectrochempy-nmr/tests/test_read_topspin.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_topspin.py
@@ -5,8 +5,12 @@
 # ======================================================================================
 # ruff: noqa: S101, F841
 
+import shutil
+from pathlib import Path
 
+import numpy as np
 import pytest
+from spectrochempy_nmr.experiment import Experiment
 
 import spectrochempy as scp
 
@@ -29,6 +33,33 @@ def _read_topspin_or_skip(*args, **kwargs):
     if result is None:
         pytest.skip("NMR test data could not be read in this environment")
     return result
+
+
+def _copy_topspin_1d_without_pdata(tmp_path: Path) -> Path:
+    source = _require_path(nmrdir / "topspin_1d" / "1")
+    target = tmp_path / "1"
+    target.mkdir()
+    for filename in ["fid", "acqu", "acqus", "pulseprogram"]:
+        src = source / filename
+        if src.exists():
+            shutil.copy2(src, target / filename)
+    return target / "fid"
+
+
+def _copy_topspin_1d_with_custom_procs(tmp_path: Path, extra_lines: list[str]) -> Path:
+    source = _require_path(nmrdir / "topspin_1d" / "1")
+    target = tmp_path / "1"
+    pdata = target / "pdata" / "1"
+    pdata.mkdir(parents=True)
+    for filename in ["fid", "acqu", "acqus", "pulseprogram"]:
+        src = source / filename
+        if src.exists():
+            shutil.copy2(src, target / filename)
+    procs = (source / "pdata" / "1" / "procs").read_text()
+    pdata.joinpath("procs").write_text(
+        procs.replace("##END=\n", "".join(extra_lines) + "##END=\n")
+    )
+    return target / "fid"
 
 
 def _has_readdir_nmr_data():
@@ -266,6 +297,141 @@ def test_processed_data_phc0_from_procs():
     assert hasattr(nd.meta, "phc0")
     assert len(nd.meta.phc0) >= 1
     assert float(nd.meta.phc0[0].magnitude) != 0.0
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_is_added_for_raw_fid():
+    nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/fid"))
+
+    assert hasattr(nd.meta, "nmr_processing")
+    assert "scp_processing" not in nd.meta.nmr_processing
+    assert nd.meta.nmr_processing["observed_state"] == {
+        "processing_history": "not_established"
+    }
+
+    profile = nd.meta.nmr_processing["vendor_profile"]
+    assert profile["vendor"] == "bruker"
+    assert profile["source_files"] == ["procs"]
+
+    params = profile["parameters"]
+    assert params["WDW"] == 1
+    assert params["LB"] == 0.0 * scp.ur.Hz
+    assert params["GB"] == 0
+    assert params["SSB"] == 0
+    assert params["SI"] == 16384
+    assert params["FT_mod"] == 6
+    assert float(params["PHC0"].magnitude) == pytest.approx(52.43836)
+    assert float(params["PHC1"].magnitude) == pytest.approx(-16.8366)
+    assert str(params["PHC0"].units) == "deg"
+    assert str(params["PHC1"].units) == "deg"
+    assert params["OFFSET"] == pytest.approx(253.0909)
+    assert params["FCOR"] == 1
+    assert params["PKNL"] is True
+    assert params["NC_proc"] == -5
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_is_added_for_processed_1r():
+    nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/pdata/1/1r"))
+
+    assert hasattr(nd.meta, "nmr_processing")
+    assert "scp_processing" not in nd.meta.nmr_processing
+    profile = nd.meta.nmr_processing["vendor_profile"]
+    assert profile["vendor"] == "bruker"
+    assert profile["source_files"] == ["procs"]
+    assert float(profile["parameters"]["PHC0"].magnitude) == pytest.approx(52.43836)
+    assert float(profile["parameters"]["PHC1"].magnitude) == pytest.approx(-16.8366)
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_without_procs_uses_observed_state_only(tmp_path):
+    nd = scp.read_topspin(_copy_topspin_1d_without_pdata(tmp_path))
+
+    assert hasattr(nd.meta, "nmr_processing")
+    assert nd.meta.nmr_processing == {
+        "observed_state": {"processing_history": "not_established"}
+    }
+    assert "scp_processing" not in nd.meta.nmr_processing
+    assert np.iscomplexobj(nd.data)
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_preserves_extra_procs_parameter(tmp_path):
+    nd = scp.read_topspin(
+        _copy_topspin_1d_with_custom_procs(
+            tmp_path, ["##$X_TEST= 7\n", "##$X_FLAG= yes\n"]
+        )
+    )
+
+    params = nd.meta.nmr_processing["vendor_profile"]["parameters"]
+    assert params["X_TEST"] == 7
+    assert params["X_FLAG"] is True
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_copy_is_independent():
+    nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/fid"))
+    copied = nd.copy()
+
+    assert copied.meta.nmr_processing == nd.meta.nmr_processing
+    assert copied.meta.nmr_processing is not nd.meta.nmr_processing
+    assert (
+        copied.meta.nmr_processing["vendor_profile"]
+        is not nd.meta.nmr_processing["vendor_profile"]
+    )
+    assert (
+        copied.meta.nmr_processing["vendor_profile"]["parameters"]
+        is not nd.meta.nmr_processing["vendor_profile"]["parameters"]
+    )
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_persists_through_save_and_load(tmp_path):
+    nd = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/fid"))
+    target = tmp_path / "topspin_vendor_profile.scp"
+
+    nd.dump(target)
+    restored = scp.NDDataset.load(target)
+
+    assert restored.meta.nmr_processing == nd.meta.nmr_processing
+    assert "nmr_processing" in str(restored.meta)
+    assert "nmr_processing" in restored.meta._repr_html_()
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_does_not_change_raw_data_without_procs(tmp_path):
+    original = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/fid"))
+    stripped = scp.read_topspin(_copy_topspin_1d_without_pdata(tmp_path))
+
+    np.testing.assert_array_equal(np.asarray(original.data), np.asarray(stripped.data))
+    assert stripped.meta.nmr_processing == {
+        "observed_state": {"processing_history": "not_established"}
+    }
+
+
+@pytest.mark.skipif(not NMRDATA.exists(), reason="NMR test data not available")
+def test_topspin_vendor_profile_is_not_consumed_by_experiment_process(tmp_path):
+    original = _read_topspin_or_skip(_require_path(nmrdir / "topspin_1d/1/fid"))
+    stripped = original.copy()
+    stripped.meta.readonly = False
+    stripped.meta.data.pop("nmr_processing", None)
+    stripped.meta.readonly = True
+
+    processed_with_profile = Experiment(original).process(
+        apodization="em",
+        lb=5.0,
+        size=16384,
+    )
+    processed_without_profile = Experiment(stripped).process(
+        apodization="em",
+        lb=5.0,
+        size=16384,
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(processed_with_profile.data),
+        np.asarray(processed_without_profile.data),
+    )
 
 
 # --------------------------------------------------------------------------

--- a/src/spectrochempy/utils/meta.py
+++ b/src/spectrochempy/utils/meta.py
@@ -233,10 +233,13 @@ class Meta:
                 if isinstance(v, dict):
                     key = f"{v['name']} [{k}]" if "name" in v else k
                     # case of opus metadata for example:
-                    if list(v["data"].keys()) == ["value"]:
-                        s += _make_section(key, v["data"]["value"])
+                    if "data" in v and isinstance(v["data"], dict):
+                        if list(v["data"].keys()) == ["value"]:
+                            s += _make_section(key, v["data"]["value"])
+                        else:
+                            s += _make_section(key, _make_html(v["data"]), details=True)
                     else:
-                        s += _make_section(key, _make_html(v["data"]), details=True)
+                        s += _make_section(key, _make_html(v), details=True)
             return s
 
         s = "<div class='scp-output'>"

--- a/tests/test_utils/test_meta.py
+++ b/tests/test_utils/test_meta.py
@@ -321,6 +321,45 @@ def test_nested_meta_update():
     meta.update(update_meta)
     assert meta.nested.key == "new value"
 
+
+def test_repr_html_supports_plain_nested_dicts():
+    """Plain nested dicts should render without requiring a ``data`` wrapper."""
+    meta = Meta(
+        title="demo",
+        nmr_processing={
+            "vendor_profile": {
+                "vendor": "bruker",
+                "source_files": ["procs"],
+                "parameters": {"LB": 2.0 * ur.Hz},
+            },
+            "observed_state": {"processing_history": "not_established"},
+        },
+    )
+
+    html = meta._repr_html_()
+
+    assert "nmr_processing" in html
+    assert "vendor_profile" in html
+    assert "bruker" in html
+    assert "processing_history" in html
+
+
+def test_repr_html_preserves_historical_data_wrapped_dicts():
+    """Historical nested dicts exposing a ``data`` payload should still render."""
+    meta = Meta(
+        opus={
+            "name": "history-block",
+            "data": {
+                "value": "OPUS value",
+            },
+        }
+    )
+
+    html = meta._repr_html_()
+
+    assert "history-block [opus]" in html
+    assert "OPUS value" in html
+
     # Update with a dictionary
     meta2 = Meta()
     nested_meta = {"key": "value"}


### PR DESCRIPTION
## Summary

This PR implements the first public follow-up from `spectrochempy_maintainer#6` and its merged maintainer RFC on the NMR processing-parameter contract.

Scope is intentionally narrow:

- preserve the TopSpin direct-dimension vendor processing profile in runtime metadata;
- keep it descriptive only;
- do not replay vendor processing;
- do not apply any vendor parameter implicitly;
- do not add any SpectroChemPy `requested` / `applied` processing trace yet.

## Prior reader characterization

Before this PR:

- `read_topspin._read_topspin()` already resolved `procs_files = _get_files(f_procno, "proc")` and passed them to both `read_fid()` and `read_pdata()`.
- a raw TopSpin `fid` therefore auto-discovered a neighboring `pdata/<procno>/procs` when present.
- a processed TopSpin `1r` reached the same direct-dimension `procs` values through `read_pdata()`.
- the vendored parser already read at least these direct-dimension `procs` parameters on the bundled `topspin_1d` reference:
  - `WDW`, `LB`, `GB`, `SSB`, `SI`, `FT_mod`, `PHC0`, `PHC1`, `OFFSET`, `FCOR`, `PKNL`, `NC_proc`
- only a small subset survived in `dataset.meta` after reader normalization:
  - notably `phc0`, `phc1`, `sf`, `sw_p`, and on processed data `si`
- the rest were read and then lost.

## Public representation added

This PR adds a descriptive TopSpin processing profile under:

```python
dataset.meta.nmr_processing
```

Current runtime shape:

```python
{
    "vendor_profile": {
        "vendor": "bruker",
        "source_files": ["procs"],
        "parameters": {
            ...
        },
    },
    "observed_state": {
        "processing_history": "not_established",
    },
}
```

When no `procs` file is found, the retained behavior is:

```python
{
    "observed_state": {
        "processing_history": "not_established",
    }
}
```

No `scp_processing` key is introduced in this PR.

## Parameters preserved

At minimum, this PR preserves the targeted TopSpin direct-dimension parameters when present:

- `WDW`
- `LB`
- `GB`
- `SSB`
- `SI`
- `FT_mod`
- `PHC0`
- `PHC1`
- `OFFSET`
- `FCOR`
- `PKNL`
- `NC_proc`

It also preserves additional `procs` parameters already read by the parser, instead of dropping unknown extras silently.

## Units retained vs left raw

Retained with explicit units:

- `LB` -> `Hz`
- `PHC0` -> `deg`
- `PHC1` -> `deg`

Intentionally left as raw vendor values:

- `GB`
- `OFFSET`
- `FCOR`
- `NC_proc`
- `WDW`
- `FT_mod`
- `SSB`
- all other unvalidated `procs` fields

## Negative guarantees

This PR does **not**:

- replay TopSpin processing;
- apply any `procs` parameter automatically to raw FIDs;
- modify numerical reader output for `fid` or `1r`;
- add `processing="vendor"`;
- add any SpectroChemPy `requested` / `applied` trace;
- change the current `phase="metadata"` behavior.

A focused regression test also confirms that removing `meta.nmr_processing` from an already-read dataset does not change `Experiment(...).process(apodization="em", lb=5.0, size=16384)`.

## Persistence and representation notes

Characterized on the current public code path:

- the nested payload survives `dataset.copy()` correctly;
- the public `save()` / `load()` round-trip preserves it;
- a JSON-stable list was used for `source_files` instead of a tuple so the public round-trip preserves the exact shape;
- a small `Meta._repr_html_()` adjustment was needed so ordinary nested dictionaries render correctly.

One pre-existing limitation remains outside the scope of this PR:

- the raw `dataset.dumps(encoding="base64")` then `NDDataset.loads(json.loads(...))` path is still not a reliable persistence proof for this campaign because direct use of that path already exposes an unrelated coordinate-restoration weakness.

## Documentation

This PR adds a short public NMR plugin note documenting that:

- the vendor profile lives in `dataset.meta.nmr_processing`;
- it is descriptive only;
- it is never applied automatically;
- `1r` history is not thereby established;
- replay and SpectroChemPy `requested` / `applied` traces are separate future work.

## Validation

Passed:

- `python -m pytest plugins/spectrochempy-nmr/tests/test_read_topspin.py -k 'vendor_profile or phc0_from_procs or 1d_fid_metadata or 1d_processed_metadata'`
- `python -m pytest plugins/spectrochempy-nmr/tests/test_topspin_semantic_characterization.py plugins/spectrochempy-nmr/tests/test_experiment.py -k 'topspin_1d or construct_from_processed_1d or construct_from_real_fid or fid_classification or processed_1d_classification or topSpin or process_emits_no_runtime_warning'`
- `python -m pytest plugins/spectrochempy-nmr/tests/test_experiment.py`
- `python -m pytest plugins/spectrochempy-nmr/tests/test_read_topspin.py -k 'not missing_file'`
- `pre-commit run --all-files`

Characterized but not fixed here:

- `plugins/spectrochempy-nmr/tests/test_read_topspin.py::test_read_topspin_missing_file` still depends on a network-resolved importer fallback and failed in this environment for that pre-existing reason.

## Remaining limitations / next step

Still out of scope after this PR:

- any vendor replay mode;
- any numerical validation of replay against TopSpin processing;
- any `scp_processing` / `requested` / `applied` trace;
- any cross-vendor normalization layer.

Planned next step remains a separate PR for the SpectroChemPy-owned `requested` / `applied` processing trace.