### PR TITLE
CI: harden release PR workflow outputs

### DIFF
--- a/.github/workflows/prepare_new_release.yml
+++ b/.github/workflows/prepare_new_release.yml
@@ -117,7 +117,7 @@ jobs:
             fi
 
             if grep -q "Resource not accessible by integration" "$stderr_file"; then
-              echo "::warning::GitHub App token could not access $endpoint; retrying with github.token."
+              echo "::warning::GitHub App token could not access $endpoint; retrying with github.token." >&2
               rm -f "$stderr_file"
               GH_TOKEN="$FALLBACK_GH_TOKEN" gh api --method "$method" "$endpoint" "$@"
               return $?
@@ -166,15 +166,14 @@ jobs:
               echo "::warning::Could not add ${{ github.actor }} as reviewer on existing PR $pr_number."
             fi
           else
-            pr_fields="$(gh_api_with_fallback POST \
+            pr_json="$(gh_api_with_fallback POST \
               "repos/${{ github.repository }}/pulls" \
               -f title="$pr_title" \
               -f body="$pr_body" \
               -f head="release/$RELEASE_VERSION" \
-              -f base="master" \
-              --template '{{.number}} {{.html_url}}')"
-            pr_number="${pr_fields%% *}"
-            pr_url="${pr_fields#* }"
+              -f base="master")"
+            pr_number="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["number"])')"
+            pr_url="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["html_url"])')"
 
             if ! GH_TOKEN="$APP_GH_TOKEN" gh api \
               --method POST \
@@ -182,6 +181,13 @@ jobs:
               -f "reviewers[]=${{ github.actor }}" >/dev/null; then
               echo "::warning::Could not add ${{ github.actor }} as reviewer on new PR $pr_number."
             fi
+          fi
+
+          if ! gh_api_with_fallback POST \
+            "repos/${{ github.repository }}/issues/$pr_number/labels" \
+            -f "labels[]=no-changelog" \
+            -f "labels[]=non-standard-prefix" >/dev/null; then
+            echo "::warning::Could not apply labels to release PR $pr_number."
           fi
 
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- keep fallback warnings on stderr so they do not pollute captured shell variables
- parse the created PR JSON explicitly before writing `number` and `url` to `GITHUB_OUTPUT`
- automatically label release PRs with `no-changelog` and `non-standard-prefix`

## Why
On Saturday, August 8, 2026, `Prepare a new release` did create the release PR, but the step still emitted two follow-up problems:

```text
gh: Not Found (HTTP 404)
Error: Invalid format '1499 https://github.com/spectrochempy/spectrochempy/pull/1499'
```

The PR creation itself succeeded, but warning output and field extraction were not robust enough afterward. This PR fixes that final cleanup path and ensures the release PR carries the labels needed by repository policy.

## Validation
- `pre-commit run --all-files`
