### PR TITLE
CI: automate core release PR with app token and auto-merge

### DIFF
--- a/.github/workflows/prepare_new_release.yml
+++ b/.github/workflows/prepare_new_release.yml
@@ -160,10 +160,11 @@ jobs:
           if ! gh pr merge "${{ steps.release-pr.outputs.number }}" \
             --repo "${{ github.repository }}" \
             --auto \
-            --merge \
+            --squash \
             --match-head-commit "${{ steps.make-commit.outputs.commit }}"; then
             echo "::error::Failed to enable auto-merge for ${{ steps.release-pr.outputs.url }}."
             echo "::error::Check that the repository setting 'Allow auto-merge' is enabled and that the spectrochempy-releaser app can manage pull requests."
+            echo "::error::The repository ruleset must also allow squash merges for master."
             exit 1
           fi
 
@@ -172,5 +173,5 @@ jobs:
             echo
             echo "- PR: ${{ steps.release-pr.outputs.url }}"
             echo "- Head commit: ${{ steps.make-commit.outputs.commit }}"
-            echo "- Merge mode: auto-merge (merge commit)"
+            echo "- Merge mode: auto-merge (squash)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare_new_release.yml
+++ b/.github/workflows/prepare_new_release.yml
@@ -31,10 +31,18 @@ jobs:
     if: github.repository == 'spectrochempy/spectrochempy'
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check Zenodo integration is enabled
         run: |
@@ -88,24 +96,81 @@ jobs:
       - name: Push new branch
         run: git push origin release/${{ github.event.inputs.versionString }}
 
-      - name: Create pull request into master
-        uses: thomaseizinger/create-pull-request@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          head: release/${{ github.event.inputs.versionString }}
-          base: master
-          reviewers: ${{ github.actor }}
-          title: Release version ${{ github.event.inputs.versionString }}
-          body: |
-            Hi @${{ github.actor }}!
+      - name: Create or reuse pull request into master
+        id: release-pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_VERSION: ${{ github.event.inputs.versionString }}
+        run: |
+          body_file="$RUNNER_TEMP/release-pr-body.md"
+          cat > "$body_file" <<EOF
+          Hi @${{ github.actor }}!
 
-            This PR was created in response to a manual trigger of the release workflow
-            here:
-            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+          This PR was created in response to a manual trigger of the release workflow
+          here:
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
 
-            I've updated the docs/whatsnew/*rst files, CITATION.cff, zenodo.json plus eventual
-            changes on the requirements/environment files:
-            ${{ steps.make-commit.outputs.commit }}.
-            Merging this PR should be followed by the creation of the corresponding
-            draft release.
-            Publishing this release will trigger publishing on pypi, anaconda and zenodo.
+          I've updated the docs/whatsnew/*rst files, CITATION.cff, zenodo.json plus eventual
+          changes on the requirements/environment files:
+          ${{ steps.make-commit.outputs.commit }}.
+
+          Auto-merge is enabled automatically by this workflow. The PR will merge with the
+          normal repository requirements once the required checks and reviews pass.
+
+          Publishing this release will trigger publishing on pypi, anaconda and zenodo.
+          EOF
+
+          pr_number="$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "release/$RELEASE_VERSION" \
+            --base master \
+            --state open \
+            --json number \
+            --jq '.[0].number')"
+
+          if [ -n "$pr_number" ] && [ "$pr_number" != "null" ]; then
+            pr_url="$(gh pr view "$pr_number" --repo "${{ github.repository }}" --json url --jq .url)"
+            gh pr edit "$pr_number" \
+              --repo "${{ github.repository }}" \
+              --title "Release version $RELEASE_VERSION" \
+              --body-file "$body_file"
+            if ! gh pr edit "$pr_number" \
+              --repo "${{ github.repository }}" \
+              --add-reviewer "${{ github.actor }}"; then
+              echo "::warning::Could not add ${{ github.actor }} as reviewer on existing PR $pr_number."
+            fi
+          else
+            pr_url="$(gh pr create \
+              --repo "${{ github.repository }}" \
+              --base master \
+              --head "release/$RELEASE_VERSION" \
+              --title "Release version $RELEASE_VERSION" \
+              --body-file "$body_file" \
+              --reviewer "${{ github.actor }}")"
+            pr_number="$(gh pr view "$pr_url" --repo "${{ github.repository }}" --json number --jq .number)"
+          fi
+
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge on release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if ! gh pr merge "${{ steps.release-pr.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --auto \
+            --merge \
+            --match-head-commit "${{ steps.make-commit.outputs.commit }}"; then
+            echo "::error::Failed to enable auto-merge for ${{ steps.release-pr.outputs.url }}."
+            echo "::error::Check that the repository setting 'Allow auto-merge' is enabled and that the spectrochempy-releaser app can manage pull requests."
+            exit 1
+          fi
+
+          {
+            echo "### Release PR prepared"
+            echo
+            echo "- PR: ${{ steps.release-pr.outputs.url }}"
+            echo "- Head commit: ${{ steps.make-commit.outputs.commit }}"
+            echo "- Merge mode: auto-merge (merge commit)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/maintainers/emergency-recovery.md
+++ b/maintainers/emergency-recovery.md
@@ -9,6 +9,10 @@ release, avec leur cause et la résolution appliquée.
 
 ## Les checks ne démarrent pas sur une PR de release
 
+> État : incident historique du flux fondé sur `GITHUB_TOKEN`, résolu par la
+> migration de `prepare_new_release.yml` vers la GitHub App
+> `spectrochempy-releaser`.
+
 ### Symptôme
 
 Sur une Pull Request de release créée par `github-actions[bot]`, les
@@ -29,17 +33,20 @@ les workflows de CI (tests, builds) ne démarrent pas.
 
 ### Résolution
 
-- Vérifier manuellement les modifications dans la PR
-- Si tout est correct, **merge manuellement** la PR (les checks sont requis
-  mais peuvent être contournés par un administrateur)
-- Une fois mergée, les workflows post-merge fonctionneront normalement
-  (push event via `GITHUB_TOKEN`)
+- Mettre à jour `prepare_new_release.yml` pour utiliser un jeton de la GitHub
+  App `spectrochempy-releaser` au lieu du seul `GITHUB_TOKEN` pour le
+  checkout, la création de PR et l'activation de l'auto-merge
+- Relancer le workflow **Prepare a new release**
+- Vérifier que les checks démarrent bien sur la PR recréée ou mise à jour
+- Vérifier que l'option de dépôt **Allow auto-merge** est activée si le
+  workflow échoue au moment du `gh pr merge --auto`
 
 ### Prévention
 
-- Utiliser un **PAT dédié** (Personal Access Token) pour le checkout dans
-  `prepare_new_release.yml`, ce qui déclencherait les événements GitHub
-  normalement
+- Conserver la GitHub App `spectrochempy-releaser` installée avec une clé
+  privée valide et les permissions nécessaires sur le dépôt
+- Éviter de revenir à un flux de PR de release créé uniquement avec
+  `GITHUB_TOKEN`
 
 ---
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -197,7 +197,7 @@ Le workflow :
   - `CITATION.cff`
   - `zenodo.json`
 - Ouvre une **Pull Request** vers `master` avec le token de la GitHub App
-- Active l'**auto-merge** (merge commit) sur cette PR
+- Active l'**auto-merge** (squash) sur cette PR
 
 ### 4. Vérifier la PR de release
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -13,7 +13,7 @@ du dépôt `spectrochempy/spectrochempy` :
 | Secret | Usage |
 |--------|-------|
 | `ANACONDA_API_TOKEN` | Publication sur Anaconda.org (compte `spectrocat`) — core + plugins |
-| `RELEASER_APP_PRIVATE_KEY` | Clé privée de la GitHub App `spectrochempy-releaser` (pour contourner la protection de branche lors des releases de plugins) |
+| `RELEASER_APP_PRIVATE_KEY` | Clé privée de la GitHub App `spectrochempy-releaser` (automation des releases core via PR + auto-merge, et contournement des règles pour les pushes/tags de release plugin) |
 
 | Variable | Usage |
 |----------|-------|
@@ -41,10 +41,22 @@ Ce bypass est nécessaire car `release_plugin.yml` crée un commit de bump de
 version et le pousse directement sur `master` avant de créer le tag de
 release.
 
+Pour les **releases core**, le workflow `prepare_new_release.yml`
+s'authentifie désormais aussi avec cette GitHub App, mais dans un mode plus
+strict : l'app crée la branche `release/X.Y.Z`, ouvre la PR de release et
+active l'**auto-merge**. La fusion elle-même reste soumise aux checks et aux
+reviews normaux du dépôt ; elle n'utilise pas de bypass humain. Cette
+authentification via GitHub App évite aussi le mode `approval-required`
+associé aux PR créées avec le seul `GITHUB_TOKEN`.
+
 La création et la suppression de tags sont protégées par des **tag rulesets**
 séparés. La GitHub App `spectrochempy-releaser` doit également figurer dans
 la liste de bypass de ces rulesets.
 
+> **Important** : l'option de dépôt **Allow auto-merge** doit être activée
+> (`Settings → General → Pull Requests → Allow auto-merge`) pour que la PR de
+> release core puisse être fusionnée automatiquement après CI verte.
+>
 > **Important** : ne pas conserver simultanément une ancienne **Branch
 > protection rule** (legacy) sur `master`. Les règles de dépôt sont
 > cumulatives, et une legacy rule continuerait de bloquer l'application de
@@ -68,6 +80,13 @@ Avant de lancer une release plugin :
 > La configuration ci-dessus a été validée par une release plugin complète
 > réussie (bump sur `master`, création de tag, GitHub Release, publication
 > PyPI).
+
+Avant de lancer une release core :
+
+- [ ] Confirmer que l'option **Allow auto-merge** du dépôt est activée
+- [ ] Confirmer que la GitHub App `spectrochempy-releaser` est installée sur
+      le repo avec les permissions nécessaires pour créer/éditer une PR et
+      activer l'auto-merge
 
 ### Comptes externes
 
@@ -177,7 +196,8 @@ Le workflow :
   - `docs/sources/whatsnew/latest.rst`
   - `CITATION.cff`
   - `zenodo.json`
-- Ouvre une **Pull Request** vers `master`
+- Ouvre une **Pull Request** vers `master` avec le token de la GitHub App
+- Active l'**auto-merge** (merge commit) sur cette PR
 
 ### 4. Vérifier la PR de release
 
@@ -188,11 +208,14 @@ Dans la Pull Request :
 - Vérifier que les versions sont correctes
 - Si des dépendances ont changé, vérifier `pyproject.toml` et
   `environments/environment_build.yml` également
+- Vérifier que l'état **auto-merge enabled** apparaît bien sur la PR
 
-### 5. Merge de la PR
+### 5. Laisser GitHub fusionner la PR
 
-- Cliquer **Merge pull request**
-- La fusion déclenche automatiquement le workflow
+- Ne pas merger manuellement la PR par bypass si les checks ne sont pas verts
+- Une fois les checks requis et l'éventuelle review satisfaits, GitHub fusionne
+  automatiquement la PR
+- Cette fusion déclenche automatiquement le workflow
   **Publish a draft new release**
 
 ### 6. Draft Release GitHub
@@ -621,7 +644,7 @@ entrées sont incorrectes car :
 ### Avant toute release
 
 - [ ] Vérifier que les secrets GitHub nécessaires sont valides :
-      - Core : `ANACONDA_API_TOKEN` (Trusted Publishing PyPI ne nécessite pas de token secret)
+      - Core : `ANACONDA_API_TOKEN`, `RELEASER_APP_PRIVATE_KEY` + `RELEASER_APP_ID` (Trusted Publishing PyPI ne nécessite pas de token secret)
       - Plugins : `ANACONDA_API_TOKEN`, `RELEASER_APP_PRIVATE_KEY` + `RELEASER_APP_ID` (Trusted Publishing PyPI ne nécessite pas de token secret)
 - [ ] Vérifier l'état des services externes (Zenodo, PyPI, Anaconda.org)
 - [ ] Lancer les tests CI sur la branche cible
@@ -638,9 +661,10 @@ entrées sont incorrectes car :
       `spectrochempy` sur PyPI → Trusted Publishers → GitHub repository
       `spectrochempy/spectrochempy`, workflow `build_package.yml`,
       environment `pypi`)
+- [ ] Vérifier que l'option **Allow auto-merge** du dépôt est activée
 - [ ] Lancer **Prepare a new release** avec la version X.Y.Z
 - [ ] Vérifier la PR de release (CITATION.cff, zenodo.json, whatsnew)
-- [ ] Merger la PR → attendre la Draft Release
+- [ ] Vérifier que l'auto-merge est activé sur la PR → attendre la Draft Release
 - [ ] Vérifier la Draft Release, puis publier
 - [ ] Vérifier PyPI : `pip install spectrochempy==X.Y.Z`
 - [ ] Vérifier Anaconda : `anaconda show spectrocat/spectrochempy`

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -1852,6 +1852,16 @@ and `St`.
             self._revalidate_component_dependent_traits()
 
     def _revalidate_component_dependent_traits(self):
+        # This normalization is intentionally internal-only. We re-run the
+        # existing validators to preserve their scientific checks, but when a
+        # symbolic user-facing value such as ``"all"`` or ``"default"``
+        # resolves to a concrete list/array we write the normalized value
+        # directly into trait storage instead of going through ``setattr``.
+        #
+        # This deliberately skips Traitlets notifications, including config
+        # persistence and any future observers on these legacy traits. If a
+        # future observer must react to this normalization step, this helper
+        # will need to be revisited rather than assuming observers are called.
         validators = {
             "closureTarget": self._validate_closureTarget,
             "getC_to_C_idx": self._validate_getC_to_C_idx,


### PR DESCRIPTION
## Summary
- switch `prepare_new_release.yml` from `GITHUB_TOKEN` PR writes to the `spectrochempy-releaser` app token
- create or reuse the core release PR with `gh`, then enable `--auto --squash` so core releases wait for normal checks and reviews instead of a manual merge click
- update `maintainers/release-process.md` and `maintainers/emergency-recovery.md` to document the new app-token and auto-merge flow
- add a clarifying `MCRALS` comment around the internal `_trait_values` normalization used during legacy constraint revalidation

## Out of scope
- no change to the public release payload for `0.12.1`
- no new config-persistence mechanism beyond the already merged `#1488` / `#1490` work
- no broader refactor of MCRALS trait handling

## Why
The previous core release flow still depended on a human merge step on the release PR. That made it too easy to merge before CI was green and also kept the PR creation path on `GITHUB_TOKEN`, which GitHub documents as capable of leaving workflow-created PRs in an approval-gated state.

This change moves the sensitive GitHub write path onto the existing release app and lets GitHub complete the merge only after the normal repository requirements are satisfied.

The extra `MCRALS` comment is intentionally small: it documents that the direct `_trait_values` write is an internal-only normalization step that deliberately skips Traitlets notifications, including config persistence and any future observers on those legacy traits.

This PR replaces `#1486`, whose CI/check association became unreliable after repeated history rewrites.

## Validation
- `git diff --check`
- inspected refreshed diff against `origin/master`

Related: `#1486`, `#1487`, `#1488`, `#1490`