### PR TITLE
FIX: preserve analysis source provenance before input coercion

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,18 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Analysis outputs that reuse the stored scientific input (e.g. ``PCA.scores``,
+  ``components``, diagnostics, ``result`` outputs, ``PLSRegression`` X-side and
+  Y-side surfaces, ``Optimize.fitted``) now preserve the exact ``author`` of the
+  scientific source dataset instead of recreating the runtime ``user@host``
+  value through the internal ``NDDataset`` input conversion. The snapshot is
+  captured once at ``fit`` time and is never overwritten by later direct calls:
+  a direct ``NDDataset`` argument remains authoritative for the output of that
+  call only, X-side outputs use the X source and Y-side outputs use the Y
+  source, array-like inputs are unaffected, and input datasets are not mutated.
+  Supervised predictions (``predict``) keep their previous behavior until the
+  multi-source provenance policy is implemented.
+
 
 .. section
 

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.12
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.12.2
     v0.12.1
     v0.12.0

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,76 +6,23 @@
 
 :orphan:
 
-What's New in Revision 0.12.2
+What's New in Revision 0.12.3.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.2.
+These are the changes in SpectroChemPy-0.12.3.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
 Bug Fixes
 ~~~~~~~~~
 
-- CSV export and JCAMP writing now reject datasets they cannot represent
-  honestly before creating or truncating any file: complex datasets for both
-  formats, and JCAMP datasets without a ``y`` coordinate. No partial or
-  corrupt file is left behind and the source dataset is unmodified.
-
-- JCAMP ``LINK`` files now compute ``FIRSTY``, ``LASTY``, ``MAXY`` and
-  ``MINY`` separately for each spectrum block instead of repeating the first
-  or global extrema across all blocks. The scientific payload and singleton
-  exports are unchanged.
-
-- JCAMP writing now emits truthful ``XUNITS``/``YUNITS`` tags instead of
-  always claiming ``1/CM`` and ``ABSORBANCE``. Numeric values are written
-  unchanged: only exact-scale mappings are accepted (``cm^-1``, ``um``,
-  ``nm``, ``absorbance``, ``transmittance``, or no unit), while merely
-  convertible or arbitrary named units such as ``m^-1``, ``dimensionless``
-  and ``count`` are rejected before any file is created. The reader now maps
-  ``YUNITS=ARBITRARY UNITS`` back to an unset dataset unit.
-
-- Native ``.scp`` and ``.pscp`` persistence now preserves dataset history
-  entries exactly across load/save round-trips instead of collapsing
-  non-empty history to the first entry and retimestamping it during native
-  reconstruction.
-
-- Filter and smoothing outputs (``smooth``, ``savgol``, ``savgol_filter``,
-  ``whittaker``) now preserve the source dataset ``name`` and append a single
-  history entry while retaining all prior entries, instead of renaming with a
-  ``_Filter.transform`` suffix and replacing the history. Savitzky-Golay
-  derivative outputs (``deriv > 0``), ``denoise`` and analysis outputs are
-  unchanged.
-
-- ``concatenate()`` and ``stack()`` now treat their outputs as multi-source
-  derived datasets for identity and provenance metadata. They no longer
-  silently inherit ``name``, ``origin``, ``filename``, ``meta`` or timestamps
-  from a single source dataset, use deterministic synthesized ``description``
-  and ``history`` text, and preserve ``title`` and ``acquisition_date`` only
-  on exact consensus. All scientific assembly behavior and the input datasets
-  are unchanged.
-
-- Arithmetic on masked datasets now follows the explicit-mask policy: only
-  the explicit operand masks are preserved (as their broadcast union for two
-  datasets) and newly invalid numeric values are no longer auto-masked.
-  Division by zero on the masked path leaves visible ``inf``/``nan`` exactly
-  like the unmasked path, ``2 / ds`` with a masked zero preserves the mask,
-  and ufunc domain errors on masked inputs (e.g. ``log`` or ``sqrt`` of a
-  masked negative) never extend the mask.
-
-- Domain errors on *visible* values (division by zero, overflow, invalid
-  value) now emit the standard NumPy ``RuntimeWarning`` and return the
-  visible ``inf``/``nan`` (or complex promotion) instead of raising a
-  ``ValueError``, identically to the unmasked path. ``np.ma.masked`` is
-  usable as either operand of ``+``, ``-``, ``*`` and ``/``, although the
-  ``np.ma.masked <op> ds`` operator forms may still be intercepted by NumPy
-  and return a ``numpy.ma.MaskedArray`` (the type asymmetry is inherent to
-  NumPy, not to SpectroChemPy).
-
-Deprecations
-~~~~~~~~~~~~
-
-- Writer keyword arguments ``protocol=`` and ``description=`` are now
-  deprecated across the generic, specialized and namespace writer APIs.
-  Writer dispatch continues to be determined only by the filename suffix and
-  exported description metadata continues to come from ``dataset.description``.
-  Passing either keyword emits a ``DeprecationWarning`` in 0.12.x and will
-  raise ``TypeError`` in 0.13.0.
+- Analysis outputs that reuse the stored scientific input (e.g. ``PCA.scores``,
+  ``components``, diagnostics, ``result`` outputs, ``PLSRegression`` X-side and
+  Y-side surfaces, ``Optimize.fitted``) now preserve the exact ``author`` of the
+  scientific source dataset instead of recreating the runtime ``user@host``
+  value through the internal ``NDDataset`` input conversion. The snapshot is
+  captured once at ``fit`` time and is never overwritten by later direct calls:
+  a direct ``NDDataset`` argument remains authoritative for the output of that
+  call only, X-side outputs use the X source and Y-side outputs use the Y
+  source, array-like inputs are unaffected, and input datasets are not mutated.
+  Supervised predictions (``predict``) keep their previous behavior until the
+  multi-source provenance policy is implemented.

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -5,6 +5,7 @@
 # ======================================================================================
 """Module implementing the base abstract classes to define estimators such as PCA, ..."""
 
+import copy
 import logging
 import warnings
 
@@ -22,6 +23,45 @@ from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.exceptions import NotFittedError
 from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.traits import NDDatasetType
+
+
+# ======================================================================================
+# Base class AnalysisConfigurable
+# ======================================================================================
+class AnalysisSourceMetadata:
+    """
+    Internal snapshot of the metadata of a scientific source dataset.
+
+    It is captured from the raw ``X`` / ``Y`` input *before* any
+    ``NDDatasetType`` / ``NDDataset(value)`` coercion or internal preprocessing,
+    so that model outputs can reuse the exact source metadata (e.g. ``author``)
+    instead of the values recreated by the coercion step.
+
+    This is deliberately not a second dataset: it only holds a disconnected
+    copy of the metadata fields, independent of the source object (no shared
+    mutable reference to ``meta``, ``coordset``, ``history`` or ``mask``).
+
+    Only ``author`` is currently consumed by the output wrapping decorator.
+    The other fields are preserved for the deterministic identity/history
+    alignment (see the accepted analysis output metadata policy, PR 2).
+    """
+
+    def __init__(self, source: NDDataset):
+        self.name = source.name
+        self.title = source.title
+        self.description = source.description
+        self.author = source.author
+        self.origin = source.origin
+        self.filename = source.filename
+        self.meta = copy.deepcopy(source.meta)
+        self.units = source.units
+        self.created = source.created
+        self.modified = source.modified
+        self.acquisition_date = source.acquisition_date
+        self.history = list(source.history or [])
+        self.dims = tuple(source.dims)
+        self.coordset = source.coordset.copy() if source.coordset is not None else None
+        self.mask = source.mask.copy() if source.mask is not None else None
 
 
 # ======================================================================================
@@ -57,6 +97,17 @@ class AnalysisConfigurable(BaseConfigurable):
     _fitted = tr.Bool(False, help="False if the model was not yet fitted")
     _outfit = tr.Any(help="the output of the _fit method - generally a tuple")
 
+    _X_source_metadata = tr.Instance(
+        AnalysisSourceMetadata,
+        allow_none=True,
+        help="Snapshot of the metadata of the scientific source assigned to _X",
+    )
+    _Y_source_metadata = tr.Instance(
+        AnalysisSourceMetadata,
+        allow_none=True,
+        help="Snapshot of the metadata of the scientific source assigned to _Y",
+    )
+
     # ----------------------------------------------------------------------------------
     # Configuration parameters (mostly defined in subclass
     # as they depend on the model estimator)
@@ -83,6 +134,47 @@ class AnalysisConfigurable(BaseConfigurable):
             # We should not be able to use any methods requiring fit results
             # until the fit method has been executed
             self._fitted = False
+
+    # ----------------------------------------------------------------------------------
+    # Private metadata snapshot helpers
+    # ----------------------------------------------------------------------------------
+    def _capture_source_metadata(self, role, value, force=False):
+        """
+        Capture (or clear) the metadata snapshot of a scientific source input.
+
+        This helper must be called with the raw input value *before* any
+        ``NDDatasetType`` / ``NDDataset(value)`` coercion or internal
+        preprocessing, at each ``_X`` / ``_Y`` assignment site of a ``fit``.
+
+        Persistent snapshots are only replaced or cleared by ``fit``.
+        Argument-less methods reuse them, and direct-call methods never touch
+        them: a direct ``NDDataset`` argument is used as temporary authority
+        for that call only.
+
+        Parameters
+        ----------
+        role : `str`
+            ``"_X"`` or ``"_Y"``.
+        value : `NDDataset`, array-like or `None`
+            Raw value about to be assigned to the ``_X`` / ``_Y`` trait.
+        force : `bool`, optional
+            ``fit`` semantics: ``True`` clears the snapshot when `value` is
+            ``None`` instead of keeping it.
+
+        Notes
+        -----
+        - an ``NDDataset`` source replaces the current snapshot;
+        - an array-like source clears the snapshot (no scientific source
+          metadata to preserve);
+        - ``None`` keeps the current snapshot unless ``force`` is ``True``.
+        """
+        if value is None and not force:
+            return
+        if isinstance(value, NDDataset):
+            snapshot = AnalysisSourceMetadata(value)
+        else:
+            snapshot = None
+        setattr(self, f"{role}_source_metadata", snapshot)
 
     # ----------------------------------------------------------------------------------
     # Private validation and default getter methods
@@ -138,7 +230,9 @@ class AnalysisConfigurable(BaseConfigurable):
 
         # fire the X and eventually Y validation and preprocessing.
         # X and Y are expected to be resp. NDDataset and NDDataset or list of NDDataset.
+        self._capture_source_metadata("_X", X, force=True)
         self._X = X
+        self._capture_source_metadata("_Y", Y, force=True)
         if Y is not None:
             self._Y = Y
 
@@ -671,7 +765,7 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
     # Public methods
     # ----------------------------------------------------------------------------------
 
-    @_wrap_ndarray_output_to_nddataset(meta_from="_Y", title=None)
+    @_wrap_ndarray_output_to_nddataset(meta_from="_Y", title=None, use_snapshot=False)
     def predict(self, X=None):
         r"""
         Predict targets of given observations.
@@ -1097,7 +1191,9 @@ class LinearRegressionAnalysis(AnalysisConfigurable):
 
         # fire the X and Y validation and preprocessing.
         if Y is not None:
+            self._capture_source_metadata("_X", X, force=True)
             self._X = _make2D(X)
+            self._capture_source_metadata("_Y", Y, force=True)
             self._Y = Y
         else:
             # X should contain the X and Y information (X being the coord and Y the data)
@@ -1106,7 +1202,9 @@ class LinearRegressionAnalysis(AnalysisConfigurable):
                     "The passed argument must have a x coordinates,"
                     "or X input and Y target must be passed separately",
                 )
+            self._capture_source_metadata("_X", X.coord(0), force=True)
             self._X = _make2D(X.coord(0))
+            self._capture_source_metadata("_Y", X, force=True)
             self._Y = X
 
         # _X_preprocessed has been computed when X was set, as well as _Y_preprocessed.

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -326,7 +326,7 @@ for reproducible results across multiple function calls.""",
     @property
     def scores(self):
         """Returns PCA scores."""
-        return self.transform(self.X)
+        return self.transform()
 
     @property
     def result(self):

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -443,6 +443,7 @@ class _set_output:
         typey=None,
         typesingle=None,
         preserve_identity=False,
+        use_snapshot=True,  # reuse the fit metadata snapshot on stored paths
     ):
         self.method = method
         update_wrapper(self, method)
@@ -453,6 +454,7 @@ class _set_output:
         self.typey = typey
         self.typesingle = typesingle
         self.preserve_identity = preserve_identity
+        self.use_snapshot = use_snapshot
 
     @preserve_signature
     def __get__(self, obj, objtype):
@@ -470,11 +472,64 @@ class _set_output:
         if args and type(args[0]) is type(obj):
             args = args[1:]
 
-        original_X = None
-        if args and isinstance(args[0], NDDataset):
-            original_X = args[0]
-        elif isinstance(kwargs.get("dataset"), NDDataset):
-            original_X = kwargs["dataset"]
+        # Identify the direct X and Y arguments of the call, if any.  Three
+        # states are distinguished per role: no direct argument (the fitted
+        # snapshot is reused), a direct NDDataset (its exact author is used),
+        # and a direct array-like (no scientific provenance: the snapshot is
+        # ignored and the runtime value is kept).  An explicit ``None`` counts
+        # as "no direct argument" since it means "reuse the stored input".
+        sentinel = object()
+        direct_X = sentinel
+        direct_Y = sentinel
+        x_params = ("X", "dataset", "X_transform")
+        y_params = ("Y", "Y_transform")
+        try:
+            bound = signature(self.method).bind_partial(obj, *args, **kwargs)
+        except TypeError:
+            bound = None
+        if bound is not None:
+            for name, param in signature(self.method).parameters.items():
+                if name == "self":
+                    continue
+                if param.kind is inspect.Parameter.VAR_KEYWORD:
+                    for key, value in bound.arguments.get(name, {}).items():
+                        if value is None:
+                            continue
+                        if key in x_params:
+                            direct_X = value
+                        elif key in y_params:
+                            direct_Y = value
+                elif (
+                    param.kind
+                    in (
+                        inspect.Parameter.POSITIONAL_ONLY,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        inspect.Parameter.KEYWORD_ONLY,
+                    )
+                    and name in bound.arguments
+                ):
+                    value = bound.arguments[name]
+                    if value is None:
+                        continue
+                    if name in x_params:
+                        direct_X = value
+                    elif name in y_params:
+                        direct_Y = value
+        else:
+            # Fallback for exotic signatures: first two positional arguments
+            # and the recognized keyword arguments.
+            if args and args[0] is not None:
+                direct_X = args[0]
+            if len(args) > 1 and args[1] is not None:
+                direct_Y = args[1]
+            for key in x_params:
+                if kwargs.get(key) is not None:
+                    direct_X = kwargs[key]
+                    break
+            for key in y_params:
+                if kwargs.get(key) is not None:
+                    direct_Y = kwargs[key]
+                    break
 
         # get the method output - one or two arrays depending on the method and *args
         output = self.method(obj, *args, **kwargs)
@@ -507,11 +562,19 @@ class _set_output:
 
             # Now set the NDDataset attributes from the original X
 
-            # determine the input X dataset
+            # determine the input dataset of the current role
             X = getattr(obj, meta_from)
-            metadata_source = (
-                original_X if meta_from == "_X" and original_X is not None else X
-            )
+            direct_source = direct_X if meta_from == "_X" else direct_Y
+            if direct_source is not sentinel and isinstance(direct_source, NDDataset):
+                # A direct scientific source is authoritative for this call.
+                metadata_source = direct_source
+                use_snapshot = False
+            else:
+                metadata_source = X
+                # The snapshot is reused only when no direct argument of this
+                # role was given: a direct array-like carries no provenance
+                # and must not leak the fitted source author.
+                use_snapshot = self.use_snapshot and direct_source is sentinel
 
             # Promote 1D metadata source (e.g., _Y with 1D y) to 2D for
             # coordinate assignment so that dims[1], coord(1), shape[1] etc.
@@ -534,7 +597,22 @@ class _set_output:
                 X = X_new
 
             X_transf.meta = copy.deepcopy(metadata_source.meta)
-            X_transf.author = copy.copy(metadata_source.author)
+            # The exact author of the scientific source is preferred over the
+            # value recreated by the NDDataset coercion of the stored input.
+            # A direct NDDataset argument is authoritative for the output of
+            # its role (X or Y); a direct array-like argument carries no
+            # scientific provenance and keeps the runtime value; stored
+            # ``_X`` / ``_Y`` outputs reuse the metadata snapshot captured at
+            # ``fit`` time only when no direct argument of that role was
+            # given.  Supervised (multi-source) outputs such as ``predict``
+            # do not use the snapshot (deferred to the multi-source policy,
+            # PR 2).
+            author = metadata_source.author
+            if use_snapshot:
+                source_metadata = getattr(obj, f"{meta_from}_source_metadata", None)
+                if source_metadata is not None:
+                    author = source_metadata.author
+            X_transf.author = copy.copy(author)
             X_transf.description = copy.copy(metadata_source.description)
             X_transf.origin = copy.copy(metadata_source.origin)
             X_transf.filename = copy.copy(metadata_source.filename)
@@ -697,6 +775,7 @@ def _wrap_ndarray_output_to_nddataset(
     typey=None,
     typesingle=None,
     preserve_identity=False,
+    use_snapshot=True,
 ):
     # wrap _set_output to allow for deferred calling
     if method:
@@ -714,6 +793,7 @@ def _wrap_ndarray_output_to_nddataset(
                 typey=typey,
                 typesingle=typesingle,
                 preserve_identity=preserve_identity,
+                use_snapshot=use_snapshot,
             )
 
         out = wrapper

--- a/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
@@ -1,0 +1,49 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+"""
+Optimize no-regression provenance tests.
+
+``Optimize`` inherits the analysis provenance snapshot from
+``AnalysisConfigurable``.  Its fitted and components outputs are produced
+through the ``transform`` path and must preserve the scientific source
+``author``, while the numeric fit results must be unchanged.
+
+``residuals`` is a pure-arithmetic output (observed - fitted) and keeps the
+runtime user/host author; aligning it with the scientific source is deferred
+to the later multi-source policy PR (PR 2).
+"""
+
+import numpy as np
+
+import spectrochempy as scp
+
+
+def test_optimize_fitted_and_components_preserve_source_author(
+    synthetic_two_peak_dataset, optimize_script
+):
+    ds = synthetic_two_peak_dataset
+    ds.author = "optimize_author"
+    data_before = ds.data.copy()
+
+    opt = scp.Optimize(script=optimize_script).fit(ds)
+    result = opt.result
+
+    assert result.fitted.author == "optimize_author"
+    assert result.components.author == "optimize_author"
+
+    # Numeric no-regression: residuals still equal observed minus fitted.
+    expected = ds - result.fitted
+    np.testing.assert_allclose(
+        np.ma.asarray(result.residuals.masked_data),
+        np.ma.asarray(expected.masked_data),
+    )
+    assert result.residuals.units == ds.units
+
+    # Input must not be mutated by the fit.
+    assert np.array_equal(ds.data, data_before)
+    assert ds.author == "optimize_author"

--- a/tests/test_analysis/test_decomposition/test_analysis_output_semantics_baseline.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_output_semantics_baseline.py
@@ -202,7 +202,7 @@ class TestMetadataAndProvenance:
         assert scores.name == "source_name_PCA.transform"
         assert scores.title != semantic_dataset.title
         assert scores.units is None
-        assert scores.author != semantic_dataset.author
+        assert scores.author == semantic_dataset.author
         assert scores.origin == semantic_dataset.origin
         assert scores.filename == semantic_dataset.filename
         assert scores.meta.project == semantic_dataset.meta.project
@@ -228,7 +228,7 @@ class TestMetadataAndProvenance:
 
         assert ev_ratio.title == "explained variance ratio"
         assert ev_ratio.units == "percent"
-        assert ev_ratio.author != semantic_dataset.author
+        assert ev_ratio.author == semantic_dataset.author
         assert ev_ratio.meta.project == semantic_dataset.meta.project
         assert ev_ratio.meta is not semantic_dataset.meta
         assert ev_ratio.history[-1].endswith(

--- a/tests/test_analysis/test_decomposition/test_analysis_source_provenance.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_source_provenance.py
@@ -1,0 +1,428 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+"""
+Permanent tests for the analysis source-provenance snapshot.
+
+These tests validate the G14 provenance behavior of the accepted maintainer
+policy `spectrochempy_maintainer/rfcs/analysis-output-metadata-policy.md`
+(PR 1: provenance snapshot and path consistency):
+
+- stored single-source analysis outputs preserve the exact ``author`` of the
+  scientific source instead of recreating the runtime user/host value through
+  ``NDDatasetType`` / ``NDDataset(value)`` coercion;
+- the provenance snapshot is captured once at ``fit`` time; a direct
+  ``NDDataset`` argument is authoritative for that call only and never
+  overwrites the fitted-model snapshot (model vs call provenance are kept
+  distinct);
+- ``fit`` always replaces or clears the snapshots from its new inputs, so no
+  obsolete metadata survives a refit;
+- X-side and Y-side outputs use their own scientific source; supervised
+  ``predict`` is multi-source and keeps its previous behavior until PR 2;
+- input datasets are never mutated and output metadata is independent of later
+  source mutation.
+
+Fields other than ``author`` (name, title, description, history, filename,
+created, modified, acquisition_date, units, ...) are deliberately unchanged
+here; they are aligned in the later policy PRs.
+"""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis._base._analysisbase import AnalysisConfigurable
+from spectrochempy.analysis.crossdecomposition.pls import PLSRegression
+from spectrochempy.analysis.decomposition.efa import EFA
+from spectrochempy.analysis.decomposition.fast_ica import FastICA
+from spectrochempy.analysis.decomposition.nmf import NMF
+from spectrochempy.analysis.decomposition.pca import PCA
+from spectrochempy.utils.system import get_user_and_node
+
+
+@pytest.fixture()
+def source_dataset():
+    """Small PCA dataset with rich metadata and an explicit author."""
+    y = scp.Coord(np.linspace(0.0, 5.0, 6), title="time", units="s")
+    x = scp.Coord(np.linspace(400.0, 700.0, 4), title="wavelength", units="nm")
+    ds = scp.NDDataset(
+        np.array(
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [1.0, 2.0, 3.0, 4.0],
+                [2.0, 3.0, 4.0, 5.0],
+                [3.0, 4.0, 5.0, 6.0],
+                [4.0, 5.0, 6.0, 7.0],
+                [5.0, 6.0, 7.0, 8.0],
+            ]
+        ),
+        coordset=[y, x],
+        units="absorbance",
+        title="source title",
+        name="source_name",
+    )
+    ds.author = "source_author"
+    ds.meta.project = "provenance"
+    ds.history = ["original history entry"]
+    return ds
+
+
+@pytest.fixture()
+def other_author_dataset(source_dataset):
+    """A different scientific source with a distinct author."""
+    other = source_dataset.copy()
+    other.author = "other_author"
+    other.name = "other_name"
+    other.title = "other title"
+    return other
+
+
+@pytest.fixture()
+def pls_inputs():
+    """PLSRegression X/Y training inputs with distinct authors."""
+    rng = np.random.default_rng(0)
+    X = scp.NDDataset(rng.normal(size=(20, 5)), title="X training")
+    X.author = "x_author"
+    Y = scp.NDDataset(rng.normal(size=(20, 3)), title="Y training")
+    Y.author = "y_author"
+    return X, Y
+
+
+@pytest.fixture()
+def mixture_dataset():
+    """Smooth mixture dataset suitable for NMF/FastICA/EFA."""
+    time = np.linspace(0.0, 1.0, 12)
+    wavelength = np.linspace(400.0, 700.0, 6)
+    concentrations = np.column_stack(
+        [
+            np.exp(-0.5 * ((time - 0.30) / 0.10) ** 2),
+            0.7 * np.exp(-0.5 * ((time - 0.70) / 0.12) ** 2),
+        ]
+    )
+    spectra = np.vstack(
+        [
+            1.0 + 0.2 * np.cos(np.linspace(0.0, np.pi, wavelength.size)),
+            0.8 + 0.3 * np.sin(np.linspace(0.0, np.pi, wavelength.size)),
+        ]
+    )
+    ds = scp.NDDataset(
+        concentrations @ spectra,
+        coordset=[scp.Coord(time), scp.Coord(wavelength)],
+        title="mixture",
+    )
+    ds.author = "mixture_author"
+    return ds
+
+
+class TestSourceNonMutation:
+    """Prove that analysis does not mutate its scientific sources."""
+
+    def test_fit_and_outputs_do_not_mutate_source(self, source_dataset):
+        ds = source_dataset
+        before = (
+            ds.data.copy(),
+            ds.mask.copy(),
+            ds.author,
+            list(ds.history),
+            ds.meta.project,
+            ds.title,
+            ds.name,
+            list(ds.dims),
+        )
+
+        pca = PCA(n_components=2).fit(ds)
+        _ = pca.transform()
+        _ = pca.scores
+        _ = pca.result.scores
+        _ = pca.components
+        _ = pca.ev_ratio
+        _ = pca.inverse_transform()
+
+        assert np.array_equal(ds.data, before[0])
+        assert np.array_equal(ds.mask, before[1])
+        assert ds.author == before[2]
+        assert ds.history == before[3]
+        assert ds.meta.project == before[4]
+        assert ds.title == before[5]
+        assert ds.name == before[6]
+        assert ds.dims == before[7]
+
+    def test_output_metadata_independent_of_later_source_mutation(self, source_dataset):
+        ds = source_dataset
+        pca = PCA(n_components=2).fit(ds)
+        scores = pca.scores
+        components = pca.components
+
+        # Mutating the source after the snapshot must not affect the outputs.
+        ds.author = "mutated_after_fit"
+        ds.meta["injected"] = "value"
+        ds.history = ["mutated history"]
+        ds.title = "mutated title"
+
+        assert scores.author == "source_author"
+        assert components.author == "source_author"
+        assert scores.meta is not ds.meta
+        assert scores.meta.project == "provenance"
+        assert "injected" not in scores.meta
+        assert scores.history[-1].endswith("Created using method PCA.transform")
+
+
+class TestPCAMonoSource:
+    """PCA stored and direct paths agree on the scientific source author."""
+
+    def test_stored_outputs_preserve_source_author(self, source_dataset):
+        pca = PCA(n_components=2).fit(source_dataset)
+
+        assert pca.transform().author == "source_author"
+        assert pca.scores.author == "source_author"
+        assert pca.result.scores.author == "source_author"
+        assert pca.components.author == "source_author"
+        assert pca.loadings.author == "source_author"
+        assert pca.ev_ratio.author == "source_author"
+        assert pca.ev.author == "source_author"
+        assert pca.inverse_transform().author == "source_author"
+
+    def test_direct_call_uses_argument_author(
+        self, source_dataset, other_author_dataset
+    ):
+        pca = PCA(n_components=2).fit(source_dataset)
+
+        assert pca.transform(other_author_dataset).author == "other_author"
+        assert pca.inverse_transform(pca.transform(other_author_dataset)).author == (
+            "other_author"
+        )
+
+    def test_fit_transform_uses_direct_author(self, other_author_dataset):
+        scores = PCA(n_components=2).fit_transform(other_author_dataset)
+        assert scores.author == "other_author"
+
+    def test_refit_replaces_snapshot(self, source_dataset, other_author_dataset):
+        pca = PCA(n_components=2)
+        pca.fit(source_dataset)
+        assert pca.scores.author == "source_author"
+
+        pca.fit(other_author_dataset)
+        assert pca.scores.author == "other_author"
+
+    def test_fit_snapshot_survives_direct_transform(
+        self, source_dataset, other_author_dataset
+    ):
+        pca = PCA(n_components=2).fit(source_dataset)
+
+        # The direct call is authoritative for its own output only.
+        assert pca.transform(other_author_dataset).author == "other_author"
+
+        # The fit snapshot is untouched: components and stored paths keep
+        # the provenance of the fitted model, not of the transformed data.
+        assert pca.components.author == "source_author"
+        assert pca.scores.author == "source_author"
+        assert pca.transform().author == "source_author"
+
+    def test_array_like_input_has_no_stale_source_author(self, source_dataset):
+        pca = PCA(n_components=2).fit(source_dataset.data)
+
+        assert pca._X_source_metadata is None
+        assert pca.scores.author == get_user_and_node()
+        assert pca.transform(source_dataset.data).author == get_user_and_node()
+
+    def test_direct_array_like_does_not_leak_snapshot_author(self, source_dataset):
+        pca = PCA(n_components=2).fit(source_dataset)
+
+        # A direct array-like argument carries no scientific provenance: even
+        # though a fit snapshot exists, it must not leak into the output.
+        assert pca.transform(source_dataset.data).author == get_user_and_node()
+
+        # The snapshot is untouched and still serves the stored paths.
+        assert pca.scores.author == "source_author"
+        assert pca.transform().author == "source_author"
+
+    def test_refit_without_y_clears_y_snapshot(self, source_dataset):
+        Y = source_dataset.copy()
+        Y.author = "stale_y_author"
+
+        pca = PCA(n_components=2)
+        # Exercise the base fit signature that accepts Y (not exposed by PCA).
+        AnalysisConfigurable.fit(pca, source_dataset, Y)
+        assert pca._X_source_metadata is not None
+        assert pca._X_source_metadata.author == "source_author"
+        assert pca._Y_source_metadata is not None
+        assert pca._Y_source_metadata.author == "stale_y_author"
+
+        # A new fit without Y must not keep the obsolete Y snapshot.
+        pca.fit(source_dataset)
+        assert pca._X_source_metadata is not None
+        assert pca._X_source_metadata.author == "source_author"
+        assert pca._Y_source_metadata is None
+
+    def test_refit_from_array_like_clears_snapshots(self, source_dataset):
+        pca = PCA(n_components=2).fit(source_dataset)
+        assert pca._X_source_metadata is not None
+
+        # Array-like inputs carry no scientific metadata: the snapshots must
+        # be cleared, never inherited from a previous dataset fit.
+        pca.fit(source_dataset.data)
+        assert pca._X_source_metadata is None
+        assert pca._Y_source_metadata is None
+
+
+class TestPLSRegressionYside:
+    """PLS X-side and Y-side outputs use their own scientific source."""
+
+    def test_x_and_y_snapshots_are_distinct(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        assert pls._X_source_metadata is not None
+        assert pls._Y_source_metadata is not None
+        assert pls._X_source_metadata.author == "x_author"
+        assert pls._Y_source_metadata.author == "y_author"
+        assert pls._X_source_metadata is not pls._Y_source_metadata
+
+    def test_x_side_outputs_use_x_author(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        for output in (
+            pls.x_scores,
+            pls.x_loadings,
+            pls.x_weights,
+            pls.x_rotations,
+            pls.result.x_scores,
+            pls.result.x_loadings,
+        ):
+            assert output.author == "x_author"
+
+    def test_y_side_outputs_use_y_author(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        for output in (
+            pls.y_scores,
+            pls.y_loadings,
+            pls.y_weights,
+            pls.y_rotations,
+            pls.result.y_scores,
+            pls.result.y_loadings,
+        ):
+            assert output.author == "y_author"
+
+    def test_predict_provenance_deferred_until_pr2(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        # A supervised prediction combines Xtrain + Ytrain + Xpredict: the
+        # accepted RFC does not define a partial Y-only merge. PR 1 leaves
+        # predict() unchanged; the runtime value is the recreated user/host.
+        prediction = pls.predict()
+        assert prediction.author != "y_author"
+        assert prediction.author != "x_author"
+        assert prediction.author == get_user_and_node()
+
+        # A direct X argument changes the data used, not the provenance
+        # model: still the recreated runtime value until PR 2.
+        Xnew = X.copy()
+        Xnew.author = "predict_author"
+        assert pls.predict(Xnew).author == get_user_and_node()
+
+    def test_transform_both_uses_respective_authors(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        x_scores, y_scores = pls.transform(X, Y, both=True)
+        assert x_scores.author == "x_author"
+        assert y_scores.author == "y_author"
+
+    def test_transform_direct_y_argument_is_authoritative(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        # A direct Y argument is authoritative for the Y-side output of that
+        # call only, even when its author differs from the fitted Y source.
+        Xother = X.copy()
+        Xother.author = "x_other_author"
+        Yother = Y.copy()
+        Yother.author = "y_other_author"
+
+        x_scores, y_scores = pls.transform(Xother, Yother, both=True)
+        assert x_scores.author == "x_other_author"
+        assert y_scores.author == "y_other_author"
+
+        # The fit snapshots are untouched by the direct call.
+        assert pls._X_source_metadata.author == "x_author"
+        assert pls._Y_source_metadata.author == "y_author"
+
+        # Without a direct Y argument, the Y-side output falls back to the
+        # fitted Y snapshot, while the direct X argument stays authoritative
+        # for the X-side output.
+        x_scores, y_scores = pls.transform(Xother, both=True)
+        assert x_scores.author == "x_other_author"
+        assert y_scores.author == "y_author"
+
+    def test_direct_array_like_y_does_not_leak_snapshot_author(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        # Direct array-like X and Y carry no scientific provenance: the fitted
+        # snapshots must not leak into either side of the output.
+        x_scores, y_scores = pls.transform(X.data, Y.data, both=True)
+        assert x_scores.author == get_user_and_node()
+        assert y_scores.author == get_user_and_node()
+
+    def test_inverse_transform_direct_y_transform_authority(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        Xt = X.copy()
+        Xt.author = "x_transform_author"
+        Yt = Y.copy()
+        Yt.author = "y_transform_author"
+        x_scores, y_scores = pls.transform(Xt, Yt, both=True)
+
+        # The Y_transform keyword is recognized as the direct Y argument and
+        # is authoritative for the Y-side reconstruction of this call.
+        X_rec, Y_rec = pls.inverse_transform(x_scores, y_scores, both=True)
+        assert X_rec.author == "x_transform_author"
+        assert Y_rec.author == "y_transform_author"
+
+    def test_fit_transform_uses_direct_authors(self, pls_inputs):
+        X, Y = pls_inputs
+        pls = PLSRegression(n_components=2)
+        x_scores = pls.fit_transform(X, Y)
+        assert x_scores.author == "x_author"
+
+
+class TestOtherDecompositionFamilies:
+    """NMF, FastICA and EFA preserve the source author on stored outputs."""
+
+    def test_nmf(self, mixture_dataset):
+        nmf = NMF(
+            n_components=2,
+            init="nndsvda",
+            max_iter=500,
+            random_state=0,
+        ).fit(mixture_dataset)
+
+        assert nmf.transform().author == "mixture_author"
+        assert nmf.components.author == "mixture_author"
+        assert nmf.result.W.author == "mixture_author"
+
+    def test_fast_ica(self, mixture_dataset):
+        ica = FastICA(
+            n_components=2,
+            max_iter=500,
+            random_state=0,
+        ).fit(mixture_dataset)
+
+        assert ica.A.author == "mixture_author"
+        assert ica.components.author == "mixture_author"
+        assert ica.result.A.author == "mixture_author"
+
+    def test_efa(self, mixture_dataset):
+        efa = EFA(n_components=2).fit(mixture_dataset)
+
+        assert efa.f_ev.author == "mixture_author"
+        assert efa.result.f_ev.author == "mixture_author"

--- a/tests/test_processing/test_processing_wrapper_semantics_baseline.py
+++ b/tests/test_processing/test_processing_wrapper_semantics_baseline.py
@@ -299,14 +299,10 @@ class TestPcaWrapper:
         r = ds.denoise(ratio=99.0)
         assert r.name == "ds_name_PCA.inverse_transform"
 
-    def test_author_from_system(self, ds):
-        """
-        Notable: denoise overrides author with system hostname,
-        unlike Filter wrappers which preserve it.
-        """
+    def test_author_preserved(self, ds):
+        """Notable: denoise preserves the scientific source author."""
         r = ds.denoise(ratio=99.0)
-        assert r.author != "test_author"
-        assert "@" in r.author  # likely "user@hostname" format
+        assert r.author == "test_author"
 
     def test_origin_preserved(self, ds):
         r = ds.denoise(ratio=99.0)


### PR DESCRIPTION
## Summary

PR 1 of the accepted analysis-output-metadata-policy (§15 sequencing). Fixes G14: stored single-source analysis outputs now preserve the exact scientific-source `author` instead of recreating the runtime `user@host` value through the internal `NDDataset` input conversion.

Start SHA on public `master`: `d711673dc9b28dd78604ae2a2138459aa13628be`

## Root cause

`_X` / `_Y` are `NDDatasetType(allow_none=True)` traits. On assignment, `NDDatasetType.validate` calls `NDDataset(value)`; for an input that is already an `NDDataset` this conversion is a lossy reconstruction that re-defaults `author` to `get_user_and_node()` (and empties `description`/`history`). The output decorator reused the converted stored input, so property/`result` paths always carried the runtime `user@host` author.

## What changed

- `src/spectrochempy/analysis/_base/_analysisbase.py`
  - new internal `AnalysisSourceMetadata` snapshot class (disconnected, deep-copied metadata — not a dataset);
  - `_X_source_metadata` / `_Y_source_metadata` traits;
  - `_capture_source_metadata(role, value, force=False)` helper — `NDDataset` replaces the snapshot, array-like clears it, `None` keeps it unless `force=True`;
  - snapshots are captured only at `fit` time (`force=True`, so a refit always replaces/clears them, including `fit(X, Y=None)` clearing the Y snapshot); direct calls (`transform`, `inverse_transform`, `score`) never touch the snapshots.
- `src/spectrochempy/utils/decorators.py` — `_wrap_ndarray_output_to_nddataset(use_snapshot=True)` falls back to `obj.{meta_from}_source_metadata.author` on stored-input paths; the direct X and Y arguments are tracked separately by signature binding (positional + `X`/`X_transform`/`dataset` and `Y`/`Y_transform` kwargs) with three states per role: no direct argument (fitted snapshot reused), direct `NDDataset` (its exact author used), direct array-like (snapshot ignored, runtime value kept); `use_snapshot=False` (used by supervised `predict`) disables the fallback.
- `src/spectrochempy/analysis/decomposition/pca.py` — `PCA.scores` now `return self.transform()` instead of `self.transform(self.X)`.

## Behavior

- stored outputs (`PCA.scores`/`components`/`loadings`/diagnostics/`result.*`, `transform()`, `inverse_transform()`) preserve the source `author`;
- the snapshot is captured once at `fit` time; a direct `transform(Xother)` / `transform(Xother, Yother)` is authoritative for the outputs of its role(s) only and never overwrites the fitted-model snapshot; a direct array-like argument (e.g. `transform(X.data)`) carries no provenance and does not leak the fitted source author;
- `fit` always replaces or clears the snapshots from its new inputs (array-like inputs clear them; `fit(X, Y=None)` clears the Y snapshot), so no obsolete metadata survives a refit;
- PLSRegression X-side outputs use the X source, Y-side outputs (scores/loadings) use the Y source — distinct authors, no partial merge; a direct X and/or Y argument is authoritative for the corresponding side of that call only (e.g. `transform(Xother, Yother, both=True)` yields `x_other_author` / `y_other_author`, and `inverse_transform` recognizes `Y_transform`); supervised `predict` is multi-source (Xtrain + Ytrain + Xpredict) and keeps its previous behavior until the PR 2 canonical merge policy;
- Optimize `fitted`/`components` preserve the source `author` (`residuals` is a pure-arithmetic output, deferred to PR 2);
- array-like inputs are unaffected (runtime `user@host`, snapshot stays `None`);
- inputs are never mutated; output metadata is independent of later source mutation;
- `name`, `title`, `description`, `history`, units are intentionally unchanged (PR 2 / PR 3 scope).

## Tests

- `test_analysis_source_provenance.py` (23): non-mutation, metadata independence from later source mutation, PCA mono-source stored/direct/refit/array-like (incl. a direct array-like after a dataset fit not leaking the snapshot), fit-snapshot survival across direct calls, refit clearing (with/without Y, array-like), PLS X-side vs Y-side with per-role direct authority (incl. distinct `Yother.author`, direct array-like Y, `Y_transform` on `inverse_transform`) and `predict` deferred, NMF/FastICA/EFA.
- `test_optimize_provenance.py` (1): fitted/components author preserved, numeric residuals unchanged, input not mutated.
- `test_analysis_output_semantics_baseline.py`: two `author != semantic_dataset.author` assertions updated to `==` (matching the new policy).
- `test_processing_wrapper_semantics_baseline.py`: aligned with the preserved source author.

## Validation

- `pytest tests/test_analysis/test_decomposition tests/test_analysis/test_crossdecomposition` → 715 passed.
- `pytest tests/test_analysis/test_curvefitting/test_optimize.py test_optimize_result.py test_optimize_provenance.py` → 73 passed.
- Focused provenance/baseline files → 160 passed.
- `pre-commit run --all-files`: passed.
- Changelog entry added; `latest.rst`/`index.rst` regenerated via the release-note tooling.

## Remaining risks

- `Optimize.result.residuals` keeps the runtime author (pure-arithmetic output; deferred to PR 2 as documented).
- Supervised `predict` provenance (multi-source canonical merge) is deferred to PR 2; this PR intentionally does not change its behavior.
- `ImportPathMismatchError` when combining sibling `test_analysis/*` dirs in a single pytest invocation is a pre-existing collection quirk, unrelated to this change.
