### PR TITLE
ENH: record requested/applied NMR processing trace

### DIFF
--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -53,8 +53,38 @@ descriptive only:
 - it is not replayed automatically by ``scp.nmr.Experiment(...).process()``;
 - it does not establish the exact historical processing sequence of an already
   processed vendor spectrum such as TopSpin ``1r``;
-- SpectroChemPy-owned ``requested`` / ``applied`` processing traces are handled
-  separately and are not yet part of this metadata.
+- SpectroChemPy-owned processing traces are handled separately from the vendor
+  profile.
+
+SpectroChemPy Processing Trace
+==============================
+
+The result of ``scp.nmr.Experiment(...).process()`` records the
+SpectroChemPy-owned processing call in
+``result.meta.nmr_processing["scp_processing"]``:
+
+.. code-block:: python
+
+    experiment = scp.nmr.Experiment(fid)
+    result = experiment.process(apodization="em", lb=5.0)
+
+    trace = result.meta.nmr_processing["scp_processing"]
+    requested = trace["requested"]
+    applied = trace["applied"]
+
+This trace is attached to the result only. The source dataset is not mutated.
+
+- ``requested`` contains only the arguments explicitly provided to
+  ``Experiment.process()``.
+- ``applied`` contains only the operations that SpectroChemPy actually
+  executed and the values those operations really consumed.
+- ``dataset.meta.nmr_processing["vendor_profile"]`` remains descriptive vendor
+  metadata and is never applied automatically.
+- the trace records the SpectroChemPy processing associated with the current
+  result, not a complete historical processing history for the dataset.
+- vendor replay is not implemented.
+- ``phase="metadata"`` keeps its current dataset-metadata phase path and does
+  not replay TopSpin ``PHC0`` / ``PHC1`` from ``procs``.
 
 Compatibility aliases
 =====================

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -37,6 +37,15 @@ New Features
   FIDs, does not replay vendor processing, and does not yet expose any
   SpectroChemPy ``requested`` / ``applied`` processing trace.
 
+- The result of ``scp.nmr.Experiment.process()`` now records a structured
+  SpectroChemPy-owned processing trace in
+  ``result.meta.nmr_processing["scp_processing"]``. The ``requested`` mapping
+  keeps only the arguments explicitly provided by the user, while ``applied``
+  keeps only the operations that were actually executed and the values they
+  really consumed. The source dataset remains unchanged, vendor ``procs``
+  metadata stays descriptive, and ``phase="metadata"`` still does not replay
+  TopSpin ``PHC0`` / ``PHC1``.
+
 - `read_matlab()` now reconstructs `NDDataset` objects from the minimal
   MATLAB exchange payload written by `write_matlab()`, restoring the
   dataset's name, title, units, description, dimension names, and

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -33,6 +33,15 @@ New Features
   FIDs, does not replay vendor processing, and does not yet expose any
   SpectroChemPy ``requested`` / ``applied`` processing trace.
 
+- The result of ``scp.nmr.Experiment.process()`` now records a structured
+  SpectroChemPy-owned processing trace in
+  ``result.meta.nmr_processing["scp_processing"]``. The ``requested`` mapping
+  keeps only the arguments explicitly provided by the user, while ``applied``
+  keeps only the operations that were actually executed and the values they
+  really consumed. The source dataset remains unchanged, vendor ``procs``
+  metadata stays descriptive, and ``phase="metadata"`` still does not replay
+  TopSpin ``PHC0`` / ``PHC1``.
+
 - `read_matlab()` now reconstructs `NDDataset` objects from the minimal
   MATLAB exchange payload written by `write_matlab()`, restoring the
   dataset's name, title, units, description, dimension names, and

--- a/plugins/spectrochempy-nmr/README.md
+++ b/plugins/spectrochempy-nmr/README.md
@@ -46,6 +46,14 @@ The current explicit apodization contract covers the public modes already
 exposed by `Experiment.process()`: `em(lb=...)`, `gm(lb=..., gb=...)`, and
 `sp(ssb=..., pow=...)`.
 
+The result of `Experiment.process()` also records the SpectroChemPy-owned
+processing trace in `result.meta.nmr_processing["scp_processing"]`.
+`requested` contains only the arguments explicitly provided by the user,
+whereas `applied` contains only the operations that were actually executed and
+the values they really consumed. This trace is attached to the result only:
+the source dataset is not mutated, the vendor `procs` profile remains purely
+descriptive, and `phase="metadata"` does not replay TopSpin `PHC0`/`PHC1`.
+
 The NMR ppm/frequency unit context is also provided by this plugin:
 
 ```python

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import re
 from numbers import Real
 from typing import TYPE_CHECKING
+from typing import cast
 
 import numpy as np
 
@@ -31,6 +32,29 @@ _APODIZATION_ALLOWED_PARAMS = {
     "gm": ("lb", "gb"),
     "sp": ("ssb", "pow"),
 }
+
+
+class _DefaultSentinel:
+    """Private default marker with a stable signature representation."""
+
+    def __init__(self, rendered: str):
+        self._rendered = rendered
+
+    def __repr__(self) -> str:
+        return self._rendered
+
+
+_UNSET_NONE = _DefaultSentinel("None")
+_UNSET_ZERO = _DefaultSentinel("0.0")
+_DEFAULT_APODIZATION = cast(str | None, _UNSET_NONE)
+_DEFAULT_LB = cast(float | Quantity | None, _UNSET_NONE)
+_DEFAULT_GB = cast(float | Quantity | None, _UNSET_NONE)
+_DEFAULT_SSB = cast(float | None, _UNSET_NONE)
+_DEFAULT_POW = cast(float | None, _UNSET_NONE)
+_DEFAULT_SIZE = cast(int | None, _UNSET_NONE)
+_DEFAULT_PHASE = cast(str | None, _UNSET_NONE)
+_DEFAULT_PHC0 = cast(float, _UNSET_ZERO)
+_DEFAULT_PHC1 = cast(float, _UNSET_ZERO)
 
 
 # ---------------------------------------------------------------------------
@@ -419,15 +443,15 @@ class Experiment:
     def process(
         self,
         *,
-        apodization: str | None = None,
-        lb: float | Quantity | None = None,
-        gb: float | Quantity | None = None,
-        ssb: float | None = None,
-        pow: float | None = None,
-        size: int | None = None,
-        phase: str | None = None,
-        phc0: float = 0.0,
-        phc1: float = 0.0,
+        apodization: str | None = _DEFAULT_APODIZATION,
+        lb: float | Quantity | None = _DEFAULT_LB,
+        gb: float | Quantity | None = _DEFAULT_GB,
+        ssb: float | None = _DEFAULT_SSB,
+        pow: float | None = _DEFAULT_POW,
+        size: int | None = _DEFAULT_SIZE,
+        phase: str | None = _DEFAULT_PHASE,
+        phc0: float = _DEFAULT_PHC0,
+        phc1: float = _DEFAULT_PHC1,
     ) -> NDDataset:
         """
         State-aware NMR processing.
@@ -487,6 +511,27 @@ class Experiment:
         """
 
         ds = self._dataset
+        explicit_arguments = {
+            "apodization": apodization is not _UNSET_NONE,
+            "lb": lb is not _UNSET_NONE,
+            "gb": gb is not _UNSET_NONE,
+            "ssb": ssb is not _UNSET_NONE,
+            "pow": pow is not _UNSET_NONE,
+            "size": size is not _UNSET_NONE,
+            "phase": phase is not _UNSET_NONE,
+            "phc0": phc0 is not _UNSET_ZERO,
+            "phc1": phc1 is not _UNSET_ZERO,
+        }
+
+        apodization = None if apodization is _UNSET_NONE else apodization
+        lb = None if lb is _UNSET_NONE else lb
+        gb = None if gb is _UNSET_NONE else gb
+        ssb = None if ssb is _UNSET_NONE else ssb
+        pow = None if pow is _UNSET_NONE else pow
+        size = None if size is _UNSET_NONE else size
+        phase = None if phase is _UNSET_NONE else phase
+        phc0 = 0.0 if phc0 is _UNSET_ZERO else phc0
+        phc1 = 0.0 if phc1 is _UNSET_ZERO else phc1
 
         if self.ndim > 1:
             msg = (
@@ -508,6 +553,7 @@ class Experiment:
                 phase=phase,
                 phc0=phc0,
                 phc1=phc1,
+                explicit_arguments=explicit_arguments,
             )
         if self.is_frequency_domain:
             self._reject_frequency_domain_apodization_requests(
@@ -522,6 +568,7 @@ class Experiment:
                 phase=phase,
                 phc0=phc0,
                 phc1=phc1,
+                explicit_arguments=explicit_arguments,
             )
         msg = (
             f"Cannot process data in '{self.domain}' domain. "
@@ -572,6 +619,7 @@ class Experiment:
         phase: str | None,
         phc0: float,
         phc1: float,
+        explicit_arguments: dict[str, bool],
     ) -> NDDataset:
         """Process time-domain data: apodize → zero-fill → FFT → phase."""
         work = ds.copy()
@@ -584,19 +632,35 @@ class Experiment:
             ssb=ssb,
             pow=pow,
         )
+        requested = self._build_requested_trace(
+            explicit_arguments,
+            apodization=apodization,
+            apodization_kwargs=apodization_kwargs,
+            size=size,
+            phase=phase,
+            phc0=phc0,
+            phc1=phc1,
+        )
+        applied: dict[str, object] = {}
         if apodization is not None:
             work = self._apply_apodization(work, apodization, **apodization_kwargs)
+            applied["apodization"] = apodization.lower()
+            applied.update(self._normalize_trace_mapping(apodization_kwargs))
 
         # 2. Zero-filling / FFT sizing
         if size is not None:
+            initial_size = int(work.shape[-1])
             from spectrochempy.processing.fft.zero_filling import (  # noqa: PLC0415
                 zf_size,
             )
 
             work = zf_size(work, size=size)
+            if int(work.shape[-1]) != initial_size:
+                applied["zero_filling"] = {"size": int(work.shape[-1])}
 
         # 3. FFT
         work = work.fft()
+        applied["fft"] = True
 
         # 3b. Encoding-specific intermediate phase convention adjustments
         work = self._apply_default_post_fft_phase(work)
@@ -604,9 +668,21 @@ class Experiment:
         # 4. Phase correction
         if phase is not None:
             work = self._apply_phase(work, phase, phc0=phc0, phc1=phc1)
+            applied["phase"] = self._build_applied_phase_trace(
+                phase,
+                phc0=phc0,
+                phc1=phc1,
+            )
 
         # 5. Calibrate the final spectral axis using canonical NMR metadata.
-        return self._calibrate_1d_spectral_axis(work)
+        calibrated = self._calibrate_1d_spectral_axis(work)
+        if self._axis_calibration_changed_axis(work, calibrated):
+            applied["axis_calibration"] = str(calibrated.coord(0).units)
+        return self._attach_scp_processing_trace(
+            calibrated,
+            requested=requested,
+            applied=applied,
+        )
 
     def _process_frequency_domain(
         self,
@@ -615,14 +691,144 @@ class Experiment:
         phase: str | None,
         phc0: float,
         phc1: float,
+        explicit_arguments: dict[str, bool],
     ) -> NDDataset:
         """Process frequency-domain data: phase only (no re-FFT)."""
         work = ds.copy()
+        requested = self._build_requested_trace(
+            explicit_arguments,
+            apodization=None,
+            apodization_kwargs={},
+            size=None,
+            phase=phase,
+            phc0=phc0,
+            phc1=phc1,
+        )
+        applied: dict[str, object] = {}
 
         if phase is not None:
             work = self._apply_phase(work, phase, phc0=phc0, phc1=phc1)
+            applied["phase"] = self._build_applied_phase_trace(
+                phase,
+                phc0=phc0,
+                phc1=phc1,
+            )
 
-        return work
+        return self._attach_scp_processing_trace(
+            work,
+            requested=requested,
+            applied=applied,
+        )
+
+    def _build_requested_trace(
+        self,
+        explicit_arguments: dict[str, bool],
+        *,
+        apodization: str | None,
+        apodization_kwargs: dict[str, float | Quantity],
+        size: int | None,
+        phase: str | None,
+        phc0: float,
+        phc1: float,
+    ) -> dict[str, object]:
+        """Record only the arguments explicitly provided by the user."""
+        requested: dict[str, object] = {}
+        if explicit_arguments["apodization"]:
+            requested["apodization"] = apodization
+        for name, value in apodization_kwargs.items():
+            if explicit_arguments[name]:
+                requested[name] = self._normalize_trace_value(name, value)
+        if explicit_arguments["size"]:
+            requested["size"] = int(size) if size is not None else None
+        if explicit_arguments["phase"]:
+            requested["phase"] = phase
+        if explicit_arguments["phc0"]:
+            requested["phc0"] = self._normalize_trace_value("phc0", phc0)
+        if explicit_arguments["phc1"]:
+            requested["phc1"] = self._normalize_trace_value("phc1", phc1)
+        return requested
+
+    def _normalize_trace_mapping(
+        self,
+        mapping: dict[str, float | Quantity],
+    ) -> dict[str, object]:
+        """Normalize trace values to a persistence-friendly public shape."""
+        return {
+            name: self._normalize_trace_value(name, value)
+            for name, value in mapping.items()
+        }
+
+    def _normalize_trace_value(
+        self,
+        name: str,
+        value: float | int | str | Quantity | None,
+    ) -> object:
+        """Normalize trace values with the public units expected by the contract."""
+        if name in {"lb", "gb"} and value is not None:
+            return self._as_hz_quantity(value)
+        if name in {"phc0", "phc1"} and value is not None:
+            return float(value) * ur.deg
+        if name == "size" and value is not None:
+            return int(value)
+        return value
+
+    def _as_hz_quantity(self, value: float | Quantity) -> Quantity:
+        """Represent frequency-like processing values as quantities in Hz."""
+        if isinstance(value, Quantity):
+            return value.to(ur.Hz)
+        return float(value) * ur.Hz
+
+    def _build_applied_phase_trace(
+        self,
+        mode: str,
+        *,
+        phc0: float,
+        phc1: float,
+    ) -> dict[str, object]:
+        """Record only the phase information actually consumed by the phase step."""
+        phase_trace: dict[str, object] = {"mode": mode}
+        if mode == "manual":
+            phase_trace["phc0"] = self._normalize_trace_value("phc0", phc0)
+            phase_trace["phc1"] = self._normalize_trace_value("phc1", phc1)
+        return phase_trace
+
+    def _axis_calibration_changed_axis(
+        self, before: NDDataset, after: NDDataset
+    ) -> bool:
+        """Return True when the final calibration step changed the public axis."""
+        before_coord = before.coord(0)
+        after_coord = after.coord(0)
+        if str(before_coord.units) != str(after_coord.units):
+            return True
+        if before_coord.title != after_coord.title:
+            return True
+        return not np.array_equal(
+            np.asarray(before_coord.data), np.asarray(after_coord.data)
+        )
+
+    def _attach_scp_processing_trace(
+        self,
+        ds: NDDataset,
+        *,
+        requested: dict[str, object],
+        applied: dict[str, object],
+    ) -> NDDataset:
+        """Attach the SpectroChemPy processing trace to the result dataset only."""
+        readonly = ds.meta.readonly
+        ds.meta.readonly = False
+
+        existing = getattr(ds.meta, "nmr_processing", None)
+        nmr_processing = dict(existing) if existing is not None else {}
+        nmr_processing["observed_state"] = {
+            "processing_history": "spectrochempy_process_recorded"
+        }
+        nmr_processing["scp_processing"] = {
+            "requested": requested,
+            "applied": applied,
+        }
+        ds.meta["nmr_processing"] = nmr_processing
+        ds.meta.readonly = readonly
+        return ds
 
     def _validate_apodization_arguments(
         self,

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -552,6 +552,8 @@ class TestProcessTimeDomain:
             np.asarray(manual.x.data),
             atol=1.0e-12,
         )
+        assert str(public.x.units) == str(manual.x.units)
+        np.testing.assert_array_equal(np.asarray(public.mask), np.asarray(manual.mask))
 
     @pytest.mark.parametrize(
         ("kwargs", "match"),
@@ -613,6 +615,8 @@ class TestProcessTimeDomain:
 
         np.testing.assert_allclose(public.data, manual.data, atol=1.0e-12)
         np.testing.assert_allclose(public.x.data, manual.x.data, atol=1.0e-12)
+        assert str(public.x.units) == str(manual.x.units)
+        np.testing.assert_array_equal(np.asarray(public.mask), np.asarray(manual.mask))
 
     def test_sp_process_matches_manual_apodize_then_fft_on_synthetic_fid(self):
         ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
@@ -634,6 +638,8 @@ class TestProcessTimeDomain:
 
         np.testing.assert_allclose(public.data, manual.data, atol=1.0e-12)
         np.testing.assert_allclose(public.x.data, manual.x.data, atol=1.0e-12)
+        assert str(public.x.units) == str(manual.x.units)
+        np.testing.assert_array_equal(np.asarray(public.mask), np.asarray(manual.mask))
 
     def test_gm_parameter_defaults_match_core_defaults_on_synthetic_fid(self):
         ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
@@ -991,6 +997,95 @@ class TestPublic1DRealAxisValidation:
         assert spectrum.x.linear
         assert runtime_messages == []
 
+    def test_process_trace_records_only_explicit_requests_and_actual_time_domain_steps(
+        self,
+    ):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+
+        result = Experiment(ds).process(apodization="em", lb=5.0, size=128)
+
+        assert getattr(ds.meta, "nmr_processing", None) is None
+        trace = result.meta.nmr_processing["scp_processing"]
+        assert trace["requested"] == {
+            "apodization": "em",
+            "lb": 5.0 * ur.Hz,
+            "size": 128,
+        }
+        assert trace["applied"] == {
+            "apodization": "em",
+            "lb": 5.0 * ur.Hz,
+            "zero_filling": {"size": 128},
+            "fft": True,
+            "axis_calibration": "ppm",
+        }
+        assert result.meta.nmr_processing["observed_state"] == {
+            "processing_history": "spectrochempy_process_recorded"
+        }
+
+    def test_process_trace_distinguishes_explicit_none_from_omitted_phase(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+
+        implicit = Experiment(ds.copy()).process()
+        explicit = Experiment(ds.copy()).process(phase=None)
+
+        np.testing.assert_allclose(np.asarray(explicit.data), np.asarray(implicit.data))
+        np.testing.assert_allclose(
+            np.asarray(explicit.x.data),
+            np.asarray(implicit.x.data),
+        )
+        assert implicit.meta.nmr_processing["scp_processing"]["requested"] == {}
+        assert explicit.meta.nmr_processing["scp_processing"]["requested"] == {
+            "phase": None
+        }
+        assert "phase" not in implicit.meta.nmr_processing["scp_processing"]["applied"]
+        assert "phase" not in explicit.meta.nmr_processing["scp_processing"]["applied"]
+
+    def test_process_trace_does_not_report_zero_filling_when_size_is_unchanged(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+
+        result = Experiment(ds).process(size=64)
+
+        trace = result.meta.nmr_processing["scp_processing"]
+        assert trace["requested"] == {"size": 64}
+        assert "zero_filling" not in trace["applied"]
+        assert trace["applied"]["fft"] is True
+
+    def test_process_trace_replaces_previous_trace_instead_of_building_history(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+
+        first = Experiment(ds).process(apodization="em", lb=3.0, size=128)
+        second = Experiment(first).process(phase=None)
+
+        assert first.meta.nmr_processing["scp_processing"]["requested"] == {
+            "apodization": "em",
+            "lb": 3.0 * ur.Hz,
+            "size": 128,
+        }
+        assert second.meta.nmr_processing["scp_processing"]["requested"] == {
+            "phase": None,
+        }
+        assert second.meta.nmr_processing["scp_processing"]["applied"] == {}
+
+    def test_process_trace_persists_through_copy_and_dump_roundtrip(self, tmp_path):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        result = Experiment(ds).process(apodization="gm", lb=2.0, gb=1.0, size=128)
+        copied = result.copy()
+        target = tmp_path / "nmr_trace.scp"
+
+        assert copied.meta.nmr_processing == result.meta.nmr_processing
+        assert copied.meta.nmr_processing is not result.meta.nmr_processing
+        assert (
+            copied.meta.nmr_processing["scp_processing"]
+            is not result.meta.nmr_processing["scp_processing"]
+        )
+
+        result.dump(target)
+        restored = scp.NDDataset.load(target)
+
+        assert restored.meta.nmr_processing == result.meta.nmr_processing
+        assert "scp_processing" in str(restored.meta)
+        assert "scp_processing" in restored.meta._repr_html_()
+
 
 # ---------------------------------------------------------------------------
 # Processing — frequency-domain 1D
@@ -1036,6 +1131,26 @@ class TestProcessFrequencyDomain:
         exp = Experiment(spec)
         _ = exp.process(phase="manual", phc0=10.0)
         np.testing.assert_array_equal(spec.data, original_data)
+
+    @pytest.mark.skipif(not _has_topspin_1d_pdata(), reason="TopSpin 1D pdata missing")
+    def test_frequency_domain_trace_records_phase_without_fft(self):
+        spec = _read_or_skip(nmrdir / "topspin_1d/1/pdata/1/1r")
+
+        result = Experiment(spec).process(phase="manual", phc0=10.0)
+
+        trace = result.meta.nmr_processing["scp_processing"]
+        assert trace["requested"] == {
+            "phase": "manual",
+            "phc0": 10.0 * ur.deg,
+        }
+        assert trace["applied"] == {
+            "phase": {
+                "mode": "manual",
+                "phc0": 10.0 * ur.deg,
+                "phc1": 0.0 * ur.deg,
+            }
+        }
+        assert "scp_processing" not in spec.meta.nmr_processing
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/spectrochempy-nmr/tests/test_read_topspin.py
+++ b/plugins/spectrochempy-nmr/tests/test_read_topspin.py
@@ -432,6 +432,21 @@ def test_topspin_vendor_profile_is_not_consumed_by_experiment_process(tmp_path):
         np.asarray(processed_with_profile.data),
         np.asarray(processed_without_profile.data),
     )
+    assert (
+        processed_with_profile.meta.nmr_processing["vendor_profile"]
+        == original.meta.nmr_processing["vendor_profile"]
+    )
+    assert processed_with_profile.meta.nmr_processing["scp_processing"][
+        "requested"
+    ] == {
+        "apodization": "em",
+        "lb": 5.0 * scp.ur.Hz,
+        "size": 16384,
+    }
+    assert (
+        processed_with_profile.meta.nmr_processing["scp_processing"]["applied"]["lb"]
+        == 5.0 * scp.ur.Hz
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -190,11 +190,15 @@ def test_write_jcamp_masked_values(tmp_path):
 
     f = ds.write_jcamp(tmp_path / "masked.jdx", confirm=False)
     text = f.read_text()
+    xydata_section = text.split("##XYDATA=(X++(Y..Y))\n", maxsplit=1)[1].split(
+        "##END",
+        maxsplit=1,
+    )[0]
 
-    # the masked underlying value never leaks into the file
-    assert "999" not in text
+    # the masked underlying value never leaks into the exported numeric payload
+    assert "999" not in xydata_section
     # each masked point is written as the JCAMP missing marker
-    assert text.count("? ") == 10
+    assert xydata_section.count("? ") == 10
     # header extrema ignore the masked samples
     assert "##MAXY=0.900000" in text
     assert "##MINY=0.100000" in text


### PR DESCRIPTION
## Summary

This PR implements the next public step after the maintainer RFC and after `#1473`: a structured SpectroChemPy-owned processing trace on the result of `scp.nmr.Experiment.process()`.

It adds:

- `result.meta.nmr_processing["scp_processing"]`
- `scp_processing["requested"]` for explicitly provided user arguments only
- `scp_processing["applied"]` for operations actually executed and values actually consumed
- `observed_state.processing_history = "spectrochempy_process_recorded"` on the result only

## Out of scope

This PR does **not** introduce:

- vendor replay
- implicit application of `procs`
- automatic mapping from vendor names to SpectroChemPy processing parameters
- any numeric change in the validated public 1D workflow
- any 2D reintroduction

Related:

- maintainer RFC: `spectrochempy_maintainer/rfcs/nmr-processing-parameter-contract.md`
- previous public step: #1473

## Baseline characterization

Before this PR, `Experiment.process()` had the public signature:

```python
process(
    *,
    apodization=None,
    lb=None,
    gb=None,
    ssb=None,
    pow=None,
    size=None,
    phase=None,
    phc0=0.0,
    phc1=0.0,
)
```

Actual 1D behavior was:

- time-domain: copy -> optional apodization -> optional zero filling -> FFT -> optional phase -> axis calibration
- frequency-domain: copy -> reject explicit apodization -> optional phase
- `phase="metadata"` remained a dataset-metadata phase path and did **not** replay TopSpin `PHC0/PHC1`

The main contract gap was that omitted arguments were not distinguishable from explicit default-valued arguments.

## Trace model implemented here

The result now receives:

```python
result.meta.nmr_processing["scp_processing"] = {
    "requested": {...},
    "applied": {...},
}
```

### `requested`

`requested` contains only arguments explicitly provided by the user.

Example:

```python
Experiment(fid).process(apodization="em", lb=5.0, size=16384)
```

records:

```python
{
    "apodization": "em",
    "lb": 5.0 * ur.Hz,
    "size": 16384,
}
```

It does **not** inject omitted defaults such as `phase=None` or `phc1=0.0`.

To make that distinction observable without changing the public call surface, this PR uses private module-level sentinels behind the same public-looking signature defaults.

### `applied`

`applied` is built close to the executed branches and records only operations that were actually executed.

Current rules:

- time-domain apodization records the chosen mode and only the parameters that were really consumed
- zero filling is recorded only when the requested `size` really changes the data length
- FFT is recorded only on the time-domain path
- phase is recorded only when a phase step is actually executed
- manual phase records `phc0` / `phc1` as consumed values in degrees
- `phase="metadata"` records only the actual metadata-phase path, not vendor replay
- axis calibration is recorded only when the final calibration step actually changes the public axis

This PR intentionally does **not** build a cumulative history.

## Pre-existing trace policy

If the source dataset already carries `meta.nmr_processing["scp_processing"]`, the source remains unchanged and the result replaces that trace with the trace of the current call only.

This keeps the first implementation step minimal and avoids inventing a multi-step historical model before a dedicated contract exists.

## Vendor-profile separation

When `vendor_profile` is present:

- it is preserved on the result through normal metadata copying
- none of its values are copied into `requested`
- none of its values are copied into `applied`
- user arguments keep absolute precedence

So `vendor_profile["parameters"]["LB"]` never overrides `process(lb=...)` in this PR.

## Source immutability and numeric stability

The source dataset is not mutated.

The new trace is attached only after a successful processing call finishes.

The validated public 1D numeric pipeline is unchanged. The existing manual-equivalence tests for `em`, `gm`, and `sp` still pass, and they were tightened here to also compare mask and axis units.

## Validation

Focused passing validation:

- `plugins/spectrochempy-nmr/tests/test_experiment.py`
- `plugins/spectrochempy-nmr/tests/test_read_topspin.py::test_topspin_vendor_profile_is_not_consumed_by_experiment_process`
- `tests/test_utils/test_meta.py`
- `pre-commit run --all-files`

Additional broader plugin validation was also run. It still shows unrelated failures outside this PR scope in existing 2D characterization/validation coverage, one encoding-dispatch test, and an offline missing-file test path that attempts a network fetch.

## Remaining limitations

This PR still does **not** claim:

- vendor replay
- complete processing-history reconstruction
- cross-vendor normalization of processing parameters
- any stronger semantic meaning for `phase="metadata"` than the currently implemented metadata-phase path

Those remain follow-up work for the future vendor-replay campaign.