### PR TITLE
MAINT: deprecate dead writer protocol and description kwargs

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -75,6 +75,12 @@ Deprecations
 ~~~~~~~~~~~~
 .. Add here new deprecations (do not delete this comment)
 
+- Writer kwargs `protocol=` and `description=` are now deprecated across the
+  generic, specialized and namespace writer APIs. Writer dispatch continues to
+  be determined only by the filename suffix, exported description metadata
+  continues to come from `dataset.description`, and passing either kwarg will
+  raise `TypeError` in `0.13.0`.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -42,3 +42,12 @@ Bug Fixes
 - CSV export now rejects complex datasets before creating or truncating a file,
   instead of writing complex-valued CSV content that SpectroChemPy cannot read
   back correctly.
+
+Deprecations
+~~~~~~~~~~~~
+
+- Writer kwargs `protocol=` and `description=` are now deprecated across the
+  generic, specialized and namespace writer APIs. Writer dispatch continues to
+  be determined only by the filename suffix, exported description metadata
+  continues to come from `dataset.description`, and passing either kwarg will
+  raise `TypeError` in `0.13.0`.

--- a/src/spectrochempy/core/writers/exporter.py
+++ b/src/spectrochempy/core/writers/exporter.py
@@ -8,6 +8,8 @@
 __all__ = ["write"]
 __dataset_methods__ = __all__
 
+import warnings
+
 from traitlets import Any
 from traitlets import HasTraits
 
@@ -15,6 +17,27 @@ from spectrochempy.core.readers.filetypes import registry
 from spectrochempy.utils.file import check_filename_to_save
 from spectrochempy.utils.file import pathclean
 from spectrochempy.utils.file import patterns
+
+
+def _warn_deprecated_writer_kwargs(kwargs):
+    if "protocol" in kwargs:
+        warnings.warn(
+            "Writer keyword argument `protocol` is deprecated and will be "
+            "removed in 0.13.0. Writer dispatch is determined by the filename "
+            "suffix or by using an explicit specialized / namespaced writer "
+            "API; `protocol=` does not select the writer.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+    if "description" in kwargs:
+        warnings.warn(
+            "Writer keyword argument `description` is deprecated and will be "
+            "removed in 0.13.0. Exported description metadata comes from "
+            "`dataset.description`, not from a write-time `description=` "
+            "override.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
 
 
 # --------------------------------------------------------------------------------------
@@ -34,6 +57,7 @@ class Exporter(HasTraits):
         args = self._setup_object(*args)
 
         try:
+            _warn_deprecated_writer_kwargs(kwargs)
             if "filetypes" not in kwargs:
                 kwargs["filetypes"] = list(self.filetypes.values())
                 if args and args[0] is not None:  # filename
@@ -119,12 +143,16 @@ def write(dataset, filename=None, **kwargs):
     Other Parameters
     ----------------
     protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
-        Protocol used for writing. If not provided, the correct protocol
-        is inferred (whenever it is possible) from the file name extension.
+        Deprecated. Writer dispatch is determined by the file name extension or
+        by using an explicit specialized writer API. Passing `protocol=` emits
+        a `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
     directory : str, optional
         Where to write the specified `filename` . If not specified, write in the current directory.
     description: str, optional
-        A Custom description.
+        Deprecated. Exported description metadata comes from
+        `dataset.description`, not from a write-time override. Passing
+        `description=` emits a `DeprecationWarning` in 0.12 and will raise
+        `TypeError` in 0.13.0.
     csv_delimiter : str, optional
         Set the column delimiter in CSV file.
         By default it is the one set in SpectroChemPy `Preferences` .

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -31,14 +31,14 @@ def write_csv(*args, **kwargs):
         If not provided, a dialog is opened to select a file for writing.
     directory : str, optional
         Where to write the specified `filename` . If not specified, write in the current directory.
-    description: str, optional
-        A Custom description.
     delimiter : str, optional
         Set the column delimiter in CSV file.
         By default it is ',' or the one set in SpectroChemPy `Preferences` .
     **kwargs
         Additional keyword arguments accepted by the generic writer API.
-        This specialized writer always exports CSV files.
+        This specialized writer always exports CSV files. Deprecated generic
+        writer kwargs such as `protocol=` and `description=` still emit a
+        `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
 
     Returns
     -------

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -31,11 +31,11 @@ def write_jcamp(*args, **kwargs):
         If not provided, a dialog is opened to select a file for writing.
     directory : str, optional
         Where to write the specified `filename` . If not specified, write in the current directory.
-    description: str, optional
-        A Custom description.
     **kwargs
         Additional keyword arguments accepted by the generic writer API.
-        This specialized writer always exports JCAMP-DX files.
+        This specialized writer always exports JCAMP-DX files. Deprecated
+        generic writer kwargs such as `protocol=` and `description=` still emit
+        a `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
 
     Returns
     -------

--- a/src/spectrochempy/core/writers/write_matlab.py
+++ b/src/spectrochempy/core/writers/write_matlab.py
@@ -29,7 +29,9 @@ def write_matlab(*args, **kwargs):
         If not provided, a dialog is opened to select a file for writing.
     **kwargs
         Additional keyword arguments accepted by the generic writer API.
-        This specialized writer always exports MATLAB `.mat` files.
+        This specialized writer always exports MATLAB `.mat` files. Deprecated
+        generic writer kwargs such as `protocol=` and `description=` still emit
+        a `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
 
     Returns
     -------

--- a/tests/test_core/test_writers/test_exporter.py
+++ b/tests/test_core/test_writers/test_exporter.py
@@ -5,11 +5,13 @@
 # ======================================================================================
 # ruff: noqa
 
+from pathlib import Path
+
 import pytest
+from spectrochempy.utils import testing
 
 import spectrochempy as scp
 from spectrochempy.core.dataset.nddataset import NDDataset
-from spectrochempy.utils import testing
 
 
 def test_write(mock_cwd, ndataset_1d):
@@ -66,6 +68,48 @@ def test_write_xls_uses_unsupported_format_path(ndataset_1d):
 
     with pytest.raises(ValueError, match=r"Unsupported export format `\.xls`"):
         nd.write("unsupported.xls", overwrite=True)
+
+
+def test_generic_write_protocol_kwarg_warns_but_keeps_default_scp_save(
+    mock_cwd, ndataset_1d
+):
+    nd = ndataset_1d.copy()
+    nd.name = "synthetic"
+    target = Path("synthetic.scp")
+    if target.exists():
+        target.unlink()
+
+    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated"):
+        filename = scp.write(nd, protocol="csv")
+
+    assert filename.stem == "synthetic"
+    assert filename.suffix == ".scp"
+    assert filename.exists()
+
+    nd2 = NDDataset.load(filename)
+    testing.assert_dataset_equal(nd2, nd)
+    filename.unlink()
+
+
+def test_generic_write_description_kwarg_warns_but_uses_dataset_description(
+    tmp_path, ndataset_1d
+):
+    nd = ndataset_1d.copy()
+    nd.name = "synthetic"
+    nd.description = "source description"
+    original_description = nd.description
+
+    target = tmp_path / "synthetic.scp"
+
+    with pytest.warns(DeprecationWarning, match="`description` is deprecated"):
+        filename = scp.write(nd, target, description="custom", confirm=False)
+
+    assert filename == target
+    assert filename.exists()
+    assert nd.description == original_description
+
+    reloaded = NDDataset.load(filename)
+    assert reloaded.description == "source description"
 
 
 # EOF

--- a/tests/test_core/test_writers/test_write_csv.py
+++ b/tests/test_core/test_writers/test_write_csv.py
@@ -186,3 +186,53 @@ def test_write_csv_valid_real_round_trip_still_works(tmp_path, ds_1d_with_coords
     assert back.shape == (1, 5)
     np.testing.assert_allclose(back.data.ravel(), dataset.data)
     np.testing.assert_allclose(back.x.data, dataset.x.data)
+
+
+@pytest.mark.parametrize("api", ["method", "namespace"])
+def test_write_csv_deprecated_protocol_warns_and_still_writes_csv(
+    tmp_path, ds_1d_with_coords, api
+):
+    dataset = ds_1d_with_coords.copy()
+    dataset.title = "absorbance"
+    dataset.units = "absorbance"
+    dataset.name = f"real_csv_{api}"
+    target = tmp_path / f"{api}.csv"
+
+    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated"):
+        if api == "method":
+            path = dataset.write_csv(target, protocol="matlab", confirm=False)
+        else:
+            path = scp.csv.write(dataset, target, protocol="matlab", confirm=False)
+
+    assert path == target
+    assert path.suffix == ".csv"
+    text = path.read_text()
+    assert "wavenumber / cm^-1,absorbance / a.u." in text
+
+    back = scp.read_csv(path)
+    np.testing.assert_allclose(back.data.ravel(), dataset.data)
+    np.testing.assert_allclose(back.x.data, dataset.x.data)
+
+
+@pytest.mark.parametrize("api", ["method", "namespace"])
+def test_write_csv_deprecated_description_warns_without_overriding_export(
+    tmp_path, ds_1d_with_coords, api
+):
+    dataset = ds_1d_with_coords.copy()
+    dataset.title = "absorbance"
+    dataset.units = "absorbance"
+    dataset.name = f"real_csv_{api}"
+    dataset.description = "source description"
+    target = tmp_path / f"{api}.csv"
+
+    with pytest.warns(DeprecationWarning, match="`description` is deprecated"):
+        if api == "method":
+            path = dataset.write_csv(target, description="custom", confirm=False)
+        else:
+            path = scp.csv.write(dataset, target, description="custom", confirm=False)
+
+    assert path == target
+    assert dataset.description == "source description"
+    text = path.read_text()
+    assert "custom" not in text
+    assert "source description" not in text

--- a/tests/test_core/test_writers/test_write_matlab.py
+++ b/tests/test_core/test_writers/test_write_matlab.py
@@ -113,3 +113,46 @@ def test_write_matlab_does_not_modify_source_dataset(tmp_path):
     dataset.write_matlab(tmp_path / "trace.mat", confirm=False)
 
     assert dataset.filename == original_filename
+
+
+@pytest.mark.parametrize("api", ["method", "namespace"])
+def test_write_matlab_deprecated_description_warns_but_uses_dataset_description(
+    tmp_path, api
+):
+    dataset = scp.NDDataset(
+        np.linspace(0.1, 0.5, 5),
+        name="spectrum",
+        title="absorbance",
+        units="mV",
+        description="source description",
+    )
+    target = tmp_path / f"{api}.mat"
+
+    with pytest.warns(DeprecationWarning, match="`description` is deprecated"):
+        if api == "method":
+            path = dataset.write_matlab(target, description="custom", confirm=False)
+        else:
+            path = scp.matlab.write(
+                dataset, target, description="custom", confirm=False
+            )
+
+    assert path == target
+    assert dataset.description == "source description"
+    exported = loadmat(path, simplify_cells=True)
+    assert exported["description"] == "source description"
+
+
+@pytest.mark.parametrize("api", ["method", "namespace"])
+def test_write_matlab_deprecated_protocol_warns_but_still_writes_matlab(tmp_path, api):
+    dataset = scp.NDDataset(np.arange(5.0), name="trace")
+    target = tmp_path / f"{api}.mat"
+
+    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated"):
+        if api == "method":
+            path = dataset.write_matlab(target, protocol="csv", confirm=False)
+        else:
+            path = scp.matlab.write(dataset, target, protocol="csv", confirm=False)
+
+    assert path == target
+    exported = loadmat(path, simplify_cells=True)
+    assert np.array_equal(exported["data"], np.arange(5.0))


### PR DESCRIPTION
## Summary
- deprecate writer `protocol=` and `description=` on the shared exporter path
- keep writer dispatch suffix-based and keep exported description metadata sourced from `dataset.description`
- add regression coverage for generic, specialized, and namespace writer entry points and document the deprecation in the release notes

## Why
These kwargs were still documented on the public writer surface, but runtime behavior never implemented them as real controls. `protocol=` did not drive writer dispatch, and `description=` did not override exported metadata. This PR makes that behavior explicit with a warning-first transition before the planned `0.13.0` `TypeError`.

## Validation
- `XDG_CACHE_HOME=/private/tmp MPLCONFIGDIR=/private/tmp/mpl micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_exporter.py tests/test_core/test_writers/test_write_csv.py tests/test_core/test_writers/test_write_matlab.py`
- `XDG_CACHE_HOME=/private/tmp PRE_COMMIT_HOME=/private/tmp/pre-commit pre-commit run --all-files`