### PR TITLE
FIX: compute JCAMP LINK extrema per spectrum

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -38,6 +38,11 @@ Bug Fixes
   No partial or corrupt file is left behind and the source dataset is
   unmodified.
 
+- JCAMP `LINK` files now compute `FIRSTY`, `LASTY`, `MAXY` and `MINY`
+  separately for each spectrum block instead of repeating the first/global
+  extrema across all blocks. The scientific payload, singleton exports and
+  unit tags are unchanged.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -26,3 +26,8 @@ Bug Fixes
   with complex data (previously silently written with corrupted content).
   No partial or corrupt file is left behind and the source dataset is
   unmodified.
+
+- JCAMP `LINK` files now compute `FIRSTY`, `LASTY`, `MAXY` and `MINY`
+  separately for each spectrum block instead of repeating the first/global
+  extrema across all blocks. The scientific payload, singleton exports and
+  unit tags are unchanged.

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -152,8 +152,9 @@ def _write_jcamp(*args, **kwargs):
             fid.write(f"##MINX={minx:.6f}\n")
             fid.write(f"##XFACTOR={xfactor}\n")
 
-            firsty, lasty = ydata[0, 0], ydata[0, -1]
-            maxy, miny = np.nanmax(ydata), np.nanmin(ydata)
+            spectrum = ydata[i]
+            firsty, lasty = spectrum[0], spectrum[-1]
+            maxy, miny = np.nanmax(spectrum), np.nanmin(spectrum)
             yfactor = 1.0e-8
 
             fid.write(f"##FIRSTY={firsty:.6f}\n")

--- a/tests/test_core/test_writers/test_write_jcamp.py
+++ b/tests/test_core/test_writers/test_write_jcamp.py
@@ -6,11 +6,13 @@
 # ruff: noqa
 
 import warnings
+from datetime import datetime
 
 import numpy as np
 import pytest
 
 import spectrochempy as scp
+from spectrochempy.utils.datetimeutils import UTC
 
 
 def _dataset_without_y():
@@ -39,6 +41,63 @@ def _complex_dataset_with_y():
         coordset=[y, x],
         name="complex",
     )
+
+
+def _linked_dataset():
+    x = scp.Coord([4000.0, 3999.0, 3998.0, 3997.0], units="cm^-1", title="wavenumber")
+    y = scp.Coord([0.0, 1.0, 2.0])
+    y.labels = np.array(
+        [
+            [datetime(2024, 1, 1, 12, 0, tzinfo=UTC), "spec_a"],
+            [datetime(2024, 1, 1, 12, 1, tzinfo=UTC), "spec_b"],
+            [datetime(2024, 1, 1, 12, 2, tzinfo=UTC), "spec_c"],
+        ],
+        dtype=object,
+    )
+    ds = scp.NDDataset(
+        np.array(
+            [
+                [1.0, 5.0, np.nan, 2.0],
+                [7.0, -3.0, 4.0, 6.0],
+                [0.5, 8.0, -1.0, 9.0],
+            ],
+        ),
+        coordset=[y, x],
+        units="absorbance",
+        name="linked_extrema",
+    )
+    ds.mask = np.array(
+        [
+            [False, False, False, False],
+            [False, False, True, False],
+            [False, False, False, False],
+        ],
+        dtype=bool,
+    )
+    return ds
+
+
+def _parse_jcamp_blocks(text):
+    blocks = []
+    current = None
+    for line in text.splitlines():
+        if line.startswith("##TITLE="):
+            title = line.split("=", 1)[1]
+            if current and current.get("xydata"):
+                blocks.append(current)
+            current = {"TITLE": title, "xydata": []}
+            continue
+        if current is None:
+            continue
+        if line.startswith("##") and "=" in line:
+            key, value = line[2:].split("=", 1)
+            current[key] = value
+            continue
+        if line and not line.startswith("##"):
+            current["xydata"].append(line)
+    if current and current.get("xydata"):
+        blocks.append(current)
+    return blocks
 
 
 def test_write_jcamp_rejects_dataset_without_y_coordinate(tmp_path):
@@ -124,7 +183,94 @@ def test_write_jcamp_valid_dataset_round_trip(tmp_path):
     assert "##JCAMP-DX=5.01" in text
     assert "##DATA TYPE=INFRARED SPECTRUM" in text
     assert "##XYDATA=(X++(Y..Y))" in text
+    assert "##FIRSTY=1.000000" in text
+    assert "##LASTY=6.000000" in text
+    assert "##MAXY=6.000000" in text
+    assert "##MINY=1.000000" in text
+    assert "##XUNITS=1/CM" in text
+    assert "##YUNITS=ABSORBANCE" in text
 
     back = scp.read_jcamp(path)
     assert back.shape == (1, 6)
     assert np.allclose(back.data, dataset.data)
+
+
+def test_write_jcamp_link_extrema_are_computed_per_spectrum(tmp_path):
+    dataset = _linked_dataset()
+
+    specialized = dataset.write_jcamp(
+        tmp_path / "linked_specialized.jdx", confirm=False
+    )
+    generic = scp.write(dataset, tmp_path / "linked_generic.jdx", confirm=False)
+
+    specialized_text = specialized.read_text()
+    generic_text = generic.read_text()
+    specialized_blocks = _parse_jcamp_blocks(specialized_text)
+    generic_blocks = _parse_jcamp_blocks(generic_text)
+
+    assert [block["TITLE"] for block in specialized_blocks] == [
+        "spec_a",
+        "spec_b",
+        "spec_c",
+    ]
+    assert [block["TITLE"] for block in generic_blocks] == [
+        "spec_a",
+        "spec_b",
+        "spec_c",
+    ]
+
+    expected = [
+        {
+            "FIRSTY": "1.000000",
+            "LASTY": "2.000000",
+            "MAXY": "5.000000",
+            "MINY": "1.000000",
+        },
+        {
+            "FIRSTY": "7.000000",
+            "LASTY": "6.000000",
+            "MAXY": "7.000000",
+            "MINY": "-3.000000",
+        },
+        {
+            "FIRSTY": "0.500000",
+            "LASTY": "9.000000",
+            "MAXY": "9.000000",
+            "MINY": "-1.000000",
+        },
+    ]
+
+    assert len(specialized_blocks) == 3
+    assert len(generic_blocks) == 3
+
+    for block, expected_values in zip(specialized_blocks, expected, strict=True):
+        assert {key: block[key] for key in expected_values} == expected_values
+        assert block["XUNITS"] == "1/CM"
+        assert block["YUNITS"] == "ABSORBANCE"
+
+    for block, expected_values in zip(generic_blocks, expected, strict=True):
+        assert {key: block[key] for key in expected_values} == expected_values
+
+    assert [block["FIRSTY"] for block in specialized_blocks] != ["1.000000"] * 3
+    assert [block["LASTY"] for block in specialized_blocks] != ["2.000000"] * 3
+    assert [block["MAXY"] for block in specialized_blocks] != ["9.000000"] * 3
+    assert [block["MINY"] for block in specialized_blocks] != ["-3.000000"] * 3
+
+    for specialized_block, generic_block in zip(
+        specialized_blocks, generic_blocks, strict=True
+    ):
+        assert specialized_block["xydata"] == generic_block["xydata"]
+
+    back = scp.read_jcamp(specialized)
+    expected_data = np.array(
+        [
+            [1.0, 5.0, np.nan, 2.0],
+            [7.0, -3.0, np.nan, 6.0],
+            [0.5, 8.0, -1.0, 9.0],
+        ],
+    )
+    np.testing.assert_allclose(
+        np.nan_to_num(back.data, nan=0.0),
+        np.nan_to_num(expected_data, nan=0.0),
+    )
+    assert np.array_equal(np.isnan(back.data), np.isnan(expected_data))


### PR DESCRIPTION
## Summary

This PR fixes the JCAMP `LINK` writer so `FIRSTY`, `LASTY`, `MAXY`, and `MINY` are computed per spectrum block instead of repeating the first-spectrum or global extrema across every block.

## Out of scope

JCAMP unit tags remain unchanged and still use the current hardcoded `XUNITS=1/CM` and `YUNITS=ABSORBANCE` policy. This PR does not change `XYDATA` formatting, quantization, factors, generic writer dispatch, reader behavior, or the JCAMP safety guards added in #1505.

## Root cause

Inside `_write_jcamp()`, the writer iterated over spectra with `i` but still computed:

- `FIRSTY`/`LASTY` from `ydata[0, ...]`
- `MAXY`/`MINY` from `np.nanmax(ydata)` / `np.nanmin(ydata)`

As a result, every block in a `LINK` file repeated the first or global extrema instead of the current spectrum's extrema.

## What changed

- compute `FIRSTY` and `LASTY` from the current spectrum block
- compute `MAXY` and `MINY` from valid values in the current spectrum block only
- add regression coverage for multi-spectrum `LINK` exports, singleton exports, specialized writer coverage, and generic `.jdx` dispatch coverage

## Validation

- `micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_write_jcamp.py -q`
- `micromamba run -n scpy-core python -m pytest tests/test_core/test_readers/test_read_jcamp.py -q`
- `pre-commit run --all-files`
- `git diff --check`

## Notes

- The scientific payload is unchanged.
- Singleton JCAMP exports keep their previous behavior.
- This change follows the writer audit tracked in `spectrochempy_maintainer#15`.
