### PR TITLE
FIX: preserve metadata lineage for Category A filters

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
+  now preserve the source dataset `name` and append a single history entry while
+  retaining all prior entries, instead of renaming with a ``_Filter.transform``
+  suffix and replacing the history. Savitzky-Golay derivative outputs
+  (`deriv > 0`), ``denoise`` and analysis outputs are unchanged.
+
 
 .. section
 

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.12
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.12.1
     v0.12.0
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,10 +6,10 @@
 
 :orphan:
 
-What's New in Revision 0.12.1.dev
+What's New in Revision 0.12.2.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.1.dev.
+These are the changes in SpectroChemPy-0.12.2.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
 Bug Fixes

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,21 +6,17 @@
 
 :orphan:
 
-What's New in Revision 0.12.1
+What's New in Revision 0.12.1.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.1.
+These are the changes in SpectroChemPy-0.12.1.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
 Bug Fixes
 ~~~~~~~~~
 
-- Concurrent writes from `MetaConfigurable` instances such as `MCRALS` no longer
-  corrupt shared JSON config files. SpectroChemPy now serializes same-process
-  config updates, writes JSON atomically, preserves corrupted files under a
-  backup name, and avoids emitting raw persistence exceptions on stdout.
-
-- Internal `MCRALS` revalidation after `_n_components` changes no longer emits
-  transient config-file writes for normalized legacy constraint traits during
-  `fit()`, while explicit user changes to persisted parameters still behave as
-  before.
+- Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
+  now preserve the source dataset `name` and append a single history entry while
+  retaining all prior entries, instead of renaming with a ``_Filter.transform``
+  suffix and replacing the history. Savitzky-Golay derivative outputs
+  (`deriv > 0`), ``denoise`` and analysis outputs are unchanged.

--- a/src/spectrochempy/processing/_base/_processingbase.py
+++ b/src/spectrochempy/processing/_base/_processingbase.py
@@ -102,7 +102,7 @@ class ProcessingConfigurable(BaseConfigurable):
     # ----------------------------------------------------------------------------------
     # Public methods and property
     # ----------------------------------------------------------------------------------
-    @_wrap_ndarray_output_to_nddataset
+    @_wrap_ndarray_output_to_nddataset(meta_from="_X", preserve_identity=True)
     def transform(self, dataset, dim=-1):
         r"""
         Transform the input dataset X using the current model.

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -183,6 +183,7 @@ and ‘nearest’.
         # path sets it, so every other method (and deriv=0) leaves the title as
         # that of the input data.
         self._output_title_suffix = None
+        self._preserve_identity = True
 
         # smooth with moving average
         # --------------------------
@@ -233,6 +234,7 @@ and ‘nearest’.
                     self.deriv, f"{self.deriv}th"
                 )
                 self._output_title_suffix = f"({ordinal} derivative)"
+                self._preserve_identity = False
 
         # Whittaker-Eilers filter
         # -----------------------

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -442,6 +442,7 @@ class _set_output:
         typex=None,
         typey=None,
         typesingle=None,
+        preserve_identity=False,
     ):
         self.method = method
         update_wrapper(self, method)
@@ -451,6 +452,7 @@ class _set_output:
         self.typex = typex
         self.typey = typey
         self.typesingle = typesingle
+        self.preserve_identity = preserve_identity
 
     @preserve_signature
     def __get__(self, obj, objtype):
@@ -499,6 +501,7 @@ class _set_output:
             meta_from_tuple = self.meta_from
 
         out = []
+        preserve = self.preserve_identity and getattr(obj, "_preserve_identity", True)
         for data, meta_from in zip(data_tuple, meta_from_tuple, strict=False):
             X_transf = NDDataset(data)
 
@@ -540,7 +543,11 @@ class _set_output:
                     X_transf.units = X.units
                 else:
                     X_transf.units = self.units
-            X_transf.name = f"{X.name}_{obj.name}.{self.method.__name__}"
+            if preserve:
+                X_transf.name = metadata_source.name
+                X_transf._history = list(metadata_source._history or [])
+            else:
+                X_transf.name = f"{X.name}_{obj.name}.{self.method.__name__}"
             X_transf.history = f"Created using method {obj.name}.{self.method.__name__}"
             if self.title is not None:
                 if self.title == "keep":
@@ -669,7 +676,10 @@ class _set_output:
             # Only squeeze if the input was originally 1D (expanded to 2D)
             # This preserves intentionally 2D datasets with shape (1, N)
             if getattr(obj, "_X_original_ndim", 2) == 1:
-                out.append(X_transf.squeeze())
+                X_transf = X_transf.squeeze()
+                if preserve:
+                    X_transf._history = X_transf._history[:-1]
+                out.append(X_transf)
             else:
                 out.append(X_transf)
 
@@ -686,6 +696,7 @@ def _wrap_ndarray_output_to_nddataset(
     typex=None,
     typey=None,
     typesingle=None,
+    preserve_identity=False,
 ):
     # wrap _set_output to allow for deferred calling
     if method:
@@ -702,6 +713,7 @@ def _wrap_ndarray_output_to_nddataset(
                 typex=typex,
                 typey=typey,
                 typesingle=typesingle,
+                preserve_identity=preserve_identity,
             )
 
         out = wrapper

--- a/tests/test_core/test_dataset/test_metadata_characterization.py
+++ b/tests/test_core/test_dataset/test_metadata_characterization.py
@@ -159,7 +159,7 @@ def test_wrapper_based_filter_preserves_scientific_context_metadata(
 ):
     result = scp.Filter(method="savgol", size=5, order=2).transform(metadata_dataset)
 
-    assert result.name == "sample_001_Filter.transform"
+    assert result.name == metadata_dataset.name
     assert result.title == metadata_dataset.title
     assert result.meta == metadata_dataset.meta
     assert result.meta is not metadata_dataset.meta
@@ -172,16 +172,17 @@ def test_wrapper_based_filter_preserves_scientific_context_metadata(
     assert_basic_metadata_preserved(
         result,
         metadata_dataset,
-        check_name=False,
-        check_title=False,
+        check_name=True,
+        check_title=True,
         check_filename=True,
         meta_keys=("project", "instrument"),
     )
     assert_units_preserved(result, metadata_dataset)
     assert_dims_equal(result, ["y", "x"])
     assert_coordset_matches(result, metadata_dataset)
-    assert len(result.history) == 1
-    assert "Created using method Filter.transform" in result.history[0]
+    assert_history_appended(
+        result, metadata_dataset, "Created using method Filter.transform"
+    )
 
 
 def test_integrate_preserves_metadata_with_operation_overrides(metadata_dataset):

--- a/tests/test_processing/test_processing_assembly_category_a_policy.py
+++ b/tests/test_processing/test_processing_assembly_category_a_policy.py
@@ -1,0 +1,143 @@
+"""
+Policy tests for the processing-assembly single-source metadata policy (RFC).
+
+Codifies the accepted RFC ``processing-assembly-metadata-policy.md`` Q1/Q2
+for the Filter family (smooth, savgol, savgol_filter, whittaker):
+
+- ``name`` is preserved;
+- ``history`` appends exactly one generated entry per complete public
+  operation, retaining all prior entries;
+- the behavior is identical across entry forms (functional wrapper,
+  NDDataset method, configurable ``Filter(...).transform``);
+- excluded families keep their historical behavior: the Savitzky-Golay
+  derivative (DQ1), ``denoise`` / ``inverse_transform`` (DQ2), and
+  Category C analysis outputs.
+
+The assertions check entry count and message prefix only, never timestamps.
+"""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis.decomposition.pca import PCA
+from spectrochempy.core.dataset.nddataset import NDDataset
+from tests.test_core.test_dataset._semantic_dataset_helpers import (
+    make_semantic_2d_dataset,
+)
+
+_OP_KWARGS = {
+    "smooth": {"size": 3},
+    "savgol": {"size": 3},
+    "savgol_filter": {"size": 3},
+    "whittaker": {"lamb": 1.0},
+}
+
+_OP_METHOD = {
+    "smooth": "avg",
+    "savgol": "savgol",
+    "savgol_filter": "savgol",
+    "whittaker": "whittaker",
+}
+
+_FILTER_ENTRY = "Created using method Filter.transform"
+
+
+def _apply(dataset, op, form, **kwargs):
+    if form == "function":
+        return getattr(scp, op)(dataset, **kwargs)
+    if form == "method":
+        return getattr(dataset, op)(**kwargs)
+    if form == "transform":
+        return scp.Filter(method=_OP_METHOD[op], **kwargs).transform(dataset)
+    raise ValueError(f"Unknown form: {form}")
+
+
+@pytest.fixture
+def ds():
+    return make_semantic_2d_dataset(
+        title="ds_title",
+        name="ds_name",
+        history="original entry",
+    )
+
+
+# ======================================================================================
+# Category A: name preserved, history appended (one entry per public operation)
+# ======================================================================================
+
+
+class TestCategoryANameAndHistory:
+    @pytest.mark.parametrize("op", ["smooth", "savgol", "savgol_filter", "whittaker"])
+    @pytest.mark.parametrize("form", ["function", "method", "transform"])
+    def test_name_preserved(self, ds, op, form):
+        result = _apply(ds, op, form, **_OP_KWARGS[op])
+        assert result.name == "ds_name"
+
+    @pytest.mark.parametrize("op", ["smooth", "savgol", "savgol_filter", "whittaker"])
+    @pytest.mark.parametrize("form", ["function", "method", "transform"])
+    def test_history_appended_single_entry(self, ds, op, form):
+        result = _apply(ds, op, form, **_OP_KWARGS[op])
+        assert len(result.history) == len(ds.history) + 1
+        assert result.history[0] == ds.history[0]
+        assert _FILTER_ENTRY in result.history[-1]
+
+    def test_prior_entries_retained_in_order(self, ds):
+        ds.history = "second entry"
+        result = ds.smooth(size=3)
+        assert len(result.history) == 3
+        assert "original entry" in result.history[0].lower()
+        assert "second entry" in result.history[1].lower()
+        assert _FILTER_ENTRY in result.history[2]
+
+    def test_entry_forms_equivalent(self, ds):
+        for form in ("function", "method", "transform"):
+            result = _apply(ds, "savgol", form, size=3)
+            assert result.name == "ds_name"
+            assert len(result.history) == 2
+            assert result.history[0] == ds.history[0]
+            assert _FILTER_ENTRY in result.history[-1]
+
+    def test_savgol_filter_no_double_entry(self, ds):
+        result = scp.savgol_filter(ds, size=3)
+        assert len(result.history) == len(ds.history) + 1
+
+
+# ======================================================================================
+# Category A: 1D inputs append exactly one entry (no internal squeeze entry)
+# ======================================================================================
+
+
+class TestCategoryA1D:
+    def test_1d_single_appended_entry(self):
+        ds1 = NDDataset(np.array([1.0, 2.0, 3.0]), name="ds1")
+        ds1.history = "original entry"
+        result = ds1.smooth(size=3)
+        assert result.name == "ds1"
+        assert result.shape == (3,)
+        assert len(result.history) == len(ds1.history) + 1
+        assert "data squeezed" not in " ".join(result.history).lower()
+
+
+# ======================================================================================
+# Exclusions: deferred families keep their historical behavior
+# ======================================================================================
+
+
+class TestCategoryAExclusions:
+    def test_savgol_derivative_unchanged(self, ds):
+        result = scp.savgol(ds, size=3, order=2, deriv=1)
+        assert result.name == "ds_name_Filter.transform"
+        assert len(result.history) == 1
+        assert _FILTER_ENTRY in result.history[0]
+
+    def test_denoise_unchanged(self, ds):
+        result = ds.denoise(ratio=99.0)
+        assert result.name == "ds_name_PCA.inverse_transform"
+        assert len(result.history) == 1
+
+    def test_pca_scores_unchanged(self, ds):
+        pca = PCA(n_components=2)
+        scores = pca.fit_transform(ds)
+        assert scores.name == "ds_name_PCA.transform"
+        assert len(scores.history) == 1

--- a/tests/test_processing/test_processing_wrapper_semantics_baseline.py
+++ b/tests/test_processing/test_processing_wrapper_semantics_baseline.py
@@ -1,22 +1,25 @@
 """
 Characterization tests for processing-wrapper semantics on NDDataset.
 
-This suite characterizes CURRENT behavior of processing wrappers
+This suite characterizes the behavior of processing wrappers
 (smooth, savgol, whittaker, basc, detrend, asls, denoise).
-It does NOT validate a desired future policy.
 
 Coverage:
     - Return type, shape, dims, CoordSet, units, masks
     - Metadata (title, name, author, description, origin, meta)
     - History, identity, provenance
 
-Two distinct assembly patterns emerge:
-    Group A (Filter/PCA-based: smooth, savgol, whittaker, denoise):
-        name appended, no modeldata attribute,
-        history rewritten
+Two distinct assembly patterns exist:
+    Group A (Filter/PCA-based: smooth, savgol, whittaker):
+        name preserved, no modeldata attribute,
+        history appended (aligned to the single-source Category A policy)
     Group B (Baseline-based: basc, detrend, asls):
         name preserved, no modeldata attribute,
         history appended
+
+The Savitzky-Golay derivative (``deriv > 0``) and the PCA-based ``denoise``
+keep their historical Group A behavior (name recompute, history replace)
+until their classification is decided (RFC DQ1 / DQ2).
 """
 
 import numpy as np
@@ -103,8 +106,8 @@ class TestFilterWrappers:
     """
     Characterize Filter-based wrappers: smooth, savgol, whittaker.
 
-    Observation: these all rewrite history, append _Filter.transform
-    to name, and expose no modeldata attribute.
+    Observation: these preserve the source name, append history
+    (retaining prior entries), and expose no modeldata attribute.
     """
 
     @pytest.mark.parametrize("method", ["smooth", "savgol", "whittaker"])
@@ -134,10 +137,10 @@ class TestFilterWrappers:
         assert r.title == "ds_title"
 
     @pytest.mark.parametrize("method", ["smooth", "savgol", "whittaker"])
-    def test_name_appended(self, ds, method):
-        """Notable: name is appended with '_Filter.transform'."""
+    def test_name_preserved(self, ds, method):
+        """Notable: name is preserved unchanged (aligned to Group B)."""
         r = _call_filter(ds, method)
-        assert r.name == "ds_name_Filter.transform"
+        assert r.name == "ds_name"
 
     def test_author_preserved(self, ds):
         r = ds.smooth(size=3)
@@ -161,15 +164,15 @@ class TestFilterWrappers:
         assert ds.meta.project == "test_project"
 
     @pytest.mark.parametrize("method", ["smooth", "savgol", "whittaker"])
-    def test_history_rewritten(self, ds, method):
+    def test_history_appended(self, ds, method):
         """
-        Notable: history is REWRITTEN, not appended.
-        Original entries are lost.
+        Notable: history is APPENDED (retaining prior entries), aligned
+        to the Group B / Category A policy.
         """
         r = _call_filter(ds, method)
-        assert len(r.history) == 1
-        assert "Created using method Filter.transform" in r.history[0]
-        assert "original" not in r.history[0].lower()
+        assert len(r.history) == 2
+        assert "original entry" in r.history[0].lower()
+        assert "Created using method Filter.transform" in r.history[1]
 
     @pytest.mark.parametrize("method", ["smooth", "savgol", "whittaker"])
     def test_modeldata_dropped(self, ds, method):
@@ -267,9 +270,10 @@ class TestPcaWrapper:
     """
     Characterize PCA-based denoise wrapper.
 
-    Observation: Follows Group A pattern (name appended, no modeldata
-    attribute, history rewritten) but with different
-    method suffix (_PCA.inverse_transform).
+    Observation: follows the historical Group A pattern (name appended,
+    no modeldata attribute, history rewritten) with the
+    ``_PCA.inverse_transform`` suffix. Its classification is deferred
+    (RFC DQ2), so this behavior is intentionally unchanged.
     """
 
     def test_return_type(self, ds):
@@ -377,19 +381,21 @@ class TestIdentityProvenance:
     Characterize identity and provenance through processing wrappers.
 
     Observations:
-    - Group A (Filter/PCA): identity partially preserved (title, author,
-      origin, meta survive), but name is modified and history rewritten,
-      suggesting a derived or transformed identity.
+    - Group A (Filter): identity preserved (name, title, author, origin,
+      meta survive) and history appended, consistent with same-object
+      identity, aligned to the Category A policy.
     - Group B (Baseline): identity preserved (all fields survive),
       history appended, consistent with same-object identity.
+    - PCA-based ``denoise`` (DQ2): identity partially preserved and
+      history rewritten (historical Group A pattern, unchanged).
     """
 
-    def test_filter_identity_partial(self, ds):
+    def test_filter_identity_preserved(self, ds):
         r = ds.smooth(size=3)
         assert r.title == ds.title
         assert r.author == ds.author
         assert r.origin == ds.origin
-        assert r.name != ds.name  # appended suffix
+        assert r.name == ds.name
 
     def test_baseline_identity_preserved(self, ds):
         r = ds.basc()
@@ -398,10 +404,11 @@ class TestIdentityProvenance:
         assert r.author == ds.author
         assert r.origin == ds.origin
 
-    def test_filter_provenance_rewritten(self, ds):
+    def test_filter_provenance_extended(self, ds):
         r = ds.smooth(size=3)
-        assert len(r.history) == 1
-        assert r.history[0] != ds.history[0]
+        assert len(r.history) == 2
+        assert r.history[0] == ds.history[0]
+        assert "Filter.transform" in r.history[1]
 
     def test_baseline_provenance_extended(self, ds):
         r = ds.basc()


### PR DESCRIPTION
## Summary

Implements the accepted Processing Assembly — Single-Source Metadata Policy (spectrochempy_maintainer RFC `processing-assembly-metadata-policy.md`) by aligning the unambiguously Category A `Filter.transform` outputs.

Scope — Category A, single-source, unambiguous (`smooth`, `savgol`, `savgol_filter`, `whittaker`):
- `name` is preserved (source dataset name, no more `_Filter.transform` suffix).
- `history` keeps all prior entries and appends exactly one generated entry per complete public operation (N → N+1).
- Behavior is identical across entry forms (functional wrappers, `NDDataset` methods, `Filter(...).transform`), including 1D inputs (the internal `Data squeezed` entry is dropped on the preserve path).

Unchanged (deferred classifications, RFC DQ1/DQ2):
- Savitzky-Golay derivative (`deriv > 0`).
- `denoise` / `PCA.inverse_transform`.
- All analysis outputs (PCA scores, etc.) and the Baseline family.

## Implementation
- Private `preserve_identity` option on `_set_output` / `_wrap_ndarray_output_to_nddataset` (default keeps the historical behavior).
- `ProcessingConfigurable.transform` opts in with `meta_from="_X"`; `Filter._transform` sets `_preserve_identity` (`False` for the Savitzky-Golay derivative).

## Tests
- New: `tests/test_processing/test_processing_assembly_category_a_policy.py` (name/history policy across forms, 1D, single-entry, exclusions).
- Updated: `test_processing_wrapper_semantics_baseline.py`, `test_metadata_characterization.py`.
- Validation: 115 passed (targeted) ; 501 passed (processing + history-semantics + analysis-output suites). Numeric output verified identical to 0.12.1.

Closes roadmap priority 2 / §7 decision 1 of the post-0.12.1 metadata revalidation.