### PR TITLE
TEST: extend NMR trace contract coverage

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -157,8 +157,8 @@ Breaking Changes
   semantics of Tauler MATLAB MCR-ALS, pyMCR, and PLS_Toolbox.  Convergence
   diagnostics also use the constrained pair, which can change convergence
   speed and iteration counts compared with the old behaviour.  The
-   unconstrained least-squares estimate is still available via the new
-   ``C_ls`` property. (:pr:`XXXX`)
+  unconstrained least-squares estimate is still available via the new
+  ``C_ls`` property. (:pr:`XXXX`)
 
 - Refactored the internal ALS iteration loop in ``MCRALS._fit`` to match the
   standard Tauler formulation: each iteration now performs exactly one C solve

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -138,8 +138,8 @@ Breaking Changes
   semantics of Tauler MATLAB MCR-ALS, pyMCR, and PLS_Toolbox.  Convergence
   diagnostics also use the constrained pair, which can change convergence
   speed and iteration counts compared with the old behaviour.  The
-   unconstrained least-squares estimate is still available via the new
-   ``C_ls`` property. (:pr:`XXXX`)
+  unconstrained least-squares estimate is still available via the new
+  ``C_ls`` property. (:pr:`XXXX`)
 
 - Refactored the internal ALS iteration loop in ``MCRALS._fit`` to match the
   standard Tauler formulation: each iteration now performs exactly one C solve

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -109,6 +109,14 @@ def _manual_public_process(experiment, dataset, apodization, *, size=None, **kwa
     return experiment._calibrate_1d_spectral_axis(work)
 
 
+def _plain_nested(value):
+    if isinstance(value, dict):
+        return {key: _plain_nested(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_nested(item) for item in value]
+    return value
+
+
 def _make_synthetic_vendor_fid(
     *,
     npts=64,
@@ -1085,6 +1093,192 @@ class TestPublic1DRealAxisValidation:
         assert restored.meta.nmr_processing == result.meta.nmr_processing
         assert "scp_processing" in str(restored.meta)
         assert "scp_processing" in restored.meta._repr_html_()
+
+    def test_process_trace_records_gm_contract_without_vendor_leakage(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        ds.meta.readonly = False
+        ds.meta.nmr_processing = {
+            "vendor_profile": {
+                "vendor": "bruker",
+                "parameters": {
+                    "LB": 9.0 * ur.Hz,
+                    "GB": 7.0,
+                    "SSB": 5,
+                },
+            },
+            "observed_state": {"processing_history": "not_established"},
+        }
+        ds.meta.readonly = True
+
+        result = Experiment(ds).process(apodization="gm", lb=2.0, gb=1.0, size=128)
+
+        trace = result.meta.nmr_processing["scp_processing"]
+        assert trace["requested"] == {
+            "apodization": "gm",
+            "lb": 2.0 * ur.Hz,
+            "gb": 1.0 * ur.Hz,
+            "size": 128,
+        }
+        assert trace["applied"] == {
+            "apodization": "gm",
+            "lb": 2.0 * ur.Hz,
+            "gb": 1.0 * ur.Hz,
+            "zero_filling": {"size": 128},
+            "fft": True,
+            "axis_calibration": "ppm",
+        }
+        assert "ssb" not in trace["requested"]
+        assert "pow" not in trace["requested"]
+        assert "ssb" not in trace["applied"]
+        assert "pow" not in trace["applied"]
+        assert result.meta.nmr_processing["vendor_profile"]["parameters"]["LB"] == (
+            9.0 * ur.Hz
+        )
+        assert result.meta.nmr_processing["vendor_profile"]["parameters"]["GB"] == 7.0
+
+    def test_process_trace_records_sp_contract_without_vendor_leakage(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        ds.meta.readonly = False
+        ds.meta.nmr_processing = {
+            "vendor_profile": {
+                "vendor": "bruker",
+                "parameters": {
+                    "LB": 9.0 * ur.Hz,
+                    "GB": 7.0,
+                    "SSB": 99,
+                },
+            },
+            "observed_state": {"processing_history": "not_established"},
+        }
+        ds.meta.readonly = True
+
+        result = Experiment(ds).process(apodization="sp", ssb=2.0, pow=2, size=128)
+
+        trace = result.meta.nmr_processing["scp_processing"]
+        assert trace["requested"] == {
+            "apodization": "sp",
+            "ssb": 2.0,
+            "pow": 2,
+            "size": 128,
+        }
+        assert trace["applied"] == {
+            "apodization": "sp",
+            "ssb": 2.0,
+            "pow": 2,
+            "zero_filling": {"size": 128},
+            "fft": True,
+            "axis_calibration": "ppm",
+        }
+        assert "lb" not in trace["requested"]
+        assert "gb" not in trace["requested"]
+        assert "lb" not in trace["applied"]
+        assert "gb" not in trace["applied"]
+        assert result.meta.nmr_processing["vendor_profile"]["parameters"]["SSB"] == 99
+
+    def test_process_trace_records_metadata_phase_without_vendor_replay(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        ds.meta.readonly = False
+        ds.meta.nmr_processing = {
+            "vendor_profile": {
+                "vendor": "bruker",
+                "parameters": {
+                    "PHC0": 52.0 * ur.deg,
+                    "PHC1": -17.0 * ur.deg,
+                },
+            },
+            "observed_state": {"processing_history": "not_established"},
+        }
+        ds.meta.readonly = True
+
+        implicit = Experiment(ds.copy()).process()
+        metadata = Experiment(ds.copy()).process(phase="metadata")
+
+        np.testing.assert_allclose(np.asarray(metadata.data), np.asarray(implicit.data))
+        np.testing.assert_allclose(
+            np.asarray(metadata.x.data),
+            np.asarray(implicit.x.data),
+        )
+
+        trace = metadata.meta.nmr_processing["scp_processing"]
+        assert trace["requested"] == {"phase": "metadata"}
+        assert trace["applied"] == {
+            "fft": True,
+            "phase": {"mode": "metadata"},
+            "axis_calibration": "ppm",
+        }
+        assert "phc0" not in trace["applied"]["phase"]
+        assert "phc1" not in trace["applied"]["phase"]
+        assert metadata.meta.nmr_processing["vendor_profile"]["parameters"]["PHC0"] == (
+            52.0 * ur.deg
+        )
+        assert metadata.meta.nmr_processing["vendor_profile"]["parameters"]["PHC1"] == (
+            -17.0 * ur.deg
+        )
+
+    def test_process_trace_distinguishes_explicit_default_value_from_omission(self):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+
+        implicit = Experiment(ds.copy()).process()
+        explicit = Experiment(ds.copy()).process(phc0=0.0)
+
+        np.testing.assert_allclose(np.asarray(explicit.data), np.asarray(implicit.data))
+        np.testing.assert_allclose(
+            np.asarray(explicit.x.data),
+            np.asarray(implicit.x.data),
+        )
+        assert implicit.meta.nmr_processing["scp_processing"]["requested"] == {}
+        assert explicit.meta.nmr_processing["scp_processing"]["requested"] == {
+            "phc0": 0.0 * ur.deg
+        }
+        assert implicit.meta.nmr_processing["scp_processing"]["applied"] == {
+            "fft": True,
+            "axis_calibration": "ppm",
+        }
+        assert explicit.meta.nmr_processing["scp_processing"]["applied"] == {
+            "fft": True,
+            "axis_calibration": "ppm",
+        }
+
+    def test_process_trace_preserves_source_observed_state_without_shared_references(
+        self,
+    ):
+        ds = _make_synthetic_vendor_fid(npts=64, sw_hz=6400.0, freq_hz=250.0)
+        ds.meta.readonly = False
+        ds.meta.nmr_processing = {
+            "vendor_profile": {
+                "vendor": "bruker",
+                "parameters": {"LB": 9.0 * ur.Hz},
+            },
+            "observed_state": {
+                "processing_history": "not_established",
+                "notes": {"status": "baseline", "items": ["a", "b"]},
+            },
+        }
+        ds.meta.readonly = True
+        initial_state = _plain_nested(ds.meta.nmr_processing)
+
+        result = Experiment(ds).process(apodization="em", lb=5.0, size=128)
+
+        assert result.meta.nmr_processing["observed_state"]["processing_history"] == (
+            "spectrochempy_process_recorded"
+        )
+        assert _plain_nested(ds.meta.nmr_processing) == initial_state
+        assert (
+            result.meta.nmr_processing["vendor_profile"]
+            is not ds.meta.nmr_processing["vendor_profile"]
+        )
+        assert (
+            result.meta.nmr_processing["observed_state"]
+            is not ds.meta.nmr_processing["observed_state"]
+        )
+
+        result.meta.readonly = False
+        result.meta.nmr_processing["scp_processing"]["requested"]["apodization"] = "gm"
+        result.meta.nmr_processing["vendor_profile"]["parameters"]["LB"] = 1.0 * ur.Hz
+        result.meta.nmr_processing["observed_state"]["processing_history"] = "changed"
+        result.meta.readonly = True
+
+        assert _plain_nested(ds.meta.nmr_processing) == initial_state
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -195,7 +195,9 @@ def test_write_jcamp_masked_values(tmp_path):
         maxsplit=1,
     )[0]
 
-    # the masked underlying value never leaks into the exported numeric payload
+    # Numeric leakage must be checked in the XYDATA payload itself: unrelated
+    # metadata such as ##OWNER may legitimately contain "999" in some
+    # environments and would otherwise cause a false-positive failure.
     assert "999" not in xydata_section
     # each masked point is written as the JCAMP missing marker
     assert xydata_section.count("? ") == 10


### PR DESCRIPTION
## Summary

This follow-up PR lands after merge of `#1476` and stays intentionally narrow.

It does **not** change the `requested/applied` architecture, does **not** start vendor replay, and does **not** change any NMR numeric behavior.

It only:

- adds the remaining contract tests requested during review;
- keeps and documents the incidental JCAMP test correction that would otherwise reintroduce a blocking false positive.

## Out of scope

- vendor replay
- implicit application of `procs`
- any `requested/applied` schema redesign
- any numeric change in the validated public 1D workflow
- any JCAMP reader/writer behavior change

Related context:

- merged runtime PR: `#1476`
- previous vendor-profile step: `#1473`
- maintainer RFC: `spectrochempy_maintainer/rfcs/nmr-processing-parameter-contract.md`

## Added contract coverage

This PR adds or strengthens explicit trace assertions for:

- `gm(lb=..., gb=...)`
- `sp(ssb=..., pow=...)`
- `phase="metadata"`
- an explicitly provided default-valued argument (`phc0=0.0`)
- deep non-mutation of source `observed_state`

### `gm` trace

The new test verifies that:

- `requested` contains only the explicit `gm` call arguments
- omitted arguments are absent
- `applied` records only `gm`, `lb`, `gb`, the actually executed zero-filling step, FFT, and axis calibration
- no `sp`/`em`-specific parameter leaks in
- no value from `vendor_profile` overrides user input

Expected and obtained trace:

```python
{
    "requested": {
        "apodization": "gm",
        "lb": 2.0 * ur.Hz,
        "gb": 1.0 * ur.Hz,
        "size": 128,
    },
    "applied": {
        "apodization": "gm",
        "lb": 2.0 * ur.Hz,
        "gb": 1.0 * ur.Hz,
        "zero_filling": {"size": 128},
        "fft": True,
        "axis_calibration": "ppm",
    },
}
```

### `sp` trace

The equivalent contract test now verifies that:

- `requested` contains only explicit `sp` arguments
- `applied` contains only `sp`, `ssb`, `pow`, the actually executed zero-filling step, FFT, and axis calibration
- no `lb`/`gb` leak in
- no vendor-profile value is copied into the trace

Expected and obtained trace:

```python
{
    "requested": {
        "apodization": "sp",
        "ssb": 2.0,
        "pow": 2,
        "size": 128,
    },
    "applied": {
        "apodization": "sp",
        "ssb": 2.0,
        "pow": 2,
        "zero_filling": {"size": 128},
        "fft": True,
        "axis_calibration": "ppm",
    },
}
```

### `phase="metadata"`

The new test characterizes the current merged behavior rather than redefining it.

It verifies that:

- `requested` contains `{"phase": "metadata"}` only when explicitly requested
- `applied` records the actual metadata-phase path only
- no `PHC0`/`PHC1` from `vendor_profile` are copied into the trace
- the numeric result remains identical to the current `phase=None` baseline on this synthetic path

Expected and obtained trace:

```python
{
    "requested": {
        "phase": "metadata",
    },
    "applied": {
        "fft": True,
        "phase": {"mode": "metadata"},
        "axis_calibration": "ppm",
    },
}
```

This still does **not** claim any TopSpin replay.

### Explicit default-valued argument

The new test shows that the private sentinel still distinguishes:

```python
experiment.process()
```

from:

```python
experiment.process(phc0=0.0)
```

Behavior verified:

- omitted `phc0` is absent from `requested`
- explicit `phc0=0.0` appears in `requested` as `0.0 * ur.deg`
- `applied` stays unchanged because no phase operation ran and therefore nothing consumed `phc0`

### Source `observed_state` non-mutation

The new test uses a source dataset carrying a nested `observed_state` and verifies that:

- the result gets `processing_history = "spectrochempy_process_recorded"`
- the source `observed_state` remains byte-for-byte equivalent in nested content
- nested mappings are not shared by reference
- mutating the result trace or result metadata after processing does not modify the source metadata

## Incidental JCAMP test correction

This PR keeps the incidental JCAMP test correction introduced during `#1476` review.

Important scope clarification:

- no JCAMP reader code is modified
- no JCAMP writer code is modified
- only the test assertion is tightened to target the actual numeric payload

### Why the old assertion is too broad

The previous assertion checked:

```python
assert "999" not in text
```

across the **entire** exported file.

That is too broad because the file also contains unrelated metadata such as:

```text
##OWNER=...
```

which may legitimately contain the character sequence `999` depending on the environment, even when the `XYDATA` numeric payload is perfectly correct.

### Deterministic reproduction of the false positive

A one-off reproduction using the old assertion with `ds.author = "owner-999-demo"` fails with:

```text
E       AssertionError: assert '999' not in '##TITLE=mas...ND\n##END=\n'
E
E         '999' is contained here:
E           NER=owner-999-demo
E         ?           +++
```

### Why the new assertion is the right target

The test now isolates the numeric `XYDATA` block and checks:

- masked sentinel `999` does not appear in the exported numeric payload
- the JCAMP missing marker `?` is emitted the expected number of times
- `MAXY` and `MINY` remain correct
- round-trip reading still restores masked positions as `NaN`

So the correction narrows the assertion to the contractually relevant payload without reducing the real numeric coverage of the test.

## Validation

Focused passing validation:

- `python -m pytest plugins/spectrochempy-nmr/tests/test_experiment.py -k 'process_trace or metadata_phase or public_em_processing_matches or gm_process_matches or sp_process_matches' tests/test_core/test_readers/test_read_jcamp.py::test_write_jcamp_masked_values`
- `python -m pytest tests/test_core/test_readers/test_read_jcamp.py`
- `pre-commit run --files plugins/spectrochempy-nmr/tests/test_experiment.py tests/test_core/test_readers/test_read_jcamp.py`

Broader plugin validation executed:

- `python -m pytest plugins/spectrochempy-nmr/tests`

Current broader plugin-suite result remains unchanged outside this PR scope:

- 5 failing tests, all pre-existing and unrelated to this follow-up:
  - `test_fft_full_2d_chain_on_nddataset`
  - `test_fft_2d_peak_matches_manual_workflow`
  - `test_bruker_echoanti_two_step_fft_real_peak_near_reference`
  - `test_dispatch_unknown_encoding`
  - `test_read_topspin_missing_file`

The last failure still depends on an offline missing-file path that attempts a network fetch.

## Changelog

This is a test-only follow-up PR and should use the `no-changelog` label.