### PR TITLE
FIX: implement G15 analysis-output units policy

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -36,9 +36,12 @@ Bug Fixes
   are not mutated. Supervised ``PLSRegression.predict()`` now applies the
   accepted multi-source provenance order (``Xtrain``, ``Ytrain``, then the
   prediction input), ``Optimize.result.residuals`` now follows the same
-  canonical derived-output policy as fitted data, and SVD diagnostic
-  ``NDDataset`` outputs now use the common diagnostic metadata contract while
-  raw ``U``/``s``/``VT`` factors remain unchanged.
+  canonical derived-output policy as fitted data, latent analysis factors now
+  follow the accepted unitless/default-units policy, source-domain
+  reconstructions and residuals preserve exact source units, supervised
+  predictions preserve exact ``Ytrain`` units, and SVD diagnostic ``NDDataset``
+  outputs now use the common diagnostic metadata contract while raw
+  ``U``/``s``/``VT`` factors remain unchanged.
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -25,6 +25,9 @@ Bug Fixes
   are not mutated. Supervised ``PLSRegression.predict()`` now applies the
   accepted multi-source provenance order (``Xtrain``, ``Ytrain``, then the
   prediction input), ``Optimize.result.residuals`` now follows the same
-  canonical derived-output policy as fitted data, and SVD diagnostic
-  ``NDDataset`` outputs now use the common diagnostic metadata contract while
-  raw ``U``/``s``/``VT`` factors remain unchanged.
+  canonical derived-output policy as fitted data, latent analysis factors now
+  follow the accepted unitless/default-units policy, source-domain
+  reconstructions and residuals preserve exact source units, supervised
+  predictions preserve exact ``Ytrain`` units, and SVD diagnostic ``NDDataset``
+  outputs now use the common diagnostic metadata contract while raw
+  ``U``/``s``/``VT`` factors remain unchanged.

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -345,6 +345,64 @@ class AnalysisConfigurable(BaseConfigurable):
             return f"Created diagnostic {role_id} with {estimator} from {source_list}."
         return f"Created analysis output {role_id} with {estimator} from {source_list}."
 
+    def _analysis_additional_provenance_sources(
+        self,
+        role_id,
+        *,
+        x_source,
+        y_source,
+        direct_x,
+        direct_y,
+        direct_x_kind,
+        direct_y_kind,
+    ):
+        return ()
+
+    def _analysis_meta_authority_source(
+        self,
+        role_id,
+        *,
+        single_source,
+        provenance_sources,
+        x_source,
+        y_source,
+    ):
+        return single_source
+
+    def _analysis_units_for_role(
+        self,
+        role_id,
+        *,
+        dataset,
+        x_source,
+        y_source,
+        single_source,
+        fit_x_source=None,
+        fit_y_source=None,
+    ):
+        role_id = self._normalize_analysis_role(role_id)
+        if role_id in {
+            "scores",
+            "y_scores",
+            "components",
+            "loadings",
+            "weights",
+            "rotations",
+            "concentration_profiles",
+            "spectral_profiles",
+            "diagnostic",
+            "singular_values",
+            "explained_variance",
+        }:
+            return None
+        if role_id in {"explained_variance_ratio", "cumulative_explained_variance"}:
+            return "percent"
+        if role_id in {"reconstruction", "fitted_data", "residuals"}:
+            return x_source.units if x_source is not None else None
+        if role_id == "prediction":
+            return fit_y_source.units if fit_y_source is not None else None
+        return dataset.units
+
     def _apply_analysis_output_metadata(
         self,
         dataset,
@@ -402,32 +460,78 @@ class AnalysisConfigurable(BaseConfigurable):
                     prediction_source=x_predict,
                 ),
             )
+            dataset.units = self._analysis_units_for_role(
+                role_id,
+                dataset=dataset,
+                x_source=x_predict,
+                y_source=y_train,
+                single_source=None,
+                fit_x_source=x_train,
+                fit_y_source=y_train,
+            )
             return dataset
 
-        sources = [single_source] if single_source is not None else []
-        if single_source is not None:
-            dataset.author = copy.copy(single_source.author)
-            dataset.origin = (
-                "" if single_source.origin is None else copy.copy(single_source.origin)
+        additional_sources = list(
+            self._analysis_additional_provenance_sources(
+                role_id,
+                x_source=x_source,
+                y_source=y_source,
+                direct_x=direct_x,
+                direct_y=direct_y,
+                direct_x_kind=direct_x_kind,
+                direct_y_kind=direct_y_kind,
             )
-            dataset.meta = copy.deepcopy(single_source.meta)
+        )
+        provenance_sources = [single_source] if single_source is not None else []
+        provenance_sources.extend(
+            source for source in additional_sources if source is not None
+        )
+        meta_authority = self._analysis_meta_authority_source(
+            role_id,
+            single_source=single_source,
+            provenance_sources=provenance_sources,
+            x_source=x_source,
+            y_source=y_source,
+        )
+
+        if provenance_sources:
+            merged_author = self._analysis_ordered_unique_text(
+                [source.author for source in provenance_sources]
+            )
+            merged_origin = self._analysis_ordered_unique_text(
+                [source.origin for source in provenance_sources]
+            )
+            dataset.author = copy.copy(merged_author)
+            dataset.origin = "" if merged_origin is None else copy.copy(merged_origin)
             dataset.acquisition_date = self._analysis_acquisition_date_consensus(
-                sources
+                provenance_sources
             )
         else:
-            dataset.meta = Meta()
-            dataset.acquisition_date = None
+            dataset.author = copy.copy(getattr(dataset, "author", None))
             dataset.origin = ""
+            dataset.acquisition_date = None
+
+        if meta_authority is not None:
+            dataset.meta = copy.deepcopy(meta_authority.meta)
+        else:
+            dataset.meta = Meta()
 
         dataset.name = self._analysis_generated_name(role_id, single_source)
         dataset.title = self._analysis_role_title(role_id)
         dataset.description = self._analysis_generated_description(
-            role_id, sources=sources
+            role_id, sources=provenance_sources
         )
         dataset.filename = None
         self._analysis_reset_history(
             dataset,
-            self._analysis_generated_history(role_id, sources=sources),
+            self._analysis_generated_history(role_id, sources=provenance_sources),
+        )
+        dataset.units = self._analysis_units_for_role(
+            role_id,
+            dataset=dataset,
+            x_source=x_source,
+            y_source=y_source,
+            single_source=single_source,
         )
         return dataset
 

--- a/src/spectrochempy/analysis/crossdecomposition/pls.py
+++ b/src/spectrochempy/analysis/crossdecomposition/pls.py
@@ -243,6 +243,7 @@ class PLSRegression(CrossDecompositionAnalysis):
     @property
     @_wrap_ndarray_output_to_nddataset(
         meta_from="_Y",
+        units=None,
         typey="components",
         analysis_role="rotations",
     )
@@ -251,6 +252,7 @@ class PLSRegression(CrossDecompositionAnalysis):
 
     @property
     @_wrap_ndarray_output_to_nddataset(
+        units=None,
         typey="components",
         analysis_role="weights",
     )
@@ -260,6 +262,7 @@ class PLSRegression(CrossDecompositionAnalysis):
     @property
     @_wrap_ndarray_output_to_nddataset(
         meta_from="_Y",
+        units=None,
         typey="components",
         analysis_role="weights",
     )

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -26,6 +26,7 @@ import numpy as np
 import scipy
 import traitlets as tr
 
+from spectrochempy.analysis._base._analysisbase import AnalysisSourceMetadata
 from spectrochempy.analysis._base._analysisbase import DecompositionAnalysis
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis._base._analysisbase import _wrap_ndarray_output_to_nddataset
@@ -140,6 +141,7 @@ class _FactorMetadata:
 
     title: str | None = None
     units: object | None = None
+    provenance_sources: tuple[AnalysisSourceMetadata, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -2814,7 +2816,11 @@ and `St`.
         title = value.title
         if title in (None, "", "<untitled>"):
             title = None
-        return _FactorMetadata(title=title, units=value.units)
+        return _FactorMetadata(
+            title=title,
+            units=value.units,
+            provenance_sources=(AnalysisSourceMetadata(value),),
+        )
 
     @staticmethod
     def _profile_array(profile):
@@ -2841,7 +2847,14 @@ and `St`.
         if len(titles) > 1:
             raise ValueError(f"{label} blocks have inconsistent titles.")
         title = next(iter(titles), None)
-        return _FactorMetadata(title=title, units=reference)
+        provenance_sources = tuple(
+            source for item in metadata for source in item.provenance_sources
+        )
+        return _FactorMetadata(
+            title=title,
+            units=reference,
+            provenance_sources=provenance_sources,
+        )
 
     def _capture_factor_metadata(self, X_blocks, Y, mode=None):
         """Capture initial metadata and classify the supplied factor guess."""
@@ -2936,6 +2949,8 @@ and `St`.
         scale_preserved = self._scale_is_physically_preserved()
         C_units = context.C.units
         St_units = context.St.units
+        C_provenance_sources = ()
+        St_provenance_sources = ()
 
         supplied_St_blocks = (
             context.St_blocks
@@ -2975,6 +2990,30 @@ and `St`.
             if not scale_preserved:
                 C_units = None
                 block_St_units = [None] * len(X_blocks)
+                C_provenance_sources = ()
+                block_St_provenance_sources = [()] * len(X_blocks)
+            else:
+                if C_units is not None and context.C.units is not None:
+                    C_provenance_sources = context.C.provenance_sources
+                elif C_units is not None:
+                    C_provenance_sources = tuple(
+                        source
+                        for item in supplied_St_blocks
+                        if item.units is not None
+                        for source in item.provenance_sources
+                    )
+                else:
+                    C_provenance_sources = ()
+                block_St_provenance_sources = []
+                for source, units in zip(
+                    supplied_St_blocks, block_St_units, strict=True
+                ):
+                    if units is not None and source.units is not None:
+                        block_St_provenance_sources.append(source.provenance_sources)
+                    elif units is not None and context.C.units is not None:
+                        block_St_provenance_sources.append(context.C.provenance_sources)
+                    else:
+                        block_St_provenance_sources.append(())
 
             C_title = (
                 context.C.title
@@ -2985,7 +3024,11 @@ and `St`.
                 if C_units is not None
                 else "relative concentration"
             )
-            C_meta = _FactorMetadata(C_title, C_units)
+            C_meta = _FactorMetadata(
+                C_title,
+                C_units,
+                provenance_sources=C_provenance_sources,
+            )
             St_block_meta = tuple(
                 _FactorMetadata(
                     (
@@ -2996,9 +3039,14 @@ and `St`.
                         else X_meta.title or "spectral profiles"
                     ),
                     units,
+                    provenance_sources=block_sources,
                 )
-                for X_meta, source, units in zip(
-                    X_blocks, supplied_St_blocks, block_St_units, strict=True
+                for X_meta, source, units, block_sources in zip(
+                    X_blocks,
+                    supplied_St_blocks,
+                    block_St_units,
+                    block_St_provenance_sources,
+                    strict=True,
                 )
             )
             return _ResolvedFactorMetadata(
@@ -3027,6 +3075,22 @@ and `St`.
         if not scale_preserved:
             C_units = None
             St_units = None
+            C_provenance_sources = ()
+            St_provenance_sources = ()
+        else:
+            if C_units is not None and context.C.units is not None:
+                C_provenance_sources = context.C.provenance_sources
+            elif C_units is not None and context.St.units is not None:
+                C_provenance_sources = context.St.provenance_sources
+            else:
+                C_provenance_sources = ()
+
+            if St_units is not None and context.St.units is not None:
+                St_provenance_sources = context.St.provenance_sources
+            elif St_units is not None and context.C.units is not None:
+                St_provenance_sources = context.C.provenance_sources
+            else:
+                St_provenance_sources = ()
 
         C_title = (
             context.C.title
@@ -3042,8 +3106,16 @@ and `St`.
             and context.St.title
             else X_blocks[0].title or "spectral profiles"
         )
-        C_meta = _FactorMetadata(C_title, C_units)
-        St_meta = _FactorMetadata(St_title, St_units)
+        C_meta = _FactorMetadata(
+            C_title,
+            C_units,
+            provenance_sources=C_provenance_sources,
+        )
+        St_meta = _FactorMetadata(
+            St_title,
+            St_units,
+            provenance_sources=St_provenance_sources,
+        )
         n_C_blocks = len(X_blocks) if context.mode == "vertical" else 1
         return _ResolvedFactorMetadata(
             C=C_meta,
@@ -3065,6 +3137,56 @@ and `St`.
                 St_blocks=(_FactorMetadata("spectral profiles", None),),
                 scale_is_physically_preserved=False,
             ),
+        )
+
+    def _analysis_units_for_role(
+        self,
+        role_id,
+        *,
+        dataset,
+        x_source,
+        y_source,
+        single_source,
+        fit_x_source=None,
+        fit_y_source=None,
+    ):
+        if role_id == "concentration_profiles":
+            return self._output_factor_metadata().C.units
+        if role_id == "spectral_profiles":
+            return self._output_factor_metadata().St.units
+        return super()._analysis_units_for_role(
+            role_id,
+            dataset=dataset,
+            x_source=x_source,
+            y_source=y_source,
+            single_source=single_source,
+            fit_x_source=fit_x_source,
+            fit_y_source=fit_y_source,
+        )
+
+    def _analysis_additional_provenance_sources(
+        self,
+        role_id,
+        *,
+        x_source,
+        y_source,
+        direct_x,
+        direct_y,
+        direct_x_kind,
+        direct_y_kind,
+    ):
+        if role_id == "concentration_profiles":
+            return self._output_factor_metadata().C.provenance_sources
+        if role_id == "spectral_profiles":
+            return self._output_factor_metadata().St.provenance_sources
+        return super()._analysis_additional_provenance_sources(
+            role_id,
+            x_source=x_source,
+            y_source=y_source,
+            direct_x=direct_x,
+            direct_y=direct_y,
+            direct_x_kind=direct_x_kind,
+            direct_y_kind=direct_y_kind,
         )
 
     @staticmethod

--- a/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
@@ -42,6 +42,7 @@ def test_optimize_fitted_and_components_preserve_source_author(
     assert result.fitted.description == (
         "Fitted data from Optimize fit of optimize_source."
     )
+    assert result.fitted.units == ds.units
     assert result.fitted.filename is None
     assert result.fitted.meta.project == "curvefit"
     assert result.fitted.meta is not ds.meta
@@ -49,6 +50,7 @@ def test_optimize_fitted_and_components_preserve_source_author(
     assert result.fitted.history[-1].endswith(
         "Created fitted data with Optimize from optimize_source."
     )
+    assert opt.predict().units == ds.units
     assert result.components.author == "optimize_author"
 
     # Numeric no-regression: residuals still equal observed minus fitted.
@@ -76,3 +78,16 @@ def test_optimize_fitted_and_components_preserve_source_author(
     # Input must not be mutated by the fit.
     assert np.array_equal(ds.data, data_before)
     assert ds.author == "optimize_author"
+
+
+def test_optimize_fitted_and_residuals_preserve_none_units(
+    synthetic_two_peak_dataset, optimize_script
+):
+    ds = synthetic_two_peak_dataset.to(None, force=True)
+
+    opt = scp.Optimize(script=optimize_script).fit(ds)
+    result = opt.result
+
+    assert result.fitted.units is None
+    assert opt.predict().units is None
+    assert result.residuals.units is None

--- a/tests/test_analysis/test_decomposition/test_analysis_output_units.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_output_units.py
@@ -1,0 +1,149 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+"""G15 units policy tests for analysis-output datasets."""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis.crossdecomposition.pls import PLSRegression
+from spectrochempy.analysis.decomposition.efa import EFA
+from spectrochempy.analysis.decomposition.fast_ica import FastICA
+from spectrochempy.analysis.decomposition.nmf import NMF
+from spectrochempy.analysis.decomposition.pca import PCA
+from spectrochempy.analysis.decomposition.simplisma import SIMPLISMA
+from spectrochempy.analysis.decomposition.svd import SVD
+
+
+@pytest.fixture()
+def pls_unit_inputs():
+    rng = np.random.default_rng(0)
+    X = scp.NDDataset(rng.normal(size=(20, 5)), title="X training", units="absorbance")
+    Y = scp.NDDataset(rng.normal(size=(20, 3)), title="Y training", units="volt")
+    return X, Y
+
+
+def test_pca_latent_outputs_are_unitless(low_rank_pca_dataset):
+    pca = PCA(n_components=2).fit(low_rank_pca_dataset)
+
+    assert pca.scores.units is None
+    assert pca.components.units is None
+    assert pca.loadings.units is None
+    assert pca.explained_variance.units is None
+    assert pca.explained_variance_ratio.units == "percent"
+    assert pca.cumulative_explained_variance.units == "percent"
+
+
+def test_nmf_latent_outputs_and_reconstruction_follow_g15(efa_dataset):
+    nmf = NMF(
+        n_components=2,
+        init="nndsvda",
+        max_iter=500,
+        random_state=0,
+    ).fit(efa_dataset)
+
+    assert nmf.transform().units is None
+    assert nmf.components.units is None
+    assert nmf.inverse_transform().units == efa_dataset.units
+
+
+def test_fastica_and_efa_outputs_are_unitless(fastica_dataset, efa_dataset):
+    ica = FastICA(n_components=4, random_state=0, whiten="unit-variance").fit(
+        fastica_dataset
+    )
+    efa = EFA(n_components=2).fit(efa_dataset)
+
+    assert ica.A.units is None
+    assert ica.St.units is None
+    assert ica.components.units is None
+    assert efa.transform().units is None
+    assert efa.components.units is None
+
+
+def test_simplisma_profiles_are_unitless(simplisma_dataset):
+    sma = SIMPLISMA(n_components=2).fit(simplisma_dataset)
+
+    assert sma.C.units is None
+    assert sma.St.units is None
+
+
+def test_pls_latent_outputs_are_unitless(pls_unit_inputs):
+    X, Y = pls_unit_inputs
+    pls = PLSRegression(n_components=2).fit(X, Y)
+
+    for output in (
+        pls.x_scores,
+        pls.y_scores,
+        pls.x_loadings,
+        pls.y_loadings,
+        pls.x_weights,
+        pls.y_weights,
+        pls.x_rotations,
+        pls.y_rotations,
+    ):
+        assert output.units is None
+
+
+def test_pls_predictions_preserve_y_units(pls_unit_inputs):
+    X, Y = pls_unit_inputs
+    pls = PLSRegression(n_components=2).fit(X, Y)
+
+    assert pls.predict().units == Y.units
+
+    Xnew = X.copy()
+    Xnew.units = "counts"
+    assert pls.predict(Xnew).units == Y.units
+    assert pls.predict(X.data).units == Y.units
+
+
+def test_pls_predictions_preserve_none_y_units(pls_unit_inputs):
+    X, Y = pls_unit_inputs
+    Y = Y.to(None, force=True)
+    pls = PLSRegression(n_components=2).fit(X, Y)
+
+    assert pls.predict().units is None
+    assert pls.predict(X.copy()).units is None
+    assert pls.predict(X.data).units is None
+
+
+def test_pls_refit_replaces_prediction_units(pls_unit_inputs):
+    X, Y = pls_unit_inputs
+    pls = PLSRegression(n_components=2).fit(X, Y)
+    assert pls.predict().units == Y.units
+
+    Y2 = scp.NDDataset(Y.data.copy(), title="Y training", units="ampere")
+    pls.fit(X, Y2)
+    assert pls.predict().units == Y2.units
+
+
+def test_reconstruction_units_preserve_none(low_rank_pca_dataset, efa_dataset):
+    pca_input = low_rank_pca_dataset.to(None, force=True)
+    nmf_input = efa_dataset.to(None, force=True)
+
+    assert PCA(n_components=2).fit(pca_input).inverse_transform().units is None
+    assert (
+        NMF(
+            n_components=2,
+            init="nndsvda",
+            max_iter=500,
+            random_state=0,
+        )
+        .fit(nmf_input)
+        .inverse_transform()
+        .units
+        is None
+    )
+
+
+def test_svd_diagnostics_follow_g15(low_rank_pca_dataset):
+    svd = SVD().fit(low_rank_pca_dataset)
+
+    assert svd.singular_values.units is None
+    assert svd.explained_variance.units is None
+    assert svd.explained_variance_ratio.units == "percent"
+    assert svd.cumulative_explained_variance.units == "percent"

--- a/tests/test_analysis/test_decomposition/test_mcrals_metadata.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals_metadata.py
@@ -5,6 +5,9 @@
 # ======================================================================================
 """Physical metadata policy for MCR-ALS resolved factors."""
 
+from datetime import UTC
+from datetime import datetime
+
 import numpy as np
 import pytest
 
@@ -61,6 +64,56 @@ def test_metadata_from_calibrated_st_guess():
     assert mcr.St.x.units == X.x.units
 
 
+def test_calibrated_st_guess_adds_contributive_provenance_and_keeps_x_meta():
+    X, _, St = _standard_problem()
+    X.author = "x_author"
+    X.origin = "x_origin"
+    X.meta.project = "x_project"
+    X.acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    St0 = NDDataset(
+        St,
+        title="molar absorptivity",
+        units=ur.absorbance * ur.liter / ur.mole,
+        name="st_seed",
+    )
+    St0.author = "st_author"
+    St0.origin = "st_origin"
+    St0.meta.project = "st_project"
+    St0.acquisition_date = X._acquisition_date
+    X_before = X.copy()
+    St0_before = St0.copy()
+
+    mcr = _fit(X, St0)
+
+    for output in (mcr.C, mcr.St):
+        assert output.author == "x_author & st_author"
+        assert output.origin == "x_origin & st_origin"
+        assert output.meta.project == "x_project"
+        assert "st_project" not in repr(output.meta)
+        assert output.acquisition_date == X.acquisition_date
+
+    assert (
+        mcr.C.description
+        == "concentration profiles from MCRALS fit of mixture + st_seed."
+    )
+    assert mcr.C.history[-1].endswith(
+        "Created analysis output concentration_profiles with MCRALS from mixture + st_seed."
+    )
+    assert (
+        mcr.St.description == "spectral profiles from MCRALS fit of mixture + st_seed."
+    )
+    assert mcr.St.history[-1].endswith(
+        "Created analysis output spectral_profiles with MCRALS from mixture + st_seed."
+    )
+
+    assert X.author == X_before.author
+    assert X.origin == X_before.origin
+    assert X.meta.project == X_before.meta.project
+    assert St0.author == St0_before.author
+    assert St0.origin == St0_before.origin
+    assert St0.meta.project == St0_before.meta.project
+
+
 def test_metadata_from_calibrated_c_guess():
     X, C, _ = _standard_problem()
     C0 = NDDataset(C, title="amount concentration", units=ur.mole / ur.liter)
@@ -71,6 +124,39 @@ def test_metadata_from_calibrated_c_guess():
     assert mcr.C.units == C0.units
     assert mcr.St.title == "spectral profiles"
     assert mcr.St.units == X.units / C0.units
+
+
+def test_calibrated_c_guess_deduplicates_author_and_uses_exact_date_consensus():
+    X, C, _ = _standard_problem()
+    X.author = "shared_author"
+    X.origin = "x_origin"
+    X.meta.project = "x_project"
+    X.acquisition_date = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    C0 = NDDataset(
+        C,
+        title="amount concentration",
+        units=ur.mole / ur.liter,
+        name="c_seed",
+    )
+    C0.author = "shared_author"
+    C0.origin = "c_origin"
+    C0.acquisition_date = datetime(2024, 1, 2, 3, 4, 6, tzinfo=UTC)
+
+    mcr = _fit(X, C0)
+
+    for output in (mcr.C, mcr.St):
+        assert output.author == "shared_author"
+        assert output.origin == "x_origin & c_origin"
+        assert output.meta.project == "x_project"
+        assert output.acquisition_date is None
+
+    assert (
+        mcr.C.description
+        == "concentration profiles from MCRALS fit of mixture + c_seed."
+    )
+    assert (
+        mcr.St.description == "spectral profiles from MCRALS fit of mixture + c_seed."
+    )
 
 
 def test_compatible_both_guesses_are_accepted():
@@ -99,7 +185,13 @@ def test_incompatible_both_guesses_are_rejected():
 
 def test_unitless_guess_uses_ambiguous_scale_fallback():
     X, C, _ = _standard_problem()
-    C0 = NDDataset(C, title="unsupported guess title")
+    X.author = "x_author"
+    X.origin = "x_origin"
+    X.meta.project = "x_project"
+    C0 = NDDataset(C, title="unsupported guess title", name="c_seed")
+    C0.author = "c_author"
+    C0.origin = "c_origin"
+    C0.meta.project = "c_project"
 
     mcr = _fit(X, C0)
 
@@ -107,11 +199,28 @@ def test_unitless_guess_uses_ambiguous_scale_fallback():
     assert mcr.St.units is None
     assert mcr.C.title == "concentration profiles"
     assert mcr.St.title == "spectral profiles"
+    assert mcr.C.author == "x_author"
+    assert mcr.St.author == "x_author"
+    assert mcr.C.origin == "x_origin"
+    assert mcr.St.origin == "x_origin"
+    assert mcr.C.meta.project == "x_project"
+    assert mcr.St.meta.project == "x_project"
+    assert mcr.C.description == "concentration profiles from MCRALS fit of mixture."
+    assert mcr.St.description == "spectral profiles from MCRALS fit of mixture."
 
 
 def test_normalization_clears_calibrated_factor_units():
     X, C, _ = _standard_problem()
-    C0 = NDDataset(C, title="amount concentration", units=ur.mole / ur.liter)
+    X.author = "x_author"
+    X.origin = "x_origin"
+    C0 = NDDataset(
+        C,
+        title="amount concentration",
+        units=ur.mole / ur.liter,
+        name="c_seed",
+    )
+    C0.author = "c_author"
+    C0.origin = "c_origin"
     mcr = MCRALS(
         normSpec="max",
         nonnegConc=[],
@@ -126,6 +235,10 @@ def test_normalization_clears_calibrated_factor_units():
     assert mcr.C.units is None
     assert mcr.St.units is None
     assert mcr.C.title == "concentration profiles"
+    assert mcr.C.author == "x_author"
+    assert mcr.St.author == "x_author"
+    assert mcr.C.origin == "x_origin"
+    assert mcr.St.origin == "x_origin"
 
 
 def test_vertical_blocks_inherit_calibrated_c_metadata_and_coordinates():


### PR DESCRIPTION
## Summary
Implements PR 3 of the accepted `analysis-output-metadata-policy` runtime sequencing: the G15 units tranche.

This keeps the PR strictly focused on truthful units for analysis outputs without changing algorithms, numeric values, shapes, prediction support geometry, or the deferred mask policy.

## What changed
- centralizes analysis-output unit selection in the analysis metadata assembly layer
- makes latent/factor outputs unitless by default where the RFC requires `units is None`
- preserves exact source-domain units for reconstructions, fitted data, and residuals
- preserves exact `Ytrain` units for `PLSRegression.predict()`, including `None`
- keeps conventional diagnostics in `percent` only where explicitly accepted
- extends the existing MCRALS calibrated path so `C0`/`St0` contribute units and provenance only when they materially fix the output scale
- aligns PLS weights/rotations with the accepted unitless policy

## Why
PRs #1516 and #1517 aligned source snapshots plus deterministic identity/history. The remaining accepted runtime tranche for this campaign is G15: analysis-output units.

The previous runtime still mixed truthful unit carryover with incidental wrapper behavior. This PR moves unit authority into the same analysis-specific assembly layer introduced by #1517 so the rules are deterministic by output role.

## Validation
- `python -m pytest tests/test_analysis/test_decomposition/test_analysis_output_units.py`
- `python -m pytest tests/test_analysis/test_curvefitting/test_optimize_provenance.py`
- `python -m pytest tests/test_analysis/test_decomposition/test_mcrals_metadata.py`
- `python -m pytest tests/test_analysis/test_decomposition/test_analysis_source_provenance.py`

## Out of scope
- prediction dims/coordset/mask reconstruction
- general mask-policy work (PR 4)
- any global unit propagation change outside analysis-output assembly
- conversion of raw SVD `U` / `s` / `VT` into `NDDataset`