### PR TITLE
FIX: avoid transient MCRALS config writes during fit

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -31,6 +31,11 @@ Bug Fixes
   config updates, writes JSON atomically, preserves corrupted files under a
   backup name, and avoids emitting raw persistence exceptions on stdout.
 
+- Internal `MCRALS` revalidation after `_n_components` changes no longer emits
+  transient config-file writes for normalized legacy constraint traits during
+  `fit()`, while explicit user changes to persisted parameters still behave as
+  before.
+
 .. section
 
 Dependency Updates

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -19,3 +19,8 @@ Bug Fixes
   corrupt shared JSON config files. SpectroChemPy now serializes same-process
   config updates, writes JSON atomically, preserves corrupted files under a
   backup name, and avoids emitting raw persistence exceptions on stdout.
+
+- Internal `MCRALS` revalidation after `_n_components` changes no longer emits
+  transient config-file writes for normalized legacy constraint traits during
+  `fit()`, while explicit user changes to persisted parameters still behave as
+  before.

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -19,6 +19,7 @@ import logging
 import warnings
 from dataclasses import dataclass
 from dataclasses import field
+from types import SimpleNamespace
 
 import dill
 import numpy as np
@@ -1845,27 +1846,33 @@ and `St`.
     def _n_components_change(self, change):
         # triggered in _guess_profile
         if self._n_components > 0:
-            # perform a validation of default configuration parameters
-            # Indeed, if not forced here these parameters are validated only when they
-            # are set explicitly.
-            # Here is an ugly trick to force this validation. # TODO: better way?
-            # DEVNOTE: _validating_legacy flag prevents __setattr__ from
-            # tracking these internal re-assignments as explicit user assignments.
-            # The try/finally ensures the flag is reset even if validation raises.
-            self._validating_legacy = True
-            try:
-                with warnings.catch_warnings():
-                    warnings.simplefilter(action="ignore", category=FutureWarning)
-                    self.closureTarget = self.closureTarget
-                    self.getC_to_C_idx = self.getC_to_C_idx
-                    self.getSt_to_St_idx = self.getSt_to_St_idx
-                    self.nonnegConc = self.nonnegConc
-                    self.nonnegSpec = self.nonnegSpec
-                    self.unimodConc = self.unimodConc
-                    self.unimodSpec = self.unimodSpec
-                    self.closureConc = self.closureConc
-            finally:
-                self._validating_legacy = False
+            # Re-validate component-dependent legacy traits once the real
+            # number of components is known, but keep this internal
+            # normalization out of trait notifications and config persistence.
+            self._revalidate_component_dependent_traits()
+
+    def _revalidate_component_dependent_traits(self):
+        validators = {
+            "closureTarget": self._validate_closureTarget,
+            "getC_to_C_idx": self._validate_getC_to_C_idx,
+            "getSt_to_St_idx": self._validate_getSt_to_St_idx,
+            "nonnegConc": self._validate_nonnegConc,
+            "nonnegSpec": self._validate_nonnegSpec,
+            "unimodConc": self._validate_unimodConc,
+            "unimodSpec": self._validate_unimodSpec,
+            "closureConc": self._validate_closureConc,
+        }
+        for name, validator in validators.items():
+            current = getattr(self, name)
+            validated = validator(SimpleNamespace(value=current))
+            if self._trait_value_differs(current, validated):
+                self._trait_values[name] = validated
+
+    @staticmethod
+    def _trait_value_differs(current, validated):
+        if isinstance(current, np.ndarray) or isinstance(validated, np.ndarray):
+            return not np.array_equal(np.asarray(current), np.asarray(validated))
+        return current != validated
 
     # ----------------------------------------------------------------------------------
     # Constraints traitlet — validated, observes fitted state

--- a/tests/test_analysis/test_decomposition/test_mcrals_config_persistence.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_config_persistence.py
@@ -1,0 +1,202 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Tests for transient MCRALS config persistence behavior."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stdout
+from collections import Counter
+import io
+import threading
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis.decomposition.mcrals import MCRALS
+from spectrochempy.application.application import app
+from spectrochempy.application.config import SpectroChemPyJSONConfigManager
+
+
+class CountingConfigManager(SpectroChemPyJSONConfigManager):
+    """Count config persistence writes while keeping real JSON behavior."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.calls = []
+        self._calls_lock = threading.Lock()
+
+    def update(self, section_name, new_data):
+        with self._calls_lock:
+            self.calls.append((section_name, tuple(new_data.get(section_name, {}).keys())))
+        return super().update(section_name, new_data)
+
+
+@pytest.fixture
+def counting_manager(tmp_path):
+    previous = app.config_manager
+    manager = CountingConfigManager(config_dir=str(tmp_path))
+    app.config_manager = manager
+    try:
+        yield manager
+    finally:
+        app.config_manager = previous
+
+
+@pytest.fixture
+def simple_peak():
+    n_mz = 20
+    n_components = 2
+    n_scans = 30
+    rng = np.random.default_rng(0)
+    t = np.arange(n_scans)
+    centers = np.linspace(0.25, 0.75, n_components) * n_scans
+    C = np.stack(
+        [np.exp(-((t - c) ** 2) / (n_scans / 3.0)) for c in centers],
+        axis=1,
+    )
+    S = np.abs(rng.normal(size=(n_components, n_mz))) + 0.1
+    X = scp.NDDataset(C @ S, name="peak", title="intensity")
+    X.set_coordset(
+        y=scp.Coord(t.astype(float), title="retention time", units="s"),
+        x=scp.Coord(np.arange(n_mz), title="m/z"),
+    )
+    return X, scp.NDDataset(C.copy())
+
+
+def test_fit_revalidates_component_traits_without_persisting_internal_writes(
+    counting_manager,
+    simple_peak,
+):
+    X, C0 = simple_peak
+    mcr = MCRALS(max_iter=5, tol=1.0, log_level="WARNING")
+
+    assert [trait for _, traits in counting_manager.calls for trait in traits] == [
+        "max_iter",
+        "tol",
+        "tol_residual_change",
+    ]
+
+    counting_manager.calls.clear()
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        mcr.fit(X, C0)
+
+    assert stdout.getvalue() == ""
+    assert counting_manager.calls == []
+    assert np.array_equal(mcr.closureTarget, np.ones(X.shape[0]))
+    assert mcr.getC_to_C_idx == [0, 1]
+    assert mcr.getSt_to_St_idx == [0, 1]
+    assert mcr.nonnegConc == [0, 1]
+    assert mcr.nonnegSpec == [0, 1]
+    assert mcr.unimodConc == [0, 1]
+    assert mcr.unimodSpec == []
+    assert mcr.closureConc == []
+
+
+def test_fit_preserves_validation_failures_for_component_dependent_traits(
+    counting_manager,
+    simple_peak,
+):
+    X, C0 = simple_peak
+    mcr = MCRALS(max_iter=5, tol=1.0, log_level="WARNING", nonnegConc=[0, 1, 2])
+
+    with pytest.raises(ValueError, match="nonnegConc"):
+        mcr.fit(X, C0)
+
+
+def test_fit_preserves_valid_explicit_component_dependent_values(
+    counting_manager,
+    simple_peak,
+):
+    X, C0 = simple_peak
+    target = np.linspace(1.0, 2.0, X.shape[0]).tolist()
+    mcr = MCRALS(
+        max_iter=5,
+        tol=1.0,
+        log_level="WARNING",
+        nonnegConc=[1],
+        nonnegSpec=[0],
+        unimodConc=[1],
+        unimodSpec=[0],
+        closureConc=[0],
+        closureTarget=target,
+        getC_to_C_idx=[1, 0],
+        getSt_to_St_idx=[1, 0],
+    )
+
+    counting_manager.calls.clear()
+    mcr.fit(X, C0)
+
+    assert counting_manager.calls == []
+    assert mcr.nonnegConc == [1]
+    assert mcr.nonnegSpec == [0]
+    assert mcr.unimodConc == [1]
+    assert mcr.unimodSpec == [0]
+    assert mcr.closureConc == [0]
+    assert np.array_equal(mcr.closureTarget, np.asarray(target))
+    assert mcr.getC_to_C_idx == [1, 0]
+    assert mcr.getSt_to_St_idx == [1, 0]
+
+
+def test_explicit_user_config_change_still_persists(counting_manager):
+    mcr = MCRALS(max_iter=5, tol=1.0, log_level="WARNING")
+    counting_manager.calls.clear()
+
+    mcr.max_iter = 7
+
+    assert counting_manager.calls == [("MCRALS", ("max_iter",))]
+
+
+def test_concurrent_fits_only_persist_constructor_writes(
+    counting_manager,
+):
+    peaks = []
+    for n_scans, seed in ((30, 1), (18, 2)):
+        rng = np.random.default_rng(seed)
+        n_mz = 20
+        n_components = 2
+        t = np.arange(n_scans)
+        centers = np.linspace(0.25, 0.75, n_components) * n_scans
+        C = np.stack(
+            [np.exp(-((t - c) ** 2) / (n_scans / 3.0)) for c in centers],
+            axis=1,
+        )
+        S = np.abs(rng.normal(size=(n_components, n_mz))) + 0.1
+        X = scp.NDDataset(C @ S, name=f"peak{n_scans}", title="intensity")
+        X.set_coordset(
+            y=scp.Coord(t.astype(float), title="retention time", units="s"),
+            x=scp.Coord(np.arange(n_mz), title="m/z"),
+        )
+        peaks.append((X, scp.NDDataset(C.copy())))
+
+    counting_manager.calls.clear()
+
+    def fit_one(peak):
+        X, C0 = peak
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            mcr = MCRALS(max_iter=5, tol=1.0, log_level="WARNING")
+            mcr.fit(X, C0)
+        return stdout.getvalue(), mcr._fitted, mcr.C.shape, mcr.St.shape
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(fit_one, peak) for peak in peaks]
+        results = [future.result(timeout=10) for future in futures]
+
+    assert all(stdout == "" for stdout, _, _, _ in results)
+    assert all(fitted for _, fitted, _, _ in results)
+    assert all(c_shape[1] == 2 and st_shape[0] == 2 for _, _, c_shape, st_shape in results)
+    assert Counter(
+        trait for _, traits in counting_manager.calls for trait in traits
+    ) == Counter(
+        {
+            "max_iter": 2,
+            "tol": 2,
+            "tol_residual_change": 2,
+        }
+    )

--- a/tests/test_analysis/test_decomposition/test_mcrals_config_persistence.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_config_persistence.py
@@ -7,11 +7,11 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
-from contextlib import redirect_stdout
-from collections import Counter
 import io
 import threading
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stdout
 
 import numpy as np
 import pytest
@@ -32,7 +32,9 @@ class CountingConfigManager(SpectroChemPyJSONConfigManager):
 
     def update(self, section_name, new_data):
         with self._calls_lock:
-            self.calls.append((section_name, tuple(new_data.get(section_name, {}).keys())))
+            self.calls.append(
+                (section_name, tuple(new_data.get(section_name, {}).keys()))
+            )
         return super().update(section_name, new_data)
 
 
@@ -190,7 +192,9 @@ def test_concurrent_fits_only_persist_constructor_writes(
 
     assert all(stdout == "" for stdout, _, _, _ in results)
     assert all(fitted for _, fitted, _, _ in results)
-    assert all(c_shape[1] == 2 and st_shape[0] == 2 for _, _, c_shape, st_shape in results)
+    assert all(
+        c_shape[1] == 2 and st_shape[0] == 2 for _, _, c_shape, st_shape in results
+    )
     assert Counter(
         trait for _, traits in counting_manager.calls for trait in traits
     ) == Counter(


### PR DESCRIPTION
## Summary
Reduce transient config-file writes triggered by internal `MCRALS` revalidation after `_n_components` becomes known during `fit()`.

## Diagnosis
The JSON robustness fix from PR #1488 addressed corruption at the persistence layer, but `MCRALS` still performed internal self-reassignments in `_n_components_change()`:

- `closureTarget`
- `getC_to_C_idx`
- `getSt_to_St_idx`
- `nonnegConc`
- `nonnegSpec`
- `unimodConc`
- `unimodSpec`
- `closureConc`

Characterization showed that same-value assignment alone does not notify Traitlets in the current environment. The transient writes happened because several of these config-tagged legacy traits were normalized by their validators once `X` and `_n_components` were available.

Measured with a counting config manager subclass:
- constructor of `MCRALS(max_iter=5, tol=1.0, log_level="WARNING")`: `3` writes (`max_iter`, `tol`, `tol_residual_change`)
- simple `fit(X, C0)` before this patch: `6` writes (`closureTarget`, `getC_to_C_idx`, `getSt_to_St_idx`, `nonnegConc`, `nonnegSpec`, `unimodConc`)
- two concurrent fits before this patch: `18` writes total

## What changed
- replace the `_n_components_change()` self-reassignment pattern with explicit internal revalidation
- call the existing validators directly for component-dependent legacy traits
- update normalized values in trait storage only when the validated value actually differs
- avoid artificial trait notifications and config persistence writes during internal normalization
- keep explicit user-triggered persistence behavior unchanged
- add targeted regression tests for write counting, validation preservation, explicit user persistence, and concurrent fits
- add a changelog entry and regenerated `latest.rst`

## After this patch
Measured with the same counting manager subclass:
- constructor: still `3` writes (`max_iter`, `tol`, `tol_residual_change`)
- simple `fit(X, C0)`: `0` writes
- two concurrent fits: `6` writes total, i.e. constructor writes only

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_decomposition/test_mcrals_config_persistence.py tests/test_analysis/test_decomposition/test_mcrals.py tests/test_utils/test_metaconfigurable.py tests/test_application/test_json_config_manager.py -q`
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_decomposition/test_mcrals_metadata.py tests/test_analysis/test_decomposition/test_mcrals_constraints_api.py -q`
- `pre-commit run --all-files`

## Limits
This PR does not revisit the broader policy question of which MCRALS legacy traitlets should remain `config=True`; it only removes internal transient persistence writes while preserving scientific behavior and validator semantics.
