### PR TITLE
FIX: implement deterministic analysis output metadata

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,17 +26,19 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
-- Analysis outputs that reuse the stored scientific input (e.g. ``PCA.scores``,
-  ``components``, diagnostics, ``result`` outputs, ``PLSRegression`` X-side and
-  Y-side surfaces, ``Optimize.fitted``) now preserve the exact ``author`` of the
-  scientific source dataset instead of recreating the runtime ``user@host``
-  value through the internal ``NDDataset`` input conversion. The snapshot is
-  captured once at ``fit`` time and is never overwritten by later direct calls:
-  a direct ``NDDataset`` argument remains authoritative for the output of that
-  call only, X-side outputs use the X source and Y-side outputs use the Y
-  source, array-like inputs are unaffected, and input datasets are not mutated.
-  Supervised predictions (``predict``) keep their previous behavior until the
-  multi-source provenance policy is implemented.
+- Analysis and fitting outputs now follow deterministic derived-metadata rules
+  instead of inheriting path-dependent combinations of source identity and
+  wrapper defaults. Single-source outputs preserve the captured scientific
+  provenance from ``fit()`` time while generating canonical derived
+  ``name``/``title``/``description``/``history`` text and clearing
+  ``filename``; direct ``NDDataset`` arguments remain authoritative for that
+  call only, array-like inputs do not leak stale provenance, and input datasets
+  are not mutated. Supervised ``PLSRegression.predict()`` now applies the
+  accepted multi-source provenance order (``Xtrain``, ``Ytrain``, then the
+  prediction input), ``Optimize.result.residuals`` now follows the same
+  canonical derived-output policy as fitted data, and SVD diagnostic
+  ``NDDataset`` outputs now use the common diagnostic metadata contract while
+  raw ``U``/``s``/``VT`` factors remain unchanged.
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,14 +15,16 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
-- Analysis outputs that reuse the stored scientific input (e.g. ``PCA.scores``,
-  ``components``, diagnostics, ``result`` outputs, ``PLSRegression`` X-side and
-  Y-side surfaces, ``Optimize.fitted``) now preserve the exact ``author`` of the
-  scientific source dataset instead of recreating the runtime ``user@host``
-  value through the internal ``NDDataset`` input conversion. The snapshot is
-  captured once at ``fit`` time and is never overwritten by later direct calls:
-  a direct ``NDDataset`` argument remains authoritative for the output of that
-  call only, X-side outputs use the X source and Y-side outputs use the Y
-  source, array-like inputs are unaffected, and input datasets are not mutated.
-  Supervised predictions (``predict``) keep their previous behavior until the
-  multi-source provenance policy is implemented.
+- Analysis and fitting outputs now follow deterministic derived-metadata rules
+  instead of inheriting path-dependent combinations of source identity and
+  wrapper defaults. Single-source outputs preserve the captured scientific
+  provenance from ``fit()`` time while generating canonical derived
+  ``name``/``title``/``description``/``history`` text and clearing
+  ``filename``; direct ``NDDataset`` arguments remain authoritative for that
+  call only, array-like inputs do not leak stale provenance, and input datasets
+  are not mutated. Supervised ``PLSRegression.predict()`` now applies the
+  accepted multi-source provenance order (``Xtrain``, ``Ytrain``, then the
+  prediction input), ``Optimize.result.residuals`` now follows the same
+  canonical derived-output policy as fitted data, and SVD diagnostic
+  ``NDDataset`` outputs now use the common diagnostic metadata contract while
+  raw ``U``/``s``/``VT`` factors remain unchanged.

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -22,6 +22,7 @@ from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
 from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.exceptions import NotFittedError
 from spectrochempy.utils.exceptions import SpectroChemPyError
+from spectrochempy.utils.meta import Meta
 from spectrochempy.utils.traits import NDDatasetType
 
 
@@ -55,9 +56,9 @@ class AnalysisSourceMetadata:
         self.filename = source.filename
         self.meta = copy.deepcopy(source.meta)
         self.units = source.units
-        self.created = source.created
-        self.modified = source.modified
-        self.acquisition_date = source.acquisition_date
+        self.created = source._created
+        self.modified = source._modified
+        self.acquisition_date = source._acquisition_date
         self.history = list(source.history or [])
         self.dims = tuple(source.dims)
         self.coordset = source.coordset.copy() if source.coordset is not None else None
@@ -107,6 +108,26 @@ class AnalysisConfigurable(BaseConfigurable):
         allow_none=True,
         help="Snapshot of the metadata of the scientific source assigned to _Y",
     )
+
+    _ANALYSIS_ROLE_TITLES = {
+        "scores": "scores",
+        "y_scores": "y scores",
+        "components": "components",
+        "loadings": "loadings",
+        "weights": "weights",
+        "rotations": "rotations",
+        "concentration_profiles": "concentration profiles",
+        "spectral_profiles": "spectral profiles",
+        "reconstruction": "reconstruction",
+        "fitted_data": "fitted data",
+        "prediction": "prediction",
+        "residuals": "residuals",
+        "diagnostic": "diagnostic",
+        "singular_values": "singular values",
+        "explained_variance": "explained variance",
+        "explained_variance_ratio": "explained variance ratio",
+        "cumulative_explained_variance": "cumulative explained variance",
+    }
 
     # ----------------------------------------------------------------------------------
     # Configuration parameters (mostly defined in subclass
@@ -175,6 +196,317 @@ class AnalysisConfigurable(BaseConfigurable):
         else:
             snapshot = None
         setattr(self, f"{role}_source_metadata", snapshot)
+
+    def _normalize_analysis_role(self, role_id):
+        if role_id == "reconstruction" and type(self).__name__ == "Optimize":
+            return "fitted_data"
+        return role_id
+
+    def _analysis_role_title(self, role_id):
+        return self._ANALYSIS_ROLE_TITLES[role_id]
+
+    @staticmethod
+    def _analysis_ordered_unique_text(values):
+        ordered = []
+        seen = set()
+        for value in values:
+            if value in (None, ""):
+                continue
+            if value in seen:
+                continue
+            ordered.append(value)
+            seen.add(value)
+        if not ordered:
+            return None
+        if len(ordered) == 1:
+            return ordered[0]
+        return " & ".join(ordered)
+
+    @staticmethod
+    def _analysis_source_label(source_metadata):
+        if source_metadata is None or source_metadata.name in (None, ""):
+            return "<unnamed>"
+        return source_metadata.name
+
+    @staticmethod
+    def _analysis_source_token(source_metadata):
+        if source_metadata is None or source_metadata.name in (None, ""):
+            return None
+        return source_metadata.name
+
+    def _analysis_source_list(self, sources):
+        items = [
+            self._analysis_source_label(source)
+            for source in sources
+            if source is not None
+        ]
+        if not items:
+            return "<unnamed>"
+        return " + ".join(items)
+
+    @staticmethod
+    def _analysis_acquisition_date_consensus(sources):
+        sources = [source for source in sources if source is not None]
+        if not sources:
+            return None
+        if len(sources) == 1:
+            return sources[0].acquisition_date
+        values = [source.acquisition_date for source in sources]
+        if any(value is None for value in values):
+            return None
+        if all(value == values[0] for value in values[1:]):
+            return values[0]
+        return None
+
+    @staticmethod
+    def _analysis_snapshot_from_direct_source(source):
+        if isinstance(source, NDDataset):
+            return AnalysisSourceMetadata(source)
+        return None
+
+    def _analysis_resolve_source_metadata(self, role, direct_kind, direct_source):
+        if direct_kind == "dataset":
+            return self._analysis_snapshot_from_direct_source(direct_source)
+        if direct_kind == "arraylike":
+            return None
+        return getattr(self, f"{role}_source_metadata", None)
+
+    def _analysis_reset_history(self, dataset, payload):
+        dataset._history = []
+        dataset.history = payload
+
+    def _analysis_generated_name(self, role_id, source_metadata=None):
+        token = self._analysis_source_token(source_metadata)
+        estimator = type(self).__name__
+        if token is not None:
+            return f"{token}_{estimator}.{role_id}"
+        return f"{estimator}.{role_id}"
+
+    def _analysis_generated_description(
+        self,
+        role_id,
+        *,
+        sources=None,
+        fit_sources=None,
+        prediction_source=None,
+    ):
+        estimator = type(self).__name__
+        role_title = self._analysis_role_title(role_id)
+        source_list = self._analysis_source_list(sources or [])
+        if role_id == "prediction":
+            fit_source_list = self._analysis_source_list(fit_sources or [])
+            prediction_source_list = self._analysis_source_list([prediction_source])
+            return (
+                f"Prediction from {estimator} fit of {fit_source_list} "
+                f"applied to {prediction_source_list}."
+            )
+        if role_id == "fitted_data":
+            return f"Fitted data from {estimator} fit of {source_list}."
+        if role_id == "residuals":
+            return f"Residuals from {estimator} fit of {source_list}."
+        if role_id in {
+            "diagnostic",
+            "singular_values",
+            "explained_variance",
+            "explained_variance_ratio",
+            "cumulative_explained_variance",
+        }:
+            return f"{role_title} diagnostic from {estimator} fit of {source_list}."
+        return f"{role_title} from {estimator} fit of {source_list}."
+
+    def _analysis_generated_history(
+        self,
+        role_id,
+        *,
+        sources=None,
+        fit_sources=None,
+        prediction_source=None,
+    ):
+        estimator = type(self).__name__
+        source_list = self._analysis_source_list(sources or [])
+        if role_id == "prediction":
+            fit_source_list = self._analysis_source_list(fit_sources or [])
+            prediction_source_list = self._analysis_source_list([prediction_source])
+            return (
+                f"Created analysis output prediction with {estimator} from "
+                f"{fit_source_list}; applied to {prediction_source_list}."
+            )
+        if role_id == "fitted_data":
+            return f"Created fitted data with {estimator} from {source_list}."
+        if role_id == "residuals":
+            return f"Created residuals with {estimator} from {source_list}."
+        if role_id in {
+            "diagnostic",
+            "singular_values",
+            "explained_variance",
+            "explained_variance_ratio",
+            "cumulative_explained_variance",
+        }:
+            return f"Created diagnostic {role_id} with {estimator} from {source_list}."
+        return f"Created analysis output {role_id} with {estimator} from {source_list}."
+
+    def _analysis_apply_prediction_support(self, dataset, direct_x_kind, direct_x):
+        xpredict = None
+        if direct_x_kind == "dataset":
+            xpredict = direct_x
+        elif direct_x_kind == "none":
+            xpredict = getattr(self, "_X", None)
+        ytrain = getattr(self, "_Y", None)
+
+        if dataset.ndim == 1:
+            if xpredict is not None and xpredict.coordset is not None:
+                dim = xpredict.dims[0]
+                coord = (
+                    xpredict.coord(0).copy() if xpredict.coord(0) is not None else None
+                )
+                dataset.dims = [dim]
+                dataset.set_coordset({dim: coord})
+        elif dataset.ndim >= 2:
+            obs_dim = dataset.dims[0]
+            target_dim = dataset.dims[-1]
+            obs_coord = None
+            target_coord = None
+            if xpredict is not None:
+                obs_dim = xpredict.dims[0]
+                if xpredict.coordset is not None and xpredict.coord(0) is not None:
+                    obs_coord = xpredict.coord(0).copy()
+            if isinstance(ytrain, NDDataset) and ytrain.ndim > 1:
+                target_dim = ytrain.dims[-1]
+                if ytrain.coordset is not None and ytrain.coord(-1) is not None:
+                    target_coord = ytrain.coord(-1).copy()
+            if obs_dim == target_dim:
+                target_dim = dataset.dims[-1]
+            dataset.dims = [obs_dim, target_dim]
+            dataset.set_coordset({obs_dim: obs_coord, target_dim: target_coord})
+
+        mask = None
+        if dataset.ndim >= 1 and xpredict is not None:
+            xmask = np.ma.getmaskarray(xpredict.mask)
+            if np.any(xmask):
+                if xmask.ndim == 1 and xmask.shape[0] == dataset.shape[0]:
+                    row_mask = xmask
+                elif xmask.ndim >= 2 and xmask.shape[0] == dataset.shape[0]:
+                    row_mask = np.any(xmask.reshape(xmask.shape[0], -1), axis=1)
+                else:
+                    row_mask = None
+                if row_mask is not None:
+                    if dataset.ndim == 1:
+                        mask = row_mask.copy()
+                    else:
+                        mask = np.broadcast_to(
+                            row_mask[:, np.newaxis], dataset.shape
+                        ).copy()
+
+        if dataset.ndim >= 2 and isinstance(ytrain, NDDataset):
+            ymask = np.ma.getmaskarray(ytrain.mask)
+            if np.any(ymask):
+                if ymask.ndim == 1 and ymask.shape[0] == dataset.shape[-1]:
+                    target_mask = ymask
+                elif ymask.ndim >= 2 and ymask.shape[-1] == dataset.shape[-1]:
+                    flat = ymask.reshape(-1, ymask.shape[-1])
+                    target_mask = np.all(flat, axis=0)
+                else:
+                    target_mask = None
+                if target_mask is not None:
+                    col_mask = np.broadcast_to(
+                        target_mask[np.newaxis, :], dataset.shape
+                    )
+                    mask = (
+                        col_mask.copy()
+                        if mask is None
+                        else np.logical_or(mask, col_mask)
+                    )
+
+        dataset.mask = np.False_ if mask is None or not np.any(mask) else mask
+        return dataset
+
+    def _apply_analysis_output_metadata(
+        self,
+        dataset,
+        *,
+        role_id,
+        meta_from,
+        direct_x,
+        direct_y,
+        direct_x_kind,
+        direct_y_kind,
+    ):
+        role_id = self._normalize_analysis_role(role_id)
+        x_source = self._analysis_resolve_source_metadata("_X", direct_x_kind, direct_x)
+        y_source = self._analysis_resolve_source_metadata("_Y", direct_y_kind, direct_y)
+        single_source = x_source if meta_from == "_X" else y_source
+
+        if role_id == "prediction":
+            x_train = getattr(self, "_X_source_metadata", None)
+            y_train = getattr(self, "_Y_source_metadata", None)
+            x_predict = x_source
+            provenance_sources = [
+                source for source in (x_train, y_train, x_predict) if source is not None
+            ]
+            merged_author = self._analysis_ordered_unique_text(
+                [source.author for source in provenance_sources]
+            )
+            merged_origin = self._analysis_ordered_unique_text(
+                [source.origin for source in provenance_sources]
+            )
+            dataset.author = merged_author
+            dataset.origin = "" if merged_origin is None else merged_origin
+            dataset.meta = (
+                copy.deepcopy(y_train.meta) if y_train is not None else Meta()
+            )
+            dataset.name = self._analysis_generated_name(role_id, x_predict)
+            dataset.title = self._analysis_role_title(role_id)
+            dataset.description = self._analysis_generated_description(
+                role_id,
+                fit_sources=[
+                    source for source in (x_train, y_train) if source is not None
+                ],
+                prediction_source=x_predict,
+            )
+            dataset.filename = None
+            dataset.acquisition_date = self._analysis_acquisition_date_consensus(
+                provenance_sources
+            )
+            self._analysis_reset_history(
+                dataset,
+                self._analysis_generated_history(
+                    role_id,
+                    fit_sources=[
+                        source for source in (x_train, y_train) if source is not None
+                    ],
+                    prediction_source=x_predict,
+                ),
+            )
+            return self._analysis_apply_prediction_support(
+                dataset, direct_x_kind, direct_x
+            )
+
+        sources = [single_source] if single_source is not None else []
+        if single_source is not None:
+            dataset.author = copy.copy(single_source.author)
+            dataset.origin = (
+                "" if single_source.origin is None else copy.copy(single_source.origin)
+            )
+            dataset.meta = copy.deepcopy(single_source.meta)
+            dataset.acquisition_date = self._analysis_acquisition_date_consensus(
+                sources
+            )
+        else:
+            dataset.meta = Meta()
+            dataset.acquisition_date = None
+            dataset.origin = ""
+
+        dataset.name = self._analysis_generated_name(role_id, single_source)
+        dataset.title = self._analysis_role_title(role_id)
+        dataset.description = self._analysis_generated_description(
+            role_id, sources=sources
+        )
+        dataset.filename = None
+        self._analysis_reset_history(
+            dataset,
+            self._analysis_generated_history(role_id, sources=sources),
+        )
+        return dataset
 
     # ----------------------------------------------------------------------------------
     # Private validation and default getter methods
@@ -436,7 +768,12 @@ class DecompositionAnalysis(AnalysisConfigurable):
     # ----------------------------------------------------------------------------------
     # Public methods
     # ----------------------------------------------------------------------------------
-    @_wrap_ndarray_output_to_nddataset(units=None, title=None, typex="components")
+    @_wrap_ndarray_output_to_nddataset(
+        units=None,
+        title=None,
+        typex="components",
+        analysis_role="scores",
+    )
     def transform(self, X=None, **kwargs):
         r"""
         Apply dimensionality reduction to `X`.
@@ -490,7 +827,7 @@ class DecompositionAnalysis(AnalysisConfigurable):
 
     # Get doc sections for reuse in subclass
 
-    @_wrap_ndarray_output_to_nddataset
+    @_wrap_ndarray_output_to_nddataset(analysis_role="reconstruction")
     def inverse_transform(self, X_transform=None, **kwargs):
         r"""
         Transform data back to its original space.
@@ -580,7 +917,12 @@ class DecompositionAnalysis(AnalysisConfigurable):
             self.fit(X)
         return self.transform(X, **kwargs)
 
-    @_wrap_ndarray_output_to_nddataset(units=None, title=None, typey="components")
+    @_wrap_ndarray_output_to_nddataset(
+        units=None,
+        title=None,
+        typey="components",
+        analysis_role="components",
+    )
     def get_components(self, n_components=None):
         r"""
         Return the component's dataset: (selected :term:`n_components`, :term:`n_features`).
@@ -604,7 +946,12 @@ class DecompositionAnalysis(AnalysisConfigurable):
         return self._get_components()[:n_components]
 
     @property
-    @_wrap_ndarray_output_to_nddataset(units=None, title="keep", typey="components")
+    @_wrap_ndarray_output_to_nddataset(
+        units=None,
+        title="keep",
+        typey="components",
+        analysis_role="components",
+    )
     def components(self):
         r"""
         `NDDataset` with components in feature space (:term:`n_components`, :term:`n_features`).
@@ -765,7 +1112,12 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
     # Public methods
     # ----------------------------------------------------------------------------------
 
-    @_wrap_ndarray_output_to_nddataset(meta_from="_Y", title=None, use_snapshot=False)
+    @_wrap_ndarray_output_to_nddataset(
+        meta_from="_Y",
+        title=None,
+        use_snapshot=False,
+        analysis_role="prediction",
+    )
     def predict(self, X=None):
         r"""
         Predict targets of given observations.
@@ -844,6 +1196,7 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
         title=None,
         meta_from=("_X", "_Y"),
         typex="components",
+        analysis_role=("scores", "y_scores"),
     )
     def transform(self, X=None, Y=None, both=False, **kwargs):
         r"""

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -345,81 +345,6 @@ class AnalysisConfigurable(BaseConfigurable):
             return f"Created diagnostic {role_id} with {estimator} from {source_list}."
         return f"Created analysis output {role_id} with {estimator} from {source_list}."
 
-    def _analysis_apply_prediction_support(self, dataset, direct_x_kind, direct_x):
-        xpredict = None
-        if direct_x_kind == "dataset":
-            xpredict = direct_x
-        elif direct_x_kind == "none":
-            xpredict = getattr(self, "_X", None)
-        ytrain = getattr(self, "_Y", None)
-
-        if dataset.ndim == 1:
-            if xpredict is not None and xpredict.coordset is not None:
-                dim = xpredict.dims[0]
-                coord = (
-                    xpredict.coord(0).copy() if xpredict.coord(0) is not None else None
-                )
-                dataset.dims = [dim]
-                dataset.set_coordset({dim: coord})
-        elif dataset.ndim >= 2:
-            obs_dim = dataset.dims[0]
-            target_dim = dataset.dims[-1]
-            obs_coord = None
-            target_coord = None
-            if xpredict is not None:
-                obs_dim = xpredict.dims[0]
-                if xpredict.coordset is not None and xpredict.coord(0) is not None:
-                    obs_coord = xpredict.coord(0).copy()
-            if isinstance(ytrain, NDDataset) and ytrain.ndim > 1:
-                target_dim = ytrain.dims[-1]
-                if ytrain.coordset is not None and ytrain.coord(-1) is not None:
-                    target_coord = ytrain.coord(-1).copy()
-            if obs_dim == target_dim:
-                target_dim = dataset.dims[-1]
-            dataset.dims = [obs_dim, target_dim]
-            dataset.set_coordset({obs_dim: obs_coord, target_dim: target_coord})
-
-        mask = None
-        if dataset.ndim >= 1 and xpredict is not None:
-            xmask = np.ma.getmaskarray(xpredict.mask)
-            if np.any(xmask):
-                if xmask.ndim == 1 and xmask.shape[0] == dataset.shape[0]:
-                    row_mask = xmask
-                elif xmask.ndim >= 2 and xmask.shape[0] == dataset.shape[0]:
-                    row_mask = np.any(xmask.reshape(xmask.shape[0], -1), axis=1)
-                else:
-                    row_mask = None
-                if row_mask is not None:
-                    if dataset.ndim == 1:
-                        mask = row_mask.copy()
-                    else:
-                        mask = np.broadcast_to(
-                            row_mask[:, np.newaxis], dataset.shape
-                        ).copy()
-
-        if dataset.ndim >= 2 and isinstance(ytrain, NDDataset):
-            ymask = np.ma.getmaskarray(ytrain.mask)
-            if np.any(ymask):
-                if ymask.ndim == 1 and ymask.shape[0] == dataset.shape[-1]:
-                    target_mask = ymask
-                elif ymask.ndim >= 2 and ymask.shape[-1] == dataset.shape[-1]:
-                    flat = ymask.reshape(-1, ymask.shape[-1])
-                    target_mask = np.all(flat, axis=0)
-                else:
-                    target_mask = None
-                if target_mask is not None:
-                    col_mask = np.broadcast_to(
-                        target_mask[np.newaxis, :], dataset.shape
-                    )
-                    mask = (
-                        col_mask.copy()
-                        if mask is None
-                        else np.logical_or(mask, col_mask)
-                    )
-
-        dataset.mask = np.False_ if mask is None or not np.any(mask) else mask
-        return dataset
-
     def _apply_analysis_output_metadata(
         self,
         dataset,
@@ -477,9 +402,7 @@ class AnalysisConfigurable(BaseConfigurable):
                     prediction_source=x_predict,
                 ),
             )
-            return self._analysis_apply_prediction_support(
-                dataset, direct_x_kind, direct_x
-            )
+            return dataset
 
         sources = [single_source] if single_source is not None else []
         if single_source is not None:

--- a/src/spectrochempy/analysis/crossdecomposition/pls.py
+++ b/src/spectrochempy/analysis/crossdecomposition/pls.py
@@ -193,6 +193,7 @@ class PLSRegression(CrossDecompositionAnalysis):
         units=None,
         title=None,
         typey="components",
+        analysis_role="loadings",
     )
     def x_loadings(self):
         return self._x_loadings
@@ -203,6 +204,7 @@ class PLSRegression(CrossDecompositionAnalysis):
         units=None,
         title=None,
         typey="components",
+        analysis_role="loadings",
     )
     def y_loadings(self):
         return self._y_loadings
@@ -212,6 +214,7 @@ class PLSRegression(CrossDecompositionAnalysis):
         units=None,
         title=None,
         typex="components",
+        analysis_role="scores",
     )
     def x_scores(self):
         return self._x_scores
@@ -222,6 +225,7 @@ class PLSRegression(CrossDecompositionAnalysis):
         units=None,
         title=None,
         typex="components",
+        analysis_role="y_scores",
     )
     def y_scores(self):
         return self._y_scores
@@ -231,6 +235,7 @@ class PLSRegression(CrossDecompositionAnalysis):
         units=None,
         title=None,
         typey="components",
+        analysis_role="rotations",
     )
     def x_rotations(self):
         return self._x_rotations
@@ -239,6 +244,7 @@ class PLSRegression(CrossDecompositionAnalysis):
     @_wrap_ndarray_output_to_nddataset(
         meta_from="_Y",
         typey="components",
+        analysis_role="rotations",
     )
     def y_rotations(self):
         return self._y_rotations
@@ -246,6 +252,7 @@ class PLSRegression(CrossDecompositionAnalysis):
     @property
     @_wrap_ndarray_output_to_nddataset(
         typey="components",
+        analysis_role="weights",
     )
     def x_weights(self):
         return self._x_weights
@@ -254,6 +261,7 @@ class PLSRegression(CrossDecompositionAnalysis):
     @_wrap_ndarray_output_to_nddataset(
         meta_from="_Y",
         typey="components",
+        analysis_role="weights",
     )
     def y_weights(self):
         return self._y_weights

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -1899,6 +1899,15 @@ class Optimize(DecompositionAnalysis):
             getattr(self, "_fit_meta", {}),
             getattr(self, "_model_spec", None),
         )
+        residuals = self._apply_analysis_output_metadata(
+            residuals,
+            role_id="residuals",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
         covariance = _compute_covariance_matrix(
             self._X,
             fitted,

--- a/src/spectrochempy/analysis/decomposition/fast_ica.py
+++ b/src/spectrochempy/analysis/decomposition/fast_ica.py
@@ -281,6 +281,7 @@ array of values drawn from a normal distribution is used."""
         title=None,
         typey="features",
         typex="components",
+        analysis_role="components",
     )
     def mixing(self):
         r"""
@@ -296,6 +297,7 @@ array of values drawn from a normal distribution is used."""
         units=None,
         title=None,
         typey="components",
+        analysis_role="spectral_profiles",
     )
     def St(self):
         r"""
@@ -311,6 +313,7 @@ array of values drawn from a normal distribution is used."""
         units=None,
         title=None,
         typex="components",
+        analysis_role="scores",
     )
     def A(self):
         r"""

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -3484,8 +3484,25 @@ and `St`.
             Final accepted concentration profiles with resolved factor title,
             units, observation coordinate, and component labels.
         """
+        from spectrochempy.core.dataset.nddataset import NDDataset  # noqa: PLC0415
+
         C = super().transform(X, **kwargs)
-        return self._apply_output_metadata(C, self._output_factor_metadata().C)
+        C = self._apply_output_metadata(C, self._output_factor_metadata().C)
+        return self._apply_analysis_output_metadata(
+            C,
+            role_id="concentration_profiles",
+            meta_from="_X",
+            direct_x=X,
+            direct_y=None,
+            direct_x_kind=(
+                "dataset"
+                if isinstance(X, NDDataset)
+                else "arraylike"
+                if X is not None
+                else "none"
+            ),
+            direct_y_kind="none",
+        )
 
     def inverse_transform(self, X_transform=None, **kwargs):
         r"""
@@ -3541,8 +3558,15 @@ and `St`.
         """
         C = self.transform()
         self._apply_output_metadata(C, self._output_factor_metadata().C)
-        C.name = "Pure concentration profile, mcs-als of " + self.X.name
-        return C
+        return self._apply_analysis_output_metadata(
+            C,
+            role_id="concentration_profiles",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     @property
     def St(self):
@@ -3573,8 +3597,15 @@ and `St`.
         """
         St = self.components
         self._apply_output_metadata(St, self._output_factor_metadata().St)
-        St.name = "Pure spectra profile, mcs-als of " + self.X.name
-        return St
+        return self._apply_analysis_output_metadata(
+            St,
+            role_id="spectral_profiles",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     @property
     @_wrap_ndarray_output_to_nddataset(units=None, title=None, typex="components")

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -321,7 +321,16 @@ for reproducible results across multiple function calls.""",
     @property
     def loadings(self):
         """Return PCA loadings."""
-        return self.get_components()
+        loadings = self.get_components()
+        return self._apply_analysis_output_metadata(
+            loadings,
+            role_id="loadings",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     @property
     def scores(self):
@@ -376,6 +385,7 @@ for reproducible results across multiple function calls.""",
         units=None,
         title="explained variance",
         typesingle="components",
+        analysis_role="explained_variance",
     )
     def explained_variance(self):
         return self._pca.explained_variance_
@@ -387,6 +397,7 @@ for reproducible results across multiple function calls.""",
         units="percent",
         title="explained variance ratio",
         typesingle="components",
+        analysis_role="explained_variance_ratio",
     )
     def explained_variance_ratio(self):
         return self._pca.explained_variance_ratio_ * 100.0
@@ -398,6 +409,7 @@ for reproducible results across multiple function calls.""",
         units="percent",
         title="cumulative explained variance",
         typesingle="components",
+        analysis_role="cumulative_explained_variance",
     )
     def cumulative_explained_variance(self):
         return np.cumsum(self._pca.explained_variance_ratio_) * 100.0

--- a/src/spectrochempy/analysis/decomposition/simplisma.py
+++ b/src/spectrochempy/analysis/decomposition/simplisma.py
@@ -548,18 +548,30 @@ class SIMPLISMA(DecompositionAnalysis):
     def C(self):
         """Intensities ('concentrations') of pure compounds in spectra."""
         C = self.transform()
-        C.name = "Relative Concentrations"
         C.coord(-1).title = "# pure compound"
-        C.description = "Concentration/contribution matrix from SIMPLISMA:"  # + logs
-        return C
+        return self._apply_analysis_output_metadata(
+            C,
+            role_id="concentration_profiles",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     @property
     def St(self):
         """Spectra of pure compounds."""
         St = self.components
-        St.name = "Pure compound spectra"
-        St.description = "Pure compound spectra matrix from SIMPLISMA:"  # + logs
-        return St
+        return self._apply_analysis_output_metadata(
+            St,
+            role_id="spectral_profiles",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     @property
     def Pt(self):

--- a/src/spectrochempy/analysis/decomposition/svd.py
+++ b/src/spectrochempy/analysis/decomposition/svd.py
@@ -201,6 +201,7 @@ class SVD(DecompositionAnalysis):
         units=None,
         title="Singular values",
         typesingle="components",
+        analysis_role="singular_values",
     )
     def singular_values(self):
         """Return a NDDataset containing singular values."""
@@ -213,9 +214,15 @@ class SVD(DecompositionAnalysis):
         """Return a NDDataset of the explained variance."""
         size = self.sv.size
         ev = self.sv**2 / (size - 1)
-        ev.name = "ev"
-        ev.title = "explained variance"
-        return ev
+        return self._apply_analysis_output_metadata(
+            ev,
+            role_id="explained_variance",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     ev = explained_variance
 
@@ -223,10 +230,16 @@ class SVD(DecompositionAnalysis):
     def explained_variance_ratio(self):
         """Return Explained Variance per singular values."""
         ratio = self.ev * 100.0 / np.sum(self.ev)
-        ratio.name = "ev_ratio"
-        ratio.title = "explained variance ratio"
         ratio.units = "percent"
-        return ratio
+        return self._apply_analysis_output_metadata(
+            ratio,
+            role_id="explained_variance_ratio",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     ev_ratio = explained_variance_ratio
 
@@ -234,10 +247,16 @@ class SVD(DecompositionAnalysis):
     def cumulative_explained_variance(self):
         """Return Cumulative Explained Variance."""
         ev_cum = np.cumsum(self.ev_ratio)
-        ev_cum.name = "ev_cum"
-        ev_cum.title = "cumulative explained variance"
         ev_cum.units = "percent"
-        return ev_cum
+        return self._apply_analysis_output_metadata(
+            ev_cum,
+            role_id="cumulative_explained_variance",
+            meta_from="_X",
+            direct_x=None,
+            direct_y=None,
+            direct_x_kind="none",
+            direct_y_kind="none",
+        )
 
     ev_cum = cumulative_explained_variance
 

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -444,6 +444,7 @@ class _set_output:
         typesingle=None,
         preserve_identity=False,
         use_snapshot=True,  # reuse the fit metadata snapshot on stored paths
+        analysis_role=None,
     ):
         self.method = method
         update_wrapper(self, method)
@@ -455,6 +456,7 @@ class _set_output:
         self.typesingle = typesingle
         self.preserve_identity = preserve_identity
         self.use_snapshot = use_snapshot
+        self.analysis_role = analysis_role
 
     @preserve_signature
     def __get__(self, obj, objtype):
@@ -481,6 +483,8 @@ class _set_output:
         sentinel = object()
         direct_X = sentinel
         direct_Y = sentinel
+        direct_X_kind = "none"
+        direct_Y_kind = "none"
         x_params = ("X", "dataset", "X_transform")
         y_params = ("Y", "Y_transform")
         try:
@@ -497,8 +501,18 @@ class _set_output:
                             continue
                         if key in x_params:
                             direct_X = value
+                            direct_X_kind = (
+                                "dataset"
+                                if isinstance(value, NDDataset)
+                                else "arraylike"
+                            )
                         elif key in y_params:
                             direct_Y = value
+                            direct_Y_kind = (
+                                "dataset"
+                                if isinstance(value, NDDataset)
+                                else "arraylike"
+                            )
                 elif (
                     param.kind
                     in (
@@ -513,22 +527,40 @@ class _set_output:
                         continue
                     if name in x_params:
                         direct_X = value
+                        direct_X_kind = (
+                            "dataset" if isinstance(value, NDDataset) else "arraylike"
+                        )
                     elif name in y_params:
                         direct_Y = value
+                        direct_Y_kind = (
+                            "dataset" if isinstance(value, NDDataset) else "arraylike"
+                        )
         else:
             # Fallback for exotic signatures: first two positional arguments
             # and the recognized keyword arguments.
             if args and args[0] is not None:
                 direct_X = args[0]
+                direct_X_kind = (
+                    "dataset" if isinstance(args[0], NDDataset) else "arraylike"
+                )
             if len(args) > 1 and args[1] is not None:
                 direct_Y = args[1]
+                direct_Y_kind = (
+                    "dataset" if isinstance(args[1], NDDataset) else "arraylike"
+                )
             for key in x_params:
                 if kwargs.get(key) is not None:
                     direct_X = kwargs[key]
+                    direct_X_kind = (
+                        "dataset" if isinstance(kwargs[key], NDDataset) else "arraylike"
+                    )
                     break
             for key in y_params:
                 if kwargs.get(key) is not None:
                     direct_Y = kwargs[key]
+                    direct_Y_kind = (
+                        "dataset" if isinstance(kwargs[key], NDDataset) else "arraylike"
+                    )
                     break
 
         # get the method output - one or two arrays depending on the method and *args
@@ -557,8 +589,14 @@ class _set_output:
 
         out = []
         preserve = self.preserve_identity and getattr(obj, "_preserve_identity", True)
-        for data, meta_from in zip(data_tuple, meta_from_tuple, strict=False):
+        for idx, (data, meta_from) in enumerate(
+            zip(data_tuple, meta_from_tuple, strict=False)
+        ):
             X_transf = NDDataset(data)
+            if isinstance(self.analysis_role, tuple):
+                role_id = self.analysis_role[idx]
+            else:
+                role_id = self.analysis_role
 
             # Now set the NDDataset attributes from the original X
 
@@ -757,8 +795,32 @@ class _set_output:
                 X_transf = X_transf.squeeze()
                 if preserve:
                     X_transf._history = X_transf._history[:-1]
+                if role_id is not None and hasattr(
+                    obj, "_apply_analysis_output_metadata"
+                ):
+                    X_transf = obj._apply_analysis_output_metadata(
+                        X_transf,
+                        role_id=role_id,
+                        meta_from=meta_from,
+                        direct_x=None if direct_X is sentinel else direct_X,
+                        direct_y=None if direct_Y is sentinel else direct_Y,
+                        direct_x_kind=direct_X_kind,
+                        direct_y_kind=direct_Y_kind,
+                    )
                 out.append(X_transf)
             else:
+                if role_id is not None and hasattr(
+                    obj, "_apply_analysis_output_metadata"
+                ):
+                    X_transf = obj._apply_analysis_output_metadata(
+                        X_transf,
+                        role_id=role_id,
+                        meta_from=meta_from,
+                        direct_x=None if direct_X is sentinel else direct_X,
+                        direct_y=None if direct_Y is sentinel else direct_Y,
+                        direct_x_kind=direct_X_kind,
+                        direct_y_kind=direct_Y_kind,
+                    )
                 out.append(X_transf)
 
         if len(out) == 1:
@@ -776,6 +838,7 @@ def _wrap_ndarray_output_to_nddataset(
     typesingle=None,
     preserve_identity=False,
     use_snapshot=True,
+    analysis_role=None,
 ):
     # wrap _set_output to allow for deferred calling
     if method:
@@ -794,6 +857,7 @@ def _wrap_ndarray_output_to_nddataset(
                 typesingle=typesingle,
                 preserve_identity=preserve_identity,
                 use_snapshot=use_snapshot,
+                analysis_role=analysis_role,
             )
 
         out = wrapper

--- a/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
@@ -6,17 +6,15 @@
 # ruff: noqa
 
 """
-Optimize no-regression provenance tests.
+Optimize provenance and derived-identity policy tests.
 
-``Optimize`` inherits the analysis provenance snapshot from
-``AnalysisConfigurable``.  Its fitted and components outputs are produced
-through the ``transform`` path and must preserve the scientific source
-``author``, while the numeric fit results must be unchanged.
-
-``residuals`` is a pure-arithmetic output (observed - fitted) and keeps the
-runtime user/host author; aligning it with the scientific source is deferred
-to the later multi-source policy PR (PR 2).
+`Optimize` inherits the analysis source snapshot from `AnalysisConfigurable`.
+Its fitted outputs and residual datasets must now follow the accepted
+analysis-output metadata policy for source-domain derived results.
 """
+
+from datetime import UTC
+from datetime import datetime
 
 import numpy as np
 
@@ -28,12 +26,29 @@ def test_optimize_fitted_and_components_preserve_source_author(
 ):
     ds = synthetic_two_peak_dataset
     ds.author = "optimize_author"
+    ds.origin = "optimize_origin"
+    ds.name = "optimize_source"
+    ds.acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds.meta.project = "curvefit"
     data_before = ds.data.copy()
 
     opt = scp.Optimize(script=optimize_script).fit(ds)
     result = opt.result
 
     assert result.fitted.author == "optimize_author"
+    assert result.fitted.origin == "optimize_origin"
+    assert result.fitted.name == "optimize_source_Optimize.fitted_data"
+    assert result.fitted.title == "fitted data"
+    assert result.fitted.description == (
+        "Fitted data from Optimize fit of optimize_source."
+    )
+    assert result.fitted.filename is None
+    assert result.fitted.meta.project == "curvefit"
+    assert result.fitted.meta is not ds.meta
+    assert result.fitted.acquisition_date == ds.acquisition_date
+    assert result.fitted.history[-1].endswith(
+        "Created fitted data with Optimize from optimize_source."
+    )
     assert result.components.author == "optimize_author"
 
     # Numeric no-regression: residuals still equal observed minus fitted.
@@ -43,6 +58,20 @@ def test_optimize_fitted_and_components_preserve_source_author(
         np.ma.asarray(expected.masked_data),
     )
     assert result.residuals.units == ds.units
+    assert result.residuals.author == "optimize_author"
+    assert result.residuals.origin == "optimize_origin"
+    assert result.residuals.name == "optimize_source_Optimize.residuals"
+    assert result.residuals.title == "residuals"
+    assert result.residuals.description == (
+        "Residuals from Optimize fit of optimize_source."
+    )
+    assert result.residuals.filename is None
+    assert result.residuals.meta.project == "curvefit"
+    assert result.residuals.meta is not ds.meta
+    assert result.residuals.acquisition_date == ds.acquisition_date
+    assert result.residuals.history[-1].endswith(
+        "Created residuals with Optimize from optimize_source."
+    )
 
     # Input must not be mutated by the fit.
     assert np.array_equal(ds.data, data_before)

--- a/tests/test_analysis/test_decomposition/test_analysis_output_semantics_baseline.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_output_semantics_baseline.py
@@ -1,31 +1,24 @@
 """
-Characterization tests for analysis output semantics.
+Policy tests for deterministic analysis output metadata.
 
-This suite characterizes CURRENT behavior of representative public analysis
-outputs. It does NOT validate a desired future policy.
+This suite validates the accepted maintainer policy
+`spectrochempy_maintainer/rfcs/analysis-output-metadata-policy.md`
+for representative decomposition outputs in the PR 2 runtime tranche:
 
-Coverage:
-    - Latent analysis outputs (`transform()`, `components`, concentration and
-      spectral profiles)
-    - Diagnostic outputs (explained variance, singular values)
-    - Reconstruction outputs (`inverse_transform()`)
-    - CoordSet synthesis around the generated component axis
-    - Metadata and provenance propagation through analysis wrappers
-    - Current API limitation for `SVD`
+- canonical derived identity (`name`, `title`, `description`, `filename`);
+- canonical provenance/history text;
+- independent copied metadata;
+- fresh result timestamps distinct from source acquisition lineage;
+- preserved structural support where the RFC says the source remains the
+  scientific context authority.
 
-Key observed patterns:
-    - Most decomposition outputs are derived analysis objects rather than
-      same-object dataset transformations
-    - Latent outputs synthesize a `k` component axis while preserving the
-      surviving source axis metadata
-    - Latent and diagnostic outputs usually rewrite `name` and `history`
-      and frequently drop data units
-    - Reconstruction outputs return to the source geometry and keep source
-      scientific context more closely
-    - `SVD` currently exposes diagnostic vectors and raw factor arrays, but
-      does not implement the generic reduction API
+The numerical outputs themselves are covered elsewhere; this file focuses on
+the exact public metadata contract for representative families.
 """
 
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -65,6 +58,9 @@ def semantic_dataset():
     ds.description = "source description"
     ds.origin = "test_origin"
     ds.filename = Path("source.spc")
+    ds.acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds._created = datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC)
+    ds._modified = datetime(2021, 1, 2, 3, 4, 5, tzinfo=UTC)
     ds.meta.project = "analysis-output"
     ds.meta.tags = ["baseline"]
     ds.history = ["original history entry"]
@@ -192,52 +188,72 @@ class TestLatentOutputs:
 
 
 class TestMetadataAndProvenance:
-    """Characterize metadata propagation on analysis wrappers."""
+    """Validate canonical metadata propagation on representative outputs."""
 
-    def test_transform_rewrites_name_history_and_drops_title_units(
-        self, semantic_dataset
-    ):
+    def test_transform_applies_canonical_scores_metadata(self, semantic_dataset):
+        before = datetime.now(UTC)
         scores = PCA(n_components=2).fit(semantic_dataset).transform()
+        after = datetime.now(UTC)
 
-        assert scores.name == "source_name_PCA.transform"
-        assert scores.title != semantic_dataset.title
+        assert scores.name == "source_name_PCA.scores"
+        assert scores.title == "scores"
+        assert scores.description == "scores from PCA fit of source_name."
         assert scores.units is None
         assert scores.author == semantic_dataset.author
         assert scores.origin == semantic_dataset.origin
-        assert scores.filename == semantic_dataset.filename
+        assert scores.filename is None
         assert scores.meta.project == semantic_dataset.meta.project
         assert scores.meta.tags == semantic_dataset.meta.tags
         assert scores.meta is not semantic_dataset.meta
-        assert scores.history[-1].endswith("Created using method PCA.transform")
+        assert scores.acquisition_date == semantic_dataset.acquisition_date
+        assert (
+            before - timedelta(seconds=1)
+            <= scores._created
+            <= after + timedelta(seconds=1)
+        )
+        assert (
+            before - timedelta(seconds=1)
+            <= scores._modified
+            <= after + timedelta(seconds=1)
+        )
+        assert scores.history[-1].endswith(
+            "Created analysis output scores with PCA from source_name."
+        )
 
-    def test_components_keep_source_title_but_rewrite_name_and_history(
-        self, semantic_dataset
-    ):
+    def test_components_apply_canonical_component_identity(self, semantic_dataset):
         loadings = PCA(n_components=2).fit(semantic_dataset).components
 
         assert loadings.name == "source_name_PCA.components"
-        assert loadings.title == semantic_dataset.title
+        assert loadings.title == "components"
         assert loadings.units is None
-        assert loadings.description == ""
-        assert loadings.history[-1].endswith("Created using method PCA.components")
+        assert loadings.description == "components from PCA fit of source_name."
+        assert loadings.filename is None
+        assert loadings.history[-1].endswith(
+            "Created analysis output components with PCA from source_name."
+        )
 
-    def test_diagnostic_output_rewrites_title_and_preserves_metadata_copy(
+    def test_diagnostic_output_uses_canonical_diagnostic_text_and_metadata_copy(
         self, semantic_dataset
     ):
         ev_ratio = PCA(n_components=2).fit(semantic_dataset).ev_ratio
 
         assert ev_ratio.title == "explained variance ratio"
+        assert ev_ratio.name == "source_name_PCA.explained_variance_ratio"
+        assert ev_ratio.description == (
+            "explained variance ratio diagnostic from PCA fit of source_name."
+        )
         assert ev_ratio.units == "percent"
         assert ev_ratio.author == semantic_dataset.author
         assert ev_ratio.meta.project == semantic_dataset.meta.project
         assert ev_ratio.meta is not semantic_dataset.meta
+        assert ev_ratio.filename is None
         assert ev_ratio.history[-1].endswith(
-            "Created using method PCA.explained_variance_ratio"
+            "Created diagnostic explained_variance_ratio with PCA from source_name."
         )
 
 
 class TestReconstructionOutputs:
-    """Characterize reconstruction outputs as source-geometry returns."""
+    """Validate source-geometry reconstructions as derived outputs."""
 
     def test_pca_inverse_transform_returns_source_geometry_and_context(
         self, semantic_dataset
@@ -248,11 +264,15 @@ class TestReconstructionOutputs:
         assert reconstructed.dims == semantic_dataset.dims
         assert reconstructed.y.title == semantic_dataset.y.title
         assert reconstructed.x.title == semantic_dataset.x.title
-        assert reconstructed.title == semantic_dataset.title
+        assert reconstructed.title == "reconstruction"
         assert reconstructed.units == semantic_dataset.units
-        assert reconstructed.name == "source_name_PCA.inverse_transform"
+        assert reconstructed.name == "source_name_PCA.reconstruction"
+        assert reconstructed.description == (
+            "reconstruction from PCA fit of source_name."
+        )
+        assert reconstructed.filename is None
         assert reconstructed.history[-1].endswith(
-            "Created using method PCA.inverse_transform"
+            "Created analysis output reconstruction with PCA from source_name."
         )
 
     def test_nmf_inverse_transform_returns_source_geometry_and_context(
@@ -273,12 +293,12 @@ class TestReconstructionOutputs:
         assert reconstructed.dims == efa_dataset.dims
         assert reconstructed.y.title == efa_dataset.y.title
         assert reconstructed.x.title == efa_dataset.x.title
-        assert reconstructed.title == efa_dataset.title
+        assert reconstructed.title == "reconstruction"
         assert reconstructed.units == efa_dataset.units
 
 
 class TestDiagnosticOutputs:
-    """Characterize diagnostic outputs that summarize fitted models."""
+    """Validate diagnostic analysis datasets."""
 
     def test_pca_explained_variance_ratio_is_component_vector(self, semantic_dataset):
         ev_ratio = PCA(n_components=2).fit(semantic_dataset).ev_ratio
@@ -296,8 +316,17 @@ class TestDiagnosticOutputs:
         assert sv.shape == (semantic_dataset.shape[1],)
         assert sv.dims == ["k"]
         assert sv.k.title == "components"
-        assert sv.title == "Singular values"
+        assert sv.title == "singular values"
+        assert sv.name == "source_name_SVD.singular_values"
+        assert sv.description == (
+            "singular values diagnostic from SVD fit of source_name."
+        )
+        assert sv.author == semantic_dataset.author
+        assert sv.filename is None
         assert sv.units is None
+        assert sv.history[-1].endswith(
+            "Created diagnostic singular_values with SVD from source_name."
+        )
 
 
 class TestCurrentApiLimits:

--- a/tests/test_analysis/test_decomposition/test_analysis_source_provenance.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_source_provenance.py
@@ -21,14 +21,15 @@ policy `spectrochempy_maintainer/rfcs/analysis-output-metadata-policy.md`
   distinct);
 - ``fit`` always replaces or clears the snapshots from its new inputs, so no
   obsolete metadata survives a refit;
-- X-side and Y-side outputs use their own scientific source; supervised
-  ``predict`` is multi-source and keeps its previous behavior until PR 2;
+- X-side and Y-side outputs use their own scientific source;
+- supervised ``predict`` now follows the accepted multi-source PR 2 policy
+  (`Xtrain`, `Ytrain`, `Xpredict`) without leaking stale fitted provenance;
 - input datasets are never mutated and output metadata is independent of later
   source mutation.
 
-Fields other than ``author`` (name, title, description, history, filename,
-created, modified, acquisition_date, units, ...) are deliberately unchanged
-here; they are aligned in the later policy PRs.
+The PR 1 author guarantees remain covered here and are complemented by the PR 2
+deterministic identity/provenance/history rules where the accepted policy now
+requires them.
 """
 
 import numpy as np
@@ -168,7 +169,9 @@ class TestSourceNonMutation:
         assert scores.meta is not ds.meta
         assert scores.meta.project == "provenance"
         assert "injected" not in scores.meta
-        assert scores.history[-1].endswith("Created using method PCA.transform")
+        assert scores.history[-1].endswith(
+            "Created analysis output scores with PCA from source_name."
+        )
 
 
 class TestPCAMonoSource:
@@ -310,23 +313,46 @@ class TestPLSRegressionYside:
         ):
             assert output.author == "y_author"
 
-    def test_predict_provenance_deferred_until_pr2(self, pls_inputs):
+    def test_predict_merges_training_and_prediction_provenance(self, pls_inputs):
         X, Y = pls_inputs
+        X.name = "xtrain"
+        X.origin = "origin_xtrain"
+        Y.name = "ytrain"
+        Y.origin = "origin_ytrain"
         pls = PLSRegression(n_components=2).fit(X, Y)
 
-        # A supervised prediction combines Xtrain + Ytrain + Xpredict: the
-        # accepted RFC does not define a partial Y-only merge. PR 1 leaves
-        # predict() unchanged; the runtime value is the recreated user/host.
         prediction = pls.predict()
-        assert prediction.author != "y_author"
-        assert prediction.author != "x_author"
-        assert prediction.author == get_user_and_node()
+        assert prediction.author == "x_author & y_author"
+        assert prediction.origin == "origin_xtrain & origin_ytrain"
+        assert prediction.title == "prediction"
+        assert prediction.name == "xtrain_PLSRegression.prediction"
+        assert prediction.description == (
+            "Prediction from PLSRegression fit of xtrain + ytrain applied to xtrain."
+        )
+        assert prediction.history[-1].endswith(
+            "Created analysis output prediction with PLSRegression from "
+            "xtrain + ytrain; applied to xtrain."
+        )
+        assert prediction.filename is None
+        assert prediction.meta is not Y.meta
 
-        # A direct X argument changes the data used, not the provenance
-        # model: still the recreated runtime value until PR 2.
         Xnew = X.copy()
         Xnew.author = "predict_author"
-        assert pls.predict(Xnew).author == get_user_and_node()
+        Xnew.origin = "origin_predict"
+        Xnew.name = "xpredict"
+        direct_prediction = pls.predict(Xnew)
+        assert direct_prediction.author == "x_author & y_author & predict_author"
+        assert (
+            direct_prediction.origin == "origin_xtrain & origin_ytrain & origin_predict"
+        )
+        assert direct_prediction.name == "xpredict_PLSRegression.prediction"
+        assert direct_prediction.description == (
+            "Prediction from PLSRegression fit of xtrain + ytrain applied to xpredict."
+        )
+        assert direct_prediction.history[-1].endswith(
+            "Created analysis output prediction with PLSRegression from "
+            "xtrain + ytrain; applied to xpredict."
+        )
 
     def test_transform_both_uses_respective_authors(self, pls_inputs):
         X, Y = pls_inputs
@@ -335,6 +361,25 @@ class TestPLSRegressionYside:
         x_scores, y_scores = pls.transform(X, Y, both=True)
         assert x_scores.author == "x_author"
         assert y_scores.author == "y_author"
+
+    def test_predict_direct_array_like_does_not_leak_old_dataset_provenance(
+        self, pls_inputs
+    ):
+        X, Y = pls_inputs
+        X.name = "xtrain"
+        Y.name = "ytrain"
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        prediction = pls.predict(X.data)
+        assert prediction.author == "x_author & y_author"
+        assert prediction.name == "PLSRegression.prediction"
+        assert prediction.description == (
+            "Prediction from PLSRegression fit of xtrain + ytrain applied to <unnamed>."
+        )
+        assert prediction.history[-1].endswith(
+            "Created analysis output prediction with PLSRegression from "
+            "xtrain + ytrain; applied to <unnamed>."
+        )
 
     def test_transform_direct_y_argument_is_authoritative(self, pls_inputs):
         X, Y = pls_inputs

--- a/tests/test_analysis/test_decomposition/test_analysis_source_provenance.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_source_provenance.py
@@ -32,6 +32,9 @@ deterministic identity/provenance/history rules where the accepted policy now
 requires them.
 """
 
+from datetime import datetime
+from datetime import timezone
+
 import numpy as np
 import pytest
 
@@ -317,8 +320,10 @@ class TestPLSRegressionYside:
         X, Y = pls_inputs
         X.name = "xtrain"
         X.origin = "origin_xtrain"
+        X.meta.from_x = "x_only"
         Y.name = "ytrain"
         Y.origin = "origin_ytrain"
+        Y.meta.from_y = "y_only"
         pls = PLSRegression(n_components=2).fit(X, Y)
 
         prediction = pls.predict()
@@ -335,6 +340,8 @@ class TestPLSRegressionYside:
         )
         assert prediction.filename is None
         assert prediction.meta is not Y.meta
+        assert prediction.meta.from_y == "y_only"
+        assert "from_x" not in prediction.meta
 
         Xnew = X.copy()
         Xnew.author = "predict_author"
@@ -353,6 +360,153 @@ class TestPLSRegressionYside:
             "Created analysis output prediction with PLSRegression from "
             "xtrain + ytrain; applied to xpredict."
         )
+        assert direct_prediction.meta is not Y.meta
+        assert direct_prediction.meta.from_y == "y_only"
+        direct_prediction.meta.from_y = "mutated"
+        assert Y.meta.from_y == "y_only"
+
+    def test_predict_consensus_discards_absent_values_and_preserves_exact_text(
+        self, pls_inputs
+    ):
+        X, Y = pls_inputs
+        X.origin = " Lab A "
+        X.name = "xtrain"
+        Y.author = ""
+        Y.origin = "lab a"
+        Y.name = "ytrain"
+        pls = PLSRegression(n_components=2).fit(X, Y)
+        pls._X_source_metadata.author = None
+
+        Xnew = X.copy()
+        Xnew.author = "predict_author"
+        Xnew.origin = " Lab A "
+        Xnew.name = ""
+
+        prediction = pls.predict(Xnew)
+        assert prediction.author == "predict_author"
+        assert prediction.origin == " Lab A  & lab a"
+        assert prediction.name == "xtrain_PLSRegression.prediction"
+        assert prediction.description == (
+            "Prediction from PLSRegression fit of xtrain + ytrain applied to xtrain."
+        )
+        assert prediction.history[-1].endswith(
+            "Created analysis output prediction with PLSRegression from "
+            "xtrain + ytrain; applied to xtrain."
+        )
+
+    def test_predict_empty_snapshot_name_uses_unnamed_text_and_no_name_prefix(
+        self, pls_inputs
+    ):
+        X, Y = pls_inputs
+        X.name = "xtrain"
+        Y.name = "ytrain"
+        pls = PLSRegression(n_components=2).fit(X, Y)
+        pls._X_source_metadata.name = ""
+
+        prediction = pls.predict()
+        assert prediction.name == "PLSRegression.prediction"
+        assert prediction.description == (
+            "Prediction from PLSRegression fit of <unnamed> + ytrain applied to <unnamed>."
+        )
+        assert prediction.history[-1].endswith(
+            "Created analysis output prediction with PLSRegression from "
+            "<unnamed> + ytrain; applied to <unnamed>."
+        )
+
+    @pytest.mark.parametrize(
+        ("x_date", "y_date", "predict_date", "expect_consensus"),
+        [
+            pytest.param(
+                None,
+                None,
+                None,
+                False,
+                id="all-missing",
+            ),
+            pytest.param(
+                "same",
+                "same",
+                "same",
+                True,
+                id="exact-consensus",
+            ),
+            pytest.param(
+                "same",
+                "different",
+                "same",
+                False,
+                id="divergent-dates",
+            ),
+            pytest.param(
+                "same",
+                None,
+                "same",
+                False,
+                id="partial-missing",
+            ),
+        ],
+    )
+    def test_predict_acquisition_date_uses_exact_consensus(
+        self, pls_inputs, x_date, y_date, predict_date, expect_consensus
+    ):
+        X, Y = pls_inputs
+        base = datetime(2026, 8, 11, 10, 0, tzinfo=timezone.utc)
+        X.acquisition_date = base if x_date == "same" else None
+        Y.acquisition_date = (
+            base
+            if y_date == "same"
+            else datetime(2026, 8, 11, 11, 0, tzinfo=timezone.utc)
+            if y_date == "different"
+            else None
+        )
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        Xnew = X.copy()
+        Xnew.acquisition_date = base if predict_date == "same" else None
+        prediction = pls.predict(Xnew)
+
+        if expect_consensus:
+            assert prediction._acquisition_date == base
+        else:
+            assert prediction.acquisition_date is None
+
+    def test_refit_replaces_prediction_snapshots_without_stale_metadata(
+        self, pls_inputs
+    ):
+        X, Y = pls_inputs
+        X.author = "x_author_1"
+        X.origin = "origin_x_1"
+        X.name = "xtrain1"
+        X.meta.marker = "x1"
+        Y.author = "y_author_1"
+        Y.origin = "origin_y_1"
+        Y.name = "ytrain1"
+        Y.meta.marker = "y1"
+
+        pls = PLSRegression(n_components=2).fit(X, Y)
+
+        X2 = X.copy()
+        X2.author = "x_author_2"
+        X2.origin = "origin_x_2"
+        X2.name = "xtrain2"
+        X2.meta.marker = "x2"
+        Y2 = Y.copy()
+        Y2.author = "y_author_2"
+        Y2.origin = "origin_y_2"
+        Y2.name = "ytrain2"
+        Y2.meta.marker = "y2"
+
+        pls.fit(X2, Y2)
+        prediction = pls.predict()
+
+        assert prediction.author == "x_author_2 & y_author_2"
+        assert prediction.origin == "origin_x_2 & origin_y_2"
+        assert prediction.name == "xtrain2_PLSRegression.prediction"
+        assert prediction.description == (
+            "Prediction from PLSRegression fit of xtrain2 + ytrain2 applied to xtrain2."
+        )
+        assert prediction.meta.marker == "y2"
+        assert "y1" not in repr(prediction.meta)
 
     def test_transform_both_uses_respective_authors(self, pls_inputs):
         X, Y = pls_inputs

--- a/tests/test_analysis/test_decomposition/test_mcrals_metadata.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_metadata.py
@@ -49,9 +49,9 @@ def test_metadata_from_calibrated_st_guess():
 
     mcr = _fit(X, St0)
 
-    assert mcr.St.title == "molar absorptivity"
+    assert mcr.St.title == "spectral profiles"
     assert mcr.St.units == St0.units
-    assert mcr.C.title == "concentration"
+    assert mcr.C.title == "concentration profiles"
     assert mcr.C.units == X.units / St0.units
     np.testing.assert_array_equal(mcr.C.y.data, X.y.data)
     assert mcr.C.y.title == X.y.title
@@ -67,9 +67,9 @@ def test_metadata_from_calibrated_c_guess():
 
     mcr = _fit(X, C0)
 
-    assert mcr.C.title == "amount concentration"
+    assert mcr.C.title == "concentration profiles"
     assert mcr.C.units == C0.units
-    assert mcr.St.title == X.title
+    assert mcr.St.title == "spectral profiles"
     assert mcr.St.units == X.units / C0.units
 
 
@@ -105,8 +105,8 @@ def test_unitless_guess_uses_ambiguous_scale_fallback():
 
     assert mcr.C.units is None
     assert mcr.St.units is None
-    assert mcr.C.title == "relative concentration"
-    assert mcr.St.title == X.title
+    assert mcr.C.title == "concentration profiles"
+    assert mcr.St.title == "spectral profiles"
 
 
 def test_normalization_clears_calibrated_factor_units():
@@ -125,7 +125,7 @@ def test_normalization_clears_calibrated_factor_units():
 
     assert mcr.C.units is None
     assert mcr.St.units is None
-    assert mcr.C.title == "relative concentration"
+    assert mcr.C.title == "concentration profiles"
 
 
 def test_vertical_blocks_inherit_calibrated_c_metadata_and_coordinates():
@@ -194,7 +194,7 @@ def test_horizontal_spectral_blocks_keep_block_physical_metadata():
 
     assert mcr.C.units == ur.mole / ur.liter
     assert mcr.St.units is None
-    assert mcr.St.title == "concatenated spectral profiles"
+    assert mcr.St.title == "spectral profiles"
     assert blocks[0].title == "absorbance"
     assert blocks[0].units == St0_uv.units
     assert blocks[1].title == "ellipticity"

--- a/tests/test_analysis/test_decomposition/test_nmf.py
+++ b/tests/test_analysis/test_decomposition/test_nmf.py
@@ -107,7 +107,7 @@ def test_nmf_fit_components_and_metadata(nmf_dataset, nmf_model):
     assert_dataset_equal(nmf_model.X, nmf_dataset)
     assert nmf_model.components.shape == (3, nmf_dataset.shape[1])
     assert nmf_model.components.dims == ["k", "x"]
-    assert nmf_model.components.title == nmf_dataset.title
+    assert nmf_model.components.title == "components"
     assert nmf_model.components.x.title == nmf_dataset.x.title
     assert nmf_model.components.x.units == nmf_dataset.x.units
     assert np.all(nmf_model.components.data >= -NMF_NONNEGATIVE_TOL)
@@ -152,7 +152,7 @@ def test_nmf_transform_fit_transform_and_inverse(nmf_dataset, nmf_model):
 
     reconstructed = nmf_model.inverse_transform()
     assert reconstructed.shape == dataset.shape
-    assert reconstructed.title == dataset.title
+    assert reconstructed.title == "reconstruction"
     assert reconstructed.units == dataset.units
     assert reconstructed.dims == dataset.dims
     assert_allclose(reconstructed.data, dataset.data, rtol=3.0e-2, atol=1.0e-3)

--- a/tests/test_analysis/test_decomposition/test_pca.py
+++ b/tests/test_analysis/test_decomposition/test_pca.py
@@ -139,7 +139,7 @@ def test_pca_transform_fit_transform_and_inverse(low_rank_pca_dataset):
     assert X_hat_2.shape == dataset.shape
     X_hat = pca.inverse_transform()
     assert_allclose(X_hat.data, dataset.data, atol=1.0e-12)
-    assert X_hat.title == dataset.title
+    assert X_hat.title == "reconstruction"
     assert X_hat.units == dataset.units
     assert X_hat.dims == dataset.dims
 

--- a/tests/test_analysis/test_decomposition/test_svd.py
+++ b/tests/test_analysis/test_decomposition/test_svd.py
@@ -60,7 +60,7 @@ def test_svd(low_rank_dataset):
     assert svd.U.shape == (4, 4)
     assert svd.VT.shape == (4, 5)
     assert svd.sv.shape == (4,)
-    assert svd.sv.title == "Singular values"
+    assert svd.sv.title == "singular values"
     assert svd.sv.dims == ["k"]
     assert_allclose(svd.s, [5.0, 3.0, 0.0, 0.0])
     assert_allclose(svd.ev_ratio.data, [2500.0 / 34.0, 900.0 / 34.0, 0.0, 0.0])
@@ -102,7 +102,7 @@ def test_svd_compute_uv_false(low_rank_dataset):
     # Singular values are correct
     assert_allclose(svd.s, [5.0, 3.0, 0.0, 0.0])
     assert svd.sv.shape == (4,)
-    assert svd.sv.title == "Singular values"
+    assert svd.sv.title == "singular values"
     # Diagnostics work correctly
     assert svd.ev.shape == (4,)
     assert svd.ev_ratio.shape == (4,)

--- a/tests/test_processing/test_processing_assembly_category_a_policy.py
+++ b/tests/test_processing/test_processing_assembly_category_a_policy.py
@@ -133,11 +133,11 @@ class TestCategoryAExclusions:
 
     def test_denoise_unchanged(self, ds):
         result = ds.denoise(ratio=99.0)
-        assert result.name == "ds_name_PCA.inverse_transform"
+        assert result.name == "ds_name_PCA.reconstruction"
         assert len(result.history) == 1
 
     def test_pca_scores_unchanged(self, ds):
         pca = PCA(n_components=2)
         scores = pca.fit_transform(ds)
-        assert scores.name == "ds_name_PCA.transform"
+        assert scores.name == "ds_name_PCA.scores"
         assert len(scores.history) == 1

--- a/tests/test_processing/test_processing_wrapper_semantics_baseline.py
+++ b/tests/test_processing/test_processing_wrapper_semantics_baseline.py
@@ -270,10 +270,9 @@ class TestPcaWrapper:
     """
     Characterize PCA-based denoise wrapper.
 
-    Observation: follows the historical Group A pattern (name appended,
-    no modeldata attribute, history rewritten) with the
-    ``_PCA.inverse_transform`` suffix. Its classification is deferred
-    (RFC DQ2), so this behavior is intentionally unchanged.
+    Observation: follows the PR 2 canonical analysis-output policy for
+    reconstruction outputs: generated reconstruction identity, no modeldata
+    attribute, and canonical rewritten history.
     """
 
     def test_return_type(self, ds):
@@ -292,12 +291,12 @@ class TestPcaWrapper:
 
     def test_title_preserved(self, ds):
         r = ds.denoise(ratio=99.0)
-        assert r.title == "ds_title"
+        assert r.title == "reconstruction"
 
     def test_name_appended(self, ds):
-        """Notable: name is appended with '_PCA.inverse_transform'."""
+        """Notable: name uses the canonical reconstruction role id."""
         r = ds.denoise(ratio=99.0)
-        assert r.name == "ds_name_PCA.inverse_transform"
+        assert r.name == "ds_name_PCA.reconstruction"
 
     def test_author_preserved(self, ds):
         """Notable: denoise preserves the scientific source author."""
@@ -313,10 +312,10 @@ class TestPcaWrapper:
         assert r.meta.project == "test_project"
 
     def test_history_rewritten(self, ds):
-        """Notable: history rewritten (Group A pattern)."""
+        """Notable: history is rewritten to the canonical reconstruction entry."""
         r = ds.denoise(ratio=99.0)
         assert len(r.history) == 1
-        assert "Created using method PCA.inverse_transform" in r.history[0]
+        assert "Created analysis output reconstruction with PCA from ds_name." in r.history[0]
 
     def test_modeldata_dropped(self, ds):
         """Notable: wrappers no longer expose a modeldata attribute."""
@@ -382,8 +381,8 @@ class TestIdentityProvenance:
       identity, aligned to the Category A policy.
     - Group B (Baseline): identity preserved (all fields survive),
       history appended, consistent with same-object identity.
-    - PCA-based ``denoise`` (DQ2): identity partially preserved and
-      history rewritten (historical Group A pattern, unchanged).
+    - PCA-based ``denoise`` (DQ2): scientific provenance preserved, but
+      analysis-output identity follows the canonical reconstruction contract.
     """
 
     def test_filter_identity_preserved(self, ds):

--- a/tests/test_processing/test_processing_wrapper_semantics_baseline.py
+++ b/tests/test_processing/test_processing_wrapper_semantics_baseline.py
@@ -315,7 +315,10 @@ class TestPcaWrapper:
         """Notable: history is rewritten to the canonical reconstruction entry."""
         r = ds.denoise(ratio=99.0)
         assert len(r.history) == 1
-        assert "Created analysis output reconstruction with PCA from ds_name." in r.history[0]
+        assert (
+            "Created analysis output reconstruction with PCA from ds_name."
+            in r.history[0]
+        )
 
     def test_modeldata_dropped(self, ds):
         """Notable: wrappers no longer expose a modeldata attribute."""


### PR DESCRIPTION
## Summary

- implement PR 2 of the accepted analysis-output metadata policy in the analysis-specific runtime layer
- generate deterministic derived metadata for covered analysis and fitting outputs: canonical name/title/description/history, filename reset, acquisition-date handling, provenance merge, and meta deep-copy behavior
- keep supervised prediction work in PR 2 limited to identity/provenance/history; prediction support and mask assembly remain deferred to PR 4

## Root cause

Analysis and fitting outputs still depended on wrapper path and internal NDDataset coercion details after #1516. That left identity, textual provenance, and history inconsistent across direct calls, stored properties, result views, predictions, and arithmetic-derived residual outputs.

This branch now also removes an overreach discovered during review: the temporary prediction support helper had started reconstructing prediction dimensions/coordinates and prediction masks, which belongs to the later PR 4 masks/support tranche rather than to PR 2.

## Runtime scope

- canonical role-based metadata helper layer in analysis code only
- supervised PLS prediction provenance/order aligned with the accepted RFC
- Optimize fitted/residual outputs aligned with the same derived-output contract
- SVD diagnostic NDDataset outputs aligned without changing raw U/s/VT factors
- no prediction support reconstruction in this PR
- no prediction mask assembly in this PR
- no widening of NDDatasetType
- no G15 units tranche
- no general mask-policy tranche

## Validation

- `/Users/christian/micromamba/envs/scpy-core/bin/python -m pytest tests/test_analysis/test_decomposition/test_analysis_source_provenance.py`
- targeted provenance assertions added for prediction `meta` deep-copy/content, absent and empty textual sources, unnamed snapshot names, acquisition-date consensus, and refit snapshot replacement

## Notes

- the CI follow-up commit only realigns tests that were still asserting the superseded pre-PR2 metadata contract
- raw SVD U/s/VT outputs remain unchanged
- units policy (G15) remains intentionally deferred
- prediction coordset/mask authority remains intentionally deferred to the later PR 4 tranche
