### PR TITLE
FIX: align concatenate and stack metadata policy

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -58,6 +58,13 @@ Bug Fixes
   exactly across load/save round-trips instead of collapsing non-empty history
   to the first entry and retimestamping it during native reconstruction.
 
+- `concatenate()` and `stack()` now treat their outputs as multi-source derived
+  datasets for identity and provenance metadata. They no longer silently
+  inherit `name`, `origin`, `filename`, `meta`, or timestamps from one source
+  dataset, use deterministic synthesized `description` and `history` text,
+  preserve `title` and `acquisition_date` only on exact consensus, and keep
+  all scientific assembly behavior and input datasets unchanged.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -47,6 +47,13 @@ Bug Fixes
   exactly across load/save round-trips instead of collapsing non-empty history
   to the first entry and retimestamping it during native reconstruction.
 
+- `concatenate()` and `stack()` now treat their outputs as multi-source derived
+  datasets for identity and provenance metadata. They no longer silently
+  inherit `name`, `origin`, `filename`, `meta`, or timestamps from one source
+  dataset, use deterministic synthesized `description` and `history` text,
+  preserve `title` and `acquisition_date` only on exact consensus, and keep
+  all scientific assembly behavior and input datasets unchanged.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -88,6 +88,7 @@ class NDIO(tr.HasTraits):
     """
 
     _filename = tr.Union((tr.Instance(pathlib.Path), tr.Unicode()), allow_none=True)
+    _filename_explicit_none = tr.Bool(False)
 
     def __init__(self, **kwargs):
         if "filename" in kwargs:
@@ -103,6 +104,8 @@ class NDIO(tr.HasTraits):
     @property
     def filename(self) -> pathlib.Path | None:
         """Get current filename for this dataset."""
+        if self._filename_explicit_none:
+            return None
         if self._filename:
             filename = self._filename
             if isinstance(self._filename, str):
@@ -115,8 +118,9 @@ class NDIO(tr.HasTraits):
             return pathlib.Path(self.name).with_suffix(SCPY_SUFFIX[self._implements()])
 
     @filename.setter
-    def filename(self, val: str | pathlib.Path) -> None:
+    def filename(self, val: str | pathlib.Path | None) -> None:
         self._filename = pathclean(val)
+        self._filename_explicit_none = val is None
 
     @property
     def filetype(self) -> list[str]:

--- a/src/spectrochempy/core/dataset/basearrays/ndarray.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndarray.py
@@ -1173,6 +1173,9 @@ class NDArray(tr.HasTraits):
                 _attr = do_copy(getattr(self, f"_{attr}"))
                 setattr(new, f"_{attr}", _attr)
 
+        if hasattr(self, "_filename_explicit_none"):
+            new._filename_explicit_none = self._filename_explicit_none
+
         # name must be changed
         if not keepname:
             new.name = ""  # default

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -402,6 +402,10 @@ class Project(AbstractProject, NDIO):
         new._name = self._name
         new._explicit_name = self._explicit_name
         new._meta = cpy.deepcopy(self._meta, memo=memo)
+        if hasattr(self, "_filename"):
+            new._filename = cpy.deepcopy(self._filename, memo=memo)
+        if hasattr(self, "_filename_explicit_none"):
+            new._filename_explicit_none = self._filename_explicit_none
 
         if deep:
             for name, ds in self._datasets.items():

--- a/src/spectrochempy/core/project/project.py
+++ b/src/spectrochempy/core/project/project.py
@@ -402,8 +402,6 @@ class Project(AbstractProject, NDIO):
         new._name = self._name
         new._explicit_name = self._explicit_name
         new._meta = cpy.deepcopy(self._meta, memo=memo)
-        if hasattr(self, "_filename"):
-            new._filename = cpy.deepcopy(self._filename, memo=memo)
         if hasattr(self, "_filename_explicit_none"):
             new._filename_explicit_none = self._filename_explicit_none
 

--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -918,6 +918,9 @@ def merge_datasets(datasets, **kwargs):
 
         # Try to merge each shape group
         for shape_group in shape_groups.values():
+            if len(shape_group) == 1:
+                merged_datasets.extend(shape_group)
+                continue
             try:
                 if shape_group[0].ndim == 1:
                     merged = stack(shape_group)

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -101,7 +101,9 @@ def concatenate(*datasets, **kwargs):
 
     if _should_promote_1d_column_concatenation(datasets, kwargs):
         return _stack_1d_profiles_as_columns(
-            datasets, metadata_sources=metadata_sources
+            datasets,
+            metadata_sources=metadata_sources,
+            operation=operation,
         )
 
     # get axis from arguments
@@ -264,6 +266,7 @@ def stack(*datasets, **kwargs):
         return _stack_1d_profiles_as_columns(
             datasets,
             metadata_sources=source_datasets,
+            operation="stack",
         )
     if axis not in (0, None):
         raise NotImplementedError("stack() currently supports only axis=0 or axis=1")
@@ -291,7 +294,7 @@ def stack(*datasets, **kwargs):
     )
 
 
-def _stack_1d_profiles_as_columns(datasets, *, metadata_sources=None):
+def _stack_1d_profiles_as_columns(datasets, *, metadata_sources=None, operation):
     if not datasets:
         raise ValueError("stack() requires at least one dataset")
 
@@ -335,7 +338,7 @@ def _stack_1d_profiles_as_columns(datasets, *, metadata_sources=None):
     return concatenate(
         *promoted,
         dims=newdim,
-        _metadata_operation="stack",
+        _metadata_operation=operation,
         _metadata_sources=metadata_sources,
     )
 

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -7,7 +7,7 @@ __all__ = ["concatenate", "stack"]
 
 __dataset_methods__ = __all__
 
-from warnings import warn
+from copy import deepcopy
 
 import numpy as np
 
@@ -16,6 +16,7 @@ from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.utils import exceptions
 from spectrochempy.utils.datetimeutils import utcnow
 from spectrochempy.utils.decorators import deprecated
+from spectrochempy.utils.meta import Meta
 from spectrochempy.utils.objects import OrderedSet
 
 
@@ -85,13 +86,23 @@ def concatenate(*datasets, **kwargs):
         deprecated("force_stack", replace="method stack()", removed="0.13.0")
         return stack(datasets)
 
+    operation = kwargs.pop("_metadata_operation", "concatenate")
+    metadata_sources = kwargs.pop("_metadata_sources", None)
+    if operation not in {"concatenate", "stack"}:
+        raise ValueError(f"Unsupported metadata operation context: {operation}")
+
+    source_datasets = _normalize_datasets(datasets)
+    source_datasets = [_reject_coord_input(dataset) for dataset in source_datasets]
+    if metadata_sources is None:
+        metadata_sources = source_datasets
+
     # get a copy of input datasets in order that input data are not modified
-    datasets = _get_copy(datasets)
-    # Reject Coord inputs — Coord must be explicitly wrapped in NDDataset
-    datasets = [_reject_coord_input(d) for d in datasets]
+    datasets = [dataset.copy() for dataset in source_datasets]
 
     if _should_promote_1d_column_concatenation(datasets, kwargs):
-        return _stack_1d_profiles_as_columns(datasets)
+        return _stack_1d_profiles_as_columns(
+            datasets, metadata_sources=metadata_sources
+        )
 
     # get axis from arguments
     axis, dim = datasets[0].get_axis(**kwargs)
@@ -170,28 +181,7 @@ def concatenate(*datasets, **kwargs):
     out._mask = mask
     out._units = units
 
-    out.description = f"Concatenation of {len(datasets)}  datasets:\n"
-    out.description += f"( {datasets[0].name}"
-    out.title = datasets[0].title
-    authortuple = (datasets[0].author,)
-
-    for dataset in datasets[1:]:
-        if out.title != dataset.title:
-            warn(
-                "Different data title => the title is that of the 1st dataset",
-                stacklevel=2,
-            )
-
-        if dataset.author not in authortuple:
-            authortuple = authortuple + (dataset.author,)
-
-        out.author = " & ".join([str(author) for author in authortuple])
-
-        out.description += f", {dataset.name}"
-
-    out.description += " )"
-    out._date = out._modified = utcnow()
-    out.history = ["Created by concatenate"]
+    _apply_combination_metadata(out, metadata_sources, operation=operation)
 
     return out
 
@@ -261,16 +251,20 @@ def stack(*datasets, **kwargs):
     (200, 2)
 
     """
-    datasets = _get_copy(datasets)
+    source_datasets = _normalize_datasets(datasets)
+    source_datasets = [_reject_coord_input(dataset) for dataset in source_datasets]
+    datasets = [dataset.copy() for dataset in source_datasets]
     # Reject Coord inputs — Coord must be explicitly wrapped in NDDataset
-    datasets = [_reject_coord_input(d) for d in datasets]
     axis = kwargs.pop("axis", 0)
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"stack() got unexpected keyword argument(s): {unexpected}")
 
     if axis in (1, -1):
-        return _stack_1d_profiles_as_columns(datasets)
+        return _stack_1d_profiles_as_columns(
+            datasets,
+            metadata_sources=source_datasets,
+        )
     if axis not in (0, None):
         raise NotImplementedError("stack() currently supports only axis=0 or axis=1")
 
@@ -289,15 +283,22 @@ def stack(*datasets, **kwargs):
         dataset.add_coordset(newcoord)
         dataset.dims = [newcoord.name] + dataset.dims
 
-    return concatenate(*datasets, dims=0)
+    return concatenate(
+        *datasets,
+        dims=0,
+        _metadata_operation="stack",
+        _metadata_sources=source_datasets,
+    )
 
 
-def _stack_1d_profiles_as_columns(datasets):
+def _stack_1d_profiles_as_columns(datasets, *, metadata_sources=None):
     if not datasets:
         raise ValueError("stack() requires at least one dataset")
 
     # Reject Coord inputs — Coord must be explicitly wrapped in NDDataset
     datasets = [_reject_coord_input(d) for d in datasets]
+    if metadata_sources is None:
+        metadata_sources = datasets
 
     shapes = {ds.shape for ds in datasets}
     if len(shapes) != 1:
@@ -331,7 +332,12 @@ def _stack_1d_profiles_as_columns(datasets):
         dataset.set_coordset({source_dim: xcoord, newdim: column_coord})
         promoted.append(dataset)
 
-    return concatenate(*promoted, dims=newdim)
+    return concatenate(
+        *promoted,
+        dims=newdim,
+        _metadata_operation="stack",
+        _metadata_sources=metadata_sources,
+    )
 
 
 def _should_promote_1d_column_concatenation(datasets, kwargs):
@@ -371,8 +377,111 @@ def _reject_coord_input(obj):
     return obj
 
 
-def _get_copy(datasets):
-    # get a copy of datasets from the input
+def _normalize_datasets(datasets):
     if isinstance(datasets, tuple) and isinstance(datasets[0], list | tuple):
         datasets = datasets[0]
-    return [ds.copy() for ds in datasets]
+    return list(datasets)
+
+
+def _apply_combination_metadata(out, datasets, *, operation):
+    names = _render_names(datasets)
+
+    out._name = ""
+    out._title = _consensus_text(dataset.title for dataset in datasets)
+    out.description = _make_description(operation, names)
+    out.author = _merge_authors(datasets)
+    out.origin = _merge_origins(datasets)
+    out.filename = None
+    out._meta = _combine_meta(datasets)
+    out._acquisition_date = _consensus_acquisition_date(datasets)
+    out.history = [_make_history_entry(operation, names)]
+
+    operation_time = utcnow()
+    out._date = operation_time
+    out._created = operation_time
+    out._modified = operation_time
+
+
+def _effective_text(value):
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _consensus_text(values):
+    effective = [_effective_text(value) for value in values]
+    if any(value is None for value in effective):
+        return None
+    first = effective[0]
+    if all(value == first for value in effective[1:]):
+        return first
+    return None
+
+
+def _deduplicated_texts(values):
+    texts = []
+    for value in values:
+        text = _effective_text(value)
+        if text is None or text in texts:
+            continue
+        texts.append(text)
+    return texts
+
+
+def _render_names(datasets):
+    names = []
+    for dataset in datasets:
+        name = _effective_text(dataset._name)
+        names.append(name if name is not None else "<unnamed>")
+    return names
+
+
+def _make_description(operation, names):
+    label = "Concatenation" if operation == "concatenate" else "Stack"
+    rendered = ", ".join(names)
+    return f"{label} of {len(names)} datasets:\n( {rendered} )"
+
+
+def _merge_authors(datasets):
+    authors = _deduplicated_texts(dataset.author for dataset in datasets)
+    if not authors:
+        return ""
+    if len(authors) == 1:
+        return authors[0]
+    return " & ".join(authors)
+
+
+def _merge_origins(datasets):
+    origins = [_effective_text(dataset.origin) for dataset in datasets]
+    if origins and all(origin is not None for origin in origins):
+        first = origins[0]
+        if all(origin == first for origin in origins[1:]):
+            return first
+
+    distinct = _deduplicated_texts(origins)
+    if not distinct:
+        return ""
+    if len(distinct) == 1:
+        return distinct[0]
+    return f"multiple: {' | '.join(distinct)}"
+
+
+def _combine_meta(datasets):
+    first_meta = datasets[0].meta
+    if all(dataset.meta == first_meta for dataset in datasets[1:]):
+        return deepcopy(first_meta)
+    return Meta()
+
+
+def _consensus_acquisition_date(datasets):
+    first = datasets[0]._acquisition_date
+    if first is None:
+        return None
+    if all(dataset._acquisition_date == first for dataset in datasets[1:]):
+        return deepcopy(first)
+    return None
+
+
+def _make_history_entry(operation, names):
+    rendered = ", ".join(names)
+    return f"Created by {operation} from {len(names)} datasets: {rendered}"

--- a/tests/test_core/test_dataset/test_combination_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_combination_semantics_baseline.py
@@ -1,19 +1,7 @@
-"""
-Characterization tests for combination operation semantics on NDDataset.
+"""Semantic tests for concatenate()/stack() multi-source metadata policy."""
 
-This suite characterizes CURRENT behavior of concatenate() and stack().
-It does NOT validate a desired future policy.
-
-Coverage:
-    - concatenate: data, CoordSet, units, masks, metadata, history,
-      identity/provenance, edge cases
-    - stack: data, CoordSet, metadata, provenance
-
-Result Assembly Pattern observations (see RFC):
-    Combination operations follow Pattern B (Rebuild / Synthesize):
-    the result is assembled from a copy of the last dataset with
-    selective field overwrites, not a pure copy-first approach.
-"""
+from datetime import UTC
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -22,6 +10,7 @@ from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.processing.transformation.concatenate import concatenate
 from spectrochempy.processing.transformation.concatenate import stack
+from spectrochempy.utils.datetimeutils import utcnow
 from spectrochempy.utils.exceptions import DimensionsCompatibilityError
 from spectrochempy.utils.exceptions import UnitsCompatibilityError
 from tests.test_core.test_dataset._semantic_dataset_helpers import assert_dims_equal
@@ -358,56 +347,93 @@ class TestConcatenateMasks:
 
 
 class TestConcatenateMetadata:
-    r"""
-    Characterize metadata propagation through concatenation.
+    def test_title_requires_exact_consensus(self, dataset_x, dataset_y):
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c._title is None
+        assert c.title == "<untitled>"
 
-    Observations (not policy):
-    - title comes from the FIRST dataset (with warning if different)
-    - name comes from the LAST dataset (via copy of last input)
-    - author is merged with ' & ' separator
-    - description is synthesized: 'Concatenation of N datasets:\n( name1, name2, ... )'
-    - origin comes from the LAST dataset (via copy)
-    - meta comes from the LAST dataset (via copy)
-    """
-
-    def test_title_from_first_dataset(self, dataset_x, dataset_y):
+    def test_title_preserved_on_exact_consensus(self, dataset_x, dataset_y):
+        dataset_y.title = "dataset_x"
         c = concatenate(dataset_x, dataset_y, dims="x")
         assert c.title == "dataset_x"
 
-    def test_name_from_last_dataset(self, dataset_x, dataset_y):
+    def test_name_is_cleared_to_auto_generated_identity(self, dataset_x, dataset_y):
         c = concatenate(dataset_x, dataset_y, dims="x")
-        assert c.name == "dataset_y_name"
+        assert c._name == ""
+        assert c.name.startswith("NDDataset")
+        assert c.name not in {dataset_x.name, dataset_y.name}
 
     def test_author_merged(self, dataset_x, dataset_y):
         c = concatenate(dataset_x, dataset_y, dims="x")
-        assert "author_x" in c.author
-        assert "author_y" in c.author
-        assert " & " in c.author
+        assert c.author == "author_x & author_y"
 
     def test_author_deduplicated(self, dataset_x):
-        """Notable behavior: same author is not duplicated."""
         c = concatenate(dataset_x, dataset_x, dims="x")
-        assert c.author.count("author_x") == 1
+        assert c.author == "author_x"
 
     def test_description_synthesized(self, dataset_x, dataset_y):
         c = concatenate(dataset_x, dataset_y, dims="x")
-        assert "Concatenation of 2  datasets" in c.description
-        assert "dataset_x_name" in c.description
-        assert "dataset_y_name" in c.description
+        assert (
+            c.description
+            == "Concatenation of 2 datasets:\n( dataset_x_name, dataset_y_name )"
+        )
 
-    def test_origin_from_last_dataset(self, dataset_x, dataset_y):
+    def test_description_uses_unnamed_placeholder(self, dataset_x, dataset_y):
+        dataset_x._name = ""
+        dataset_y._name = ""
         c = concatenate(dataset_x, dataset_y, dims="x")
-        assert c.origin == "origin_y"
+        assert c.description == "Concatenation of 2 datasets:\n( <unnamed>, <unnamed> )"
 
-    def test_meta_from_last_dataset(self, dataset_x, dataset_y):
+    def test_origin_synthesized_for_multiple_sources(self, dataset_x, dataset_y):
         c = concatenate(dataset_x, dataset_y, dims="x")
-        assert c.meta.project == "project_y"
+        assert c.origin == "multiple: origin_x | origin_y"
 
-    def test_meta_deep_copied(self, dataset_x, dataset_y):
-        """Notable behavior: modifying result meta should not affect source."""
+    def test_origin_preserved_on_exact_consensus(self, dataset_x, dataset_y):
+        dataset_y.origin = "origin_x"
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c.origin == "origin_x"
+
+    def test_meta_cleared_when_payloads_differ(self, dataset_x, dataset_y):
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c.meta.project is None
+
+    def test_meta_deep_copied_from_first_on_consensus(self, dataset_x, dataset_y):
+        dataset_y.meta.project = dataset_x.meta.project
         c = concatenate(dataset_x, dataset_y, dims="x")
         c.meta.project = "modified"
-        assert dataset_y.meta.project == "project_y"
+        assert dataset_x.meta.project == "project_x"
+        assert dataset_y.meta.project == "project_x"
+
+    def test_filename_cleared(self, dataset_x, dataset_y):
+        dataset_x.filename = "dataset_x.scp"
+        dataset_y.filename = "dataset_y.scp"
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c.filename is None
+
+    def test_acquisition_date_requires_exact_consensus(self, dataset_x, dataset_y):
+        dataset_x.acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+        dataset_y.acquisition_date = datetime(2024, 1, 3, 3, 4, 5, tzinfo=UTC)
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c.acquisition_date is None
+
+    def test_acquisition_date_preserved_on_consensus(self, dataset_x, dataset_y):
+        acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+        dataset_x.acquisition_date = acquisition_date
+        dataset_y.acquisition_date = acquisition_date
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c._acquisition_date == acquisition_date
+        assert c.acquisition_date == acquisition_date.astimezone(c._timezone).isoformat(
+            sep=" ",
+            timespec="seconds",
+        )
+
+    def test_created_and_modified_describe_new_result(self, dataset_x, dataset_y):
+        before = utcnow()
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        after = utcnow()
+        assert before <= c._created <= after
+        assert before <= c._modified <= after
+        assert c._created == c._modified
 
 
 # ======================================================================================
@@ -416,20 +442,15 @@ class TestConcatenateMetadata:
 
 
 class TestConcatenateHistory:
-    """
-    Characterize history behavior through concatenation.
-
-    Notable behavior: history is REWRITTEN, not appended.
-    Original history entries from input datasets are lost.
-    """
-
     def test_history_rewritten(self, dataset_x, dataset_y):
         c = concatenate(dataset_x, dataset_y, dims="x")
         assert len(c.history) == 1
-        assert "Created by concatenate" in c.history[0]
+        assert (
+            "Created by concatenate from 2 datasets: dataset_x_name, dataset_y_name"
+            in c.history[0]
+        )
 
     def test_original_history_lost(self, dataset_x, dataset_y):
-        """Notable behavior: input dataset history is not preserved."""
         c = concatenate(dataset_x, dataset_y, dims="x")
         assert c.history[0] != dataset_x.history[0]
         assert c.history[0] != dataset_y.history[0]
@@ -445,41 +466,27 @@ class TestConcatenateHistory:
 
 
 class TestConcatenateIdentityProvenance:
-    """
-    Observe identity and provenance patterns in concatenation.
-
-    Observations (not policy):
-    - title, author, description, name are handled individually
-      (title: first, name: last, author: merged, description: synthesized)
-      This is NOT a copy-first identity preservation pattern.
-    - origin and meta come from the last dataset (copy artifact)
-    - history is rewritten — provenance is not preserved
-    - This most closely resembles Pattern B (Rebuild / Synthesize):
-      the result is a synthesized object, not an identity-preserved
-      transformation of the first input.
-    """
-
     def test_identity_pattern_is_rebuild(self, dataset_x, dataset_y):
-        """
-        Concatenation is not identity-preserving:
-        the result is a synthesized multi-source object.
-        """
         c = concatenate(dataset_x, dataset_y, dims="x")
-        assert c.title != dataset_y.title  # title not from last
-        assert c.name != dataset_x.name  # name not from first
-        assert c.author != dataset_x.author  # author merged
-        assert c.description != dataset_x.description  # synthesized
-        assert c.description != dataset_y.description
+        assert c._title is None
+        assert c._name == ""
+        assert c.author == "author_x & author_y"
+        assert (
+            c.description
+            == "Concatenation of 2 datasets:\n( dataset_x_name, dataset_y_name )"
+        )
+        assert c.origin == "multiple: origin_x | origin_y"
 
     def test_provenance_rewritten(self, dataset_x, dataset_y):
-        """History is rewritten — provenance from inputs is lost."""
         c = concatenate(dataset_x, dataset_y, dims="x")
         assert c.history != dataset_x.history
         assert c.history != dataset_y.history
-        assert "Created by concatenate" in c.history[0]
+        assert (
+            "Created by concatenate from 2 datasets: dataset_x_name, dataset_y_name"
+            in c.history[0]
+        )
 
     def test_same_title_no_warning(self):
-        """No warning when both datasets have the same title."""
         x = Coord(np.linspace(4000.0, 1000.0, 7))
         y = Coord(np.linspace(0.0, 60.0, 5))
         a = NDDataset(np.arange(35.0).reshape(5, 7), coordset=[y, x], title="same")
@@ -494,15 +501,7 @@ class TestConcatenateIdentityProvenance:
 
 
 class TestStackCharacterization:
-    """
-    Characterize stack() current behavior.
-
-    stack prepends a new dimension, creates a coordinate with labels
-    from dataset names, then delegates to concatenate(dims=0).
-
-    Note: stack requires datasets to have CoordSets — bare datasets
-    (no CoordSet) raise KeyError. All tests below use CoordSet datasets.
-    """
+    """stack() shares the concatenate() multi-source metadata policy."""
 
     @pytest.fixture
     def stack_pair_1d(self):
@@ -545,26 +544,26 @@ class TestStackCharacterization:
         labels = s[s.dims[0]].labels
         assert labels is not None
 
-    def test_stack_title_from_first(self, stack_pair_1d):
+    def test_stack_title_requires_consensus(self, stack_pair_1d):
         a, b = stack_pair_1d
         a.title = "first"
         b.title = "second"
         s = stack(a, b)
-        assert s.title == "first"
+        assert s._title is None
+        assert s.title == "<untitled>"
 
     def test_stack_history_rewritten(self, stack_pair_1d):
         a, b = stack_pair_1d
         s = stack(a, b)
         assert len(s.history) == 1
-        assert "Created by concatenate" in s.history[0]
+        assert "Created by stack from 2 datasets: alpha, beta" in s.history[0]
 
     def test_stack_author_merged(self, stack_pair_1d):
         a, b = stack_pair_1d
         a.author = "alice"
         b.author = "bob"
         s = stack(a, b)
-        assert "alice" in s.author
-        assert "bob" in s.author
+        assert s.author == "alice & bob"
 
     def test_stack_incompatible_shapes_raises(self):
         x1 = Coord(np.linspace(0.0, 10.0, 7))
@@ -588,44 +587,37 @@ class TestStackCharacterization:
     # stack() origin propagation
     # ------------------------------------------------------------------
 
-    def test_stack_origin_from_last_dataset(self):
-        """
-        Notable: origin propagates from the LAST dataset
-        (consistent with concatenate's copy-of-last pattern).
-        """
+    def test_stack_origin_synthesized_from_all_inputs(self):
         x = Coord(np.linspace(0.0, 10.0, 3))
         a = NDDataset(np.array([10.0, 20.0, 30.0]), coordset=[x])
         b = NDDataset(np.array([40.0, 50.0, 60.0]), coordset=[x])
         a.origin = "origin_first"
         b.origin = "origin_last"
         s = stack(a, b)
-        assert s.origin == "origin_last"
+        assert s.origin == "multiple: origin_first | origin_last"
 
     # ------------------------------------------------------------------
     # stack() custom meta propagation
     # ------------------------------------------------------------------
 
-    def test_stack_meta_from_last_dataset(self):
-        """Notable: custom meta propagates from the LAST dataset."""
+    def test_stack_meta_cleared_when_payloads_differ(self):
         x = Coord(np.linspace(0.0, 10.0, 3))
         a = NDDataset(np.array([10.0, 20.0, 30.0]), coordset=[x])
         b = NDDataset(np.array([40.0, 50.0, 60.0]), coordset=[x])
         a.meta.project = "project_first"
         b.meta.project = "project_last"
         s = stack(a, b)
-        assert s.meta.project == "project_last"
+        assert s.meta.project is None
 
     def test_stack_meta_deep_copied(self):
-        """
-        Notable: result meta is deep-copied, not aliased
-        to the source dataset object.
-        """
         x = Coord(np.linspace(0.0, 10.0, 3))
         a = NDDataset(np.array([10.0, 20.0, 30.0]), coordset=[x])
         b = NDDataset(np.array([40.0, 50.0, 60.0]), coordset=[x])
+        a.meta.project = "original"
         b.meta.project = "original"
         s = stack(a, b)
         s.meta.project = "modified"
+        assert a.meta.project == "original"
         assert b.meta.project == "original"
 
 

--- a/tests/test_core/test_dataset/test_combination_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_combination_semantics_baseline.py
@@ -371,7 +371,9 @@ class TestConcatenateMetadata:
         c = concatenate(dataset_x, dataset_x, dims="x")
         assert c.author == "author_x"
 
-    def test_author_ignores_absent_values_and_preserves_order(self, dataset_x, dataset_y):
+    def test_author_ignores_absent_values_and_preserves_order(
+        self, dataset_x, dataset_y
+    ):
         dataset_x.author = ""
         dataset_y.author = " author_y "
         dataset_z = dataset_y.copy()
@@ -386,7 +388,9 @@ class TestConcatenateMetadata:
             == "Concatenation of 2 datasets:\n( dataset_x_name, dataset_y_name )"
         )
 
-    def test_text_consensus_is_case_and_whitespace_sensitive(self, dataset_x, dataset_y):
+    def test_text_consensus_is_case_and_whitespace_sensitive(
+        self, dataset_x, dataset_y
+    ):
         dataset_x.title = "Shared"
         dataset_y.title = " shared "
         c = concatenate(dataset_x, dataset_y, dims="x")

--- a/tests/test_core/test_dataset/test_combination_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_combination_semantics_baseline.py
@@ -371,12 +371,27 @@ class TestConcatenateMetadata:
         c = concatenate(dataset_x, dataset_x, dims="x")
         assert c.author == "author_x"
 
+    def test_author_ignores_absent_values_and_preserves_order(self, dataset_x, dataset_y):
+        dataset_x.author = ""
+        dataset_y.author = " author_y "
+        dataset_z = dataset_y.copy()
+        dataset_z.author = "author_z"
+        c = concatenate(dataset_x, dataset_y, dataset_z, dims="x")
+        assert c.author == " author_y  & author_z"
+
     def test_description_synthesized(self, dataset_x, dataset_y):
         c = concatenate(dataset_x, dataset_y, dims="x")
         assert (
             c.description
             == "Concatenation of 2 datasets:\n( dataset_x_name, dataset_y_name )"
         )
+
+    def test_text_consensus_is_case_and_whitespace_sensitive(self, dataset_x, dataset_y):
+        dataset_x.title = "Shared"
+        dataset_y.title = " shared "
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c._title is None
+        assert c.title == "<untitled>"
 
     def test_description_uses_unnamed_placeholder(self, dataset_x, dataset_y):
         dataset_x._name = ""
@@ -393,16 +408,29 @@ class TestConcatenateMetadata:
         c = concatenate(dataset_x, dataset_y, dims="x")
         assert c.origin == "origin_x"
 
+    def test_origin_ignores_partial_absence(self, dataset_x, dataset_y):
+        dataset_x.origin = ""
+        dataset_y.origin = "origin_y"
+        c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c.origin == "origin_y"
+
     def test_meta_cleared_when_payloads_differ(self, dataset_x, dataset_y):
         c = concatenate(dataset_x, dataset_y, dims="x")
         assert c.meta.project is None
 
     def test_meta_deep_copied_from_first_on_consensus(self, dataset_x, dataset_y):
         dataset_y.meta.project = dataset_x.meta.project
+        dataset_x.meta.processing = ["baseline"]
+        dataset_y.meta.processing = ["baseline"]
         c = concatenate(dataset_x, dataset_y, dims="x")
+        assert c.meta == dataset_x.meta
+        assert c.meta is not dataset_x.meta
         c.meta.project = "modified"
+        c.meta.processing.append("changed")
         assert dataset_x.meta.project == "project_x"
         assert dataset_y.meta.project == "project_x"
+        assert dataset_x.meta.processing == ["baseline"]
+        assert dataset_y.meta.processing == ["baseline"]
 
     def test_filename_cleared(self, dataset_x, dataset_y):
         dataset_x.filename = "dataset_x.scp"
@@ -434,6 +462,19 @@ class TestConcatenateMetadata:
         assert before <= c._created <= after
         assert before <= c._modified <= after
         assert c._created == c._modified
+
+    def test_input_timestamps_remain_unchanged(self, dataset_x, dataset_y):
+        dataset_x._created = datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC)
+        dataset_x._modified = datetime(2020, 1, 2, 4, 4, 5, tzinfo=UTC)
+        dataset_y._created = datetime(2021, 1, 2, 3, 4, 5, tzinfo=UTC)
+        dataset_y._modified = datetime(2021, 1, 2, 4, 4, 5, tzinfo=UTC)
+
+        concatenate(dataset_x, dataset_y, dims="x")
+
+        assert dataset_x._created == datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC)
+        assert dataset_x._modified == datetime(2020, 1, 2, 4, 4, 5, tzinfo=UTC)
+        assert dataset_y._created == datetime(2021, 1, 2, 3, 4, 5, tzinfo=UTC)
+        assert dataset_y._modified == datetime(2021, 1, 2, 4, 4, 5, tzinfo=UTC)
 
 
 # ======================================================================================
@@ -556,6 +597,12 @@ class TestStackCharacterization:
         a, b = stack_pair_1d
         s = stack(a, b)
         assert len(s.history) == 1
+        assert "Created by stack from 2 datasets: alpha, beta" in s.history[0]
+
+    def test_stack_axis_1_metadata_matches_stack_contract(self, stack_pair_1d):
+        a, b = stack_pair_1d
+        s = stack(a, b, axis=1)
+        assert s.description == "Stack of 2 datasets:\n( alpha, beta )"
         assert "Created by stack from 2 datasets: alpha, beta" in s.history[0]
 
     def test_stack_author_merged(self, stack_pair_1d):

--- a/tests/test_core/test_dataset/test_dataset_creation.py
+++ b/tests/test_core/test_dataset/test_dataset_creation.py
@@ -180,6 +180,14 @@ def test_dataset_filename():
 
     ndd2.filename = None
     assert ndd2.filename is None
+    ndd2.filename = "restored.spc"
+    assert ndd2.filename == Path("restored.spc")
+
+    ndd3 = scp.NDDataset([7.0, 8.0, 9.0], name="named")
+    assert ndd3.filename == Path("named.scp")
+    ndd3.filename = None
+    ndd3.name = "renamed"
+    assert ndd3.filename is None
 
 
 def test_nddataset_deepcopy():

--- a/tests/test_core/test_dataset/test_dataset_creation.py
+++ b/tests/test_core/test_dataset/test_dataset_creation.py
@@ -178,6 +178,9 @@ def test_dataset_filename():
     ndd2.filename = "zzzz"
     assert ndd2.filename == Path("zzzz")
 
+    ndd2.filename = None
+    assert ndd2.filename is None
+
 
 def test_nddataset_deepcopy():
     """Deep copy via copy.deepcopy or copy() isolates all mutable state."""

--- a/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
@@ -326,7 +326,7 @@ class TestMultiSourceOperations:
         assert "Inplace binary op" in _entry(ds1.history[-1])
 
     def test_concatenate_replaces_history(self):
-        """Concatenate REPLACES history with 'Created by concatenate'."""
+        """Concatenate replaces history with a single synthesized entry."""
         a = scp.NDDataset([[1.0, 2.0], [3.0, 4.0]], name="A")
         b = scp.NDDataset([[5.0, 6.0], [7.0, 8.0]], name="B")
         a.history = ["History A"]
@@ -335,7 +335,9 @@ class TestMultiSourceOperations:
         result = scp.concatenate(a, b)
 
         assert len(result.history) == 1
-        assert _entry(result.history[0]) == "Created by concatenate"
+        assert (
+            _entry(result.history[0]) == "Created by concatenate from 2 datasets: A, B"
+        )
 
     def test_importer_merge_replaces_history(self):
         """Importer merge replaces history with 'Merged from several files'."""
@@ -595,7 +597,9 @@ class TestHistoryLoss:
         a.history = ["Input A history"]
         b.history = ["Input B history"]
         result = scp.concatenate(a, b)
-        assert _entry(result.history[0]) == "Created by concatenate"
+        assert (
+            _entry(result.history[0]) == "Created by concatenate from 2 datasets: A, B"
+        )
 
     def test_integration_loses_prior_history(self):
         """Integration results lose prior operation history."""

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -8,6 +8,7 @@
 """Tests for the ndplugin module"""
 
 import base64
+import copy
 import json
 import pickle
 import zipfile
@@ -145,6 +146,34 @@ def test_ndio_2D(ndataset_2d, tmp_path):
     nd = NDDataset.load(tmp_path / "essai2D")
     assert nd.directory == tmp_path
     f.unlink()
+
+
+def test_filename_none_copy_and_deepcopy_preserve_explicit_none():
+    ds = NDDataset([1.0, 2.0, 3.0], name="filename_none")
+    ds.filename = None
+
+    shallow = ds.copy()
+    deep = copy.deepcopy(ds)
+
+    assert ds.filename is None
+    assert shallow.filename is None
+    assert deep.filename is None
+
+
+def test_filename_none_not_serialized_as_extra_schema_field(tmp_path):
+    ds = NDDataset([1.0, 2.0, 3.0], name="schema_filename_none")
+    ds.filename = None
+    filename = ds.save_as(tmp_path / "schema_filename_none", confirm=False)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    assert "_filename_explicit_none" not in js
+    assert "filename_explicit_none" not in js
+
+    loaded = NDDataset.load(filename)
+    assert loaded.filename == filename
 
 
 def test_ndio_roundtrip_preserves_selected_non_first_default(tmp_path):

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -1167,6 +1167,16 @@ class TestSerializationRoundtrip:
         loaded = Project.load(filename)
         assert loaded.filename == filename
 
+    def test_project_copy_preserves_only_explicit_filename_none(self):
+        proj = Project(name="project_copy_filename_none")
+        proj.add_dataset(NDDataset([1.0, 2.0, 3.0], name="data"))
+        proj.filename = None
+
+        copied = proj.copy()
+
+        assert copied.filename is None
+        assert copied.name == proj.name
+
     def test_save_as_creates_new_file(self, ds1):
         proj = Project(name="overwrite_test")
         proj.add_dataset(ds1)

--- a/tests/test_core/test_projects/test_projects.py
+++ b/tests/test_core/test_projects/test_projects.py
@@ -1150,6 +1150,23 @@ class TestSerializationRoundtrip:
         assert loaded.name == "filename_name_wins"
         assert loaded.meta.description == "saved metadata"
 
+    def test_project_filename_none_not_serialized_as_extra_schema_field(self, tmp_path):
+        proj = Project(name="project_filename_none")
+        proj.add_dataset(NDDataset([1.0, 2.0, 3.0], name="data"))
+        proj.filename = None
+
+        filename = proj.save_as(tmp_path / "project_filename_none")
+
+        with zipfile.ZipFile(filename, "r") as zipf:
+            member = zipf.namelist()[0]
+            js = json.loads(zipf.read(member).decode("utf-8"))
+
+        assert "_filename_explicit_none" not in js
+        assert "filename_explicit_none" not in js
+
+        loaded = Project.load(filename)
+        assert loaded.filename == filename
+
     def test_save_as_creates_new_file(self, ds1):
         proj = Project(name="overwrite_test")
         proj.add_dataset(ds1)

--- a/tests/test_core/test_readers/test_read_matlab.py
+++ b/tests/test_core/test_readers/test_read_matlab.py
@@ -68,6 +68,22 @@ def test_read_matlab_multiple_variables(tmp_path):
     assert not any(ds.name.startswith("__") for ds in datasets)
 
 
+def test_read_matlab_singleton_shape_groups_preserve_variable_names(tmp_path):
+    path = tmp_path / "singleton_groups.mat"
+    savemat(
+        path,
+        {
+            "alpha": np.arange(6.0).reshape(2, 3),
+            "beta": np.arange(8.0).reshape(2, 4),
+        },
+    )
+
+    datasets = read_matlab(path)
+
+    assert isinstance(datasets, list)
+    assert {ds.name for ds in datasets} == {"alpha", "beta"}
+
+
 def test_read_matlab_single_1d_array_currently_uses_row_shape_and_no_coordset(tmp_path):
     path = tmp_path / "single_1d.mat"
     savemat(path, {"trace": np.arange(5)})

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -86,6 +86,9 @@ def test_concatenate(IR_dataset_2D):
 
     # titles
     s0.title = "new_title"
+    assert concatenate(s0, s1).title == "<untitled>"
+
+    s1.title = "new_title"
     assert concatenate(s0, s1).title == "new_title"
 
     # incompatible dimensions
@@ -368,3 +371,101 @@ def test_stack_regression():
     assert result.shape == (2, 2, 3)
     # The new leading dimension coordinate should have two labels
     assert len(result.dims) == 3
+
+
+def test_concatenate_resets_multi_source_identity_metadata():
+    x = scp.Coord(np.arange(3.0), name="x")
+    y = scp.Coord(np.arange(2.0), name="y")
+    ds1 = scp.NDDataset(
+        np.ones((2, 3)),
+        coordset=[y, x],
+        name="left",
+        title="shared",
+    )
+    ds2 = scp.NDDataset(
+        np.full((2, 3), 2.0),
+        coordset=[y, x],
+        name="right",
+        title="shared",
+    )
+    ds1.origin = "origin-left"
+    ds2.origin = "origin-right"
+    ds1.filename = "left.scp"
+    ds2.filename = "right.scp"
+
+    result = concatenate(ds1, ds2, dims="x")
+
+    assert result._name == ""
+    assert result.name.startswith("NDDataset")
+    assert result.title == "shared"
+    assert result.description == "Concatenation of 2 datasets:\n( left, right )"
+    assert result.origin == "multiple: origin-left | origin-right"
+    assert result.filename is None
+    assert "Created by concatenate from 2 datasets: left, right" in result.history[0]
+
+
+def test_stack_uses_stack_specific_metadata_text():
+    x = scp.Coord(np.arange(3.0), name="x")
+    ds1 = scp.NDDataset(np.array([1.0, 2.0, 3.0]), coordset=[x], name="left")
+    ds2 = scp.NDDataset(np.array([4.0, 5.0, 6.0]), coordset=[x], name="right")
+
+    result = stack(ds1, ds2)
+
+    assert result.description == "Stack of 2 datasets:\n( left, right )"
+    assert "Created by stack from 2 datasets: left, right" in result.history[0]
+
+
+def test_concatenate_does_not_mutate_inputs():
+    x = scp.Coord(np.arange(3.0), name="x")
+    y = scp.Coord(np.arange(2.0), name="y")
+    ds1 = scp.NDDataset(
+        np.ones((2, 3)),
+        coordset=[y, x],
+        name="left",
+        title="left-title",
+    )
+    ds2 = scp.NDDataset(
+        np.full((2, 3), 2.0),
+        coordset=[y, x],
+        name="right",
+        title="right-title",
+    )
+    ds1.filename = "left.scp"
+    ds2.filename = "right.scp"
+    original_ds1_dims = list(ds1.dims)
+    original_ds2_dims = list(ds2.dims)
+    original_ds1_filename = ds1.filename
+    original_ds2_filename = ds2.filename
+
+    concatenate(ds1, ds2, dims="x")
+
+    assert ds1.dims == original_ds1_dims
+    assert ds2.dims == original_ds2_dims
+    assert ds1.title == "left-title"
+    assert ds2.title == "right-title"
+    assert ds1.filename == original_ds1_filename
+    assert ds2.filename == original_ds2_filename
+
+
+def test_stack_does_not_mutate_inputs_for_axis_0_or_axis_1():
+    x = scp.Coord(np.arange(3.0), name="x")
+    axis0_left = scp.NDDataset(np.array([1.0, 2.0, 3.0]), coordset=[x], name="left")
+    axis0_right = scp.NDDataset(
+        np.array([4.0, 5.0, 6.0]),
+        coordset=[x],
+        name="right",
+    )
+    axis1_left = axis0_left.copy()
+    axis1_right = axis0_right.copy()
+
+    stack(axis0_left, axis0_right)
+    stack(axis1_left, axis1_right, axis=1)
+
+    assert axis0_left.shape == (3,)
+    assert axis0_right.shape == (3,)
+    assert axis0_left.dims == ["x"]
+    assert axis0_right.dims == ["x"]
+    assert axis1_left.shape == (3,)
+    assert axis1_right.shape == (3,)
+    assert axis1_left.dims == ["x"]
+    assert axis1_right.dims == ["x"]

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -5,6 +5,9 @@
 # ======================================================================================
 # ruff: noqa
 
+from datetime import UTC
+from datetime import datetime
+
 import numpy as np
 import pytest
 
@@ -184,6 +187,13 @@ def test_concatenate_axis_1_for_1d_profiles():
     assert result.shape == (5, 3)
     assert result.dims == ["x", "y"]
     assert result.y.labels is not None
+    assert result.description == (
+        "Concatenation of 3 datasets:\n( <unnamed>, <unnamed>, <unnamed> )"
+    )
+    assert (
+        "Created by concatenate from 3 datasets: <unnamed>, <unnamed>, <unnamed>"
+        in result.history[0]
+    )
 
 
 # ==============================================================================
@@ -415,6 +425,17 @@ def test_stack_uses_stack_specific_metadata_text():
     assert "Created by stack from 2 datasets: left, right" in result.history[0]
 
 
+def test_stack_axis_1_uses_stack_specific_metadata_text():
+    x = scp.Coord(np.arange(3.0), name="x")
+    ds1 = scp.NDDataset(np.array([1.0, 2.0, 3.0]), coordset=[x], name="left")
+    ds2 = scp.NDDataset(np.array([4.0, 5.0, 6.0]), coordset=[x], name="right")
+
+    result = stack(ds1, ds2, axis=1)
+
+    assert result.description == "Stack of 2 datasets:\n( left, right )"
+    assert "Created by stack from 2 datasets: left, right" in result.history[0]
+
+
 def test_concatenate_does_not_mutate_inputs():
     x = scp.Coord(np.arange(3.0), name="x")
     y = scp.Coord(np.arange(2.0), name="y")
@@ -445,6 +466,50 @@ def test_concatenate_does_not_mutate_inputs():
     assert ds2.title == "right-title"
     assert ds1.filename == original_ds1_filename
     assert ds2.filename == original_ds2_filename
+
+
+def test_concatenate_does_not_mutate_input_state_beyond_identity_metadata():
+    x = scp.Coord(np.arange(3.0), name="x")
+    masked = np.ma.array([1.0, 2.0, 3.0], mask=[False, True, False])
+    ds1 = scp.NDDataset(masked, coordset=[x], units="m", name="left")
+    ds2 = scp.NDDataset(masked * 2.0, coordset=[x], units="m", name="right")
+    ds1.history = "left history"
+    ds2.history = "right history"
+    ds1.meta.project = "shared"
+    ds2.meta.project = "shared"
+    ds1._created = datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds1._modified = datetime(2020, 1, 2, 4, 4, 5, tzinfo=UTC)
+    ds2._created = datetime(2021, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds2._modified = datetime(2021, 1, 2, 4, 4, 5, tzinfo=UTC)
+    before_ds1_data = ds1.data.copy()
+    before_ds2_data = ds2.data.copy()
+    before_ds1_mask = ds1.mask.copy()
+    before_ds2_mask = ds2.mask.copy()
+    before_ds1_history = list(ds1.history)
+    before_ds2_history = list(ds2.history)
+    before_ds1_created = ds1._created
+    before_ds2_created = ds2._created
+    before_ds1_modified = ds1._modified
+    before_ds2_modified = ds2._modified
+    before_ds1_units = ds1.units
+    before_ds2_units = ds2.units
+
+    concatenate(ds1, ds2, axis=1)
+
+    np.testing.assert_allclose(ds1.data, before_ds1_data)
+    np.testing.assert_allclose(ds2.data, before_ds2_data)
+    np.testing.assert_array_equal(ds1.mask, before_ds1_mask)
+    np.testing.assert_array_equal(ds2.mask, before_ds2_mask)
+    assert ds1.units == before_ds1_units
+    assert ds2.units == before_ds2_units
+    assert ds1.history == before_ds1_history
+    assert ds2.history == before_ds2_history
+    assert ds1.meta.project == "shared"
+    assert ds2.meta.project == "shared"
+    assert ds1._created == before_ds1_created
+    assert ds2._created == before_ds2_created
+    assert ds1._modified == before_ds1_modified
+    assert ds2._modified == before_ds2_modified
 
 
 def test_stack_does_not_mutate_inputs_for_axis_0_or_axis_1():


### PR DESCRIPTION
## Summary
- align `concatenate()` and `stack()` with the accepted multi-source metadata policy
- clear inherited single-source identity/provenance fields and synthesize deterministic description/history text
- update targeted semantic tests and release notes, including public `filename=None` behavior

## Why
`concatenate()` and `stack()` were still mixing first-input, last-input and recomputed metadata behavior. That made dataset identity and provenance depend partly on copy artifacts instead of the accepted maintainer contract.

## Impact
This changes only dataset-level identity/provenance metadata for these multi-source assembly operations. Scientific assembly behavior stays unchanged: data order, values, shapes, masks, coordinates, labels, unit compatibility and unit normalization still follow the existing runtime behavior, and input datasets remain unmodified.

## Validation
- `python -m pytest tests/test_processing/test_transformation/test_concatenate.py`
- `python -m pytest tests/test_core/test_dataset/test_combination_semantics_baseline.py tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py tests/test_core/test_dataset/test_dataset_creation.py`
- `git diff --check`
- `pre-commit run --all-files`