### PR TITLE
FIX: preserve history exactly across native SCP persistence

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,6 +54,10 @@ Bug Fixes
   instead of writing complex-valued CSV content that SpectroChemPy cannot read
   back correctly.
 
+- Native `.scp` and `.pscp` persistence now preserves dataset history entries
+  exactly across load/save round-trips instead of collapsing non-empty history
+  to the first entry and retimestamping it during native reconstruction.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -43,6 +43,10 @@ Bug Fixes
   instead of writing complex-valued CSV content that SpectroChemPy cannot read
   back correctly.
 
+- Native `.scp` and `.pscp` persistence now preserves dataset history entries
+  exactly across load/save round-trips instead of collapsing non-empty history
+  to the first entry and retimestamping it during native reconstruction.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -462,7 +462,11 @@ class NDIO(tr.HasTraits):
                         pass
 
                     elif key in ["_history"]:
-                        obj.history = val
+                        from spectrochempy.core.dataset.nddataset import (
+                            _restore_portable_history,
+                        )
+
+                        obj._history = _restore_portable_history(val)
 
                     else:
                         if isinstance(val, TYPE_BOOL) and key == "_mask":

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -11,6 +11,8 @@ import base64
 import json
 import pickle
 import zipfile
+from datetime import UTC
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -20,6 +22,7 @@ from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.utils.exceptions import SpectroChemPyError
+from spectrochempy.utils.jsonutils import json_loads
 from spectrochempy.utils.testing import assert_array_equal, assert_dataset_equal
 
 # Basic
@@ -42,6 +45,50 @@ def _rewrite_dataset_data_payload_as_legacy_pickle(filename):
 
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.writestr(member, json.dumps(js, indent=2))
+
+
+def _make_exact_history_entries():
+    return [
+        (
+            datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC),
+            "ENTRY_A: first line\nsecond line",
+        ),
+        (
+            datetime(2024, 1, 2, 3, 5, 5, tzinfo=UTC),
+            "ENTRY_B / punctuation?! µ identical payload",
+        ),
+        (
+            datetime(2024, 1, 2, 3, 6, 5, tzinfo=UTC),
+            "ENTRY_B / punctuation?! µ identical payload",
+        ),
+    ]
+
+
+def _make_history_dataset(name="native_history"):
+    ds = NDDataset(
+        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        dims=["y", "x"],
+        coordset=[
+            Coord([0.0, 1.0], name="y", title="time", units="s"),
+            Coord([10.0, 20.0, 30.0], name="x", title="wavenumber", units="cm^-1"),
+        ],
+        name=name,
+        title="native history demo",
+        description="native roundtrip",
+        meta={"sample": "demo", "nested": {"state": "exact-history"}},
+        mask=np.array([[False, True, False], [False, False, False]]),
+    )
+    return ds
+
+
+def _assert_exact_history(restored, expected):
+    assert restored.history == expected.history
+    assert restored._history == expected._history
+
+
+def _assert_preserved_dataset_roundtrip(restored, expected):
+    assert_dataset_equal(restored, expected)
+    _assert_exact_history(restored, expected)
 
 
 def test_ndio_generic(ndataset_1d, tmp_path, monkeypatch):
@@ -259,6 +306,112 @@ def test_ndio_safe_roundtrip_uses_versioned_payload(tmp_path):
 
     loaded = NDDataset.load(filename)
     assert_dataset_equal(loaded, ds)
+
+
+@pytest.mark.parametrize(
+    "history_entries",
+    [
+        pytest.param([], id="empty"),
+        pytest.param(_make_exact_history_entries()[:1], id="single"),
+        pytest.param(_make_exact_history_entries(), id="multiple"),
+    ],
+)
+def test_ndio_loads_roundtrip_preserves_exact_history_without_zip(history_entries):
+    ds = _make_history_dataset()
+    ds._history = list(history_entries)
+
+    rebuilt = NDDataset.loads(json_loads(ds.dumps()))
+
+    _assert_preserved_dataset_roundtrip(rebuilt, ds)
+
+
+def test_ndio_loads_restores_serialized_history_instead_of_using_public_setter():
+    ds = _make_history_dataset()
+    ds._history = _make_exact_history_entries()
+    serialized_history = list(ds.history)
+
+    rebuilt = NDDataset.loads(json_loads(ds.dumps()))
+    setter_target = NDDataset()
+    setter_target.history = serialized_history
+
+    _assert_exact_history(rebuilt, ds)
+    assert setter_target.history != ds.history
+    assert setter_target._history != ds._history
+
+
+def test_ndio_dump_load_preserves_exact_history_across_repeated_cycles(tmp_path):
+    source = _make_history_dataset(name="history_cycles")
+    source._history = _make_exact_history_entries()
+    current = source
+
+    for cycle in range(3):
+        filename = current.save_as(tmp_path / f"history_cycle_{cycle}", confirm=False)
+        current = NDDataset.load(filename)
+        _assert_preserved_dataset_roundtrip(current, source)
+
+
+def test_ndio_save_load_allows_normal_history_append_after_restore(
+    tmp_path, monkeypatch
+):
+    source = _make_history_dataset(name="history_append")
+    source._history = _make_exact_history_entries()[:2]
+    restored = NDDataset.load(
+        source.save_as(tmp_path / "history_append", confirm=False)
+    )
+
+    appended_at = datetime(2024, 1, 2, 4, 0, 0, tzinfo=UTC)
+    monkeypatch.setattr(
+        "spectrochempy.core.dataset.nddataset.utcnow", lambda: appended_at
+    )
+    restored.history = "ENTRY_C appended after load"
+
+    reloaded = NDDataset.load(
+        restored.save_as(tmp_path / "history_append_again", confirm=False)
+    )
+
+    assert reloaded._history[:2] == source._history
+    assert reloaded._history[2] == (appended_at, "ENTRY_C appended after load")
+    assert reloaded.history[-1].endswith("> ENTRY_C appended after load")
+
+
+def test_native_public_scp_surfaces_preserve_exact_history(tmp_path):
+    function_ds = _make_history_dataset(name="function_surface")
+    function_ds._history = _make_exact_history_entries()
+    function_filename = scp.write(
+        function_ds,
+        tmp_path / "function_surface.scp",
+        overwrite=True,
+    )
+    function_loaded = scp.load(function_filename)
+    _assert_preserved_dataset_roundtrip(function_loaded, function_ds)
+
+    method_ds = _make_history_dataset(name="method_surface")
+    method_ds._history = _make_exact_history_entries()
+    method_filename = method_ds.write(tmp_path / "method_surface.scp", overwrite=True)
+    method_loaded = scp.read(method_filename)
+    _assert_preserved_dataset_roundtrip(method_loaded, method_ds)
+
+
+def test_ndio_load_without_history_field_keeps_dataset_loadable(tmp_path):
+    ds = _make_history_dataset(name="missing_history")
+    ds._history = _make_exact_history_entries()
+    filename = ds.save_as(tmp_path / "missing_history", confirm=False)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    js.pop("history", None)
+
+    with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(member, json.dumps(js, indent=2))
+
+    loaded = NDDataset.load(filename)
+
+    assert loaded.history == []
+    assert_array_equal(loaded.data, ds.data)
+    assert_array_equal(loaded.mask, ds.mask)
+    assert loaded.meta["nested"] == ds.meta["nested"]
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -6,6 +6,8 @@ import base64
 import json
 import pickle
 import zipfile
+from datetime import UTC
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -57,6 +59,19 @@ def _assert_project_membership(project, child, key, *, present):
     else:
         assert key not in project.projects_names
         assert child not in project.projects
+
+
+def _make_project_history_entries(prefix):
+    return [
+        (datetime(2024, 2, 1, 8, 0, 0, tzinfo=UTC), f"{prefix} ENTRY_A"),
+        (datetime(2024, 2, 1, 8, 1, 0, tzinfo=UTC), f"{prefix} ENTRY_B"),
+        (datetime(2024, 2, 1, 8, 2, 0, tzinfo=UTC), f"{prefix} ENTRY_B"),
+    ]
+
+
+def _assert_exact_dataset_history(restored, expected):
+    assert restored.history == expected.history
+    assert restored._history == expected._history
 
 
 # =============================================================================
@@ -1186,6 +1201,26 @@ class TestSerializationRoundtrip:
 
         loaded = Project.load(filename, allow_unsafe_legacy=True)
         assert "data" in loaded.datasets_names
+
+    def test_save_load_preserves_exact_child_dataset_histories(self, tmp_path):
+        proj = Project(name="history_project")
+        first = NDDataset([1.0, 2.0, 3.0], name="first", title="first dataset")
+        second = NDDataset([4.0, 5.0, 6.0], name="second", title="second dataset")
+        first._history = _make_project_history_entries("FIRST")
+        second._history = _make_project_history_entries("SECOND")
+        proj.add_dataset(first)
+        proj.add_dataset(second)
+
+        filename = proj.save_as(tmp_path / "history_project")
+        loaded = Project.load(filename)
+
+        _assert_exact_dataset_history(loaded["first"], first)
+        _assert_exact_dataset_history(loaded["second"], second)
+
+        second_cycle = Project.load(loaded.save_as(tmp_path / "history_project_cycle2"))
+
+        _assert_exact_dataset_history(second_cycle["first"], first)
+        _assert_exact_dataset_history(second_cycle["second"], second)
 
 
 class TestArgNamesEdgeCases:


### PR DESCRIPTION
## Summary

This PR preserves `NDDataset.history` exactly across native `.scp` and `.pscp` persistence without changing the native JSON/ZIP schema.

Start SHA on public `master`: `e11a55968a78d457796dd574c80fe513e89d1e7a`
Branch head SHA: `447446a164818cba0f682343f96374c68f048c22`

## Root cause

The native payload already stored `history` correctly as `list[str]`, but native reconstruction in `NDIO.loads()` remapped that serialized value to `_history` and then passed it through the public setter:

`history` -> `_history` -> `obj.history = serialized_value`

That setter is designed to append a new runtime entry, not to restore a serialized state. For non-empty history it therefore:

- kept only the first entry
- replaced the historical timestamp with load time
- preserved the original timestamp only as message text
- produced double timestamps in the public representation
- worsened corruption across repeated native cycles

## What changed

- keep the native schema unchanged: `history: list[str]`
- keep the ZIP structure, key names, and format version unchanged
- keep the public `history` setter semantics unchanged
- restore native history via the existing internal helper `_restore_portable_history(...)`
- assign the restored tuples directly to `obj._history` during native deserialization

This covers:

- `NDDataset.dumps()` + `json_loads(...)` + `NDDataset.loads()`
- `.scp` dump/load
- `scp.write(... .scp)` / `scp.load()`
- `dataset.write(... .scp)` / `scp.read()`
- datasets nested inside `.pscp` project files

## Compatibility

- no schema migration
- no new timestamps created at load time
- no entry loss on valid native files
- existing double-timestamp strings from already-corrupted historical files are restored as-is, without adding another corruption layer
- portable xarray/NetCDF persistence is unchanged
- the separate out-of-scope issue `NDDataset.loads(json.loads(ds.dumps()))` is intentionally not addressed here

## Tests added

- exact native round-trip through `dumps()` -> `json_loads(...)` -> `loads()` for empty, single-entry, and multi-entry history
- regression test proving the old public-setter path would collapse/restamp the history
- repeated `.scp` dump/load cycles remain stable
- adding a new history entry after load still works normally
- public `.scp` surfaces via `scp.write`/`scp.load` and `dataset.write`/`scp.read`
- missing `history` field remains loadable
- `.pscp` project round-trip preserves distinct child dataset histories across two cycles

## Validation

- `micromamba run -n scpy-core python -m pytest tests/test_core/test_dataset/test_mixins/test_ndio.py tests/test_core/test_projects/test_projects.py`
- `micromamba run -n scpy-core python -m pytest tests/test_core/test_dataset/test_portable_persistence_characterization.py`
- `micromamba run -n scpy-core pre-commit run --all-files`
- `git diff --check`

Results:

- native/project tests: `126 passed`
- portable persistence tests: `9 passed`
- pre-commit: passed
- diff check: passed

## Files changed

- `src/spectrochempy/core/dataset/arraymixins/ndio.py`
- `tests/test_core/test_dataset/test_mixins/test_ndio.py`
- `tests/test_core/test_projects/test_projects.py`
- `docs/sources/whatsnew/changelog.rst`
- `docs/sources/whatsnew/latest.rst`

## Maintainer note

Characterization source: `spectrochempy_maintainer/notes/audits/writer-baseline-characterization-2026-08-09.md`

## Out of scope

- any change to the public `history` format
- any `.scp` / `.pscp` schema change
- portable persistence refactors
- `NDDataset.loads(json.loads(...))` raw-dict support
- unrelated writer/runtime work