### PR TITLE
REL: prepare 0.12.0 plugin bounds and changelog cleanup

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -234,7 +234,11 @@ jobs:
         run: |
           set -e
           start=$SECONDS
-          python -m spectrochempy.ci.install_plugins --editable all
+          python -m spectrochempy.ci.install_plugins --editable --no-deps all
+          # Install plugin runtime dependencies explicitly.  In the monorepo
+          # editable workflow we must avoid resolving the core package from
+          # PyPI before the next core release exists there.
+          python -m pip install osqp xlrd numpy-quaternion tensorly
           duration=$((SECONDS - start))
           echo "plugin installation: ${duration}s" | tee -a "$CI_TIMING_FILE"
 

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -95,14 +95,15 @@ used by PyPI wheels:
 .. code-block:: bash
 
     pip install -e .
-    python -m spectrochempy.ci.install_plugins --editable all
+    python -m spectrochempy.ci.install_plugins --editable --no-deps all
+    pip install osqp xlrd numpy-quaternion tensorly
     pip install -e plugins/spectrochempy-cantera  # experimental, not auto-discovered
 
 The bundled plugins can also be installed with the helper:
 
 .. code-block:: bash
 
-    python -m spectrochempy.ci.install_plugins --editable all
+    python -m spectrochempy.ci.install_plugins --editable --no-deps all
 
 After installation, SpectroChemPy discovers the plugins automatically via
 the ``spectrochempy.plugins`` entry point group.

--- a/docs/sources/devguide/plugins/packaging.rst
+++ b/docs/sources/devguide/plugins/packaging.rst
@@ -60,7 +60,7 @@ Key points:
 * The **entry point name** (``myplugin``) must match your plugin's
   ``name`` attribute.
 * ``spectrochempy`` must be listed as a dependency with a compatibility
-   range, e.g. ``spectrochempy>=0.10,<0.12``.
+   range, e.g. ``spectrochempy>=0.12,<0.13``.
 * Use ``requires-python = ">=3.11"`` to match SpectroChemPy's minimum.
 * Official plugins in the monorepo use a static ``version`` field.
   ``setuptools_scm`` is not used because plugin and core tags share the

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -31,26 +31,6 @@ New Features
   criteria.
 .. Add here new public features (do not delete this comment)
 
-- TopSpin datasets now preserve a descriptive vendor processing profile in
-  ``dataset.meta.nmr_processing``. The profile records the vendor ``procs``
-  values with stable provenance, but it is not applied automatically to raw
-  FIDs, does not replay vendor processing, and does not yet expose any
-  SpectroChemPy ``requested`` / ``applied`` processing trace.
-
-- The result of ``scp.nmr.Experiment.process()`` now records a structured
-  SpectroChemPy-owned processing trace in
-  ``result.meta.nmr_processing["scp_processing"]``. The ``requested`` mapping
-  keeps only the arguments explicitly provided by the user, while ``applied``
-  keeps only the operations that were actually executed and the values they
-  really consumed. The source dataset remains unchanged, vendor ``procs``
-  metadata stays descriptive, and ``phase="metadata"`` still does not replay
-  TopSpin ``PHC0`` / ``PHC1``.
-
-- `read_matlab()` now reconstructs `NDDataset` objects from the minimal
-  MATLAB exchange payload written by `write_matlab()`, restoring the
-  dataset's name, title, units, description, dimension names, and
-  coordinates (values, units, and titles). (#1270)
-
 - NMR support has been significantly expanded.  SpectroChemPy now provides
   ``scp.nmr.Experiment`` as a state-aware NMR scientific model, alongside new
   official readers for Agilent/Varian, JEOL JDF, TecMag TNT, and SIMPSON
@@ -58,11 +38,24 @@ New Features
   (``scp.nmr.read(...)``, ``scp.topspin.read(...)``, ``scp.agilent.read(...)``)
   while preserving the familiar root-level compatibility aliases.  The
   currently validated public workflow is centered on 1D NMR data; the 2D
-  workflow remains under separate scientific characterization.
+  workflow remains under separate scientific characterization.  Extra NMR
+  validation datasets can also now be fetched on demand with
+  ``download_extra_testdata()``.
 
-- Extra NMR validation datasets can now be fetched on demand with
-  ``download_extra_testdata()``, which clones the additional test corpus from
-  ``spectrochempy_data`` into ``~/.spectrochempy/testdata-extra/``.
+- TopSpin datasets now preserve a descriptive vendor processing profile in
+  ``dataset.meta.nmr_processing``, and the result of
+  ``scp.nmr.Experiment.process()`` now records a structured
+  SpectroChemPy-owned processing trace in
+  ``result.meta.nmr_processing["scp_processing"]``.  Vendor ``procs`` values
+  remain descriptive, the source dataset remains unchanged, ``requested``
+  keeps only arguments explicitly provided by the user, ``applied`` keeps only
+  operations that actually ran, and ``phase="metadata"`` still does not
+  replay TopSpin ``PHC0`` / ``PHC1``.
+
+- `read_matlab()` now reconstructs `NDDataset` objects from the minimal
+  MATLAB exchange payload written by `write_matlab()`, restoring the
+  dataset's name, title, units, description, dimension names, and
+  coordinates (values, units, and titles). (#1270)
 
 - Plotting and analysis displays are more informative by default.  Score-plot
   labels can now use ``adjustText`` for collision-aware placement, and PCA
@@ -83,16 +76,6 @@ Bug Fixes
   or ``apodization=None, lb=...`` now raise explicit errors instead of being
   silently ignored.
 
-- `plot()` and `plot_multiple()` no longer crash when `marker=None` or
-  `ls=None` is passed explicitly. Both are matplotlib's own standard
-  values (no marker, default linestyle), so passing them is legitimate,
-  not invalid input. (#1462)
-
-- 2D ``plot_map()``/``plot()`` now keep a readable layout for datasets whose
-  X and Y axes share units but span very different numeric ranges.  Explicit
-  ``figsize=...`` overrides are also now honored reliably when a plotting call
-  reuses an existing figure with ``clear=False``.
-
 - `read_matlab()` no longer crashes on `.mat` files containing a plain MATLAB
   cell-array variable. It previously raised an unguarded `TypeError` (surfaced
   only as a swallowed `UserWarning`, with the function silently returning
@@ -104,27 +87,25 @@ Bug Fixes
   metadata handling is more robust, ``scp.nmr.Experiment`` now correctly
   classifies non-Bruker datasets, and JEOL time-domain coordinates are created
   with the proper units so operations such as ``em()`` no longer fail on JEOL
-  time-domain data.
+  time-domain data.  ``em(lb=0)`` and ``em(lb=0.0 * ur.Hz)`` are now treated
+  as valid no-op calls instead of raising a ``ZeroDivisionError``.
 
 - Public NMR documentation and examples no longer imply that 2D processing is
   already a stable supported workflow.  The public API, gallery and maintainer
   messaging are now aligned on a temporary recentring to validated 1D NMR
   processing while the 2D pipeline continues as a separate characterization
-  effort.
-
-- Plotting behavior has been corrected in a few visible edge cases:
-  ``legend=True`` now works again for 2D lines/stack plots, and labels
-  auto-derived from coordinate metadata are displayed as expected in the
-  resulting legend.
-
-- ``em(lb=0)`` and ``em(lb=0.0 * ur.Hz)`` are now treated as valid no-op
-  calls instead of raising a ``ZeroDivisionError``.
-
-- The public NMR examples are now more consistent with the validated 1D scope:
-  the gallery no longer publishes the unstable CP and 2D workflows, the
-  apodization and relaxation examples were clarified visually, and inverse FFT
-  reconstruction now restores a correct NMR time axis in the 1D Fourier
+  effort.  The gallery no longer publishes the unstable CP and 2D workflows,
+  the apodization and relaxation examples were clarified visually, and inverse
+  FFT reconstruction now restores a correct NMR time axis in the 1D Fourier
   tutorial.
+
+- Plotting behavior has been corrected in several visible edge cases:
+  ``plot()`` and ``plot_multiple()`` no longer crash when ``marker=None`` or
+  ``ls=None`` is passed explicitly, 2D ``plot_map()`` / ``plot()`` now keep a
+  readable layout when X and Y share units but span very different numeric
+  ranges, explicit ``figsize=...`` overrides are honored more reliably with
+  ``clear=False``, and ``legend=True`` again works as expected for 2D
+  lines/stack plots with coordinate-derived labels. (#1460, #1462)
 
 
 .. section
@@ -140,16 +121,13 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
 
-- The TopSpin reader (``scp.nmr.read_topspin``) now supports 1D and 2D data
-  only. Reading 3D/4D data raises ``NotImplementedError``. The previous
-  "nD" claim was not backed by a suitable hypercomplex representation for
-  dimensions higher than two.
-
-- The public ``scp.nmr.Experiment.process()`` workflow is now intentionally
-  limited to validated 1D NMR experiments.  Multi-dimensional datasets may
-  still be read, classified and inspected, but 2D processing is temporarily
-  out of the public supported scope while the scientific characterization work
-  continues.
+- The public NMR scope is now stated more narrowly and more honestly.  The
+  TopSpin reader (``scp.nmr.read_topspin``) now supports 1D and 2D data only,
+  with 3D/4D reads raising ``NotImplementedError``, and the public
+  ``scp.nmr.Experiment.process()`` workflow is intentionally limited to
+  validated 1D NMR experiments.  Multi-dimensional datasets may still be
+  read, classified and inspected, but 2D processing is temporarily out of the
+  public supported scope while the scientific characterization work continues.
 
 - ``MCRALS.constraints`` is now a validated traitlet, enabling both constructor
   and post-construction assignment while preserving the distinction between
@@ -159,21 +137,15 @@ Breaking Changes
 
 - MCRALS public outputs ``C``, ``St`` and residuals now correspond to the
   **constrained** factor pair ``(C_constrained, St_constrained)`` instead of
-  the previous mixed pair ``(C_LS, St_constrained)``.  This matches the
-  semantics of Tauler MATLAB MCR-ALS, pyMCR, and PLS_Toolbox.  Convergence
-  diagnostics also use the constrained pair, which can change convergence
-  speed and iteration counts compared with the old behaviour.  The
-  unconstrained least-squares estimate is still available via the new
-  ``C_ls`` property. (:pr:`XXXX`)
-
-- Refactored the internal ALS iteration loop in ``MCRALS._fit`` to match the
-  standard Tauler formulation: each iteration now performs exactly one C solve
-  followed by one constraint pass, then one St solve followed by one constraint
-  pass (previously the concentration constraint pipeline ran twice per
-  iteration, causing side-effects to double for ``ModelProfile`` generators).
-  This may change iterate counts and numerical results under active
-  constraints, but the publicly documented ``C @ St ≈ X`` reconstruction
-  invariant is preserved. (:pr:`XXXX`)
+  the previous mixed pair ``(C_LS, St_constrained)``, and the unconstrained
+  least-squares estimate is now exposed separately via ``C_ls``.  The
+  internal ALS iteration loop was also realigned with the standard Tauler
+  formulation so each iteration performs one C solve plus constraint pass and
+  one St solve plus constraint pass.  Together these changes align
+  SpectroChemPy more closely with Tauler MATLAB MCR-ALS, pyMCR, and
+  PLS_Toolbox, but they can change convergence speed, iteration counts, and
+  numerical results under active constraints while preserving the documented
+  ``C @ St ≈ X`` reconstruction invariant. (#1453)
 
 
 .. section
@@ -188,7 +160,7 @@ Deprecations
 - Plotting names are being regularized: ``AnalysisBase.plotmerit`` is
   deprecated in favor of ``plot_merit``, and ``parityplot`` is deprecated in
   favor of ``plot_parity``.  The old aliases remain available for now and are
-  scheduled for removal in version 0.12.
+  scheduled for removal in version 0.13.0.
 
 
 .. section
@@ -208,15 +180,12 @@ Developer
   with numerical assertions, and targeted plugin tests now check observable
   processing behavior instead of manual inspection only.
 
-- Plotting internals were consolidated across core and plugin composite
-  functions.  Shared figure/axes lifecycle helpers now reduce duplicated
-  plotting boilerplate, composite plotting APIs are more consistent, and the
-  non-functional Plotly/Dash backend has been removed from the maintained code
-  path.
-
-- Developer-facing documentation and infrastructure were also cleaned up:
-  examples now favor SpectroChemPy-native idioms over raw NumPy patterns,
-  generic NMRGlue helpers were factored into a shared base module, and the
-  official plugin marker used by CI and publishing now relies on the private
+- Plotting internals, examples, and plugin infrastructure were also cleaned
+  up: shared figure/axes lifecycle helpers now reduce duplicated boilerplate,
+  composite plotting APIs are more consistent, the non-functional Plotly/Dash
+  backend has been removed from the maintained code path, examples now favor
+  SpectroChemPy-native idioms over raw NumPy patterns, generic NMRGlue helpers
+  were factored into a shared base module, and the official plugin marker used
+  by CI and publishing now relies on the private
   ``[tool.spectrochempy] official-plugin = true`` field instead of an invalid
   Trove classifier.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,26 +27,6 @@ New Features
   columns have been removed because they did not map clearly to the stopping
   criteria.
 
-- TopSpin datasets now preserve a descriptive vendor processing profile in
-  ``dataset.meta.nmr_processing``. The profile records the vendor ``procs``
-  values with stable provenance, but it is not applied automatically to raw
-  FIDs, does not replay vendor processing, and does not yet expose any
-  SpectroChemPy ``requested`` / ``applied`` processing trace.
-
-- The result of ``scp.nmr.Experiment.process()`` now records a structured
-  SpectroChemPy-owned processing trace in
-  ``result.meta.nmr_processing["scp_processing"]``. The ``requested`` mapping
-  keeps only the arguments explicitly provided by the user, while ``applied``
-  keeps only the operations that were actually executed and the values they
-  really consumed. The source dataset remains unchanged, vendor ``procs``
-  metadata stays descriptive, and ``phase="metadata"`` still does not replay
-  TopSpin ``PHC0`` / ``PHC1``.
-
-- `read_matlab()` now reconstructs `NDDataset` objects from the minimal
-  MATLAB exchange payload written by `write_matlab()`, restoring the
-  dataset's name, title, units, description, dimension names, and
-  coordinates (values, units, and titles). (#1270)
-
 - NMR support has been significantly expanded.  SpectroChemPy now provides
   ``scp.nmr.Experiment`` as a state-aware NMR scientific model, alongside new
   official readers for Agilent/Varian, JEOL JDF, TecMag TNT, and SIMPSON
@@ -54,11 +34,24 @@ New Features
   (``scp.nmr.read(...)``, ``scp.topspin.read(...)``, ``scp.agilent.read(...)``)
   while preserving the familiar root-level compatibility aliases.  The
   currently validated public workflow is centered on 1D NMR data; the 2D
-  workflow remains under separate scientific characterization.
+  workflow remains under separate scientific characterization.  Extra NMR
+  validation datasets can also now be fetched on demand with
+  ``download_extra_testdata()``.
 
-- Extra NMR validation datasets can now be fetched on demand with
-  ``download_extra_testdata()``, which clones the additional test corpus from
-  ``spectrochempy_data`` into ``~/.spectrochempy/testdata-extra/``.
+- TopSpin datasets now preserve a descriptive vendor processing profile in
+  ``dataset.meta.nmr_processing``, and the result of
+  ``scp.nmr.Experiment.process()`` now records a structured
+  SpectroChemPy-owned processing trace in
+  ``result.meta.nmr_processing["scp_processing"]``.  Vendor ``procs`` values
+  remain descriptive, the source dataset remains unchanged, ``requested``
+  keeps only arguments explicitly provided by the user, ``applied`` keeps only
+  operations that actually ran, and ``phase="metadata"`` still does not
+  replay TopSpin ``PHC0`` / ``PHC1``.
+
+- `read_matlab()` now reconstructs `NDDataset` objects from the minimal
+  MATLAB exchange payload written by `write_matlab()`, restoring the
+  dataset's name, title, units, description, dimension names, and
+  coordinates (values, units, and titles). (#1270)
 
 - Plotting and analysis displays are more informative by default.  Score-plot
   labels can now use ``adjustText`` for collision-aware placement, and PCA
@@ -75,16 +68,6 @@ Bug Fixes
   or ``apodization=None, lb=...`` now raise explicit errors instead of being
   silently ignored.
 
-- `plot()` and `plot_multiple()` no longer crash when `marker=None` or
-  `ls=None` is passed explicitly. Both are matplotlib's own standard
-  values (no marker, default linestyle), so passing them is legitimate,
-  not invalid input. (#1462)
-
-- 2D ``plot_map()``/``plot()`` now keep a readable layout for datasets whose
-  X and Y axes share units but span very different numeric ranges.  Explicit
-  ``figsize=...`` overrides are also now honored reliably when a plotting call
-  reuses an existing figure with ``clear=False``.
-
 - `read_matlab()` no longer crashes on `.mat` files containing a plain MATLAB
   cell-array variable. It previously raised an unguarded `TypeError` (surfaced
   only as a swallowed `UserWarning`, with the function silently returning
@@ -96,41 +79,36 @@ Bug Fixes
   metadata handling is more robust, ``scp.nmr.Experiment`` now correctly
   classifies non-Bruker datasets, and JEOL time-domain coordinates are created
   with the proper units so operations such as ``em()`` no longer fail on JEOL
-  time-domain data.
+  time-domain data.  ``em(lb=0)`` and ``em(lb=0.0 * ur.Hz)`` are now treated
+  as valid no-op calls instead of raising a ``ZeroDivisionError``.
 
 - Public NMR documentation and examples no longer imply that 2D processing is
   already a stable supported workflow.  The public API, gallery and maintainer
   messaging are now aligned on a temporary recentring to validated 1D NMR
   processing while the 2D pipeline continues as a separate characterization
-  effort.
-
-- Plotting behavior has been corrected in a few visible edge cases:
-  ``legend=True`` now works again for 2D lines/stack plots, and labels
-  auto-derived from coordinate metadata are displayed as expected in the
-  resulting legend.
-
-- ``em(lb=0)`` and ``em(lb=0.0 * ur.Hz)`` are now treated as valid no-op
-  calls instead of raising a ``ZeroDivisionError``.
-
-- The public NMR examples are now more consistent with the validated 1D scope:
-  the gallery no longer publishes the unstable CP and 2D workflows, the
-  apodization and relaxation examples were clarified visually, and inverse FFT
-  reconstruction now restores a correct NMR time axis in the 1D Fourier
+  effort.  The gallery no longer publishes the unstable CP and 2D workflows,
+  the apodization and relaxation examples were clarified visually, and inverse
+  FFT reconstruction now restores a correct NMR time axis in the 1D Fourier
   tutorial.
+
+- Plotting behavior has been corrected in several visible edge cases:
+  ``plot()`` and ``plot_multiple()`` no longer crash when ``marker=None`` or
+  ``ls=None`` is passed explicitly, 2D ``plot_map()`` / ``plot()`` now keep a
+  readable layout when X and Y share units but span very different numeric
+  ranges, explicit ``figsize=...`` overrides are honored more reliably with
+  ``clear=False``, and ``legend=True`` again works as expected for 2D
+  lines/stack plots with coordinate-derived labels. (#1460, #1462)
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- The TopSpin reader (``scp.nmr.read_topspin``) now supports 1D and 2D data
-  only. Reading 3D/4D data raises ``NotImplementedError``. The previous
-  "nD" claim was not backed by a suitable hypercomplex representation for
-  dimensions higher than two.
-
-- The public ``scp.nmr.Experiment.process()`` workflow is now intentionally
-  limited to validated 1D NMR experiments.  Multi-dimensional datasets may
-  still be read, classified and inspected, but 2D processing is temporarily
-  out of the public supported scope while the scientific characterization work
-  continues.
+- The public NMR scope is now stated more narrowly and more honestly.  The
+  TopSpin reader (``scp.nmr.read_topspin``) now supports 1D and 2D data only,
+  with 3D/4D reads raising ``NotImplementedError``, and the public
+  ``scp.nmr.Experiment.process()`` workflow is intentionally limited to
+  validated 1D NMR experiments.  Multi-dimensional datasets may still be
+  read, classified and inspected, but 2D processing is temporarily out of the
+  public supported scope while the scientific characterization work continues.
 
 - ``MCRALS.constraints`` is now a validated traitlet, enabling both constructor
   and post-construction assignment while preserving the distinction between
@@ -140,21 +118,15 @@ Breaking Changes
 
 - MCRALS public outputs ``C``, ``St`` and residuals now correspond to the
   **constrained** factor pair ``(C_constrained, St_constrained)`` instead of
-  the previous mixed pair ``(C_LS, St_constrained)``.  This matches the
-  semantics of Tauler MATLAB MCR-ALS, pyMCR, and PLS_Toolbox.  Convergence
-  diagnostics also use the constrained pair, which can change convergence
-  speed and iteration counts compared with the old behaviour.  The
-  unconstrained least-squares estimate is still available via the new
-  ``C_ls`` property. (:pr:`XXXX`)
-
-- Refactored the internal ALS iteration loop in ``MCRALS._fit`` to match the
-  standard Tauler formulation: each iteration now performs exactly one C solve
-  followed by one constraint pass, then one St solve followed by one constraint
-  pass (previously the concentration constraint pipeline ran twice per
-  iteration, causing side-effects to double for ``ModelProfile`` generators).
-  This may change iterate counts and numerical results under active
-  constraints, but the publicly documented ``C @ St ≈ X`` reconstruction
-  invariant is preserved. (:pr:`XXXX`)
+  the previous mixed pair ``(C_LS, St_constrained)``, and the unconstrained
+  least-squares estimate is now exposed separately via ``C_ls``.  The
+  internal ALS iteration loop was also realigned with the standard Tauler
+  formulation so each iteration performs one C solve plus constraint pass and
+  one St solve plus constraint pass.  Together these changes align
+  SpectroChemPy more closely with Tauler MATLAB MCR-ALS, pyMCR, and
+  PLS_Toolbox, but they can change convergence speed, iteration counts, and
+  numerical results under active constraints while preserving the documented
+  ``C @ St ≈ X`` reconstruction invariant. (#1453)
 
 Deprecations
 ~~~~~~~~~~~~
@@ -165,7 +137,7 @@ Deprecations
 - Plotting names are being regularized: ``AnalysisBase.plotmerit`` is
   deprecated in favor of ``plot_merit``, and ``parityplot`` is deprecated in
   favor of ``plot_parity``.  The old aliases remain available for now and are
-  scheduled for removal in version 0.12.
+  scheduled for removal in version 0.13.0.
 
 Developer
 ~~~~~~~~~
@@ -181,15 +153,12 @@ Developer
   with numerical assertions, and targeted plugin tests now check observable
   processing behavior instead of manual inspection only.
 
-- Plotting internals were consolidated across core and plugin composite
-  functions.  Shared figure/axes lifecycle helpers now reduce duplicated
-  plotting boilerplate, composite plotting APIs are more consistent, and the
-  non-functional Plotly/Dash backend has been removed from the maintained code
-  path.
-
-- Developer-facing documentation and infrastructure were also cleaned up:
-  examples now favor SpectroChemPy-native idioms over raw NumPy patterns,
-  generic NMRGlue helpers were factored into a shared base module, and the
-  official plugin marker used by CI and publishing now relies on the private
+- Plotting internals, examples, and plugin infrastructure were also cleaned
+  up: shared figure/axes lifecycle helpers now reduce duplicated boilerplate,
+  composite plotting APIs are more consistent, the non-functional Plotly/Dash
+  backend has been removed from the maintained code path, examples now favor
+  SpectroChemPy-native idioms over raw NumPy patterns, generic NMRGlue helpers
+  were factored into a shared base module, and the official plugin marker used
+  by CI and publishing now relies on the private
   ``[tool.spectrochempy] official-plugin = true`` field instead of an invalid
   Trove classifier.

--- a/plugins/plugin-template/pyproject.toml
+++ b/plugins/plugin-template/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.11"
 classifiers = [
 ]
 dependencies = [
-    "spectrochempy>=0.9,<0.12",
+    "spectrochempy>=0.12,<0.13",
 ]
 
 # Uncomment and adjust when scaffolding a new plugin:

--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -9,7 +9,7 @@ description = "Cantera-based thermodynamics and reactive chemistry for SpectroCh
 requires-python = ">=3.11"
 readme = "README.md"
 dependencies = [
-    "spectrochempy>=0.10,<0.12",
+    "spectrochempy>=0.12,<0.13",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-cantera/tests/test_cantera.py
+++ b/plugins/spectrochempy-cantera/tests/test_cantera.py
@@ -185,7 +185,7 @@ def test_pfr_root_compatibility_alias_warns_once():
     assert len(captured) == 1
     assert captured[0].category is DeprecationWarning
     assert "scp.PFR is deprecated since SpectroChemPy 0.9.0" in str(captured[0].message)
-    assert "will be removed in 0.11.0" in str(captured[0].message)
+    assert "will be removed in 0.13.0" in str(captured[0].message)
     assert "scp.cantera.PFR" in str(captured[0].message)
 
 

--- a/plugins/spectrochempy-carroucell/pyproject.toml
+++ b/plugins/spectrochempy-carroucell/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 classifiers = [
 ]
 dependencies = [
-    "spectrochempy>=0.10,<0.12",
+    "spectrochempy>=0.12,<0.13",
     "xlrd",
     "scipy",
 ]

--- a/plugins/spectrochempy-hypercomplex/pyproject.toml
+++ b/plugins/spectrochempy-hypercomplex/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 classifiers = [
 ]
 dependencies = [
-    "spectrochempy>=0.10,<0.12",
+    "spectrochempy>=0.12,<0.13",
     "numpy",
     "numpy-quaternion>=2024.0.7",
 ]

--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 classifiers = [
 ]
 dependencies = [
-    "spectrochempy>=0.10,<0.12",
+    "spectrochempy>=0.12,<0.13",
     "scipy",
     "osqp",
 ]

--- a/plugins/spectrochempy-iris/tests/test_iris.py
+++ b/plugins/spectrochempy-iris/tests/test_iris.py
@@ -281,7 +281,7 @@ def test_iris_root_alias_warns_once(monkeypatch, alias, heavy_module):
     assert f"scp.{alias} is deprecated since SpectroChemPy 0.9.0" in str(
         captured[0].message
     )
-    assert "will be removed in 0.11.0" in str(captured[0].message)
+    assert "will be removed in 0.13.0" in str(captured[0].message)
     assert f"scp.iris.{alias}" in str(captured[0].message)
 
     if heavy_module:

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 classifiers = [
 ]
 dependencies = [
-    "spectrochempy>=0.10,<0.12",
+    "spectrochempy>=0.12,<0.13",
     "numpy",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.
 ]

--- a/plugins/spectrochempy-perkinelmer/pyproject.toml
+++ b/plugins/spectrochempy-perkinelmer/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 classifiers = [
 ]
 dependencies = [
-    "spectrochempy>=0.10,<0.12",
+    "spectrochempy>=0.12,<0.13",
     "numpy",
 ]
 

--- a/plugins/spectrochempy-tensor/pyproject.toml
+++ b/plugins/spectrochempy-tensor/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 classifiers = [
 ]
 dependencies = [
-    "spectrochempy>=0.10,<0.12",
+    "spectrochempy>=0.12,<0.13",
     "tensorly",
 ]
 

--- a/plugins/spectrochempy-tensor/tests/test_tensor_plugin.py
+++ b/plugins/spectrochempy-tensor/tests/test_tensor_plugin.py
@@ -106,5 +106,5 @@ def test_root_alias_warns_once(monkeypatch):
     assert captured[0].category is DeprecationWarning
     message = str(captured[0].message)
     assert "scp.CP is deprecated since SpectroChemPy 0.9.0" in message
-    assert "will be removed in 0.11.0" in message
+    assert "will be removed in 0.13.0" in message
     assert "scp.tensor.CP" in message

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -170,7 +170,7 @@ def _plugin_root_export(name, namespace_cls):
         if export["deprecated"] and name not in _EMITTED_PLUGIN_ROOT_WARNINGS:
             warnings.warn(
                 f"scp.{name} is deprecated since SpectroChemPy 0.9.0 "
-                f"and will be removed in 0.12.0. "
+                f"and will be removed in 0.13.0. "
                 f"Use {export['replacement']} instead.",
                 DeprecationWarning,
                 stacklevel=3,

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -618,7 +618,7 @@ class DecompositionAnalysis(AnalysisConfigurable):
         )
 
     # Backward compatibility alias
-    @deprecated(replace="plot_merit", removed="0.12")
+    @deprecated(replace="plot_merit", removed="0.13.0")
     def plotmerit(self, X=None, X_hat=None, **kwargs):
         """
         Backward-compatible alias for :meth:`plot_merit`. Deprecated.
@@ -945,7 +945,7 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
         return _plot_parity(Y, Y_hat, ax=ax, clear=clear, show=show, **kwargs)
 
     # Backward compatibility alias
-    @deprecated(replace="plot_parity", removed="0.12")
+    @deprecated(replace="plot_parity", removed="0.13.0")
     def parityplot(
         self, Y=None, Y_hat=None, *, ax=None, clear=True, show=True, **kwargs
     ):

--- a/src/spectrochempy/ci/install_plugins.py
+++ b/src/spectrochempy/ci/install_plugins.py
@@ -4,9 +4,9 @@ Install SpectroChemPy plugins from the local source tree.
 
 Usage::
 
-    python -m spectrochempy.ci.install_plugins --editable all
+    python -m spectrochempy.ci.install_plugins --editable --no-deps all
     python -m spectrochempy.ci.install_plugins nmr iris
-    python -m spectrochempy.ci.install_plugins --editable perkinelmer
+    python -m spectrochempy.ci.install_plugins --editable --no-deps perkinelmer
     python -m spectrochempy.ci.install_plugins --list-names
     python -m spectrochempy.ci.install_plugins --list-names --root /workspace
 """
@@ -69,13 +69,14 @@ def _pip_install(
 
     pip = pip_cmd or [sys.executable, "-m", "pip"]
     cmd = [*pip, "install"]
-    if editable:
-        cmd.append("-e")
     if no_deps:
         cmd.append("--no-deps")
     if no_build_isolation:
         cmd.append("--no-build-isolation")
-    cmd.append(str(plugin_path))
+    if editable:
+        cmd.extend(["-e", str(plugin_path)])
+    else:
+        cmd.append(str(plugin_path))
 
     print(f"Installing {plugin} {'(editable)' if editable else ''}...")
     result = subprocess.run(cmd, capture_output=True, text=True)

--- a/src/spectrochempy/plotting/_methods.py
+++ b/src/spectrochempy/plotting/_methods.py
@@ -97,7 +97,7 @@ def normalize_backend_method(
         if warned_aliases is not None and method not in warned_aliases:
             warned_aliases.add(method)
             warnings.warn(
-                f'method="{method}" is deprecated and will be removed in 0.12.0. '
+                f'method="{method}" is deprecated and will be removed in 0.13.0. '
                 f'Use method="{canonical}" instead.',
                 DeprecationWarning,
                 stacklevel=stacklevel,

--- a/src/spectrochempy/plotting/composite/parity.py
+++ b/src/spectrochempy/plotting/composite/parity.py
@@ -139,14 +139,14 @@ def plot_parity(
     return ax
 
 
-@deprecated(replace="plot_parity", removed="0.12")
+@deprecated(replace="plot_parity", removed="0.13.0")
 def parityplot(*args, **kwargs):
     """
     Plot predicted vs measured values (parity plot).
 
     .. deprecated::
         Use :func:`plot_parity` instead.  This alias will be removed in
-        version 0.12.
+        version 0.13.0.
 
     Parameters
     ----------

--- a/src/spectrochempy/processing/alignement/__init__.py
+++ b/src/spectrochempy/processing/alignement/__init__.py
@@ -15,7 +15,7 @@ __getattr__, __dir__, __all__ = _lazy_loader.attach_stub(__name__, __file__)
 
 warnings.warn(
     "Importing from `spectrochempy.processing.alignement` is deprecated and "
-    "will be removed in 0.12.0. Use `spectrochempy.processing.alignment` instead.",
+    "will be removed in 0.13.0. Use `spectrochempy.processing.alignment` instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/src/spectrochempy/processing/alignement/align.py
+++ b/src/spectrochempy/processing/alignement/align.py
@@ -15,7 +15,7 @@ __dataset_methods__ = ["align"]
 
 warnings.warn(
     "Importing from `spectrochempy.processing.alignement.align` is deprecated "
-    "and will be removed in 0.12.0. Use "
+    "and will be removed in 0.13.0. Use "
     "`spectrochempy.processing.alignment.align` instead.",
     DeprecationWarning,
     stacklevel=2,

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -82,7 +82,7 @@ def concatenate(*datasets, **kwargs):
     """
     # check use
     if "force_stack" in kwargs:
-        deprecated("force_stack", replace="method stack()", removed="0.12.0")
+        deprecated("force_stack", replace="method stack()", removed="0.13.0")
         return stack(datasets)
 
     # get a copy of input datasets in order that input data are not modified

--- a/tests/test_core/test_scripts/test_install_plugins.py
+++ b/tests/test_core/test_scripts/test_install_plugins.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from spectrochempy.ci import install_plugins
+
+
+def test_pip_install_places_global_flags_before_editable_target(tmp_path, monkeypatch):
+    plugin_dir = tmp_path / "plugins" / "spectrochempy-nmr"
+    plugin_dir.mkdir(parents=True)
+
+    captured = {}
+
+    def fake_run(cmd, capture_output, text):
+        captured["cmd"] = cmd
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(install_plugins.subprocess, "run", fake_run)
+
+    rc = install_plugins._pip_install(
+        "spectrochempy-nmr",
+        tmp_path / "plugins",
+        editable=True,
+        pip_cmd=["python", "-m", "pip"],
+        no_deps=True,
+        no_build_isolation=True,
+    )
+
+    assert rc == 0
+    assert captured["cmd"] == [
+        "python",
+        "-m",
+        "pip",
+        "install",
+        "--no-deps",
+        "--no-build-isolation",
+        "-e",
+        str(plugin_dir),
+    ]


### PR DESCRIPTION
## Summary

- update official plugin runtime bounds to `spectrochempy>=0.12,<0.13`
- postpone remaining public deprecations that still targeted `0.12` to `0.13.0`, including compatibility-warning expectations in plugin tests
- simplify the `0.12.0` changelog so the main release themes are easier to scan, and replace the remaining MCRALS `:pr:` placeholders
- regenerate `docs/sources/whatsnew/latest.rst` through the normal project hook
- make the test workflow install local official plugins in monorepo mode so unreleased core bounds do not trigger a failing PyPI resolution during CI
- fix the editable plugin installer helper so `--no-deps` and other global pip flags are emitted before the editable target

## Root cause for the CI follow-up

The initial release-preparation diff updated official plugin bounds to `spectrochempy>=0.12,<0.13`, but the test workflow was still installing editable local plugins with dependency resolution enabled:

- `python -m spectrochempy.ci.install_plugins --editable all`

Because `0.12.x` is not yet published on PyPI, `pip` tried to satisfy the core requirement from PyPI and failed on `0.11.0` as the latest available release.

The workflow was updated to use:

- `python -m spectrochempy.ci.install_plugins --editable --no-deps all`
- `python -m pip install osqp xlrd numpy-quaternion tensorly`

A second issue then appeared: the helper itself built editable install commands in the wrong order, effectively producing `pip install -e --no-deps <path>`, which makes pip parse `--no-deps` as the editable requirement. The helper now emits global flags first and the editable target last.

This keeps the public release-preparation bounds intact while making the CI path explicitly monorepo-aware.

## Out of scope

- the final `0.12.0` release workflow itself
- the final full-repository release validation / CI pass on the exact release SHA
- maintainer-repository note publication

## Validation

- `pre-commit run --all-files`
- `pre-commit run --files .github/workflows/test_package.yml docs/sources/devguide/plugins/packaging.rst`
- `pre-commit run --files src/spectrochempy/ci/install_plugins.py tests/test_core/test_scripts/test_install_plugins.py`
- `pytest plugins/spectrochempy-tensor/tests/test_tensor_plugin.py -k root_alias_warns_once`
- `pytest plugins/spectrochempy-cantera/tests/test_cantera.py -k pfr_root_compatibility_alias_warns_once` (skipped because `cantera` is not installed in the local environment)
- `pytest tests/test_core/test_scripts/test_install_plugins.py`

## Notes

- `gh` authentication remained invalid locally, so the branch was pushed over SSH and the PR was opened through the GitHub connector.
- The Iris root-alias warning test was not re-run in this environment because importing `spectrochempy_iris` still requires `osqp`.