### PR TITLE
FIX: align masked arithmetic with the explicit-mask policy

### DIFF
--- a/docs/sources/userguide/processing/math_operations.py
+++ b/docs/sources/userguide/processing/math_operations.py
@@ -295,7 +295,9 @@ _ = out.plot(figsize=(6, 2.5))
 # ##### log
 # Natural logarithm, element-wise.
 #
-# This doesn't generate an error for negative numbers, but the output is masked for those values
+# This doesn't generate an error for negative numbers: the negative values are
+# promoted to complex numbers (with the standard NumPy ``RuntimeWarning``) and
+# the mask is never extended to the newly invalid positions.
 
 # %%
 out = np.log(dataset)
@@ -307,6 +309,9 @@ ax = out.plot(figsize=(6, 2.5), show_mask=True)
 
 # %%
 out = np.log(dataset - dataset.min())
+# log(0) = -inf at the minimum position: the invalid value stays visible (with
+# a warning) and is masked explicitly before plotting
+out[~np.isfinite(out)] = MASKED
 _ = out.plot(figsize=(6, 2.5))
 
 # %% [markdown]

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -31,9 +31,16 @@ Bug Fixes
   union for two datasets) and newly invalid numeric values are no longer
   auto-masked. In particular, division by zero on the masked path leaves
   visible `inf`/`nan` exactly like the unmasked path, `2 / ds` with a masked
-  zero no longer raises and preserves the mask, ufunc domain errors on masked
-  inputs (e.g. `log` or `sqrt` of a masked negative) never extend the mask,
-  and `np.ma.masked` is usable as either operand without an error.
+  zero preserves the mask, and ufunc domain errors on masked inputs
+  (e.g. `log` or `sqrt` of a masked negative) never extend the mask.
+  Domain errors on *visible* values (division by zero, overflow, invalid
+  value) now emit the standard NumPy ``RuntimeWarning`` and return the
+  visible `inf`/`nan` (or complex promotion) instead of raising a
+  ``ValueError``, identically to the unmasked path. Finally, `np.ma.masked`
+  is usable as either operand for ``+``, ``-``, ``*`` and ``/`` without an
+  error; the mask stays symmetric, although ``np.ma.masked <op> ds`` operator
+  forms may still be intercepted by NumPy and return a ``numpy.ma.MaskedArray``
+  (the type asymmetry is inherent to NumPy, not to SpectroChemPy).
 
 - Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
   now preserve the source dataset `name` and append a single history entry while

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,15 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Arithmetic operations on masked datasets now follow the documented mask
+  policy: only the explicit operand masks are preserved (as their broadcast
+  union for two datasets) and newly invalid numeric values are no longer
+  auto-masked. In particular, division by zero on the masked path leaves
+  visible `inf`/`nan` exactly like the unmasked path, `2 / ds` with a masked
+  zero no longer raises and preserves the mask, ufunc domain errors on masked
+  inputs (e.g. `log` or `sqrt` of a masked negative) never extend the mask,
+  and `np.ma.masked` is usable as either operand without an error.
+
 - Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
   now preserve the source dataset `name` and append a single history entry while
   retaining all prior entries, instead of renaming with a ``_Filter.transform``

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,15 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- Arithmetic operations on masked datasets now follow the documented mask
+  policy: only the explicit operand masks are preserved (as their broadcast
+  union for two datasets) and newly invalid numeric values are no longer
+  auto-masked. In particular, division by zero on the masked path leaves
+  visible `inf`/`nan` exactly like the unmasked path, `2 / ds` with a masked
+  zero no longer raises and preserves the mask, ufunc domain errors on masked
+  inputs (e.g. `log` or `sqrt` of a masked negative) never extend the mask,
+  and `np.ma.masked` is usable as either operand without an error.
+
 - Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
   now preserve the source dataset `name` and append a single history entry while
   retaining all prior entries, instead of renaming with a ``_Filter.transform``

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -20,9 +20,16 @@ Bug Fixes
   union for two datasets) and newly invalid numeric values are no longer
   auto-masked. In particular, division by zero on the masked path leaves
   visible `inf`/`nan` exactly like the unmasked path, `2 / ds` with a masked
-  zero no longer raises and preserves the mask, ufunc domain errors on masked
-  inputs (e.g. `log` or `sqrt` of a masked negative) never extend the mask,
-  and `np.ma.masked` is usable as either operand without an error.
+  zero preserves the mask, and ufunc domain errors on masked inputs
+  (e.g. `log` or `sqrt` of a masked negative) never extend the mask.
+  Domain errors on *visible* values (division by zero, overflow, invalid
+  value) now emit the standard NumPy ``RuntimeWarning`` and return the
+  visible `inf`/`nan` (or complex promotion) instead of raising a
+  ``ValueError``, identically to the unmasked path. Finally, `np.ma.masked`
+  is usable as either operand for ``+``, ``-``, ``*`` and ``/`` without an
+  error; the mask stays symmetric, although ``np.ma.masked <op> ds`` operator
+  forms may still be intercepted by NumPy and return a ``numpy.ma.MaskedArray``
+  (the type asymmetry is inherent to NumPy, not to SpectroChemPy).
 
 - Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
   now preserve the source dataset `name` and append a single history entry while

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -3067,6 +3067,7 @@ class NDMath:
         """
 
         from warnings import catch_warnings  # noqa: PLC0415
+        from warnings import warn  # noqa: PLC0415
 
         import numpy as np  # noqa: PLC0415
 
@@ -3100,19 +3101,21 @@ class NDMath:
 
                 # Warning-based fallback to complex
                 if ws and "invalid value encountered in " in ws[-1].message.args[0]:
-                    ws = []
                     if reflected:
                         data = getattr(np, fname)(
                             *args[:1], d.astype(np.complex128), *args[1:]
                         )
                     else:
                         data = getattr(np, fname)(d.astype(np.complex128), *args)
-                    if ws:
-                        raise ValueError(ws[-1].message.args[0])
-                elif ws and "overflow encountered" in ws[-1].message.args[0]:
+
+            # Emit the recorded warning outside the recording context so it
+            # reaches the caller: domain errors on visible values leave visible
+            # inf/nan (or complex promotion) instead of raising.
+            if ws:
+                if "overflow encountered" in ws[-1].message.args[0]:
                     warning_(ws[-1].message.args[0])
-                elif ws:
-                    raise ValueError(ws[-1].message.args[0])
+                else:
+                    warn(ws[-1].message.args[0], category=ws[-1].category, stacklevel=2)
         else:
             branch = _ExecutionPlan.select(fname, d, args)
             try:

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -2689,7 +2689,7 @@ class NDMath:
     # ------------------------------------------------------------------------
     # private methods
     # ------------------------------------------------------------------------
-    def _preprocess_op_inputs(self, fname, inputs):
+    def _preprocess_op_inputs(self, fname, inputs, reflected=False):
         inputs = list(inputs)  # work with a list of objs not tuples
         # print(fname)
 
@@ -2746,15 +2746,14 @@ class NDMath:
             if fname in ["mul", "multiply", "add", "iadd"]:
                 pass
             elif fname in ["truediv", "divide", "true_divide"]:
-                fname = "multiply"
-                inputs[0] = np.reciprocal(inputs[0])
+                reflected = True
             elif fname in ["isub", "sub", "subtract"]:
                 fname = "add"
                 inputs[0] = np.negative(inputs[0])
             else:
                 raise NotImplementedError
 
-        return fname, inputs, objtypes, returntype, is_masked
+        return fname, inputs, objtypes, returntype, is_masked, reflected
 
     # ------------------------------------------------------------------
     # Helper: prepare probe quantities for unit calculations
@@ -2850,9 +2849,7 @@ class NDMath:
 
             # Extract raw data from other
             if othertype in ["NDDataset", "Coord"]:
-                arg = (
-                    other._umasked(other.data, other.mask) if is_masked else other.data
-                )
+                arg = other.data
             else:
                 arg = other.m if isinstance(other, Quantity) else other
 
@@ -2960,6 +2957,7 @@ class NDMath:
         otherqs: list,
         remove_units: bool,
         compatible_units: bool,
+        reflected: bool = False,
     ):
         """
         Compute the resulting units for an operation.
@@ -3031,7 +3029,10 @@ class NDMath:
                 f_u = np.add
 
             try:
-                res = f_u(q, *otherqs)
+                if reflected:
+                    res = f_u(*otherqs, q) if otherqs else f_u(q)
+                else:
+                    res = f_u(q, *otherqs)
             except Exception as e:
                 if not otherqs:
                     res = q
@@ -3054,9 +3055,13 @@ class NDMath:
         d: np.ndarray,
         args: list,
         isufunc: bool,
+        reflected: bool = False,
     ) -> np.ndarray:
         """
         Execute *f* on data *d* and operand *args*.
+
+        When *reflected* is True the operation is ``scalar / data`` instead of
+        ``data / scalar``.
 
         Returns the result data array (may be masked).
         """
@@ -3068,28 +3073,40 @@ class NDMath:
         from spectrochempy.utils._logging import warning_  # noqa: PLC0415
 
         if isufunc:
+            operands = (*args[:1], d, *args[1:]) if reflected else (d, *args)
+
             with catch_warnings(record=True) as ws:
                 # ufunc-specific preprocessing
                 if fname == "log1p":
                     fname = "log"
                     d = d + 1.0
+                    operands = (d, *args)
                 if fname in ["arccos", "arcsin", "arctanh"]:
                     if np.any(np.abs(d) > 1):
                         d = d.astype(np.complex128)
+                        operands = (
+                            (*args[:1], d, *args[1:]) if reflected else (d, *args)
+                        )
                 elif fname in ["sqrt"] and np.any(d < 0):
                     d = d.astype(np.complex128)
+                    operands = (*args[:1], d, *args[1:]) if reflected else (d, *args)
 
                 if fname == "sqrt":
                     data = d ** (1.0 / 2.0)
                 elif fname == "cbrt":
                     data = np.sign(d) * np.abs(d) ** (1.0 / 3.0)
                 else:
-                    data = getattr(np, fname)(d, *args)
+                    data = getattr(np, fname)(*operands)
 
                 # Warning-based fallback to complex
                 if ws and "invalid value encountered in " in ws[-1].message.args[0]:
                     ws = []
-                    data = getattr(np, fname)(d.astype(np.complex128), *args)
+                    if reflected:
+                        data = getattr(np, fname)(
+                            *args[:1], d.astype(np.complex128), *args[1:]
+                        )
+                    else:
+                        data = getattr(np, fname)(d.astype(np.complex128), *args)
                     if ws:
                         raise ValueError(ws[-1].message.args[0])
                 elif ws and "overflow encountered" in ws[-1].message.args[0]:
@@ -3099,17 +3116,103 @@ class NDMath:
         else:
             branch = _ExecutionPlan.select(fname, d, args)
             try:
-                data = _ExecutionPlan.execute(branch, f, d, args)
+                if reflected:
+                    data = _ExecutionPlan.execute(branch, f, args[0], [d])
+                else:
+                    data = _ExecutionPlan.execute(branch, f, d, args)
             except Exception as e:
                 raise ArithmeticError(e.args[0]) from e
 
         return data
+
+    @staticmethod
+    def _explicit_operation_mask(
+        is_masked: bool,
+        obj,
+        objtype: str,
+        other,
+        othertype: str | None,
+    ) -> np.ndarray:
+        """
+        Return the explicit result mask for an arithmetic operation.
+
+        The result mask is the union of the broadcast explicit masks of the
+        NDDataset operands (a single masked source is preserved exactly).
+        ``numpy.ma`` domain masks are never included. Returns ``NOMASK`` when
+        no operand carries an explicit mask.
+        """
+        if not is_masked:
+            return NOMASK
+
+        masks: list = []
+        for operand, otype in ((obj, objtype), (other, othertype)):
+            if operand is None:
+                continue
+            if otype == "MaskedConstant":
+                m = True
+            elif otype in ("NDDataset", "Coord"):
+                m = operand.mask
+                if m is NOMASK or m is None:
+                    continue
+            elif isinstance(operand, np.ma.MaskedArray):
+                m = operand.mask
+            else:
+                continue
+            m = np.asarray(m, dtype=bool)
+            if m.ndim == 0:
+                if not bool(m):
+                    continue
+            elif not np.any(m):
+                continue
+            masks.append(m)
+
+        if not masks:
+            return NOMASK
+
+        result = masks[0]
+        for m in masks[1:]:
+            result = result | m
+        return result
+
+    @staticmethod
+    def _apply_explicit_mask(
+        data: np.ndarray,
+        d: np.ndarray,
+        is_masked: bool,
+        obj,
+        objtype: str,
+        other,
+        othertype: str | None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Restrict *data* to the explicit operand masks and return ``(data, mask)``.
+
+        Any mask produced by ``numpy.ma`` domain rules is discarded; the
+        operand input data *d* is restored at explicitly masked positions.
+        """
+        if isinstance(data, np.ma.MaskedArray):
+            data = data._data
+
+        mask = NDMath._explicit_operation_mask(
+            is_masked, obj, objtype, other, othertype
+        )
+
+        if mask is NOMASK or not np.any(mask):
+            return data, NOMASK
+
+        mask = np.broadcast_to(np.asarray(mask, dtype=bool), data.shape).copy()
+        if np.any(mask):
+            source = np.broadcast_to(d, data.shape)
+            np.copyto(data, source, where=mask)
+
+        return data, mask
 
     def _op(
         self,
         f: Callable,
         inputs: Sequence[ArrayLike],
         isufunc: bool = False,
+        reflected: bool = False,
     ) -> tuple[np.ndarray, str | None, np.ndarray, str | None]:
         # Achieve an operation f on the objs
 
@@ -3124,7 +3227,8 @@ class NDMath:
             objtypes,
             returntype,
             is_masked,
-        ) = self._preprocess_op_inputs(fname, inputs)
+            reflected,
+        ) = self._preprocess_op_inputs(fname, inputs, reflected)
 
         # Now we can proceed
 
@@ -3141,9 +3245,7 @@ class NDMath:
         # ------------------------------------------------------------------------------
         is_dataset = objtype == "NDDataset"
 
-        # Get the underlying data: If one of the input is masked, we will work with
-        # masked array
-        d = obj._umasked(obj.data, obj.mask) if is_masked and is_dataset else obj.data
+        d = obj.data
 
         # Prepare probe quantities and operand data
         q, otherqs, args = self._prepare_operation_quantities(
@@ -3160,24 +3262,16 @@ class NDMath:
 
         # Resolve operation units
         units = self._resolve_operation_units(
-            fname, f, q, otherqs, remove_units, compatible_units
+            fname, f, q, otherqs, remove_units, compatible_units, reflected
         )
 
         # perform operation on magnitudes
-        data = self._execute_operation(
-            f,
-            fname,
-            d,
-            args,
-            isufunc,
-        )
+        data = self._execute_operation(f, fname, d, args, isufunc, reflected)
 
-        # get possible mask
-        if isinstance(data, np.ma.MaskedArray):
-            mask = data._mask
-            data = data._data
-        else:
-            mask = NOMASK
+        # restrict the result mask to the explicit operand masks
+        data, mask = self._apply_explicit_mask(
+            data, d, is_masked, obj, objtype, other, othertype
+        )
 
         # return calculated data, units and mask
         return data, units, mask, returntype
@@ -3201,6 +3295,7 @@ class NDMath:
     def _check_order(fname, inputs):
         objtypes = []
         returntype = None
+        reflected = False
         for _i, obj in enumerate(inputs):
             # type
             objtype = type(obj).__name__
@@ -3221,8 +3316,7 @@ class NDMath:
             if fname in ["mul", "add", "iadd"]:
                 pass
             elif fname in ["truediv", "divide", "true_divide"]:
-                fname = "mul"
-                inputs[0] = np.reciprocal(inputs[0])
+                reflected = True
             elif fname in ["isub", "sub", "subtract"]:
                 fname = "add"
                 inputs[0] = np.negative(inputs[0])
@@ -3234,7 +3328,7 @@ class NDMath:
                 raise NotImplementedError
 
         f = getattr(np, fname) if fname in ["exp"] else getattr(operator, fname)
-        return f, inputs
+        return f, inputs, reflected
 
     @staticmethod
     def _binary_op(f, reflexive=False):
@@ -3242,7 +3336,7 @@ class NDMath:
         def func(self, other):
             fname = f.__name__
             objs = [self, other] if not reflexive else [other, self]
-            fm, objs = self._check_order(fname, objs)
+            fm, objs, reflected = self._check_order(fname, objs)
 
             if hasattr(self, "history"):
                 history = (
@@ -3252,7 +3346,7 @@ class NDMath:
             else:
                 history = None
 
-            data, units, mask, returntype = self._op(fm, objs)
+            data, units, mask, returntype = self._op(fm, objs, reflected=reflected)
             return self._op_result(data, units, mask, history, returntype)
 
         return func
@@ -3267,9 +3361,9 @@ class NDMath:
             # else:
             #    history = None
             objs = [self, other]
-            fm, objs = self._check_order(fname, objs)
+            fm, objs, reflected = self._check_order(fname, objs)
 
-            data, units, mask, returntype = self._op(fm, objs)
+            data, units, mask, returntype = self._op(fm, objs, reflected=reflected)
             self._data = data
             self._units = units
             self._mask = mask

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -3071,8 +3071,6 @@ class NDMath:
 
         import numpy as np  # noqa: PLC0415
 
-        from spectrochempy.utils._logging import warning_  # noqa: PLC0415
-
         if isufunc:
             operands = (*args[:1], d, *args[1:]) if reflected else (d, *args)
 
@@ -3110,12 +3108,10 @@ class NDMath:
 
             # Emit the recorded warning outside the recording context so it
             # reaches the caller: domain errors on visible values leave visible
-            # inf/nan (or complex promotion) instead of raising.
+            # inf/nan (or complex promotion) instead of raising. This applies
+            # uniformly to division by zero, overflow and invalid value.
             if ws:
-                if "overflow encountered" in ws[-1].message.args[0]:
-                    warning_(ws[-1].message.args[0])
-                else:
-                    warn(ws[-1].message.args[0], category=ws[-1].category, stacklevel=2)
+                warn(ws[-1].message.args[0], category=ws[-1].category, stacklevel=2)
         else:
             branch = _ExecutionPlan.select(fname, d, args)
             try:

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -3206,7 +3206,8 @@ class NDMath:
         mask = np.broadcast_to(np.asarray(mask, dtype=bool), data.shape).copy()
         if np.any(mask):
             source = np.broadcast_to(d, data.shape)
-            np.copyto(data, source, where=mask)
+            if np.can_cast(source.dtype, data.dtype, casting="same_kind"):
+                np.copyto(data, source, where=mask)
 
         return data, mask
 

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -1673,6 +1673,23 @@ def test_mask_policy_non_mutation():
     assert not ds.is_masked
 
 
+def test_mask_policy_bool_result_with_masked_input():
+    """
+    Boolean results (comparisons, ``logical_not``) on masked datasets work.
+
+    The explicit mask is preserved even when the result dtype (bool) cannot
+    represent the restored operand data (float).
+    """
+    data = np.array([-1.0, 0.5, 2.0, -3.0])
+    mask = np.array([False, True, False, False])
+    ds = NDDataset(data.copy(), mask=mask.copy())
+    cmp = ds < 0
+    assert_array_equal(cmp.mask, mask)
+    not_cmp = np.logical_not(cmp)
+    assert_array_equal(not_cmp.mask, mask)
+    assert np.issubdtype(not_cmp.data.dtype, np.bool_)
+
+
 def test_mask_policy_union_broadcasting():
     """Mask union is applied on the broadcast shapes."""
     a = NDDataset(np.ones((2, 3)), mask=[[True, False, False], [False, False, False]])

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -108,7 +108,12 @@ def test_ndmath_unary_ufuncs_simple_data(nd2d, name, comment):
 
     ref_masked = f(np.ma.MaskedArray(data, mask=mask))
     if isinstance(result_masked, NDDataset) and name not in _numpy_deviation:
-        assert_array_equal(result_masked.data, ref_masked.data)
+        # Only the explicit mask and the visible (unmasked) values are
+        # contractual for masked operands (RFC arithmetic-mask-semantics):
+        # the mask must be preserved and the unmasked data must match the
+        # NumPy reference.  Data under a masked position is non-normative.
+        assert_array_equal(result_masked.mask, mask)
+        assert_array_equal(result_masked.data[~mask], ref_masked.data[~mask])
 
 
 def test_unary_ops():
@@ -1541,6 +1546,82 @@ def test_mask_propagation():
     assert r.mask[1]
     assert r.mask[2]
     assert not r.mask[3]
+
+
+def test_mask_policy_div_by_zero_visible():
+    """
+    Masked-path division by zero leaves visible inf, no auto-mask.
+
+    RFC arithmetic-mask-semantics: the result must be identical to the
+    unmasked path on the visible (unmasked) positions.
+    """
+    ds = NDDataset(np.array([1.0, 0.0, 3.0]))
+    dsm = NDDataset(np.array([1.0, 0.0, 3.0]), mask=[False, True, False])
+    with np.errstate(divide="ignore", invalid="ignore"):
+        r = dsm / 0.0
+        ru = ds / 0.0
+    # the explicit mask is preserved, no auto-mask on new invalid values
+    assert_array_equal(r.mask, [False, True, False])
+    # visible values are identical to the unmasked path
+    assert_array_equal(r.data[~r.mask], ru.data[~np.asarray(r.mask)])
+    assert np.all(np.isinf(r.data[~r.mask]))
+
+
+def test_mask_policy_reflected_divide_masked_zero():
+    """`2 / ds` with a masked zero does not raise and preserves the mask."""
+    dsm = NDDataset(np.array([1.0, 0.0, 3.0]), mask=[False, True, False])
+    with np.errstate(divide="ignore"):
+        r = 2 / dsm
+    assert isinstance(r, NDDataset)
+    assert_array_equal(r.mask, [False, True, False])
+    assert_array_equal(r.data[~r.mask], np.array([2.0, 2.0 / 3.0]))
+
+
+def test_mask_policy_ma_masked_symmetry():
+    """
+    `np.ma.masked` is usable as either operand without AttributeError.
+
+    The ufunc forms behave symmetrically and return a fully masked
+    NDDataset.  The `np.ma.masked + ds` operator form is intercepted by
+    NumPy and returns a masked array, but never raises.
+    """
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    left = np.add(np.ma.masked, ds)
+    right = np.add(ds, np.ma.masked)
+    assert isinstance(left, NDDataset)
+    assert isinstance(right, NDDataset)
+    assert_array_equal(left.mask, [True, True, True])
+    assert_array_equal(right.mask, [True, True, True])
+    assert_array_equal(left.data, right.data)
+    r_left = np.ma.masked + ds
+    r_right = ds + np.ma.masked
+    assert_array_equal(np.ma.asarray(r_left).mask, [True, True, True])
+    assert isinstance(r_right, NDDataset)
+    assert r_right.mask.all()
+
+
+def test_mask_policy_domain_never_extends_mask():
+    """Ufunc domain errors on masked inputs never extend the mask."""
+    data = np.array([1.0, -4.0, np.e])
+    mask = np.array([False, True, False])
+    dsm = NDDataset(data.copy(), mask=mask)
+    r = np.log(dsm)
+    # the domain error occurs at the masked position: the explicit mask
+    # is preserved, no domain position is added
+    assert_array_equal(r.mask, mask)
+    # visible values are the ufunc output on the visible inputs
+    assert_array_equal(r.data[~mask], np.log(data[~mask]))
+
+
+def test_mask_policy_union_broadcasting():
+    """Mask union is applied on the broadcast shapes."""
+    a = NDDataset(np.ones((2, 3)), mask=[[True, False, False], [False, False, False]])
+    b = NDDataset(np.ones(3), mask=[False, True, False])
+    r = a + b
+    assert_array_equal(r.mask, [[True, True, False], [False, True, False]])
+    c = NDDataset(np.ones((2, 1)), mask=[[False], [True]])
+    r2 = a + c
+    assert_array_equal(r2.mask, [[True, False, False], [True, True, True]])
 
 
 def test_complex_data_operations():

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -1553,12 +1553,14 @@ def test_mask_policy_div_by_zero_visible():
     Masked-path division by zero leaves visible inf, no auto-mask.
 
     RFC arithmetic-mask-semantics: the result must be identical to the
-    unmasked path on the visible (unmasked) positions.
+    unmasked path on the visible (unmasked) positions, and the standard
+    NumPy RuntimeWarning is raised (never a ValueError).
     """
     ds = NDDataset(np.array([1.0, 0.0, 3.0]))
     dsm = NDDataset(np.array([1.0, 0.0, 3.0]), mask=[False, True, False])
-    with np.errstate(divide="ignore", invalid="ignore"):
+    with pytest.warns(RuntimeWarning):
         r = dsm / 0.0
+    with pytest.warns(RuntimeWarning):
         ru = ds / 0.0
     # the explicit mask is preserved, no auto-mask on new invalid values
     assert_array_equal(r.mask, [False, True, False])
@@ -1568,9 +1570,9 @@ def test_mask_policy_div_by_zero_visible():
 
 
 def test_mask_policy_reflected_divide_masked_zero():
-    """`2 / ds` with a masked zero does not raise and preserves the mask."""
+    """`2 / ds` with a masked zero warns (never raises) and preserves the mask."""
     dsm = NDDataset(np.array([1.0, 0.0, 3.0]), mask=[False, True, False])
-    with np.errstate(divide="ignore"):
+    with pytest.warns(RuntimeWarning):
         r = 2 / dsm
     assert isinstance(r, NDDataset)
     assert_array_equal(r.mask, [False, True, False])
@@ -1579,25 +1581,41 @@ def test_mask_policy_reflected_divide_masked_zero():
 
 def test_mask_policy_ma_masked_symmetry():
     """
-    `np.ma.masked` is usable as either operand without AttributeError.
+    `np.ma.masked` is usable as either operand for +, -, *, /.
 
     The ufunc forms behave symmetrically and return a fully masked
-    NDDataset.  The `np.ma.masked + ds` operator form is intercepted by
-    NumPy and returns a masked array, but never raises.
+    NDDataset.  The `np.ma.masked <op> ds` operator forms are intercepted by
+    NumPy and return a masked array: the *mask* stays symmetric even though
+    the *type* does not.  None of these paths raises.
     """
     ds = NDDataset(np.array([1.0, 2.0, 3.0]))
-    left = np.add(np.ma.masked, ds)
-    right = np.add(ds, np.ma.masked)
-    assert isinstance(left, NDDataset)
-    assert isinstance(right, NDDataset)
-    assert_array_equal(left.mask, [True, True, True])
-    assert_array_equal(right.mask, [True, True, True])
-    assert_array_equal(left.data, right.data)
-    r_left = np.ma.masked + ds
-    r_right = ds + np.ma.masked
-    assert_array_equal(np.ma.asarray(r_left).mask, [True, True, True])
-    assert isinstance(r_right, NDDataset)
-    assert r_right.mask.all()
+    # ufunc forms: symmetric, fully masked NDDataset
+    for f in (np.add, np.subtract, np.multiply, np.divide):
+        left = f(np.ma.masked, ds)
+        right = f(ds, np.ma.masked)
+        assert isinstance(left, NDDataset)
+        assert isinstance(right, NDDataset)
+        assert_array_equal(left.mask, [True, True, True])
+        assert_array_equal(right.mask, [True, True, True])
+    # `np.ma.masked <op> ds` operator forms are intercepted by NumPy and
+    # return a fully masked masked array (mask symmetric, type not)
+    for r in (
+        np.ma.masked + ds,
+        np.ma.masked - ds,
+        np.ma.masked * ds,
+        np.ma.masked / ds,
+    ):
+        assert_array_equal(np.ma.asarray(r).mask, [True, True, True])
+    # `ds <op> np.ma.masked` operator forms return a fully masked NDDataset;
+    # the division form warns because the raw computation divides by masked
+    # (= 0), but never raises
+    for r in (ds + np.ma.masked, ds - np.ma.masked, ds * np.ma.masked):
+        assert isinstance(r, NDDataset)
+        assert r.mask.all()
+    with pytest.warns(RuntimeWarning):
+        r_div2 = ds / np.ma.masked
+    assert isinstance(r_div2, NDDataset)
+    assert r_div2.mask.all()
 
 
 def test_mask_policy_domain_never_extends_mask():
@@ -1605,12 +1623,54 @@ def test_mask_policy_domain_never_extends_mask():
     data = np.array([1.0, -4.0, np.e])
     mask = np.array([False, True, False])
     dsm = NDDataset(data.copy(), mask=mask)
-    r = np.log(dsm)
+    with pytest.warns(RuntimeWarning):
+        r = np.log(dsm)
     # the domain error occurs at the masked position: the explicit mask
     # is preserved, no domain position is added
     assert_array_equal(r.mask, mask)
     # visible values are the ufunc output on the visible inputs
     assert_array_equal(r.data[~mask], np.log(data[~mask]))
+
+
+def test_mask_policy_visible_invalid_with_masked_position():
+    """
+    Domain invalidity on a *visible* position while another position is
+    explicitly masked: warns (never raises), promotes to complex, and the
+    mask is not extended.
+    """
+    data = np.array([-4.0, 1.0, np.e])
+    mask = np.array([False, True, False])
+    dsm = NDDataset(data.copy(), mask=mask)
+    with pytest.warns(RuntimeWarning):
+        r = np.log(dsm)
+    # the new invalid value is at the visible position 0 -> complex
+    # promotion, while position 1 stays explicitly masked and the mask is
+    # unchanged
+    assert_array_equal(r.mask, mask)
+    assert np.iscomplexobj(r.data)
+    assert_array_equal(r.data[~mask], np.log(data[~mask].astype(np.complex128)))
+    assert r.data[0].real == pytest.approx(np.log(4.0))
+
+
+def test_mask_policy_non_mutation():
+    """Arithmetic through the masked path never mutates the source dataset."""
+    data = np.array([1.0, 0.0, 3.0])
+    mask = np.array([False, True, False])
+    dsm = NDDataset(data.copy(), mask=mask.copy())
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]))
+    with pytest.warns(RuntimeWarning):
+        _ = dsm / 0.0
+    with pytest.warns(RuntimeWarning):
+        _ = 2 / dsm
+    with pytest.warns(RuntimeWarning):
+        _ = np.log(dsm)
+    _ = ds + np.ma.masked
+    _ = np.multiply(np.ma.masked, ds)
+    assert_array_equal(dsm.data, data)
+    assert_array_equal(dsm.mask, mask)
+    assert dsm.is_masked
+    assert_array_equal(ds.data, np.array([1.0, 2.0, 3.0]))
+    assert not ds.is_masked
 
 
 def test_mask_policy_union_broadcasting():


### PR DESCRIPTION
## Summary

This PR aligns the arithmetic engine with the accepted mask policy
(RFC `arithmetic-mask-semantics`, options §15/§16): explicit masks are the
only contractual mask for arithmetic, `numpy.ma` domain masks no longer leak
into the result, and the masked path is now identical to the unmasked path on
the visible (unmasked) positions.

Start SHA on public `master`: `317689e26679c54e2f7c81a64267b94085c44c34`
Branch head SHA: `70962ed4d8009862087c67f4364649d632fb5a2e5`

## Root cause

The masked path executed arithmetic through `numpy.ma`, so domain failures
(e.g. `log`/`sqrt` of a masked negative) or division by zero could leak
`numpy.ma` masks into the result (auto-masking new invalid values), and the
reflected-reciprocal path (`2 / ds`) applied `np.reciprocal` before dividing,
raising on masked zeros.

## What changed

`core/dataset/arraymixins/ndmath.py`:

- `_check_order` and `_preprocess_op_inputs` now return/thread a `reflected`
  flag; reflected division is executed as `scalar / data` instead of being
  rewritten with `np.reciprocal`.
- `_execute_operation` runs on the raw `ndarray` data (no more `_umasked`
  masked-array execution), with reflected operand ordering and a reflected
  complex-domain fallback.
- New helpers `_explicit_operation_mask` (broadcast union of the explicit
  NDDataset/Coord/`np.ma.masked`/`MaskedArray` masks, never domain masks) and
  `_apply_explicit_mask` (discard `numpy.ma` masks, restore the operand input
  data under the explicit mask; guarded with `np.can_cast(...,
  casting="same_kind")` so bool results from float operands do not raise).
- `_op` applies the explicit mask instead of reading `data._mask`.
- Domain errors on *visible* values (division by zero, overflow, invalid
  value) now emit the standard NumPy `RuntimeWarning` (via `warnings.warn` with
  the recorded category and `stacklevel=2`) and return visible `inf`/`nan` or
  complex promotion instead of raising a `ValueError`, identically to the
  unmasked path.

Behavior:

- masked-path division by zero leaves visible `inf`/`nan` (no auto-mask),
  identical to the unmasked path;
- `2 / ds` with a masked zero no longer raises and preserves the mask;
- `np.ma.masked` is usable as either operand for `+`, `-`, `*`, `/` without an
  `AttributeError`; the mask stays symmetric, although the
  `np.ma.masked <op> ds` operator forms are intercepted by NumPy and return a
  `numpy.ma.MaskedArray` (type asymmetry inherent to NumPy);
- ufunc domain errors on masked inputs never extend the mask;
- dataset–dataset masks combine as the broadcast union.

Tests:

- `test_ndmath_unary_ufuncs_simple_data`: the masked section now asserts the
  policy (mask preserved + visible data matches the NumPy reference) instead
  of the non-contractual data under the mask.
- Eight permanent policy tests added (`test_mask_policy_*`) covering the RFC
  §15 list. They assert `pytest.warns(RuntimeWarning)` (no warning
  suppression) for visible domain errors, including a domain error on a
  visible position while another position is explicitly masked, source
  non-mutation, and boolean results (`<`, `logical_not`) on masked datasets.

## Validation

- `tests/test_core/test_dataset/test_mixins/test_ndmath.py`: 251 passed.
- `tests/test_core/test_dataset/test_dataset_masking.py`: 13 passed.
- `test_math_semantics_baseline.py` + adjacent arithmetic/broadcast suites
  (`test_dataset_math`, `test_dataset_units`,
  `test_combination_semantics_baseline`, `test_shape_semantics_baseline`):
  311 passed.
- `tests/test_docs/test_py_in_docs.py` (executable docs examples): 85 passed,
  1 skipped.
- `pre-commit run --all-files`: passed.
- Changelog entry added (visible domain errors warn instead of raising;
  `np.ma.masked <op> ds` may return a `MaskedArray`); `latest.rst`
  regenerated via the release-note tooling.
- Docs userguide `math_operations.py` "log" section updated for the new
  policy: negatives are complex-promoted with a `RuntimeWarning`, and the
  `log(dataset - min)` example masks the visible `-inf` explicitly before
  plotting.

## Remaining risks

- The `np.ma.masked <op> ds` operator forms still return a NumPy `MaskedArray`
  (NumPy intercepts the left operand): the mask is symmetric but the type is
  not. The ufunc forms are symmetric and the operator forms never raise.
- `ds / np.ma.masked` (masked constant as the right operand) emits a
  `RuntimeWarning` because the raw computation divides by masked (= 0); numpy
  warnings do not report which positions triggered them, so the warning cannot
  be attributed to masked positions generically.
- A scalar `0.0` denominator emits an extra "scalar divide" warning from the
  unit-inference path (pre-existing, out of RFC scope).
- Data under a masked position is non-normative (RFC §8); the engine restores
  the operand input there.