### PR TITLE
FIX: remove duplicate CP class-page sections

### DIFF
--- a/plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py
+++ b/plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py
@@ -124,38 +124,6 @@ class CP(DecompositionAnalysis):
         Modes for which initial values are not modified during optimization.
         The last mode cannot be fixed.
 
-    Attributes
-    ----------
-    A : NDDataset
-        Factor matrix for mode 0 with shape (mode_0_size, n_components).
-    B : NDDataset
-        Factor matrix for mode 1 with shape (mode_1_size, n_components).
-    C : NDDataset
-        Factor matrix for mode 2 with shape (mode_2_size, n_components).
-    loadings : tuple
-        Tuple of factor matrices (A, B, C).
-    weights : ndarray
-        Weights from CP decomposition.
-    errors : list or None
-        Iteration errors during fitting. Available when TensorLy returns them
-        (typically with constrained_parafac). Returns None if unavailable
-        or if not fitted yet.
-    SSE : float
-        Sum of Squared Errors of the reconstruction.
-    explained_variance : float
-        Percentage of variance explained by the model.
-    core_consistency : float
-        CORCONDIA (Core Consistency) diagnostic value. Can be negative if overfactoring.
-
-    Methods
-    -------
-    fit(X)
-        Fit the CP model to a 3D dataset.
-    fit_transform(X)
-        Fit the model and return the reconstructed tensor.
-    inverse_transform()
-        Return the reconstructed tensor from fitted factors.
-
     Notes
     -----
     This method requires the optional dependency ``tensorly``.


### PR DESCRIPTION
## Summary

Remove the source-level `Attributes` and `Methods` sections from the `CP` class docstring.

## Why

`#1482` made `spectrochempy.tensor.CP` render through the normal class-page path instead of `autodata`.

That fixed the page structure, but it also exposed a second `CP`-specific issue: the class docstring still contained its own `Attributes` and `Methods` prose while the autosummary class template was now generating the same sections from the real public properties and methods.

The result is duplicated attribute/method documentation on the deployed API page.

## What changed

- remove the source-level `Attributes` section from `CP`
- remove the source-level `Methods` section from `CP`
- keep `Parameters`, `Notes`, `See Also`, and `Examples`

## Scope

This is intentionally narrow. It does not apply the same change project-wide.

`CP` is a clear duplication case because its public attributes are already real autodoc-visible properties and its workflow methods are already real public methods. Other classes such as preprocessing transformers still need separate treatment because their learned attributes are not always exposed through the same autodoc path.

## Validation

- `python3 -m py_compile plugins/spectrochempy-tensor/src/spectrochempy_tensor/decompositions/cp.py`
- `git diff --check`