### PR TITLE
DOC: clarify internal MCRALS trait normalization

### DIFF
--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -1866,6 +1866,17 @@ and `St`.
             current = getattr(self, name)
             validated = validator(SimpleNamespace(value=current))
             if self._trait_value_differs(current, validated):
+                # This normalization is intentionally internal-only. We re-run
+                # the existing validators to preserve their scientific checks,
+                # but when symbolic values such as ``"all"`` or ``"default"``
+                # resolve to concrete indices, we write the normalized value
+                # directly into trait storage instead of going through
+                # ``setattr``.
+                #
+                # This deliberately skips Traitlets notifications, including
+                # config persistence and any future observers on these legacy
+                # traits. If a future observer must react to this
+                # normalization step, this helper should be revisited.
                 self._trait_values[name] = validated
 
     @staticmethod


### PR DESCRIPTION
## Summary
- add a clarifying comment around the internal `_trait_values` normalization in `MCRALS`

## Out of scope
- no functional change
- no workflow change
- no config persistence change

## Why
This PR exists mainly as a CI probe: it isolates a tiny code-only change so we can verify whether ordinary pull requests still trigger the required checks correctly.

## Validation
- `git diff --check`
