### PR TITLE
DOC: rationalize release notes for 0.12.2

### DIFF
--- a/docs/sources/credits/credits.rst.tmpl
+++ b/docs/sources/credits/credits.rst.tmpl
@@ -25,7 +25,7 @@ and contributed to improve the documentation.
 Third-party Licenses
 ====================
 
-- Reading of TOPSPIN NMR files and digital filter removal is based on
+- Reading of NMR files and digital filter removal is based on
   `nmrglue <https://www.nmrglue.com>`_ open sourcepackage.
   [J.J. Helmus, C.P. Jaroniec, Nmrglue: An open source Python package for the analysis of multidimensional NMR data, J. Biomol. NMR 2013, 55, 355-367.
   `doi: 10.1007/s10858-013-9718-x <https://dx.doi.org/10.1007/s10858-013-9718-x>`_]. **nmrglue** is distributed under the BSD-3 License.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,60 +26,60 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
-- Arithmetic operations on masked datasets now follow the documented mask
-  policy: only the explicit operand masks are preserved (as their broadcast
-  union for two datasets) and newly invalid numeric values are no longer
-  auto-masked. In particular, division by zero on the masked path leaves
-  visible `inf`/`nan` exactly like the unmasked path, `2 / ds` with a masked
-  zero preserves the mask, and ufunc domain errors on masked inputs
-  (e.g. `log` or `sqrt` of a masked negative) never extend the mask.
-  Domain errors on *visible* values (division by zero, overflow, invalid
+- CSV export and JCAMP writing now reject datasets they cannot represent
+  honestly before creating or truncating any file: complex datasets for both
+  formats, and JCAMP datasets without a ``y`` coordinate. No partial or
+  corrupt file is left behind and the source dataset is unmodified.
+
+- JCAMP ``LINK`` files now compute ``FIRSTY``, ``LASTY``, ``MAXY`` and
+  ``MINY`` separately for each spectrum block instead of repeating the first
+  or global extrema across all blocks. The scientific payload and singleton
+  exports are unchanged.
+
+- JCAMP writing now emits truthful ``XUNITS``/``YUNITS`` tags instead of
+  always claiming ``1/CM`` and ``ABSORBANCE``. Numeric values are written
+  unchanged: only exact-scale mappings are accepted (``cm^-1``, ``um``,
+  ``nm``, ``absorbance``, ``transmittance``, or no unit), while merely
+  convertible or arbitrary named units such as ``m^-1``, ``dimensionless``
+  and ``count`` are rejected before any file is created. The reader now maps
+  ``YUNITS=ARBITRARY UNITS`` back to an unset dataset unit.
+
+- Native ``.scp`` and ``.pscp`` persistence now preserves dataset history
+  entries exactly across load/save round-trips instead of collapsing
+  non-empty history to the first entry and retimestamping it during native
+  reconstruction.
+
+- Filter and smoothing outputs (``smooth``, ``savgol``, ``savgol_filter``,
+  ``whittaker``) now preserve the source dataset ``name`` and append a single
+  history entry while retaining all prior entries, instead of renaming with a
+  ``_Filter.transform`` suffix and replacing the history. Savitzky-Golay
+  derivative outputs (``deriv > 0``), ``denoise`` and analysis outputs are
+  unchanged.
+
+- ``concatenate()`` and ``stack()`` now treat their outputs as multi-source
+  derived datasets for identity and provenance metadata. They no longer
+  silently inherit ``name``, ``origin``, ``filename``, ``meta`` or timestamps
+  from a single source dataset, use deterministic synthesized ``description``
+  and ``history`` text, and preserve ``title`` and ``acquisition_date`` only
+  on exact consensus. All scientific assembly behavior and the input datasets
+  are unchanged.
+
+- Arithmetic on masked datasets now follows the explicit-mask policy: only
+  the explicit operand masks are preserved (as their broadcast union for two
+  datasets) and newly invalid numeric values are no longer auto-masked.
+  Division by zero on the masked path leaves visible ``inf``/``nan`` exactly
+  like the unmasked path, ``2 / ds`` with a masked zero preserves the mask,
+  and ufunc domain errors on masked inputs (e.g. ``log`` or ``sqrt`` of a
+  masked negative) never extend the mask.
+
+- Domain errors on *visible* values (division by zero, overflow, invalid
   value) now emit the standard NumPy ``RuntimeWarning`` and return the
-  visible `inf`/`nan` (or complex promotion) instead of raising a
-  ``ValueError``, identically to the unmasked path. Finally, `np.ma.masked`
-  is usable as either operand for ``+``, ``-``, ``*`` and ``/`` without an
-  error; the mask stays symmetric, although ``np.ma.masked <op> ds`` operator
-  forms may still be intercepted by NumPy and return a ``numpy.ma.MaskedArray``
-  (the type asymmetry is inherent to NumPy, not to SpectroChemPy).
-
-- Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
-  now preserve the source dataset `name` and append a single history entry while
-  retaining all prior entries, instead of renaming with a ``_Filter.transform``
-  suffix and replacing the history. Savitzky-Golay derivative outputs
-  (`deriv > 0`), ``denoise`` and analysis outputs are unchanged.
-
-- JCAMP writing now rejects, before any file is created or truncated, datasets
-  without a `y` coordinate (previously producing a partial file) and datasets
-  with complex data (previously silently written with corrupted content).
-  No partial or corrupt file is left behind and the source dataset is
-  unmodified.
-
-- JCAMP `LINK` files now compute `FIRSTY`, `LASTY`, `MAXY` and `MINY`
-  separately for each spectrum block instead of repeating the first/global
-  extrema across all blocks. The scientific payload, singleton exports and
-  unit tags are unchanged.
-
-- JCAMP writing now emits truthful `XUNITS` / `YUNITS` tags instead of always
-  claiming `1/CM` and `ABSORBANCE`. The writer preserves numeric values
-  unchanged, accepts only exact-scale mappings (`cm^-1`, `um`, `nm`,
-  `absorbance`, `transmittance`, or no unit), rejects merely convertible or
-  named arbitrary units such as `m^-1`, `dimensionless`, and `count`, and the
-  reader now maps `YUNITS=ARBITRARY UNITS` back to `dataset.units = None`.
-
-- CSV export now rejects complex datasets before creating or truncating a file,
-  instead of writing complex-valued CSV content that SpectroChemPy cannot read
-  back correctly.
-
-- Native `.scp` and `.pscp` persistence now preserves dataset history entries
-  exactly across load/save round-trips instead of collapsing non-empty history
-  to the first entry and retimestamping it during native reconstruction.
-
-- `concatenate()` and `stack()` now treat their outputs as multi-source derived
-  datasets for identity and provenance metadata. They no longer silently
-  inherit `name`, `origin`, `filename`, `meta`, or timestamps from one source
-  dataset, use deterministic synthesized `description` and `history` text,
-  preserve `title` and `acquisition_date` only on exact consensus, and keep
-  all scientific assembly behavior and input datasets unchanged.
+  visible ``inf``/``nan`` (or complex promotion) instead of raising a
+  ``ValueError``, identically to the unmasked path. ``np.ma.masked`` is
+  usable as either operand of ``+``, ``-``, ``*`` and ``/``, although the
+  ``np.ma.masked <op> ds`` operator forms may still be intercepted by NumPy
+  and return a ``numpy.ma.MaskedArray`` (the type asymmetry is inherent to
+  NumPy, not to SpectroChemPy).
 
 
 .. section
@@ -102,11 +102,12 @@ Deprecations
 ~~~~~~~~~~~~
 .. Add here new deprecations (do not delete this comment)
 
-- Writer kwargs `protocol=` and `description=` are now deprecated across the
-  generic, specialized and namespace writer APIs. Writer dispatch continues to
-  be determined only by the filename suffix, exported description metadata
-  continues to come from `dataset.description`, and passing either kwarg will
-  raise `TypeError` in `0.13.0`.
+- Writer keyword arguments ``protocol=`` and ``description=`` are now
+  deprecated across the generic, specialized and namespace writer APIs.
+  Writer dispatch continues to be determined only by the filename suffix and
+  exported description metadata continues to come from ``dataset.description``.
+  Passing either keyword emits a ``DeprecationWarning`` in 0.12.x and will
+  raise ``TypeError`` in 0.13.0.
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,66 +15,67 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
-- Arithmetic operations on masked datasets now follow the documented mask
-  policy: only the explicit operand masks are preserved (as their broadcast
-  union for two datasets) and newly invalid numeric values are no longer
-  auto-masked. In particular, division by zero on the masked path leaves
-  visible `inf`/`nan` exactly like the unmasked path, `2 / ds` with a masked
-  zero preserves the mask, and ufunc domain errors on masked inputs
-  (e.g. `log` or `sqrt` of a masked negative) never extend the mask.
-  Domain errors on *visible* values (division by zero, overflow, invalid
+- CSV export and JCAMP writing now reject datasets they cannot represent
+  honestly before creating or truncating any file: complex datasets for both
+  formats, and JCAMP datasets without a ``y`` coordinate. No partial or
+  corrupt file is left behind and the source dataset is unmodified.
+
+- JCAMP ``LINK`` files now compute ``FIRSTY``, ``LASTY``, ``MAXY`` and
+  ``MINY`` separately for each spectrum block instead of repeating the first
+  or global extrema across all blocks. The scientific payload and singleton
+  exports are unchanged.
+
+- JCAMP writing now emits truthful ``XUNITS``/``YUNITS`` tags instead of
+  always claiming ``1/CM`` and ``ABSORBANCE``. Numeric values are written
+  unchanged: only exact-scale mappings are accepted (``cm^-1``, ``um``,
+  ``nm``, ``absorbance``, ``transmittance``, or no unit), while merely
+  convertible or arbitrary named units such as ``m^-1``, ``dimensionless``
+  and ``count`` are rejected before any file is created. The reader now maps
+  ``YUNITS=ARBITRARY UNITS`` back to an unset dataset unit.
+
+- Native ``.scp`` and ``.pscp`` persistence now preserves dataset history
+  entries exactly across load/save round-trips instead of collapsing
+  non-empty history to the first entry and retimestamping it during native
+  reconstruction.
+
+- Filter and smoothing outputs (``smooth``, ``savgol``, ``savgol_filter``,
+  ``whittaker``) now preserve the source dataset ``name`` and append a single
+  history entry while retaining all prior entries, instead of renaming with a
+  ``_Filter.transform`` suffix and replacing the history. Savitzky-Golay
+  derivative outputs (``deriv > 0``), ``denoise`` and analysis outputs are
+  unchanged.
+
+- ``concatenate()`` and ``stack()`` now treat their outputs as multi-source
+  derived datasets for identity and provenance metadata. They no longer
+  silently inherit ``name``, ``origin``, ``filename``, ``meta`` or timestamps
+  from a single source dataset, use deterministic synthesized ``description``
+  and ``history`` text, and preserve ``title`` and ``acquisition_date`` only
+  on exact consensus. All scientific assembly behavior and the input datasets
+  are unchanged.
+
+- Arithmetic on masked datasets now follows the explicit-mask policy: only
+  the explicit operand masks are preserved (as their broadcast union for two
+  datasets) and newly invalid numeric values are no longer auto-masked.
+  Division by zero on the masked path leaves visible ``inf``/``nan`` exactly
+  like the unmasked path, ``2 / ds`` with a masked zero preserves the mask,
+  and ufunc domain errors on masked inputs (e.g. ``log`` or ``sqrt`` of a
+  masked negative) never extend the mask.
+
+- Domain errors on *visible* values (division by zero, overflow, invalid
   value) now emit the standard NumPy ``RuntimeWarning`` and return the
-  visible `inf`/`nan` (or complex promotion) instead of raising a
-  ``ValueError``, identically to the unmasked path. Finally, `np.ma.masked`
-  is usable as either operand for ``+``, ``-``, ``*`` and ``/`` without an
-  error; the mask stays symmetric, although ``np.ma.masked <op> ds`` operator
-  forms may still be intercepted by NumPy and return a ``numpy.ma.MaskedArray``
-  (the type asymmetry is inherent to NumPy, not to SpectroChemPy).
-
-- Filter and smoothing outputs (`smooth`, `savgol`, `savgol_filter`, `whittaker`)
-  now preserve the source dataset `name` and append a single history entry while
-  retaining all prior entries, instead of renaming with a ``_Filter.transform``
-  suffix and replacing the history. Savitzky-Golay derivative outputs
-  (`deriv > 0`), ``denoise`` and analysis outputs are unchanged.
-
-- JCAMP writing now rejects, before any file is created or truncated, datasets
-  without a `y` coordinate (previously producing a partial file) and datasets
-  with complex data (previously silently written with corrupted content).
-  No partial or corrupt file is left behind and the source dataset is
-  unmodified.
-
-- JCAMP `LINK` files now compute `FIRSTY`, `LASTY`, `MAXY` and `MINY`
-  separately for each spectrum block instead of repeating the first/global
-  extrema across all blocks. The scientific payload, singleton exports and
-  unit tags are unchanged.
-
-- JCAMP writing now emits truthful `XUNITS` / `YUNITS` tags instead of always
-  claiming `1/CM` and `ABSORBANCE`. The writer preserves numeric values
-  unchanged, accepts only exact-scale mappings (`cm^-1`, `um`, `nm`,
-  `absorbance`, `transmittance`, or no unit), rejects merely convertible or
-  named arbitrary units such as `m^-1`, `dimensionless`, and `count`, and the
-  reader now maps `YUNITS=ARBITRARY UNITS` back to `dataset.units = None`.
-
-- CSV export now rejects complex datasets before creating or truncating a file,
-  instead of writing complex-valued CSV content that SpectroChemPy cannot read
-  back correctly.
-
-- Native `.scp` and `.pscp` persistence now preserves dataset history entries
-  exactly across load/save round-trips instead of collapsing non-empty history
-  to the first entry and retimestamping it during native reconstruction.
-
-- `concatenate()` and `stack()` now treat their outputs as multi-source derived
-  datasets for identity and provenance metadata. They no longer silently
-  inherit `name`, `origin`, `filename`, `meta`, or timestamps from one source
-  dataset, use deterministic synthesized `description` and `history` text,
-  preserve `title` and `acquisition_date` only on exact consensus, and keep
-  all scientific assembly behavior and input datasets unchanged.
+  visible ``inf``/``nan`` (or complex promotion) instead of raising a
+  ``ValueError``, identically to the unmasked path. ``np.ma.masked`` is
+  usable as either operand of ``+``, ``-``, ``*`` and ``/``, although the
+  ``np.ma.masked <op> ds`` operator forms may still be intercepted by NumPy
+  and return a ``numpy.ma.MaskedArray`` (the type asymmetry is inherent to
+  NumPy, not to SpectroChemPy).
 
 Deprecations
 ~~~~~~~~~~~~
 
-- Writer kwargs `protocol=` and `description=` are now deprecated across the
-  generic, specialized and namespace writer APIs. Writer dispatch continues to
-  be determined only by the filename suffix, exported description metadata
-  continues to come from `dataset.description`, and passing either kwarg will
-  raise `TypeError` in `0.13.0`.
+- Writer keyword arguments ``protocol=`` and ``description=`` are now
+  deprecated across the generic, specialized and namespace writer APIs.
+  Writer dispatch continues to be determined only by the filename suffix and
+  exported description metadata continues to come from ``dataset.description``.
+  Passing either keyword emits a ``DeprecationWarning`` in 0.12.x and will
+  raise ``TypeError`` in 0.13.0.


### PR DESCRIPTION
## Summary

Editorial, documentation-only preparation for the `0.12.2` core release. No runtime code, tests, workflows or plugins are touched.

### Scope

- **Comparison audited since `spectrochempy-v0.12.1`** (`66b7347788968e34a762b7813e846ba00be3d72a`):
  exactly 9 commits / PRs `#1504`–`#1512`, all verified against `master`
  `86d5a5bb54a6b1f3298d2f7f25082a55cb5bf8ca`. No open PR is implicitly included.
- **`changelog.rst`**: rationalized release notes for `0.12.2` — flat,
  consolidated list of user-facing fixes (no subtitles), correct RST inline
  code (double backticks), no references to non-public maintainer documents.
  Bug Fixes now read as a simple list grouping the CSV/JCAMP writer guards,
  JCAMP `LINK` extrema and unit tags, native `.scp`/`.pscp` history
  persistence, filter/`concatenate()`/`stack()` metadata, and masked
  arithmetic policy. Deprecations keep a single clear entry for `protocol=` /
  `description=` (removal in `0.13.0`).
- **`latest.rst`**: regenerated with the official generator
  (`.github/workflows/scripts/update_version_and_release_notes.py`), not
  hand-edited. It reports `0.12.2.dev`.
- **`credits.rst.tmpl`**: fix a pre-existing drift with `credits.rst` —
  "TOPSPIN NMR" reduced to "NMR", since the NMR reader is no longer
  TOPSPIN-only. The committed `credits.rst` is left unchanged; regeneration
  now matches it exactly.

### Validations

- `python .github/workflows/scripts/update_version_and_release_notes.py`
  (official `latest.rst` generator) — `index.rst` unchanged;
- docutils parse of `changelog.rst` / `latest.rst` (only the pre-existing
  template `:ref:` role warnings);
- `git diff --check`;
- `pre-commit run --all-files` — all hooks pass;
- the full `docs/make.py --whatsnew` build is blocked locally by a known,
  unrelated environment gap (`spectrochempy-iris` plugin not installed), the
  same gallery failure noted in `#1508`.

### Note

This PR does **not** trigger the release workflow. Publishing `0.12.2`
(Prepare a new release → draft → publish) remains a separate manual action
after this PR is merged.