### PR TITLE
FIX: document class-valued plugin proxies as classes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from pathlib import Path
 
 import jinja2
+from sphinx.ext.autodoc import ClassDocumenter
 
 import spectrochempy
 
@@ -882,6 +883,38 @@ def autodoc_skip_member(app, what, name, obj, skip, options):
     return skip or exclude
 
 
+def _unwrap_documented_class(obj):
+    """Return the wrapped class for class-like lazy proxies, if any."""
+    try:
+        wrapped = getattr(obj, "__wrapped__", None)
+    except Exception:
+        return None
+    return wrapped if inspect.isclass(wrapped) else None
+
+
+class SpectroChemPyClassDocumenter(ClassDocumenter):
+    """Treat class-valued plugin proxies as ordinary classes for autodoc."""
+
+    @classmethod
+    def can_document_member(cls, member, membername, isattr, parent):
+        return ClassDocumenter.can_document_member(
+            member,
+            membername,
+            isattr,
+            parent,
+        ) or _unwrap_documented_class(member) is not None
+
+    def import_object(self, raiseerror=False):
+        if not super().import_object(raiseerror=raiseerror):
+            return False
+
+        wrapped = _unwrap_documented_class(self.object)
+        if wrapped is not None:
+            self.object = wrapped
+
+        return True
+
+
 def shorter_signature(app, what, name, obj, options, signature, return_annotation):
     """Prevent displaying self in signature."""
     if what == "data":
@@ -932,6 +965,7 @@ def setup(app):
     app.connect("source-read", rstjinja)
     app.connect("autodoc-skip-member", autodoc_skip_member)
     app.connect("autodoc-process-signature", shorter_signature)
+    app.add_autodocumenter(SpectroChemPyClassDocumenter, override=True)
     app.add_css_file("css/spectrochempy.css")  # also can be a full URL
     app.config.rst_mimetype = rst_mimetype
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -897,12 +897,15 @@ class SpectroChemPyClassDocumenter(ClassDocumenter):
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
-        return ClassDocumenter.can_document_member(
-            member,
-            membername,
-            isattr,
-            parent,
-        ) or _unwrap_documented_class(member) is not None
+        return (
+            ClassDocumenter.can_document_member(
+                member,
+                membername,
+                isattr,
+                parent,
+            )
+            or _unwrap_documented_class(member) is not None
+        )
 
     def import_object(self, raiseerror=False):
         if not super().import_object(raiseerror=raiseerror):


### PR DESCRIPTION
## Summary

This patch teaches the documentation build to treat class-valued plugin proxies as class pages rather than data pages.

## Why

`spectrochempy.tensor.CP` is exposed through the plugin namespace as a lazy proxy. Autosummary currently resolves that public symbol through `autodata`, so its API page does not follow the same structure as ordinary class pages such as `spectrochempy.Optimize`.

The result is a user-visible documentation mismatch: `CP` does not get the usual `Attributes Summary` / `Methods Summary` layout even when the underlying wrapped object is a real class.

## What changed

- add a small autodoc override in `docs/conf.py`
- detect proxies exposing a wrapped class through `__wrapped__`
- unwrap those objects during autodoc import
- route them through the normal class-documenter path

## Expected impact

Public class-like plugin symbols such as `spectrochempy.tensor.CP` should now render like ordinary class reference pages, matching the structure already used by `spectrochempy.Optimize`.

## Validation

- `python3 -m py_compile docs/conf.py`
- `git diff --check`

A full Sphinx build was not run in this pass.