### PR TITLE
DOC: clarify NMR metadata phase semantics

### DIFF
--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -83,8 +83,12 @@ This trace is attached to the result only. The source dataset is not mutated.
 - the trace records the SpectroChemPy processing associated with the current
   result, not a complete historical processing history for the dataset.
 - vendor replay is not implemented.
-- ``phase="metadata"`` keeps its current dataset-metadata phase path and does
-  not replay TopSpin ``PHC0`` / ``PHC1`` from ``procs``.
+- ``phase="metadata"`` applies the dataset's current ``meta.phc0`` /
+  ``meta.phc1`` state through the existing ``pk()`` path. It does not consult
+  ``vendor_profile`` and does not replay TopSpin ``PHC0`` / ``PHC1`` from
+  ``procs``. On the validated raw TopSpin 1D oracle path it is currently
+  numerically identical to ``phase=None``; on already frequency-domain spectra
+  carrying phase metadata, it can still apply a real phase correction.
 
 Compatibility aliases
 =====================

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/experiment.py
@@ -486,8 +486,11 @@ class Experiment:
         size : int, optional
             Zero-fill target size.  Only applied to time-domain data.
         phase : str, optional
-            ``'manual'`` to apply ``phc0``/``'phc1``, ``'metadata'`` to use
-            stored phase values, or ``None`` for no phasing.
+            ``'manual'`` to apply explicit ``phc0``/``phc1``,
+            ``'metadata'`` to apply the dataset's current phase metadata via
+            ``pk()``, or ``None`` for no phasing. ``'metadata'`` uses the
+            dataset's own ``meta.phc0`` / ``meta.phc1`` state when present; it
+            does not replay ``vendor_profile`` or TopSpin ``procs`` values.
         phc0 : float
             Zero-order phase correction in degrees (manual mode).
         phc1 : float

--- a/plugins/spectrochempy-nmr/tests/test_experiment.py
+++ b/plugins/spectrochempy-nmr/tests/test_experiment.py
@@ -1198,7 +1198,6 @@ class TestPublic1DRealAxisValidation:
             np.asarray(metadata.x.data),
             np.asarray(implicit.x.data),
         )
-
         trace = metadata.meta.nmr_processing["scp_processing"]
         assert trace["requested"] == {"phase": "metadata"}
         assert trace["applied"] == {
@@ -1345,6 +1344,42 @@ class TestProcessFrequencyDomain:
             }
         }
         assert "scp_processing" not in spec.meta.nmr_processing
+
+    @pytest.mark.skipif(not _has_topspin_1d_pdata(), reason="TopSpin 1D pdata missing")
+    def test_frequency_domain_metadata_phase_uses_dataset_phase_metadata(self):
+        spec = _read_or_skip(nmrdir / "topspin_1d/1/pdata/1/1r")
+
+        implicit = Experiment(spec.copy()).process()
+        metadata = Experiment(spec.copy()).process(phase="metadata")
+        manual_from_current_meta = Experiment(spec.copy()).process(
+            phase="manual",
+            phc0=-float(spec.meta.phc0[0].magnitude),
+            phc1=-float(spec.meta.phc1[0].magnitude),
+        )
+
+        assert not np.allclose(np.asarray(metadata.data), np.asarray(implicit.data))
+        np.testing.assert_allclose(
+            np.asarray(metadata.data),
+            np.asarray(manual_from_current_meta.data),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(metadata.x.data),
+            np.asarray(implicit.x.data),
+        )
+
+        trace = metadata.meta.nmr_processing["scp_processing"]
+        assert trace["requested"] == {"phase": "metadata"}
+        assert trace["applied"] == {"phase": {"mode": "metadata"}}
+        assert (
+            metadata.meta.nmr_processing["vendor_profile"]
+            == spec.meta.nmr_processing["vendor_profile"]
+        )
+        assert metadata.meta.phc0[0] == 0.0 * ur.deg
+        assert metadata.meta.phc1[0] == 0.0 * ur.deg
+        assert metadata.meta.phased == [True]
+        assert spec.meta.phased is None
+        assert spec.meta.phc0[0] == 52.43836 * ur.deg
+        assert spec.meta.phc1[0] == -16.8366 * ur.deg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR characterizes and clarifies the current public meaning of `phase="metadata"` in `scp.nmr.Experiment.process()`.

It does **not** introduce vendor replay, does **not** change the NMR 1D numeric pipeline, and does **not** modify `requested` / `applied` architecture.

## Characterized current behavior

### Accepted API surface

`phase="metadata"` is currently accepted by the public `Experiment.process()` API and is also documented.

### What it actually uses

It uses the dataset's current phase metadata handled by the existing `pk()` path:

- `meta.phc0`
- `meta.phc1`
- `meta.phased`

It does **not** consult:

- `meta.nmr_processing["vendor_profile"]`
- TopSpin `procs` through any replay mechanism

### Raw TopSpin 1D FID path

On the validated raw TopSpin 1D oracle path:

```python
Experiment(fid).process(size=size, phase="metadata")
```

is numerically identical to:

```python
Experiment(fid).process(size=size, phase=None)
```

The merged tests already showed that this path does not replay imported TopSpin `PHC0` / `PHC1`.

### Already frequency-domain TopSpin `1r` path

On an already frequency-domain dataset:

```python
spec = scp.nmr.read(.../1r)
Experiment(spec).process(phase="metadata")
```

`phase="metadata"` is **not** a no-op.

The new characterization shows that it applies the dataset's current `meta.phc0` / `meta.phc1` state through `pk()`, and on the bundled TopSpin `1r` reference it is numerically equivalent to:

```python
Experiment(spec).process(
    phase="manual",
    phc0=-float(spec.meta.phc0[0].magnitude),
    phc1=-float(spec.meta.phc1[0].magnitude),
)
```

This happens because the current path initializes `meta.phased` to `False` before `pk()` when needed, so the existing relative-phase convention is what gets exercised.

## Decision retained

`phase="metadata"` is **kept**.

Reason:

- it is not a pure no-op globally;
- it has a real effect on supported already frequency-domain inputs;
- removing or deprecating it based only on the raw-FID path would be misleading.

## Scope of this PR

This PR only:

- clarifies the `Experiment.process()` docstring;
- clarifies the public NMR user guide;
- adds missing contract coverage for the already frequency-domain case.

It does **not**:

- replay vendor processing parameters;
- read `vendor_profile` during processing;
- reinterpret TopSpin `procs` as a public replay path;
- change any supported numeric path.

## Tests added / updated

- existing raw-FID metadata-phase trace characterization remains in place;
- new frequency-domain test proves that `phase="metadata"`:
  - differs from `phase=None` on bundled TopSpin `1r` data;
  - matches a manual phase built from the dataset's current metadata state;
  - preserves `vendor_profile` as descriptive metadata only;
  - leaves the source dataset unchanged.

## Validation

Passed locally:

- `python -m pytest plugins/spectrochempy-nmr/tests/test_experiment.py plugins/spectrochempy-nmr/tests/test_read_topspin.py::test_topspin_vendor_profile_is_not_consumed_by_experiment_process`
- `pre-commit run --all-files`

## Compatibility and limitations

- no runtime behavior is changed by this PR;
- `phase="metadata"` remains a dataset-metadata path, not a vendor replay path;
- the trace still records `{"mode": "metadata"}` without exposing an interpreted vendor replay contract;
- future vendor replay work remains separate.
