### PR TITLE
CI: fix release workflow inline Python quoting

### DIFF
--- a/.github/workflows/prepare_new_release.yml
+++ b/.github/workflows/prepare_new_release.yml
@@ -131,7 +131,7 @@ jobs:
           body_file = Path(os.environ["BODY_FILE"])
           payload_file = Path(os.environ["PAYLOAD_FILE"])
           payload = {
-              "title": f"Release version {os.environ[\"RELEASE_VERSION\"]}",
+              "title": "Release version " + os.environ["RELEASE_VERSION"],
               "body": body_file.read_text(),
           }
           payload_file.write_text(json.dumps(payload))
@@ -162,7 +162,7 @@ jobs:
             payload_file = Path(os.environ["PAYLOAD_FILE"])
             payload = json.loads(payload_file.read_text())
             payload.update({
-                "head": f"release/{os.environ[\"RELEASE_VERSION\"]}",
+                "head": "release/" + os.environ["RELEASE_VERSION"],
                 "base": "master",
             })
             payload_file.write_text(json.dumps(payload))


### PR DESCRIPTION
## Summary
- replace the two inline Python f-strings in `prepare_new_release.yml` with simple string concatenation
- keep the REST-based release PR creation logic unchanged

## Why
The `Prepare a new release` workflow still failed on Friday, August 7, 2026 in `Create or reuse pull request into master` with:

```text
SyntaxError: unexpected character after line continuation character
```

The root cause was the escaped quoting inside the `python3 -c` source string:
`os.environ["RELEASE_VERSION"]`.

## Validation
- `pre-commit run --all-files`