### PR TITLE
FIX: reject unsupported JCAMP inputs before writing (no y, complex)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -32,6 +32,12 @@ Bug Fixes
   suffix and replacing the history. Savitzky-Golay derivative outputs
   (`deriv > 0`), ``denoise`` and analysis outputs are unchanged.
 
+- JCAMP writing now rejects, before any file is created or truncated, datasets
+  without a `y` coordinate (previously producing a partial file) and datasets
+  with complex data (previously silently written with corrupted content).
+  No partial or corrupt file is left behind and the source dataset is
+  unmodified.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -20,3 +20,9 @@ Bug Fixes
   retaining all prior entries, instead of renaming with a ``_Filter.transform``
   suffix and replacing the history. Savitzky-Golay derivative outputs
   (`deriv > 0`), ``denoise`` and analysis outputs are unchanged.
+
+- JCAMP writing now rejects, before any file is created or truncated, datasets
+  without a `y` coordinate (previously producing a partial file) and datasets
+  with complex data (previously silently written with corrupted content).
+  No partial or corrupt file is left behind and the source dataset is
+  unmodified.

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -56,11 +56,33 @@ def write_jcamp(*args, **kwargs):
     return exporter(*args, **kwargs)
 
 
+def _check_dataset_supported(dataset):
+    """
+    Validate that ``dataset`` matches the JCAMP-DX model this writer supports.
+
+    The JCAMP writer requires a `y` coordinate describing the spectra axis and
+    cannot represent complex data. Both checks run before any file is created
+    or truncated and before any dataset attribute is modified.
+    """
+    try:
+        y_coord = dataset.y
+    except AttributeError:
+        y_coord = None
+    if y_coord is None:
+        raise ValueError(
+            "JCAMP export requires a `y` coordinate describing the spectra; "
+            "the dataset has no `y` coordinate.",
+        )
+    if dataset.data.dtype.kind == "c":
+        raise TypeError("JCAMP export does not support complex NDDataset data.")
+
+
 @exportermethod
 def _write_jcamp(*args, **kwargs):
     # Writes a dataset in JCAMP-DX format
 
     dataset, filename = args
+    _check_dataset_supported(dataset)
     dataset.filename = filename
 
     # Make JCAMP_DX file

--- a/tests/test_core/test_writers/test_write_jcamp.py
+++ b/tests/test_core/test_writers/test_write_jcamp.py
@@ -5,4 +5,126 @@
 # ======================================================================================
 # ruff: noqa
 
-# write test already performed in the est_read_jcamps"""
+import warnings
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+
+
+def _dataset_without_y():
+    x = scp.Coord(np.linspace(4000.0, 1000.0, 6), units="cm^-1", title="wavenumber")
+    ds = scp.NDDataset(np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]), coordset=[x])
+    ds.name = "no_y"
+    return ds
+
+
+def _dataset_with_y():
+    x = scp.Coord(np.linspace(4000.0, 1000.0, 6), units="cm^-1", title="wavenumber")
+    y = scp.Coord([0.0])
+    return scp.NDDataset(
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).reshape(1, 6),
+        coordset=[y, x],
+        units="absorbance",
+        name="valid_1d",
+    )
+
+
+def _complex_dataset_with_y():
+    x = scp.Coord([0.0, 1.0])
+    y = scp.Coord([0.0, 10.0])
+    return scp.NDDataset(
+        np.array([[1 + 2j, 2 + 1j], [3 + 0j, 4 + 1j]]),
+        coordset=[y, x],
+        name="complex",
+    )
+
+
+def test_write_jcamp_rejects_dataset_without_y_coordinate(tmp_path):
+    dataset = _dataset_without_y()
+    target = tmp_path / "no_y.jdx"
+    original_filename = dataset.filename
+
+    with pytest.raises(ValueError, match="`y` coordinate"):
+        dataset.write_jcamp(target, confirm=False)
+
+    assert not target.exists()
+    assert dataset.filename == original_filename
+
+
+def test_write_jcamp_rejects_dataset_without_y_keeps_existing_file(tmp_path):
+    dataset = _dataset_without_y()
+    target = tmp_path / "no_y.jdx"
+    target.write_text("SENTINEL")
+    original_filename = dataset.filename
+
+    with pytest.raises(ValueError, match="`y` coordinate"):
+        dataset.write_jcamp(target, confirm=False, overwrite=True)
+
+    assert target.read_text() == "SENTINEL"
+    assert dataset.filename == original_filename
+
+
+def test_write_jcamp_rejects_complex_data(tmp_path):
+    dataset = _complex_dataset_with_y()
+    target = tmp_path / "complex.jdx"
+    original_filename = dataset.filename
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=np.exceptions.ComplexWarning)
+        with pytest.raises(TypeError, match="does not support complex"):
+            dataset.write_jcamp(target, confirm=False)
+
+    assert not target.exists()
+    assert dataset.filename == original_filename
+
+
+def test_write_jcamp_rejects_complex_data_keeps_existing_file(tmp_path):
+    dataset = _complex_dataset_with_y()
+    target = tmp_path / "complex.jdx"
+    target.write_text("SENTINEL")
+    original_filename = dataset.filename
+
+    with pytest.raises(TypeError, match="does not support complex"):
+        dataset.write_jcamp(target, confirm=False, overwrite=True)
+
+    assert target.read_text() == "SENTINEL"
+    assert dataset.filename == original_filename
+
+
+def test_write_jcamp_generic_dispatch_applies_validation(tmp_path):
+    no_y = _dataset_without_y()
+    target = tmp_path / "dispatch.jdx"
+
+    with pytest.raises(ValueError, match="`y` coordinate"):
+        scp.write(no_y, target, confirm=False)
+
+    assert not target.exists()
+
+    complex_ds = _complex_dataset_with_y()
+    target = tmp_path / "dispatch_complex.jdx"
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=np.exceptions.ComplexWarning)
+        with pytest.raises(TypeError, match="does not support complex"):
+            scp.write(complex_ds, target, confirm=False)
+
+    assert not target.exists()
+
+
+def test_write_jcamp_valid_dataset_round_trip(tmp_path):
+    dataset = _dataset_with_y()
+
+    path = dataset.write_jcamp(tmp_path / "valid.jdx", confirm=False)
+
+    assert path.exists()
+    assert path.stat().st_size > 0
+    text = path.read_text()
+    assert "##JCAMP-DX=5.01" in text
+    assert "##DATA TYPE=INFRARED SPECTRUM" in text
+    assert "##XYDATA=(X++(Y..Y))" in text
+
+    back = scp.read_jcamp(path)
+    assert back.shape == (1, 6)
+    assert np.allclose(back.data, dataset.data)


### PR DESCRIPTION
## Description

The JCAMP writer accepts two currently invalid inputs and fails or corrupts
after the file has been opened:

1. a dataset without a `y` coordinate → `AttributeError` **after** opening the
   file, leaving a **partial header-only file** on disk;
2. complex data → headers receive complex strings while `int(ydata / yfactor)`
   silently truncates the XYDATA payload to the real part (numpy
   `ComplexWarning`), producing a **corrupt file**.

This PR adds explicit validation in `_write_jcamp` **before** any file is
created or truncated, and **before** the `dataset.filename` mutation:

- missing `y` coordinate → `ValueError`
  (`JCAMP export requires a `y` coordinate describing the spectra; the dataset
  has no `y` coordinate.`);
- complex data → `TypeError`
  (`JCAMP export does not support complex NDDataset data.`), consistent with
  the MATLAB writer.

The guard runs at the top of `_write_jcamp`, so it covers all entry points
(`scp.write_jcamp`, `dataset.write_jcamp`, `scp.jcamp.write`, generic
dispatch via `.jdx`/`.dx`) without touching the generic dispatch or any other
writer.

Valid JCAMP inputs keep exactly their previous behaviour (units, per-block
extrema, `YFACTOR`, masks, reader — all unchanged).

## Checklist

- [x] Tests have been added.
- [x] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
- [ ] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
- [x] Changelog entry is present (or label `no-changelog` is applied).
- [x] This PR changes runtime code, so `safe-docs-no-ci` has not been applied.