### PR TITLE
TEST: fix failing metaconfigurable mock parent setup

### DIFF
--- a/tests/test_utils/test_metaconfigurable.py
+++ b/tests/test_utils/test_metaconfigurable.py
@@ -40,8 +40,10 @@ class FailingConfigManager(MockConfigManager):
 class MockParent(Configurable):
     """Mock parent with config and config_manager."""
 
-    def __init__(self):
-        self.config_manager = MockConfigManager()
+    def __init__(self, config_manager=None):
+        self.config_manager = (
+            MockConfigManager() if config_manager is None else config_manager
+        )
         self.config = Config()
         super().__init__()  # Initialize the parent Configurable class
 
@@ -50,9 +52,7 @@ class FailingMockParent(MockParent):
     """Mock parent that injects a failing config manager."""
 
     def __init__(self):
-        self.config_manager = FailingConfigManager()
-        self.config = Config()
-        super(MockParent, self).__init__()
+        super().__init__(config_manager=FailingConfigManager())
 
 
 class A_Configurable(MetaConfigurable):


### PR DESCRIPTION
## Summary
Fix the remaining `FailingMockParent` test helper issue left on `master` after PR #1488.

## What changed
- make `MockParent` accept an injected config manager
- construct `FailingMockParent` with `super().__init__(config_manager=FailingConfigManager())`
- preserve the intentional failing persistence behavior without the incorrect `super(MockParent, self).__init__()` call

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_utils/test_metaconfigurable.py -q`
- `pre-commit run --all-files`

## Scope
This is a small follow-up test fix only. It does not change the JSON persistence behavior introduced by PR #1488.
