### PR TITLE
FIX: reject complex CSV data before writing

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -43,6 +43,10 @@ Bug Fixes
   extrema across all blocks. The scientific payload, singleton exports and
   unit tags are unchanged.
 
+- CSV export now rejects complex datasets before creating or truncating a file,
+  instead of writing complex-valued CSV content that SpectroChemPy cannot read
+  back correctly.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,3 +31,7 @@ Bug Fixes
   separately for each spectrum block instead of repeating the first/global
   extrema across all blocks. The scientific payload, singleton exports and
   unit tags are unchanged.
+
+- CSV export now rejects complex datasets before creating or truncating a file,
+  instead of writing complex-valued CSV content that SpectroChemPy cannot read
+  back correctly.

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -63,9 +63,22 @@ def write_csv(*args, **kwargs):
     return exporter(*args, **kwargs)
 
 
+def _check_dataset_supported(dataset):
+    """
+    Validate that ``dataset`` matches the CSV writer's supported data model.
+
+    The CSV writer cannot represent complex-valued payloads in a format that
+    SpectroChemPy can read back, so reject them before any write-side effect
+    such as filename mutation, squeezing, file creation, or truncation.
+    """
+    if dataset.data.dtype.kind == "c":
+        raise TypeError("CSV export does not support complex NDDataset data.")
+
+
 @exportermethod
 def _write_csv(*args, **kwargs):
     dataset, filename = args
+    _check_dataset_supported(dataset)
     dataset.filename = filename
 
     delimiter = kwargs.get("delimiter", prefs.csv_delimiter)

--- a/tests/test_core/test_writers/test_write_csv.py
+++ b/tests/test_core/test_writers/test_write_csv.py
@@ -24,6 +24,21 @@ def ds_2d_with_coords(ds_1d_with_coords):
     return scp.NDDataset(np.ones((3, 5)), coordset=[y_coord, coord])
 
 
+@pytest.fixture
+def ds_complex_no_coord():
+    return scp.NDDataset(np.array([1.0 + 2.0j, 2.0 + 1.0j, 3.0 + 0.5j]))
+
+
+@pytest.fixture
+def ds_complex_with_coord():
+    coord = scp.Coord(np.linspace(4000, 3998, 3), title="wavenumber", units="cm^-1")
+    return scp.NDDataset(
+        np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 0.25j]),
+        coordset=[coord],
+        name="complex_csv",
+    )
+
+
 def test_write_csv(mock_cwd):
     # 1D dataset without coords
     ds = scp.NDDataset([1, 2, 3])
@@ -82,3 +97,92 @@ def test_write_csv_masked_values(tmp_path):
     arr = np.asarray(back.data, dtype=float).ravel()
     assert np.isnan(arr[3:6]).all()
     assert np.isfinite(np.concatenate([arr[:3], arr[6:]])).all()
+
+
+def test_write_csv_rejects_complex_data_without_coord(tmp_path, ds_complex_no_coord):
+    target = tmp_path / "complex.csv"
+    original_filename = ds_complex_no_coord.filename
+
+    with pytest.raises(
+        TypeError,
+        match="CSV export does not support complex NDDataset data.",
+    ):
+        scp.write_csv(ds_complex_no_coord, target, confirm=False)
+
+    assert not target.exists()
+    assert ds_complex_no_coord.filename == original_filename
+
+
+def test_write_csv_rejects_complex_data_keeps_existing_file(
+    tmp_path, ds_complex_with_coord
+):
+    target = tmp_path / "complex.csv"
+    target.write_bytes(b"SENTINEL\n")
+    original_bytes = target.read_bytes()
+    original_filename = ds_complex_with_coord.filename
+
+    with pytest.raises(
+        TypeError,
+        match="CSV export does not support complex NDDataset data.",
+    ):
+        ds_complex_with_coord.write_csv(target, confirm=False, overwrite=True)
+
+    assert target.read_bytes() == original_bytes
+    assert ds_complex_with_coord.filename == original_filename
+
+
+def test_write_csv_namespace_dispatch_rejects_complex_data(
+    tmp_path, ds_complex_with_coord
+):
+    target = tmp_path / "complex_namespace.csv"
+    original_filename = ds_complex_with_coord.filename
+
+    with pytest.raises(
+        TypeError,
+        match="CSV export does not support complex NDDataset data.",
+    ):
+        scp.csv.write(ds_complex_with_coord, target, confirm=False)
+
+    assert not target.exists()
+    assert ds_complex_with_coord.filename == original_filename
+
+
+def test_write_csv_generic_dispatch_rejects_complex_data(
+    tmp_path, ds_complex_with_coord
+):
+    original_filename = ds_complex_with_coord.filename
+
+    for method_name, target_name in [
+        ("write", "complex_dataset_method.csv"),
+        ("scp.write", "complex_top_level.csv"),
+    ]:
+        target = tmp_path / target_name
+        with pytest.raises(
+            TypeError,
+            match="CSV export does not support complex NDDataset data.",
+        ):
+            if method_name == "write":
+                ds_complex_with_coord.write(target, confirm=False)
+            else:
+                scp.write(ds_complex_with_coord, target, confirm=False)
+        assert not target.exists()
+        assert ds_complex_with_coord.filename == original_filename
+
+
+def test_write_csv_valid_real_round_trip_still_works(tmp_path, ds_1d_with_coords):
+    dataset = ds_1d_with_coords.copy()
+    dataset.title = "absorbance"
+    dataset.units = "absorbance"
+    dataset.name = "real_csv"
+
+    path = scp.write_csv(dataset, tmp_path / "real.csv", confirm=False)
+
+    assert path.exists()
+    assert dataset.filename == path
+    text = path.read_text()
+    assert "wavenumber / cm^-1,absorbance / a.u." in text
+
+    back = scp.read_csv(path)
+    assert back.shape == (1, 5)
+    np.testing.assert_allclose(back.data.ravel(), dataset.data)
+    np.testing.assert_allclose(back.x.data, dataset.x.data)


### PR DESCRIPTION
## Summary

This PR makes the CSV writer reject complex `NDDataset` payloads before any write-side effect.

## Starting point

- Starting `master` SHA: `26b3fa7ac3bb084de0214cce281071f0388ec118`
- Verified in ancestry before the change:
  - `spectrochempy#1505` at `d5e9d39fe89e604df87af1dd39405de418ed29ad`
  - `spectrochempy#1506` at `26b3fa7ac3bb084de0214cce281071f0388ec118`

## Pre-fix failure mode

Before this change, CSV export accepted complex data, wrote Python complex strings such as `(1+2j)`, mutated `dataset.filename`, created or truncated the destination file, and then produced CSV content that `read_csv()` could not reconstruct.

## What changed

- add a shared CSV writer guard in `_write_csv()`
- raise `TypeError` with the exact message:
  `CSV export does not support complex NDDataset data.`
- run that validation before:
  - `dataset.filename` mutation
  - dimensionality squeezing/transformation
  - new-file creation
  - existing-file truncation

## API entry paths covered

The shared validation covers:

- `scp.write_csv(dataset, path)`
- `dataset.write_csv(path)`
- `scp.csv.write(dataset, path)`
- `scp.write(dataset, path.csv)`
- `dataset.write(path.csv)`

## Safety and preserved behavior

- rejecting a complex export to a nonexistent path leaves no file behind
- rejecting a complex export to an existing path with `overwrite=True` preserves the original bytes unchanged
- `dataset.filename` remains unchanged after rejection
- valid real-valued CSV export remains unchanged
- a valid real-valued CSV round-trip still works

## Validation

- `micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_write_csv.py -q`
- `micromamba run -n scpy-core python -m pytest tests/test_core/test_readers/test_read_csv.py -q`
- `micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_exporter.py -q`
- `pre-commit run --all-files`
- `git diff --check`

## Out of scope

- CSV formatting and delimiter behavior
- CSV reader parsing rules
- CSV metadata preservation
- masked-value handling
- `(1, n)` singleton squeezing
- dimensionality restrictions
- generic exporter dispatch behavior
- `protocol` / `description` kwargs
- JCAMP units
- `.scp` history persistence
- JCAMP, MATLAB, and `.scp` writer behavior
