### PR TITLE
FIX: preserve manual parameter entries in configurable docstrings

### DIFF
--- a/docs/sources/credits/credits.rst
+++ b/docs/sources/credits/credits.rst
@@ -28,6 +28,8 @@ Other contributions have been made by:
 
 * Vincent Gao
 
+* Revian Alifino Revaza (ORCID: `0009-0008-0898-4557 <https://orcid.org/0009-0008-0898-4557>`_)
+
 
 We thank all the users who have reported bugs, suggested improvements,
 and contributed to improve the documentation.
@@ -35,7 +37,7 @@ and contributed to improve the documentation.
 Third-party Licenses
 ====================
 
-- Reading of TOPSPIN NMR files and digital filter removal is based on
+- Reading of NMR files and digital filter removal is based on
   `nmrglue <https://www.nmrglue.com>`_ open sourcepackage.
   [J.J. Helmus, C.P. Jaroniec, Nmrglue: An open source Python package for the analysis of multidimensional NMR data, J. Biomol. NMR 2013, 55, 355-367.
   `doi: 10.1007/s10858-013-9718-x <https://dx.doi.org/10.1007/s10858-013-9718-x>`_]. **nmrglue** is distributed under the BSD-3 License.

--- a/plugins/spectrochempy-tensor/tests/test_tensor_cp.py
+++ b/plugins/spectrochempy-tensor/tests/test_tensor_cp.py
@@ -9,6 +9,7 @@
 
 import numpy as np
 import pytest
+import re
 
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._result import AnalysisResult
@@ -44,6 +45,36 @@ def _make_synthetic_3d():
 
 class TestCP:
     """Test suite for CP decomposition class."""
+
+    def test_cp_docstring_parameters_section_is_well_formed(self):
+        """Runtime docstring keeps manual entries intact and appends missing traits."""
+        doc = CP.__doc__
+        assert doc is not None
+
+        params_match = re.search(
+            r"Parameters\n----------\n(?P<body>.*?)(?:\n\nAttributes\n----------|\Z)",
+            doc,
+            re.S,
+        )
+        assert params_match is not None
+        params_body = params_match.group("body")
+        assert params_body.startswith(
+            'cvg_criterion : {"abs_rec_error", "rec_error"}, default="abs_rec_error"\n'
+            '    Stopping criterion for ALS. "abs_rec_error" uses absolute difference,',
+        )
+        assert params_body.count("n_components :") == 1
+        assert params_body.index("cvg_criterion :") < params_body.index(
+            "n_components :"
+        )
+        assert (
+            "n_components : int\n"
+            "    Number of components (rank) for the decomposition."
+        ) in params_body
+        assert "Parameters\n----------\n    Number of components" not in doc
+        assert (
+            'cvg_criterion : {"abs_rec_error", "rec_error"}, default="abs_rec_error"'
+            in params_body
+        )
 
     def test_cp_import_without_tensorly(self):
         """

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -3908,7 +3908,9 @@ _doc = MCRALS.__doc__
 
 if _doc:
     import re as _re
+    from inspect import cleandoc as _cleandoc
 
+    _doc = _cleandoc(_doc)
     _PH = "Parameters\n----------\n"
     _params_start = _doc.find(_PH)
     if _params_start >= 0:
@@ -3946,11 +3948,11 @@ if _doc:
                 _entries.append((_current_name, "\n".join(_current_lines)))
 
         for _line in _params_only.split("\n"):
-            _m = _re.match(r"^(\w+)\s*:", _line)
+            _m = _re.match(r"^\s*(\w+)\s*:", _line)
             if _m:
                 _save_entry()
                 _current_name = _m.group(1)
-                _current_lines = [_line]
+                _current_lines = [_line.lstrip()]
             elif _current_name is not None:
                 _current_lines.append(_line)
         _save_entry()
@@ -3962,7 +3964,13 @@ if _doc:
 
         # Rebuild docstring (blank line before subsequent sections is essential for numpydoc)
         MCRALS.__doc__ = (
-            _before_params + _PH + "\n".join(_filtered) + "\n\n" + _after_params
+            "\n"
+            + _before_params
+            + _PH
+            + "\n".join(_filtered)
+            + "\n\n"
+            + _after_params.rstrip()
+            + "\n"
         )
 
 

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -833,6 +833,12 @@ class MCRALS(DecompositionAnalysis):
         When `warm_start` is `True`, the existing fitted model attributes is used to
         initialize the new model in a subsequent call to `fit`.
 
+    See Also
+    --------
+    fit : Fit the MCRALS model on X.
+    transform : Apply dimensionality reduction.
+    fit_transform : Fit the model and apply dimensionality reduction.
+
     Notes
     -----
     Three dimensionless stopping diagnostics are evaluated after each ALS
@@ -860,12 +866,6 @@ class MCRALS(DecompositionAnalysis):
     resolved factor units. For horizontal augmentation, ``St_blocks`` carries
     block-specific physical metadata; the heterogeneous concatenated ``St`` is
     deliberately unitless with a neutral title.
-
-    See Also
-    --------
-    fit : Fit the MCRALS model on X.
-    transform : Apply dimensionality reduction.
-    fit_transform : Fit the model and apply dimensionality reduction.
 
     """
 
@@ -3896,14 +3896,14 @@ MCRALS.__signature__ = Signature(
     ]
 )
 
-# The decorator @signature_has_configurable_traits strips manual entries for
-# ``config=True`` traitlets (max_iter, tol, maxdiv, …) and merges auto‑generated
-# entries for ALL such traitlets (including legacy names) into a single
-# ``Parameters`` section.  We keep only entries whose name matches a param in the
-# custom ``__signature__`` (excluding VAR_POSITIONAL ``*args``) and drop everything
-# legacy.  This keeps the keep-list in sync with the public API automatically:
-# adding a param to ``__signature__`` adds it to the docstring, and removing one
-# removes it.
+# The shared decorator preserves manual entries, but it still builds the
+# ``Parameters`` section from the full set of ``config=True`` traitlets. MCRALS
+# intentionally exposes a narrower custom ``__signature__`` than that full
+# traitlet surface, so we keep only entries whose name matches a param in the
+# custom ``__signature__`` (excluding VAR_POSITIONAL ``*args``) and drop
+# everything legacy. This keeps the keep-list in sync with the public API
+# automatically: adding a param to ``__signature__`` adds it to the docstring,
+# and removing one removes it.
 _doc = MCRALS.__doc__
 
 if _doc:

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -7,6 +7,7 @@
 import copy
 import functools
 import inspect
+import re
 from functools import partial
 from functools import update_wrapper
 from inspect import Parameter
@@ -116,10 +117,110 @@ def deprecated(name=None, *, kind="method", replace="", removed=None, extra_msg=
 # ======================================================================================
 T = TypeVar("T", bound=tr.HasTraits)
 
+_KNOWN_NUMPYDOC_SECTIONS = {
+    "Parameters",
+    "Returns",
+    "Yields",
+    "Other Parameters",
+    "Raises",
+    "Warns",
+    "Warnings",
+    "See Also",
+    "Notes",
+    "References",
+    "Examples",
+    "Attributes",
+    "Methods",
+}
+_PARAMETER_DECLARATION_RE = re.compile(
+    r"^\s*([*]{0,2}[A-Za-z_]\w*(?:\s*,\s*[*]{0,2}[A-Za-z_]\w*)*)\s*:\s*",
+)
+
 
 def _get_default(value):
     """Get default argument value, given the trait default value."""
     return Parameter.empty if value == tr.Undefined else value
+
+
+def _parse_numpydoc_sections(docstring):
+    """Return the summary block and the ordered numpydoc sections."""
+    lines = docstring.splitlines()
+    summary_lines = []
+    sections = []
+    current_section = None
+    current_lines = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if (
+            stripped in _KNOWN_NUMPYDOC_SECTIONS
+            and i + 1 < len(lines)
+            and lines[i + 1].strip()
+            and set(lines[i + 1].strip()) == {"-"}
+        ):
+            if current_section is None:
+                summary_lines = current_lines
+            else:
+                sections.append((current_section, "\n".join(current_lines).rstrip()))
+
+            current_section = stripped
+            current_lines = []
+            i += 2
+            continue
+
+        current_lines.append(line)
+        i += 1
+
+    if current_section is None:
+        summary_lines = current_lines
+    else:
+        sections.append((current_section, "\n".join(current_lines).rstrip()))
+
+    return "\n".join(summary_lines).strip(), sections
+
+
+def _parse_parameter_entries(section_content):
+    """
+    Return free text and parameter entries from a numpydoc Parameters section body.
+
+    Each entry keeps the declaration line and its whole indented description.
+    """
+    preamble_lines = []
+    entries = []
+    current_names = None
+    current_lines = []
+
+    def _flush_entry():
+        if current_names is not None:
+            entries.append((current_names, "\n".join(current_lines).rstrip()))
+
+    for line in section_content.splitlines():
+        match = _PARAMETER_DECLARATION_RE.match(line)
+        if match:
+            _flush_entry()
+            current_names = tuple(name.strip() for name in match.group(1).split(","))
+            current_lines = [line]
+            continue
+
+        if current_names is None:
+            preamble_lines.append(line)
+        else:
+            current_lines.append(line)
+
+    _flush_entry()
+    return "\n".join(preamble_lines).strip("\n"), entries
+
+
+def _format_numpydoc_section(name, content):
+    """Format a numpydoc section block."""
+    underline = "-" * len(name)
+    content = content.rstrip()
+    if content:
+        return f"{name}\n{underline}\n{content}"
+    return f"{name}\n{underline}"
 
 
 def signature_has_configurable_traits(cls: type[T]) -> type[T]:
@@ -207,10 +308,7 @@ def signature_has_configurable_traits(cls: type[T]) -> type[T]:
     # Start with the existing docstring (summary + extended summary)
     existing_doc = cls.__doc__ or ""
 
-    # Build the Parameters section from traits
-    trait_params = ""
-    trait_names = {name for name, _ in traits}
-
+    trait_entry_map = {}
     for name, value in traits:
         # Determine type string
         type_ = type(value).__name__
@@ -240,142 +338,84 @@ def signature_has_configurable_traits(cls: type[T]) -> type[T]:
         else:
             default = f"``{default!r}``"
 
-        trait_params += f"{name} : {type_str}, optional, default: {default}\n"
+        lines = [f"{name} : {type_str}, optional, default: {default}"]
         desc = value.help or ""
         if desc:
-            for line in desc.splitlines():
-                trait_params += f"    {line}\n"
-        else:
-            trait_params += "\n"
+            lines.extend(f"    {line}" for line in desc.splitlines())
+        trait_entry_map[name] = "\n".join(lines)
 
-    # Parse docstring into sections using a robust line-by-line approach
-    # Known numpydoc section names
-    KNOWN_SECTIONS = {
-        "Parameters",
-        "Returns",
-        "Yields",
-        "Other Parameters",
-        "Raises",
-        "Warns",
-        "Warnings",
-        "See Also",
-        "Notes",
-        "References",
-        "Examples",
-        "Attributes",
-        "Methods",
-    }
+    summary, sections = _parse_numpydoc_sections(existing_doc)
+    params_sections = [content for name, content in sections if name == "Parameters"]
 
-    lines = existing_doc.split("\n")
-    sections_dict = {}
-    current_section = "__summary__"
-    current_content = []
-    i = 0
+    params_preamble_parts = []
+    manual_entries = []
+    seen_param_names = set()
 
-    while i < len(lines):
-        line = lines[i]
-        stripped = line.strip()
+    for params_content in params_sections:
+        params_preamble, parsed_entries = _parse_parameter_entries(params_content)
+        if params_preamble:
+            params_preamble_parts.append(params_preamble)
 
-        # Check if this is a section header
-        if stripped in KNOWN_SECTIONS and i + 1 < len(lines):
-            next_line = lines[i + 1]
-            # Check if next line is all dashes (allowing whitespace)
-            if next_line.strip() and all(c == "-" for c in next_line.strip()):
-                # Save current section
-                if current_content:
-                    content = "\n".join(current_content).rstrip()
-                    if current_section in sections_dict:
-                        sections_dict[current_section] += "\n" + content
-                    else:
-                        sections_dict[current_section] = content
-
-                # Start new section
-                current_section = stripped
-                current_content = []
-                i += 2  # Skip header and underline
+        for names, block in parsed_entries:
+            if seen_param_names.intersection(names):
                 continue
+            manual_entries.append((names, block))
+            seen_param_names.update(names)
 
-        current_content.append(line)
-        i += 1
+    public_param_order = list(cls.__signature__.parameters)
+    manual_entry_by_name = {}
+    for entry_index, (names, _) in enumerate(manual_entries):
+        for name in names:
+            manual_entry_by_name.setdefault(name, entry_index)
 
-    # Save final section
-    if current_content:
-        content = "\n".join(current_content).rstrip()
-        if current_section in sections_dict:
-            sections_dict[current_section] += "\n" + content
-        else:
-            sections_dict[current_section] = content
+    ordered_entries = []
+    used_entry_indices = set()
+    documented_names = set()
 
-    # Extract summary
-    summary = sections_dict.pop("__summary__", "").strip()
+    for param_name in public_param_order:
+        entry_index = manual_entry_by_name.get(param_name)
+        if entry_index is not None:
+            if entry_index not in used_entry_indices:
+                names, block = manual_entries[entry_index]
+                ordered_entries.append(block.rstrip())
+                used_entry_indices.add(entry_index)
+                documented_names.update(names)
+            continue
 
-    # Extract all Parameters content and merge
-    params_content = ""
-    if "Parameters" in sections_dict:
-        params_content = sections_dict.pop("Parameters").strip()
+        if param_name in trait_entry_map and param_name not in documented_names:
+            ordered_entries.append(trait_entry_map[param_name])
+            documented_names.add(param_name)
 
-    # Build merged Parameters section
-    merged_params = []
+    for entry_index, (names, block) in enumerate(manual_entries):
+        if entry_index not in used_entry_indices:
+            ordered_entries.append(block.rstrip())
+            documented_names.update(names)
 
-    # Add existing non-trait params
-    if params_content:
-        for line in params_content.split("\n"):
-            stripped = line.strip()
-            if stripped:
-                # Check if it's a parameter definition (param_name : ...)
-                import re
+    merged_params_parts = [part for part in params_preamble_parts if part.strip()]
+    merged_params_parts.extend(entry for entry in ordered_entries if entry.strip())
+    merged_params = "\n".join(merged_params_parts).strip()
+    params_block = (
+        _format_numpydoc_section("Parameters", merged_params) if merged_params else ""
+    )
 
-                param_match = re.match(r"^(\w+)\s*:", stripped)
-                if param_match:
-                    param_name = param_match.group(1)
-                    if param_name not in trait_names:
-                        merged_params.append(line)
-                else:
-                    # It's a continuation line
-                    merged_params.append(line)
-            else:
-                merged_params.append(line)
-
-    # Add trait params
-    if trait_params:
-        merged_params.append(trait_params.rstrip())
-
-    # Build final docstring with proper section order
     doc_parts = []
-
-    # Add summary
     if summary:
         doc_parts.append(summary)
 
-    # Add merged Parameters section
-    if merged_params:
-        params_section = "Parameters\n----------\n" + "\n".join(merged_params)
-        doc_parts.append(params_section)
+    inserted_params = False
+    if not params_sections and params_block:
+        doc_parts.append(params_block)
+        inserted_params = True
 
-    # Add remaining sections in preferred order
-    section_order = [
-        "Returns",
-        "Yields",
-        "Other Parameters",
-        "Raises",
-        "Warns",
-        "Warnings",
-        "See Also",
-        "Notes",
-        "References",
-        "Examples",
-        "Attributes",
-        "Methods",
-    ]
+    for section_name, content in sections:
+        if section_name == "Parameters":
+            if not inserted_params and params_block:
+                doc_parts.append(params_block)
+                inserted_params = True
+            continue
+        doc_parts.append(_format_numpydoc_section(section_name, content))
 
-    for section_name in section_order:
-        if section_name in sections_dict:
-            content = sections_dict[section_name]
-            underline = "-" * len(section_name)
-            doc_parts.append(f"{section_name}\n{underline}\n{content}")
-
-    # Join with double newlines
-    doc = "\n\n".join(doc_parts)
+    doc = "\n\n".join(part for part in doc_parts if part)
     # Add leading newline to satisfy numpydoc GL01 (expects 1 blank line at start)
     # and trailing newline for GL02 (expects 1 blank line at end)
     cls.__doc__ = "\n" + doc + "\n"

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -306,7 +306,7 @@ def signature_has_configurable_traits(cls: type[T]) -> type[T]:
     # Build docstring from traits and existing docstring
     # -------------------------------------------------
     # Start with the existing docstring (summary + extended summary)
-    existing_doc = cls.__doc__ or ""
+    existing_doc = inspect.cleandoc(cls.__doc__ or "")
 
     trait_entry_map = {}
     for name, value in traits:

--- a/tests/test_utils/test_decorators.py
+++ b/tests/test_utils/test_decorators.py
@@ -4,6 +4,7 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 import inspect
+import re
 import warnings
 
 import numpy as np
@@ -68,12 +69,80 @@ class TestSignatureHasConfigurableTraits:
 
         # Check that the docstring was updated
         assert "value : `int`" in MyClass.__doc__
-        assert "name : `str`" in MyClass.__doc__
+        assert "name : str" in MyClass.__doc__
 
         # Check instance creation with trait parameters
         instance = MyClass(value=42, name="test")
         assert instance.value == 42
         assert instance.name == "test"
+
+    def test_signature_has_configurable_traits_preserves_manual_entries(self):
+        @signature_has_configurable_traits
+        class MyClass(tr.HasTraits):
+            """
+            My test class.
+
+            Parameters
+            ----------
+            other : float
+                Manual non-configurable parameter.
+            name : str
+                Manual name description.
+                Manual name continuation.
+
+            Attributes
+            ----------
+            fitted_ : bool
+                Learned attribute.
+
+            Notes
+            -----
+            Manual note.
+            """
+
+            value = tr.Int(0, config=True, help="An integer value")
+            name = tr.Unicode("default", config=True, help="Generic trait help")
+
+            def __init__(self, name=None, other=1.0, **kwargs):
+                super().__init__(**kwargs)
+                if name is not None:
+                    self.name = name
+                self.other = other
+
+        doc = MyClass.__doc__
+        assert doc is not None
+
+        params_match = re.search(
+            r"Parameters\n----------\n(?P<body>.*?)(?:\n\nAttributes\n----------|\Z)",
+            doc,
+            re.S,
+        )
+        assert params_match is not None
+        params_body = params_match.group("body")
+
+        assert params_body.startswith(
+            "name : str\n"
+            "    Manual name description.\n"
+            "    Manual name continuation.\n"
+            "other : float\n"
+            "    Manual non-configurable parameter.\n"
+            "value : `int`, optional, default: ``0``\n"
+            "    An integer value",
+        )
+        assert params_body.count("name :") == 1
+        assert params_body.count("other :") == 1
+        assert params_body.count("value :") == 1
+        assert "Parameters\n----------\n    Manual name description." not in doc
+        assert "Attributes\n----------\nfitted_ : bool\n    Learned attribute." in doc
+        assert "Notes\n-----\nManual note." in doc
+        assert doc.count("Parameters\n----------") == 1
+        assert list(inspect.signature(MyClass).parameters) == ["name", "other", "value"]
+
+        original_doc = doc
+        original_sig = inspect.signature(MyClass)
+        signature_has_configurable_traits(MyClass)
+        assert MyClass.__doc__ == original_doc
+        assert inspect.signature(MyClass) == original_sig
 
 
 class TestWrapNdarrayOutput:


### PR DESCRIPTION
## Summary

This PR fixes the demonstrated shared bug in `signature_has_configurable_traits()` that could corrupt NumPy-style `Parameters` sections by dropping only the declaration line of a manually documented trait parameter while leaving its description behind as orphaned text.

It keeps the PR intentionally focused on that confirmed bug. It does **not** introduce a global Sphinx/template change, because the second suspected problem (`Attributes` / `Methods`) did not turn out to be a general HTML-loss bug on the representative pages I rebuilt.

## Minimal Reproduction

Before this change, classes such as `spectrochempy.tensor.CP` could end up with a runtime docstring whose `Parameters` section started with bare description lines, followed later by regenerated trait entries. That malformed runtime docstring then propagated into the generated HTML API page.

## Root Cause

`signature_has_configurable_traits()` merged `Parameters` line by line instead of entry by entry:

1. it dropped lines matching `param_name : ...` for configurable traits;
2. it kept continuation lines unconditionally;
3. it appended autogenerated trait entries later.

That split manual multiline entries and produced orphaned descriptions.

## Merge Contract Implemented

The shared decorator now:

- parses NumPy-style docstrings into sections;
- parses `Parameters` into full entries (`declaration + description`);
- keeps existing manual entries authoritative;
- adds only missing configurable-trait entries;
- keeps one `Parameters` section;
- avoids duplicate parameter entries;
- preserves the other section contents;
- is deterministic and idempotent.

## MCRALS

`MCRALS` keeps its local post-processing block.

That workaround is still needed, but now for a narrower reason: `MCRALS` intentionally exposes a custom public `__signature__` that is smaller than its full `config=True` traitlet surface, so the local filter still trims legacy traitlets from the public docstring. I also moved `See Also` before `Notes` in the source docstring so its public docstring remains consistent with its existing tests and numpydoc ordering.

## Representative Source / Runtime / RST / HTML Results

| Class | Source | Runtime | RST | HTML | Point of loss |
|---|---|---:|---:|---:|---|
| `spectrochempy.tensor.CP` | correct | corrected | correct for actual route (`autodata`) | corrected | previous loss was in shared decorator; no remaining HTML loss confirmed |
| `spectrochempy.CenterTransformer` | correct | correct | no `Attributes Summary` block in generated RST | correct | no loss; learned attribute is rendered in page body |
| `spectrochempy.AutoscaleTransformer` | correct | correct | no `Attributes Summary` block in generated RST | correct | no loss; learned attributes are rendered in page body |
| `spectrochempy.Optimize` | correct | correct | correct | correct | no loss confirmed |
| `spectrochempy.PSD` | correct | corrected | correct | corrected | previous loss was in shared decorator; no remaining HTML loss confirmed |
| `spectrochempy.MCRALS` | correct | correct with local narrowing | correct | correct | no shared-merge corruption after fix |

## Conclusion On `Attributes` / `Methods`

I did **not** find evidence that a global Sphinx/template change is required for this first PR.

What I did confirm instead is:

- `CP` currently renders through an `autodata` page, not the autosummary class template path;
- learned attributes such as `CenterTransformer.mean_` and `AutoscaleTransformer.mean_`/`std_` do appear in the final HTML body;
- their absence from an autosummary-style `Attributes Summary` block is not, by itself, proof of data loss.

So this PR stays limited to the confirmed decorator bug.

## Tests Added

- shared regression test in `tests/test_utils/test_decorators.py` for manual multiline entries, missing trait insertion, uniqueness, section preservation, and idempotence;
- targeted real-case runtime test for `CP` in `plugins/spectrochempy-tensor/tests/test_tensor_cp.py`.

## Validation

Executed locally:

- `python -m pytest tests/test_utils/test_decorators.py -q`
- `python -m pytest plugins/spectrochempy-tensor/tests/test_tensor_cp.py -q`
- `python -m pytest tests/test_analysis/test_decomposition/test_mcrals.py -q -k 'docstring or signature'`
- `python -m pytest tests/test_utils/test_decorators.py plugins/spectrochempy-tensor/tests/test_tensor_cp.py tests/test_analysis/test_decomposition/test_mcrals.py -q -k 'docstring or signature or test_signature_has_configurable_traits'`
- `pre-commit run --all-files`

I also rebuilt the targeted HTML pages for:

- `CP`
- `CenterTransformer`
- `AutoscaleTransformer`
- `Optimize`
- `PSD`
- `MCRALS`

## Expected Single-Doc Build Warnings

The targeted single-page Sphinx builds still report pre-existing / environment-specific warnings such as:

- offline intersphinx inventory fetch failures;
- duplicate `year` field in `reference/bibliography.bib` (`macchietti:2026`);
- `minigallery` being unavailable in single-doc mode.

These were not introduced by this PR.

## Deferred / Out of Scope

- no global autosummary/template rework;
- no change to `autoclass_content`, `napoleon`, or `numpydoc` configuration;
- no artificial properties added just to surface learned attributes;
- no attempt to solve unrelated signature/doc coverage gaps for inherited explicit parameters such as `log_level` / `warm_start` on some classes;
- `IRIS` was not revalidated in this pass because the local environment lacks `osqp`.
