### PR TITLE
FIX: refresh public NMR example gallery

### DIFF
--- a/docs/sources/userguide/plugins/nmr.rst
+++ b/docs/sources/userguide/plugins/nmr.rst
@@ -112,14 +112,8 @@ The generated public API page for the NMR plugin is listed in
 Examples
 ========
 
-For phase-sensitive 2D NMR workflows, install hypercomplex support as well:
-
-.. code-block:: bash
-
-    pip install spectrochempy[nmr,hypercomplex]
-
-See also the hypercomplex plugin guide for phase-sensitive 2D NMR workflows
-built on TopSpin datasets.
+The published public examples for this plugin currently focus on validated 1D
+workflows.
 
 Limitations
 ===========

--- a/docs/sources/userguide/processing/fourier.py
+++ b/docs/sources/userguide/processing/fourier.py
@@ -34,8 +34,8 @@
 # # One-dimensional (1D) Fourier transformation
 
 # %% [markdown]
-# In this notebook, we are going to transform time-domain data into 1D or 2D spectra using SpectroChemPy
-# processing tools
+# In this notebook, we transform time-domain NMR data into a 1D spectrum using
+# SpectroChemPy processing tools.
 
 # %%
 import spectrochempy as scp

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -120,6 +120,12 @@ Bug Fixes
 - ``em(lb=0)`` and ``em(lb=0.0 * ur.Hz)`` are now treated as valid no-op
   calls instead of raising a ``ZeroDivisionError``.
 
+- The public NMR examples are now more consistent with the validated 1D scope:
+  the gallery no longer publishes the unstable CP and 2D workflows, the
+  apodization and relaxation examples were clarified visually, and inverse FFT
+  reconstruction now restores a correct NMR time axis in the 1D Fourier
+  tutorial.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -112,6 +112,12 @@ Bug Fixes
 - ``em(lb=0)`` and ``em(lb=0.0 * ur.Hz)`` are now treated as valid no-op
   calls instead of raising a ``ZeroDivisionError``.
 
+- The public NMR examples are now more consistent with the validated 1D scope:
+  the gallery no longer publishes the unstable CP and 2D workflows, the
+  apodization and relaxation examples were clarified visually, and inverse FFT
+  reconstruction now restores a correct NMR time axis in the 1D Fourier
+  tutorial.
+
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 

--- a/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
+++ b/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
@@ -6,10 +6,11 @@
 # ======================================================================================
 # ruff: noqa
 """
-Loading of experimental NMR data
-=================================
+Loading of experimental 1D NMR data
+===================================
 
-In this example, we load a NMR dataset (in the Bruker format) and plot it.
+In this example, we load a 1D Bruker TopSpin NMR dataset and inspect the raw
+FID with the public ``scp.nmr.read(...)`` API.
 
 Requires the official ``spectrochempy-nmr`` plugin.
 Install with: ``pip install spectrochempy[nmr]``.
@@ -37,14 +38,13 @@ ndd = scp.nmr.read(path, expno=1, remove_digital_filter=True)
 _ = ndd.plot()
 
 # %%
-# Now load a 2D  dataset
-
-path = datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_2d"
-ndd = scp.nmr.read(path, expno=1, remove_digital_filter=True)
-_ = ndd.plot()
+# The public gallery currently focuses on validated 1D workflows. Raw 2D TopSpin
+# examples remain in the repository for later characterization, but they are not
+# presented here because multi-dimensional processing is still outside the
+# supported public scope.
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
+# This ends the example! The following line can be uncommented if no plot shows
+# when running the .py script with python.
 
 # scp.show()

--- a/plugins/spectrochempy-nmr/examples/gallery.toml
+++ b/plugins/spectrochempy-nmr/examples/gallery.toml
@@ -25,6 +25,6 @@ section = "NMR processing"
 section_ref = "examples-processing-nmr-index"
 
 [[examples]]
-path = "processing/nmr/plot_processing_cp_nmr.py"
+path = "processing/nmr/plot_processing_nmr_relax.py"
 section = "NMR processing"
 section_ref = "examples-processing-nmr-index"

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
@@ -43,11 +43,28 @@ new2, curve2 = dataset1D.copy().em(
 
 # %%
 # Plotting
-_ = dataset1D.plot(zlim=(-2, 2), color="k")
-_ = curve1.plot(color="r")
-_ = new1.plot(color="r", clear=False, label=" em = 20 hz")
-_ = curve2.plot(color="b", clear=False)
-_ = new2.plot(dcolor="b", clear=False, label=" em = 30 HZ, shifted = ")
+# --------
+# Compare the original FID with the exponential window and the apodized signal.
+ax = dataset1D.real.plot(color="k", label="original FID", xlim=(0, 15000))
+_ = curve1.plot(clear=False, color="r", ls="--", label="window, lb = 20 Hz")
+_ = new1.real.plot(clear=False, color="r", label="apodized FID, lb = 20 Hz")
+_ = ax.legend()
+
+# %%
+# Shifted windows are easier to read on a separate figure.
+ax = dataset1D.real.plot(color="k", label="original FID", xlim=(0, 15000))
+_ = curve2.plot(
+    clear=False,
+    color="b",
+    ls="--",
+    label="window, lb = 100 Hz, shifted = 10000 us",
+)
+_ = new2.real.plot(
+    clear=False,
+    color="b",
+    label="apodized FID, lb = 100 Hz, shifted = 10000 us",
+)
+_ = ax.legend()
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
@@ -58,28 +58,42 @@ new5, curve5 = dataset1D.sinm(ssb=8, retapod=True, inplace=False)
 
 # %%
 # Plotting
-_ = dataset1D.plot(zlim=(-2, 2), color="k")
-_ = curve1.plot(color="r", clear=False)
-_ = new1.plot(
-    data_only=True, color="r", clear=False, label=" sinm with ssb= 2 (cosine window)"
-)
-_ = curve2.plot(color="b", clear=False)
-_ = new2.plot(
-    data_only=True, color="b", clear=False, label=" sinm with ssb= 1 (sine window)"
-)
-_ = curve3.plot(color="m", clear=False)
-_ = new3.plot(data_only=True, color="m", clear=False, label=" qsin with ssb= 2")
-_ = curve4.plot(color="g", clear=False)
-_ = new4.plot(data_only=True, color="g", clear=False, label=" qsin with ssb= 1")
-_ = curve5.plot(color="c", ls="--", clear=False)
-_ = new5.plot(
-    data_only=True,
-    color="c",
-    ls="--",
+# --------
+# Compare sine bell windows on a first figure.
+ax = dataset1D.real.plot(color="k", label="original FID", xlim=(0, 15000))
+_ = curve1.plot(clear=False, color="r", ls="--", label="window, sinm ssb = 2")
+_ = new1.real.plot(
     clear=False,
-    label=" sinm with ssb= 8",
-    legend="best",
+    color="r",
+    label="apodized FID, sinm ssb = 2 (cosine window)",
 )
+_ = curve2.plot(clear=False, color="b", ls="--", label="window, sinm ssb = 1")
+_ = new2.real.plot(
+    clear=False,
+    color="b",
+    label="apodized FID, sinm ssb = 1 (sine window)",
+)
+_ = ax.legend()
+
+# %%
+# Compare squared sine windows on a second figure.
+ax = dataset1D.real.plot(color="k", label="original FID", xlim=(0, 15000))
+_ = curve3.plot(clear=False, color="m", ls="--", label="window, qsin ssb = 2")
+_ = new3.real.plot(clear=False, color="m", label="apodized FID, qsin ssb = 2")
+_ = curve4.plot(clear=False, color="g", ls="--", label="window, qsin ssb = 1")
+_ = new4.real.plot(clear=False, color="g", label="apodized FID, qsin ssb = 1")
+_ = ax.legend()
+
+# %%
+# Mixed sine/cosine windows are easier to inspect separately.
+ax = dataset1D.real.plot(color="k", label="original FID", xlim=(0, 15000))
+_ = curve5.plot(clear=False, color="c", ls="--", label="window, sinm ssb = 8")
+_ = new5.real.plot(
+    clear=False,
+    color="c",
+    label="apodized FID, sinm ssb = 8",
+)
+_ = ax.legend()
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
@@ -8,7 +8,19 @@
 """
 Analysis CP NMR spectra
 =======================
-Example with handling of a series of CP NMR spectra.
+
+Temporarily excluded from the public gallery.
+
+The bundled dataset is a CP/MAS contact-time series (`cpF1F2hetcor` pulse
+program, `vdlist` present on the final experiment), but the current public read
+path no longer returns the merged pseudo-2D dataset shape assumed by this
+historical script. Reading the whole directory yields a `ScpObjectList` of
+independent 1D FIDs, and the contact-time metadata needed for a reliable public
+series reconstruction are not yet exposed in a stable, documented way.
+
+The source is kept here as future characterization material for a dedicated
+CP-series follow-up, but it is not published while the public 1D example set is
+restricted to validated executable workflows.
 
 Requires the official ``spectrochempy-nmr`` plugin.
 Install with: ``pip install spectrochempy[nmr]``.

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -49,7 +49,7 @@ low_lb = scp.nmr.Experiment(fid.copy()).process(
 )
 high_lb = scp.nmr.Experiment(fid.copy()).process(
     apodization="em",
-    lb=20.0,
+    lb=50.0,
     size=16384,
     phase=None,
 )
@@ -62,9 +62,10 @@ high_lb.plot(
     ax=ax,
     color="C1",
     linestyle="--",
-    label="LB = 20 Hz",
+    label="LB = 50 Hz",
+    xlim=(-7.0, 12.0),
 )
-ax.legend()
+_ = ax.legend()
 
 # %%
 # Continue with the mildly broadened spectrum
@@ -205,5 +206,3 @@ _ = f1.plot_merit(offset=2)
 # when the example is run as a notebook (`.ipynb`).
 
 # scp.show()
-
-# %%

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
@@ -8,7 +8,14 @@
 """
 Two-dimensional NMR processing
 ==============================
-End-to-end 2D NMR processing from raw SER data to a 2D frequency-domain spectrum.
+
+Temporarily excluded from the public gallery.
+
+This source is preserved for the future 2D characterization campaign, but the
+current public NMR workflow intentionally supports only validated 1D
+processing. On the merged public branch, ``scp.nmr.Experiment.process()``
+raises `NotImplementedError` for multi-dimensional datasets, so this example is
+not published while 2D support remains under separate scientific review.
 
 This example complements :ref:`sphx_glr_plugins_spectrochempy-nmr_examples_processing_nmr_plot_processing_nmr.py`:
 

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
@@ -6,9 +6,23 @@
 # ======================================================================================
 # ruff: noqa
 """
-Processing Relaxation measurement
-=================================
-Processing NMR spectra taken for relaxation measurements
+Processing a saturation-recovery relaxation series
+==================================================
+
+This example processes a pseudo-2D series of 1D spectra acquired with a
+variable recovery delay and fits a simple saturation-recovery model to the
+dominant resonance.
+
+The bundled Bruker dataset stores the delays in ``vdlist`` and the pulse
+program indicates a CP/MAS saturation-recovery experiment. The example keeps a
+modest public scope:
+
+- process the 1D FIDs with explicit SpectroChemPy operations;
+- extract a signal trace from the dominant processed resonance;
+- fit a simple two-parameter recovery model to that trace.
+
+It does not claim replay of vendor processing, nor exact equivalence with the
+TopSpin fitting tools bundled alongside the dataset.
 
 Requires the official ``spectrochempy-nmr`` plugin.
 Install with: ``pip install spectrochempy[nmr]``.
@@ -23,9 +37,9 @@ import spectrochempy as scp
 U = scp.ur
 
 # %%
-# Importing a pseudo 2D NMR spectra
-# ---------------------------------
-# Define the folder where are the spectra
+# Import a pseudo-2D delay series
+# -------------------------------
+# Define the folder containing the Bruker experiment.
 datadir = scp.preferences.datadir
 nmrdir = datadir / "nmrdata" / "bruker" / "tests" / "nmr"
 
@@ -38,17 +52,22 @@ dataset = scp.nmr.read(nmrdir / "relax" / "100" / "ser", use_list="vdlist")
 dataset
 
 # %%
-# Plot the dataset
+# Plot the processed spectra
+# --------------------------
+# The `vdlist` delays become the secondary coordinate of the pseudo-2D series.
 ds = dataset.em(lb=15 * U.Hz)
 ds = ds.fft()
-ds = ds.pk(phc0=-10 * U.deg, phc1=0 * U.deg)
-_ = ds.plot(xlim=(-60, -140))
+ds = ds.pk(phc0=-145 * U.deg, phc1=0 * U.deg)
+_ = ds.plot(xlim=(100, -50))
 
 # %%
-# Integrate a region
-dsint = ds[:, -90.0:-115.0].simpson()
-_ = dsint.plot(marker="^", ls=":")
-dsint.real
+# Build a signal trace from the dominant resonance
+# -----------------------------------------------
+# The strongest processed peak in this series sits around 20–22 ppm.
+# We integrate a narrow ppm window around that resonance for each delay.
+signal = ds[:, 20.0:45.0].simpson()
+_ = signal.plot(marker="^", ls=":")
+signal.real
 
 # %%
 # Fit a model
@@ -60,7 +79,7 @@ fitter = scp.Optimize(log_level="INFO", method="leastsq")
 # %%
 # Define the model to fit
 def T1_model(t, I0, T1):  # no underscore in parameters names.
-    # T1 relaxation model
+    # Simple saturation-recovery model.
     import numpy as np
 
     I = I0 * (1 - np.exp(-t / T1))
@@ -83,15 +102,25 @@ shape: T1_model
 """
 
 # %%
-# Performs the fit
-_ = fitter.fit(dsint)
+# Perform the fit
+_ = fitter.fit(signal)
 
 # %%
 som = fitter.predict()
 som
 
 # %%
-_ = fitter.plotmerit(dsint, som, method="scatter", title="T1 relaxation fitting")
+# Plot the measured recovery points and the fitted curve separately so the
+# experimental series remains a true scatter plot.
+ax = signal.plot_scatter(
+    color="tab:blue",
+    marker="o",
+    markersize=5,
+    label="measured signal",
+    title="Saturation-recovery fit of the dominant resonance",
+)
+_ = som.plot(clear=False, color="tab:orange", lw=1.8, label="fitted curve")
+_ = ax.legend()
 
 # %%
 # This ends the example ! The following line can be removed or commented

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_postprocess.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/processing/fft_postprocess.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 
 from spectrochempy.core.dataset.coord import Coord  # noqa: PLC0415
-from spectrochempy.core.units import ur  # noqa: PLC0415
 
 
 def _meta_dim_index(new, dim):
@@ -68,10 +67,7 @@ def _fft_postprocess_result(new, dim=-1, inv=False, **kwargs):
     else:
         # frequency/ppm → time
         # Replace the generic core-created coordinate with a proper NMR time axis.
-        sw_val = abs(x.data[-1] - x.data[0])
-        if x.units == "ppm":
-            sw_val = (bf1.to("Hz").magnitude * sw_val) / 1.0e6
-        deltat = (1.0 / sw_val) * ur.us
+        deltat = (1.0 / sw.to("Hz")).to("us")
 
         newcoord = Coord.arange(size) * deltat
         newcoord.name = x.name

--- a/plugins/spectrochempy-nmr/tests/test_examples_gallery.py
+++ b/plugins/spectrochempy-nmr/tests/test_examples_gallery.py
@@ -3,6 +3,7 @@
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
+# ruff: noqa: S101, S603
 
 """Targeted checks for the public NMR example gallery."""
 
@@ -17,7 +18,6 @@ from pathlib import Path
 import pytest
 
 import spectrochempy as scp
-
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PLUGIN_ROOT = REPO_ROOT / "plugins" / "spectrochempy-nmr"
@@ -69,7 +69,7 @@ def test_public_nmr_gallery_examples_execute(relative_path, tmp_path):
         ]
     ).rstrip(os.pathsep)
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, str(example)],
         cwd=REPO_ROOT,
         env=env,

--- a/plugins/spectrochempy-nmr/tests/test_examples_gallery.py
+++ b/plugins/spectrochempy-nmr/tests/test_examples_gallery.py
@@ -1,0 +1,87 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+"""Targeted checks for the public NMR example gallery."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import spectrochempy as scp
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "spectrochempy-nmr"
+MANIFEST = PLUGIN_ROOT / "examples" / "gallery.toml"
+VISIBLE_EXAMPLES = [
+    "core/c_importer/plot_read_nmr_from_bruker.py",
+    "processing/apodization/plot_proc_em.py",
+    "processing/apodization/plot_proc_sp.py",
+    "processing/nmr/plot_read_nmr_topspin.py",
+    "processing/nmr/plot_processing_nmr.py",
+    "processing/nmr/plot_processing_nmr_relax.py",
+]
+
+
+def _has_nmr_example_data() -> bool:
+    root = Path(scp.preferences.datadir) / "nmrdata" / "bruker" / "tests" / "nmr"
+    required = [
+        root / "topspin_1d" / "1" / "fid",
+        root / "relax" / "100" / "ser",
+    ]
+    return all(path.exists() for path in required)
+
+
+def test_nmr_gallery_manifest_focuses_on_public_1d_examples():
+    manifest = tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+    example_paths = [entry["path"] for entry in manifest["examples"]]
+
+    assert example_paths == VISIBLE_EXAMPLES
+    assert "processing/nmr/plot_processing_cp_nmr.py" not in example_paths
+    assert "processing/nmr/plot_processing_nmr_2d.py" not in example_paths
+
+
+@pytest.mark.parametrize("relative_path", VISIBLE_EXAMPLES, ids=VISIBLE_EXAMPLES)
+def test_public_nmr_gallery_examples_execute(relative_path, tmp_path):
+    if not _has_nmr_example_data():
+        pytest.skip("Bundled NMR example data not available in this environment")
+
+    example = PLUGIN_ROOT / "examples" / relative_path
+
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+    env["MPLCONFIGDIR"] = str(tmp_path / "mpl")
+    env["SCP_CONFIG_HOME"] = str(tmp_path / "scp-config")
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(REPO_ROOT / "src"),
+            str(PLUGIN_ROOT / "src"),
+            env.get("PYTHONPATH", ""),
+        ]
+    ).rstrip(os.pathsep)
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(example)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    error_msg = (
+        f"Example failed: {relative_path}\n"
+        f"Return code: {result.returncode}\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}\n"
+    )
+    assert result.returncode == 0, error_msg

--- a/tests/test_processing/test_fft/test_nmr.py
+++ b/tests/test_processing/test_fft/test_nmr.py
@@ -97,6 +97,9 @@ def test_nmr_fft_1D(NMR_dataset_1D):
     new2 = new.ifft()
     energy_roundtrip = np.sum(np.abs(new2.data) ** 2)
     assert abs(energy_roundtrip / energy_time - 1.0) < 0.01
+    assert new2.x.units == ur.us
+    assert_array_almost_equal(new2.x.data[1] - new2.x.data[0], 4.0, decimal=6)
+    assert_array_almost_equal(new2.x.data[-1], (new2.size - 1) * 4.0, decimal=6)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- refocus the public NMR plugin examples and docs on the currently validated 1D workflow
- clarify the EM/SP apodization and relaxation examples, keep CP/2D sources out of the published gallery, and add a gallery execution smoke test
- fix the NMR inverse-FFT time-axis reconstruction used by the 1D Fourier tutorial and cover it with a regression test

## Validation
- `/Users/christian/micromamba/envs/scpy-core/bin/python -m pytest plugins/spectrochempy-nmr/tests/test_examples_gallery.py tests/test_processing/test_fft/test_nmr.py -q`
- `MPLBACKEND=Agg MPLCONFIGDIR=/private/tmp/scp-mpl-fourier HOME=/Users/christian /Users/christian/micromamba/envs/scpy-core/bin/python docs/sources/userguide/processing/fourier.py`
- `pre-commit run --all-files`

## Notes
- this keeps the latest local example adjustments and packages them as the draft PR payload
- the changelog entry is intentionally short and release-level only