### PR TITLE
FIX: align JCAMP writer unit tags with exact-scale units

### DIFF
--- a/docs/sources/userguide/importexport/importJCAMPDX.py
+++ b/docs/sources/userguide/importexport/importJCAMPDX.py
@@ -76,6 +76,17 @@ newS0
 # It is important to note here that the conversion to JCAMP-DX changes the last digits
 # of absorbance and wavenumbers:
 
+# %% [markdown]
+# The writer preserves the numeric values it writes. It does not silently convert
+# wavelength to wavenumber or transmittance to absorbance. Current export support
+# is therefore limited to exact-scale JCAMP mappings:
+#
+# - x: `cm^-1`, `um`, `nm`, or no unit (`ARBITRARY UNITS`);
+# - y: `absorbance`, `transmittance`, or no unit (`ARBITRARY UNITS`).
+#
+# Other merely convertible or named arbitrary units are rejected until you
+# convert them explicitly before export.
+
 
 # %%
 from spectrochempy.utils.compare import difference

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -43,6 +43,13 @@ Bug Fixes
   extrema across all blocks. The scientific payload, singleton exports and
   unit tags are unchanged.
 
+- JCAMP writing now emits truthful `XUNITS` / `YUNITS` tags instead of always
+  claiming `1/CM` and `ABSORBANCE`. The writer preserves numeric values
+  unchanged, accepts only exact-scale mappings (`cm^-1`, `um`, `nm`,
+  `absorbance`, `transmittance`, or no unit), rejects merely convertible or
+  named arbitrary units such as `m^-1`, `dimensionless`, and `count`, and the
+  reader now maps `YUNITS=ARBITRARY UNITS` back to `dataset.units = None`.
+
 - CSV export now rejects complex datasets before creating or truncating a file,
   instead of writing complex-valued CSV content that SpectroChemPy cannot read
   back correctly.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -32,6 +32,13 @@ Bug Fixes
   extrema across all blocks. The scientific payload, singleton exports and
   unit tags are unchanged.
 
+- JCAMP writing now emits truthful `XUNITS` / `YUNITS` tags instead of always
+  claiming `1/CM` and `ABSORBANCE`. The writer preserves numeric values
+  unchanged, accepts only exact-scale mappings (`cm^-1`, `um`, `nm`,
+  `absorbance`, `transmittance`, or no unit), rejects merely convertible or
+  named arbitrary units such as `m^-1`, `dimensionless`, and `count`, and the
+  reader now maps `YUNITS=ARBITRARY UNITS` back to `dataset.units = None`.
+
 - CSV export now rejects complex datasets before creating or truncating a file,
   instead of writing complex-valued CSV content that SpectroChemPy cannot read
   back correctly.

--- a/src/spectrochempy/core/readers/read_jcamp.py
+++ b/src/spectrochempy/core/readers/read_jcamp.py
@@ -364,6 +364,10 @@ def _read_jdx(*args, **kwargs):
     elif yunits[0].strip() == "TRANSMITTANCE":
         dataset.units = "transmittance"
         dataset.title = "transmittance"
+    elif yunits[0].strip() == "ARBITRARY UNITS":
+        # The JCAMP token describes a unitless/arbitrary ordinate. Keep the
+        # dataset units unset and do not synthesize a title from the token.
+        dataset._units = None
 
     # now add coordinates
     _x = Coord(xaxis, title=axisname, units=axisunit)

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 import numpy as np
 
+from spectrochempy.core.units import ur
 from spectrochempy.core.writers.exporter import Exporter
 from spectrochempy.core.writers.exporter import exportermethod
 from spectrochempy.utils.datetimeutils import UTC
@@ -77,12 +78,60 @@ def _check_dataset_supported(dataset):
         raise TypeError("JCAMP export does not support complex NDDataset data.")
 
 
+def _format_unit(unit):
+    return "None" if unit is None else str(unit)
+
+
+def _unit_matches_exact_scale(unit, canonical_unit):
+    """
+    Return ``True`` only for exact-scale aliases of ``canonical_unit``.
+
+    This intentionally relies on unit identity/equality, not generic
+    dimensional compatibility or convertibility: values written by the JCAMP
+    writer must not be implicitly rescaled.
+    """
+    return unit is not None and unit == ur.Unit(canonical_unit)
+
+
+def _jcamp_xunits_token(dataset):
+    x = dataset.x
+    if x.unitless:
+        return "ARBITRARY UNITS"
+    if _unit_matches_exact_scale(x.units, "cm^-1"):
+        return "1/CM"
+    if _unit_matches_exact_scale(x.units, "um"):
+        return "MICROMETERS"
+    if _unit_matches_exact_scale(x.units, "nm"):
+        return "NANOMETERS"
+    raise ValueError(
+        "JCAMP export only supports x coordinates with the exact numeric scale "
+        "of cm^-1, um/µm, nm, or no unit. "
+        f"Got x units {_format_unit(x.units)!r}. Convert explicitly before export.",
+    )
+
+
+def _jcamp_yunits_token(dataset):
+    if dataset.unitless:
+        return "ARBITRARY UNITS"
+    if _unit_matches_exact_scale(dataset.units, "absorbance"):
+        return "ABSORBANCE"
+    if _unit_matches_exact_scale(dataset.units, "transmittance"):
+        return "TRANSMITTANCE"
+    raise ValueError(
+        "JCAMP export only supports y units absorbance, transmittance, or no "
+        f"unit. Got y units {_format_unit(dataset.units)!r}. Convert explicitly "
+        "before export.",
+    )
+
+
 @exportermethod
 def _write_jcamp(*args, **kwargs):
     # Writes a dataset in JCAMP-DX format
 
     dataset, filename = args
     _check_dataset_supported(dataset)
+    xunits_token = _jcamp_xunits_token(dataset)
+    yunits_token = _jcamp_yunits_token(dataset)
     dataset.filename = filename
 
     # Make JCAMP_DX file
@@ -139,8 +188,8 @@ def _write_jcamp(*args, **kwargs):
             fid.write(f"##LONGDATE={timestamp.strftime('%Y/%m/%d')}\n")
             fid.write(f"##TIME={timestamp.strftime('%H:%M:%S')}\n")
 
-            fid.write("##XUNITS=1/CM\n")
-            fid.write("##YUNITS=ABSORBANCE\n")
+            fid.write(f"##XUNITS={xunits_token}\n")
+            fid.write(f"##YUNITS={yunits_token}\n")
 
             firstx, lastx = dataset.x.data[0], dataset.x.data[-1]
             maxx, minx = max(firstx, lastx), min(firstx, lastx)

--- a/tests/test_core/test_readers/test_read_jcamp.py
+++ b/tests/test_core/test_readers/test_read_jcamp.py
@@ -153,6 +153,26 @@ def test_read_jcamp_transmittance_units():
     assert ds.units == "transmittance"
 
 
+def test_read_jcamp_arbitrary_yunits_leave_units_unset_and_title_default():
+    jdx = """##TITLE=arbitrary_test
+##JCAMP-DX=5.01
+##DATA TYPE=INFRARED SPECTRUM
+##XUNITS=1/CM
+##YUNITS=ARBITRARY UNITS
+##FIRSTX=4000.0
+##LASTX=3996.0
+##XFACTOR=1.0
+##YFACTOR=1.0
+##NPOINTS=4
+##XYDATA=(X++(Y..Y))
+4000.0 90.0 85.0 80.0 75.0
+##END
+"""
+    ds = read_jcamp({"arbitrary_test.jdx": jdx.encode("utf8")})
+    assert ds.units is None
+    assert ds.title == "<untitled>"
+
+
 def test_read_jcamp_header_value_with_equals():
     # A header value containing "=" (e.g. a sample id) must not break the
     # ``keyword=text`` split (#1150): the parser now splits on the first "="

--- a/tests/test_core/test_writers/test_write_jcamp.py
+++ b/tests/test_core/test_writers/test_write_jcamp.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 import spectrochempy as scp
+from spectrochempy.core.units import ur
 from spectrochempy.utils.datetimeutils import UTC
 
 
@@ -30,6 +31,17 @@ def _dataset_with_y():
         coordset=[y, x],
         units="absorbance",
         name="valid_1d",
+    )
+
+
+def _single_spectrum_dataset(*, x_units="cm^-1", y_units="absorbance"):
+    x = scp.Coord(np.linspace(4000.0, 1000.0, 6), units=x_units, title="x")
+    y = scp.Coord([0.0])
+    return scp.NDDataset(
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).reshape(1, 6),
+        coordset=[y, x],
+        units=y_units,
+        name="single_policy",
     )
 
 
@@ -195,6 +207,126 @@ def test_write_jcamp_valid_dataset_round_trip(tmp_path):
     assert np.allclose(back.data, dataset.data)
 
 
+@pytest.mark.parametrize(
+    ("x_units", "expected_token", "output_stem", "expected_readback_unit"),
+    [
+        ("cm^-1", "1/CM", "cm_inv", "cm^-1"),
+        ("1/cm", "1/CM", "one_per_cm", "cm^-1"),
+        ("um", "MICROMETERS", "micrometers", "um"),
+        ("nm", "NANOMETERS", "nanometers", "nm"),
+    ],
+)
+def test_write_jcamp_emits_truthful_xunits_for_exact_scale_inputs(
+    tmp_path, x_units, expected_token, output_stem, expected_readback_unit
+):
+    dataset = _single_spectrum_dataset(x_units=x_units, y_units="absorbance")
+
+    path = dataset.write_jcamp(tmp_path / f"{output_stem}.jdx", confirm=False)
+    text = path.read_text()
+
+    assert f"##XUNITS={expected_token}" in text
+    back = scp.read_jcamp(path)
+    assert np.allclose(back.x.data, dataset.x.data)
+    assert back.x.units == ur.Unit(expected_readback_unit)
+
+
+def test_write_jcamp_emits_arbitrary_units_for_unitless_x(tmp_path):
+    dataset = _single_spectrum_dataset(x_units=None, y_units="absorbance")
+
+    path = dataset.write_jcamp(tmp_path / "unitless_x.jdx", confirm=False)
+    text = path.read_text()
+
+    assert "##XUNITS=ARBITRARY UNITS" in text
+    back = scp.read_jcamp(path)
+    assert back.x.units is None
+    assert back.x.title == "arbitrary unit"
+    assert np.allclose(back.x.data, dataset.x.data)
+
+
+@pytest.mark.parametrize(
+    ("y_units", "expected_token", "expected_readback_unit", "expected_title"),
+    [
+        ("absorbance", "ABSORBANCE", "absorbance", "absorbance"),
+        ("transmittance", "TRANSMITTANCE", "transmittance", "transmittance"),
+    ],
+)
+def test_write_jcamp_emits_truthful_yunits_for_supported_inputs(
+    tmp_path, y_units, expected_token, expected_readback_unit, expected_title
+):
+    dataset = _single_spectrum_dataset(x_units="cm^-1", y_units=y_units)
+
+    path = dataset.write_jcamp(tmp_path / f"{expected_token}.jdx", confirm=False)
+    text = path.read_text()
+
+    assert f"##YUNITS={expected_token}" in text
+    back = scp.read_jcamp(path)
+    assert np.allclose(back.data, dataset.data)
+    assert back.units == expected_readback_unit
+    assert back.title == expected_title
+
+
+def test_write_jcamp_emits_arbitrary_units_for_unitless_y(tmp_path):
+    dataset = _single_spectrum_dataset(x_units="cm^-1", y_units=None)
+
+    path = dataset.write_jcamp(tmp_path / "unitless_y.jdx", confirm=False)
+    text = path.read_text()
+
+    assert "##YUNITS=ARBITRARY UNITS" in text
+    back = scp.read_jcamp(path)
+    assert np.allclose(back.data, dataset.data)
+    assert back.units is None
+    assert back.title == "<untitled>"
+
+
+@pytest.mark.parametrize(("x_units"), ["m^-1", "Hz", "dimensionless"])
+def test_write_jcamp_rejects_unsupported_x_units_before_file_creation(
+    tmp_path, x_units
+):
+    dataset = _single_spectrum_dataset(x_units=x_units, y_units="absorbance")
+    target = tmp_path / "bad_x.jdx"
+    original_filename = dataset.filename
+
+    with pytest.raises(ValueError, match="exact numeric scale"):
+        dataset.write_jcamp(target, confirm=False)
+
+    assert not target.exists()
+    assert dataset.filename == original_filename
+
+
+@pytest.mark.parametrize(
+    ("y_units"), ["count", "dimensionless", "absolute_transmittance"]
+)
+def test_write_jcamp_rejects_unsupported_y_units_before_file_creation(
+    tmp_path, y_units
+):
+    dataset = _single_spectrum_dataset(x_units="cm^-1", y_units=y_units)
+    target = tmp_path / "bad_y.jdx"
+    original_filename = dataset.filename
+
+    with pytest.raises(ValueError, match="only supports y units"):
+        dataset.write_jcamp(target, confirm=False)
+
+    assert not target.exists()
+    assert dataset.filename == original_filename
+
+
+def test_write_jcamp_generic_dispatch_applies_unit_policy(tmp_path):
+    x_none_y_none = _single_spectrum_dataset(x_units=None, y_units=None)
+
+    target = scp.write(x_none_y_none, tmp_path / "generic_policy.jdx", confirm=False)
+    text = target.read_text()
+    assert "##XUNITS=ARBITRARY UNITS" in text
+    assert "##YUNITS=ARBITRARY UNITS" in text
+
+    rejected = _single_spectrum_dataset(x_units="m^-1", y_units="absorbance")
+    bad_target = tmp_path / "generic_bad.jdx"
+
+    with pytest.raises(ValueError, match="exact numeric scale"):
+        scp.write(rejected, bad_target, confirm=False)
+
+    assert not bad_target.exists()
+
+
 def test_write_jcamp_link_extrema_are_computed_per_spectrum(tmp_path):
     dataset = _linked_dataset()
 
@@ -274,3 +406,29 @@ def test_write_jcamp_link_extrema_are_computed_per_spectrum(tmp_path):
         np.nan_to_num(expected_data, nan=0.0),
     )
     assert np.array_equal(np.isnan(back.data), np.isnan(expected_data))
+
+
+def test_write_jcamp_link_uses_same_unit_policy_as_singletons(tmp_path):
+    x = scp.Coord([1.0, 2.0, 3.0, 4.0], units=None, title="x")
+    y = scp.Coord([0.0, 1.0])
+    y.labels = np.array(
+        [
+            [datetime(2024, 1, 1, 12, 0, tzinfo=UTC), "spec_a"],
+            [datetime(2024, 1, 1, 12, 1, tzinfo=UTC), "spec_b"],
+        ],
+        dtype=object,
+    )
+    dataset = scp.NDDataset(
+        np.array([[1.0, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0]]),
+        coordset=[y, x],
+        units=None,
+        name="linked_policy",
+    )
+
+    path = dataset.write_jcamp(tmp_path / "linked_policy.jdx", confirm=False)
+    blocks = _parse_jcamp_blocks(path.read_text())
+
+    assert len(blocks) == 2
+    for block in blocks:
+        assert block["XUNITS"] == "ARBITRARY UNITS"
+        assert block["YUNITS"] == "ARBITRARY UNITS"

--- a/tests/test_core/test_writers/test_write_jcamp.py
+++ b/tests/test_core/test_writers/test_write_jcamp.py
@@ -293,6 +293,22 @@ def test_write_jcamp_rejects_unsupported_x_units_before_file_creation(
     assert dataset.filename == original_filename
 
 
+@pytest.mark.parametrize(("x_units"), ["m^-1", "Hz", "dimensionless"])
+def test_write_jcamp_rejects_unsupported_x_units_keeps_existing_file(
+    tmp_path, x_units
+):
+    dataset = _single_spectrum_dataset(x_units=x_units, y_units="absorbance")
+    target = tmp_path / "bad_x_existing.jdx"
+    target.write_text("SENTINEL")
+    original_filename = dataset.filename
+
+    with pytest.raises(ValueError, match="exact numeric scale"):
+        dataset.write_jcamp(target, confirm=False, overwrite=True)
+
+    assert target.read_text() == "SENTINEL"
+    assert dataset.filename == original_filename
+
+
 @pytest.mark.parametrize(
     ("y_units"), ["count", "dimensionless", "absolute_transmittance"]
 )
@@ -307,6 +323,24 @@ def test_write_jcamp_rejects_unsupported_y_units_before_file_creation(
         dataset.write_jcamp(target, confirm=False)
 
     assert not target.exists()
+    assert dataset.filename == original_filename
+
+
+@pytest.mark.parametrize(
+    ("y_units"), ["count", "dimensionless", "absolute_transmittance"]
+)
+def test_write_jcamp_rejects_unsupported_y_units_keeps_existing_file(
+    tmp_path, y_units
+):
+    dataset = _single_spectrum_dataset(x_units="cm^-1", y_units=y_units)
+    target = tmp_path / "bad_y_existing.jdx"
+    target.write_text("SENTINEL")
+    original_filename = dataset.filename
+
+    with pytest.raises(ValueError, match="only supports y units"):
+        dataset.write_jcamp(target, confirm=False, overwrite=True)
+
+    assert target.read_text() == "SENTINEL"
     assert dataset.filename == original_filename
 
 

--- a/tests/test_core/test_writers/test_write_jcamp.py
+++ b/tests/test_core/test_writers/test_write_jcamp.py
@@ -294,9 +294,7 @@ def test_write_jcamp_rejects_unsupported_x_units_before_file_creation(
 
 
 @pytest.mark.parametrize(("x_units"), ["m^-1", "Hz", "dimensionless"])
-def test_write_jcamp_rejects_unsupported_x_units_keeps_existing_file(
-    tmp_path, x_units
-):
+def test_write_jcamp_rejects_unsupported_x_units_keeps_existing_file(tmp_path, x_units):
     dataset = _single_spectrum_dataset(x_units=x_units, y_units="absorbance")
     target = tmp_path / "bad_x_existing.jdx"
     target.write_text("SENTINEL")
@@ -329,9 +327,7 @@ def test_write_jcamp_rejects_unsupported_y_units_before_file_creation(
 @pytest.mark.parametrize(
     ("y_units"), ["count", "dimensionless", "absolute_transmittance"]
 )
-def test_write_jcamp_rejects_unsupported_y_units_keeps_existing_file(
-    tmp_path, y_units
-):
+def test_write_jcamp_rejects_unsupported_y_units_keeps_existing_file(tmp_path, y_units):
     dataset = _single_spectrum_dataset(x_units="cm^-1", y_units=y_units)
     target = tmp_path / "bad_y_existing.jdx"
     target.write_text("SENTINEL")


### PR DESCRIPTION
## Summary
- replace the JCAMP writer's hardcoded `XUNITS` / `YUNITS` tags with truthful exact-scale mappings
- reject unsupported or merely convertible x/y units before any file creation or `dataset.filename` mutation
- align the reader, tests, user guide note, and release notes with the accepted maintainer unit-policy RFC

## Root cause
`write_jcamp.py` always emitted `##XUNITS=1/CM` and `##YUNITS=ABSORBANCE` while preserving the numeric values it wrote. That produced scientifically misleading files whenever the source dataset was not already on the exact `cm^-1` / `absorbance` scale.

## What changed
- writer
  - keeps the existing no-`y` / no-complex safety guard
  - adds exact-scale unit validation before `dataset.filename` mutation and before file creation/truncation
  - emits:
    - `1/CM` only for exact-scale `cm^-1` aliases
    - `MICROMETERS` only for exact-scale `um` / `µm` aliases
    - `NANOMETERS` only for exact-scale `nm` aliases
    - `ARBITRARY UNITS` only for `units is None`
    - `ABSORBANCE` only for absorbance
    - `TRANSMITTANCE` only for transmittance
  - rejects merely convertible or named arbitrary units such as `m^-1`, `Hz`, `dimensionless`, `count`, and `absolute_transmittance`
- reader
  - maps `YUNITS=ARBITRARY UNITS` back to `dataset.units = None`
  - leaves the title at the reader default instead of synthesizing one from that token
- tests
  - add truthful token, rejection, generic-dispatch, singleton, and `LINK` coverage for the unit policy
  - add explicit reader coverage for `YUNITS=ARBITRARY UNITS`
- docs
  - update the JCAMP user guide note
  - add a changelog entry and regenerate `docs/sources/whatsnew/latest.rst`

## Impact
New JCAMP exports are now truthful about the numeric scales they declare. Valid inputs keep their numeric values unchanged; unsupported units fail early with clear errors instead of being mislabeled.

## Audited / decision context
- public starting SHA: `686e0b1d26c36b8aa4d0864e8e63781ba013afd5`
- maintainer decision RFC: `spectrochempy_maintainer/rfcs/jcamp-writer-unit-policy.md`
- related merged fixes already on `master`:
  - `#1505` `d5e9d39fe89e604df87af1dd39405de418ed29ad`
  - `#1506` `26b3fa7ac3bb084de0214cce281071f0388ec118`
  - `#1507` `686e0b1d26c36b8aa4d0864e8e63781ba013afd5`

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_write_jcamp.py tests/test_core/test_readers/test_read_jcamp.py`
  - 32 passed
- `git diff --check`
- `micromamba run -n scpy-core python .github/workflows/scripts/update_version_and_release_notes.py`
- attempted `micromamba run -n scpy-core python docs/make.py --whatsnew --no-sync`
  - this hit an unrelated existing gallery failure in `plot_iris_intro.py`, so I used the dedicated release-notes workflow script to regenerate `latest.rst`

## Files changed
- `src/spectrochempy/core/writers/write_jcamp.py`
- `src/spectrochempy/core/readers/read_jcamp.py`
- `tests/test_core/test_writers/test_write_jcamp.py`
- `tests/test_core/test_readers/test_read_jcamp.py`
- `docs/sources/userguide/importexport/importJCAMPDX.py`
- `docs/sources/whatsnew/changelog.rst`
- `docs/sources/whatsnew/latest.rst`

## Out of scope
- dead `protocol` / `description` kwargs
- `.scp` history persistence
- broader writer normalization work