### PR TITLE
CI: fix core release draft name without dot after v

### DIFF
--- a/.github/workflows/publish_draft_new_release.yml
+++ b/.github/workflows/publish_draft_new_release.yml
@@ -34,6 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           tag_name: spectrochempy-v${{ env.RELEASE_VERSION }}
-          name: SpectroChemPy v.${{ env.RELEASE_VERSION }}
+          name: SpectroChemPy v${{ env.RELEASE_VERSION }}
           draft: true
           prerelease: false


### PR DESCRIPTION
## Summary

`publish_draft_new_release.yml` renders the draft release title as
`SpectroChemPy v.${{ env.RELEASE_VERSION }}`, i.e. `SpectroChemPy v.0.12.2`
(dot after the `v`), while the canonical core release title used by the
project is `SpectroChemPy vX.Y.Z` (e.g. `SpectroChemPy v0.12.2`).

This PR removes the stray dot so the draft is created as
`SpectroChemPy v0.12.2`.

- Tag name (`spectrochempy-vX.Y.Z`) is unchanged.
- Behavior otherwise unchanged (draft, non-prerelease).

Pure CI/workflow change → `no-changelog` label applied.