### PR TITLE
FIX: align analysis output geometry support

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -43,6 +43,15 @@ Bug Fixes
   outputs now use the common diagnostic metadata contract while raw
   ``U``/``s``/``VT`` factors remain unchanged.
 
+- Analysis outputs now align their public geometry support with the accepted
+  family-specific rules: latent factors and profiles stay unmasked unless an
+  exact restored full-row/full-column authority exists, source-domain
+  reconstructions and fitted/residual outputs recover the public ``X``
+  coordset and mask only when their geometry matches exactly, ``PLSRegression``
+  predictions rebuild their observation axis from ``Xpredict`` and target axis
+  from ``Ytrain`` without whole-source geometry copies, and diagnostic outputs
+  remain generated and unmasked.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -31,3 +31,12 @@ Bug Fixes
   predictions preserve exact ``Ytrain`` units, and SVD diagnostic ``NDDataset``
   outputs now use the common diagnostic metadata contract while raw
   ``U``/``s``/``VT`` factors remain unchanged.
+
+- Analysis outputs now align their public geometry support with the accepted
+  family-specific rules: latent factors and profiles stay unmasked unless an
+  exact restored full-row/full-column authority exists, source-domain
+  reconstructions and fitted/residual outputs recover the public ``X``
+  coordset and mask only when their geometry matches exactly, ``PLSRegression``
+  predictions rebuild their observation axis from ``Xpredict`` and target axis
+  from ``Ytrain`` without whole-source geometry copies, and diagnostic outputs
+  remain generated and unmasked.

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -8,6 +8,7 @@
 import copy
 import logging
 import warnings
+from types import SimpleNamespace
 
 import numpy as np
 import traitlets as tr
@@ -18,6 +19,7 @@ from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.extern.traittypes import Array
 from spectrochempy.utils.baseconfigurable import BaseConfigurable
+from spectrochempy.utils.constants import NOMASK
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
 from spectrochempy.utils.decorators import deprecated
 from spectrochempy.utils.exceptions import NotFittedError
@@ -60,6 +62,7 @@ class AnalysisSourceMetadata:
         self.modified = source._modified
         self.acquisition_date = source._acquisition_date
         self.history = list(source.history or [])
+        self.shape = tuple(source.shape)
         self.dims = tuple(source.dims)
         self.coordset = source.coordset.copy() if source.coordset is not None else None
         self.mask = source.mask.copy() if source.mask is not None else None
@@ -402,6 +405,362 @@ class AnalysisConfigurable(BaseConfigurable):
         if role_id == "prediction":
             return fit_y_source.units if fit_y_source is not None else None
         return dataset.units
+
+    @staticmethod
+    def _analysis_full_rows(mask):
+        if mask is None:
+            return None
+        array = np.asarray(mask)
+        if array.ndim < 2:
+            return None
+        return np.all(array, axis=-1)
+
+    @staticmethod
+    def _analysis_full_columns(mask):
+        if mask is None:
+            return None
+        array = np.asarray(mask)
+        if array.ndim < 2:
+            return None
+        return np.all(array, axis=-2)
+
+    @staticmethod
+    def _analysis_copy_mask(mask):
+        if mask is None or np.isscalar(mask):
+            return np.False_
+        return np.array(mask, copy=True)
+
+    def _analysis_set_unmasked(self, dataset):
+        dataset._mask = NOMASK
+        return dataset
+
+    def _analysis_restore_svd_diagnostic_axis(self, dataset):
+        if type(self).__name__ != "SVD" or dataset.ndim != 1:
+            return self._analysis_set_unmasked(dataset)
+
+        target_size = min(getattr(self, "_X_shape", dataset.shape))
+        if target_size <= dataset.shape[0]:
+            return self._analysis_set_unmasked(dataset)
+
+        data = np.zeros(target_size, dtype=dataset.dtype)
+        data[: dataset.shape[0]] = np.asarray(dataset.data)
+        dataset.data = data
+
+        if dataset.dims:
+            from spectrochempy.core.dataset.coord import Coord
+
+            dim = dataset.dims[0]
+            title = "components"
+            if dataset.coordset is not None and dataset.coordset[dim] is not None:
+                title = dataset.coordset[dim].title or title
+            dataset.set_coordset(
+                {
+                    dim: Coord(
+                        None,
+                        labels=[f"#{i}" for i in range(target_size)],
+                        title=title,
+                    )
+                }
+            )
+
+        return self._analysis_set_unmasked(dataset)
+
+    def _analysis_copy_coordset(self, source):
+        if source is None or source.coordset is None:
+            return None
+        return source.coordset.copy()
+
+    def _analysis_copy_exact_geometry(self, dataset, source):
+        if source is None:
+            return self._analysis_set_unmasked(dataset)
+        dataset.dims = list(source.dims)
+        dataset._coordset = self._analysis_copy_coordset(source)
+        dataset._mask = self._analysis_copy_mask(source.mask)
+        return dataset
+
+    def _analysis_restore_axis_from_source(self, dataset, source, axis):
+        if source is None:
+            return self._analysis_set_unmasked(dataset)
+        full_mask = (
+            self._analysis_full_rows(source.mask)
+            if axis == 0
+            else self._analysis_full_columns(source.mask)
+        )
+        dataset = self._analysis_apply_full_axis_mask(dataset, full_mask, axis=axis)
+        if source.coordset is None or dataset.coordset is None:
+            return dataset
+        if axis == 0:
+            dataset.coordset[dataset.dims[0]] = source.coordset[source.dims[0]].copy()
+        elif axis == -1:
+            dataset.coordset[dataset.dims[-1]] = source.coordset[source.dims[-1]].copy()
+        return dataset
+
+    def _analysis_apply_full_axis_mask(self, dataset, full_mask, axis):
+        if full_mask is None:
+            return self._analysis_set_unmasked(dataset)
+        full_mask = np.asarray(full_mask, dtype=bool)
+        if not np.any(full_mask):
+            return self._analysis_set_unmasked(dataset)
+        if dataset.ndim == 1:
+            if axis != 0:
+                return self._analysis_set_unmasked(dataset)
+            if full_mask.shape[0] == dataset.shape[0]:
+                dataset._mask = full_mask.copy()
+                return dataset
+            if np.count_nonzero(~full_mask) != dataset.shape[0]:
+                return self._analysis_set_unmasked(dataset)
+            data = np.ma.zeros(full_mask.shape[0], dtype=dataset.dtype)
+            data[~full_mask] = np.ma.asarray(dataset.masked_data)
+            data[full_mask] = np.ma.masked
+            dataset.data = data
+            dataset._mask = np.asarray(data.mask)
+            return dataset
+        mask = np.zeros(dataset.shape, dtype=bool)
+        if axis == 0:
+            if full_mask.shape[0] == dataset.shape[0]:
+                mask[full_mask, ...] = True
+            elif np.count_nonzero(~full_mask) == dataset.shape[0]:
+                data = np.ma.zeros(
+                    (full_mask.shape[0], dataset.shape[1]), dtype=dataset.dtype
+                )
+                data[~full_mask, :] = np.ma.asarray(dataset.masked_data)
+                data[full_mask, :] = np.ma.masked
+                dataset.data = data
+                mask = np.asarray(data.mask)
+            else:
+                return self._analysis_set_unmasked(dataset)
+        elif axis == -1:
+            if full_mask.shape[0] == dataset.shape[-1]:
+                mask[..., full_mask] = True
+            elif np.count_nonzero(~full_mask) == dataset.shape[-1]:
+                data = np.ma.zeros(
+                    (dataset.shape[0], full_mask.shape[0]), dtype=dataset.dtype
+                )
+                data[:, ~full_mask] = np.ma.asarray(dataset.masked_data)
+                data[:, full_mask] = np.ma.masked
+                dataset.data = data
+                mask = np.asarray(data.mask)
+            else:
+                return self._analysis_set_unmasked(dataset)
+        else:
+            return self._analysis_set_unmasked(dataset)
+        dataset._mask = mask
+        return dataset
+
+    def _analysis_restore_full_geometry(self, dataset, source):
+        if source is None:
+            return self._analysis_set_unmasked(dataset)
+
+        if tuple(dataset.shape) == tuple(source.shape):
+            return self._analysis_copy_exact_geometry(dataset, source)
+
+        source_mask = source.mask
+        if source_mask is None:
+            return self._analysis_set_unmasked(dataset)
+
+        source_mask = np.asarray(source_mask, dtype=bool)
+        if source_mask.ndim == 1:
+            if dataset.ndim != 1 or np.count_nonzero(~source_mask) != dataset.shape[0]:
+                return self._analysis_set_unmasked(dataset)
+            data = np.ma.zeros(source.shape[0], dtype=dataset.dtype)
+            data[~source_mask] = np.ma.asarray(dataset.masked_data)
+            data[source_mask] = np.ma.masked
+            dataset.data = data
+            dataset.dims = list(source.dims)
+            dataset._coordset = self._analysis_copy_coordset(source)
+            dataset._mask = np.asarray(data.mask)
+            return dataset
+
+        rows = self._analysis_full_rows(source_mask)
+        cols = self._analysis_full_columns(source_mask)
+        data = np.ma.asarray(dataset.masked_data)
+
+        if rows.shape[0] == data.shape[0]:
+            pass
+        elif np.count_nonzero(~rows) == data.shape[0]:
+            expanded = np.ma.zeros((rows.shape[0], data.shape[1]), dtype=dataset.dtype)
+            expanded[~rows, :] = data
+            expanded[rows, :] = np.ma.masked
+            data = expanded
+        else:
+            return self._analysis_set_unmasked(dataset)
+
+        if cols.shape[0] == data.shape[1]:
+            pass
+        elif np.count_nonzero(~cols) == data.shape[1]:
+            expanded = np.ma.zeros((data.shape[0], cols.shape[0]), dtype=dataset.dtype)
+            expanded[:, ~cols] = data
+            expanded[:, cols] = np.ma.masked
+            data = expanded
+        else:
+            return self._analysis_set_unmasked(dataset)
+
+        data[source_mask] = np.ma.masked
+        dataset.data = data
+        dataset.dims = list(source.dims)
+        dataset._coordset = self._analysis_copy_coordset(source)
+        dataset._mask = np.asarray(data.mask)
+        return dataset
+
+    def _analysis_reconstruction_geometry_source(
+        self,
+        role_id,
+        *,
+        x_source,
+        direct_x_kind,
+    ):
+        if role_id not in {"reconstruction", "fitted_data", "residuals"}:
+            return None
+        if direct_x_kind != "none":
+            return None
+        if getattr(self, "_X_original_ndim", 2) == 1:
+            return SimpleNamespace(
+                shape=tuple(self._X_shape),
+                dims=tuple(self._X.dims),
+                coordset=copy.copy(self._X_coordset),
+                mask=copy.copy(self._X_mask),
+            )
+        return AnalysisSourceMetadata(self.X)
+
+    def _analysis_prediction_dims_and_coordset(self, dataset, x_predict, y_train):
+        if dataset.ndim == 1:
+            obs_dim = dataset.dims[0]
+            obs_coord = None
+            if x_predict is not None and x_predict.coordset is not None:
+                source_dim = x_predict.dims[0]
+                obs_dim = source_dim
+                obs_coord = x_predict.coordset[source_dim].copy()
+            dataset.dims = [obs_dim]
+            dataset.set_coordset({obs_dim: obs_coord})
+            return dataset
+
+        default_obs_dim, default_target_dim = dataset.dims
+        obs_dim = default_obs_dim
+        target_dim = default_target_dim
+        obs_coord = None
+        target_coord = None
+
+        if x_predict is not None and len(x_predict.dims) >= 1:
+            source_obs_dim = x_predict.dims[0]
+            if x_predict.coordset is not None:
+                obs_coord = x_predict.coordset[source_obs_dim].copy()
+            obs_dim = source_obs_dim
+
+        if y_train is not None and len(y_train.dims) >= 1:
+            source_target_dim = y_train.dims[-1]
+            if y_train.coordset is not None:
+                target_coord = y_train.coordset[source_target_dim].copy()
+            target_dim = source_target_dim
+
+        if obs_dim == target_dim:
+            obs_dim = default_obs_dim
+            target_dim = default_target_dim
+
+        dataset.dims = [obs_dim, target_dim]
+        dataset.set_coordset({obs_dim: obs_coord, target_dim: target_coord})
+        return dataset
+
+    def _analysis_prediction_mask(self, dataset, x_predict, y_train):
+        if dataset.ndim == 1:
+            obs_rows = (
+                self._analysis_full_rows(x_predict.mask)
+                if x_predict is not None
+                else None
+            )
+            return self._analysis_apply_full_axis_mask(dataset, obs_rows, axis=0)
+
+        mask = np.zeros(dataset.shape, dtype=bool)
+        contributed = False
+
+        obs_rows = (
+            self._analysis_full_rows(x_predict.mask) if x_predict is not None else None
+        )
+        if (
+            obs_rows is not None
+            and obs_rows.shape[0] == dataset.shape[0]
+            and np.any(obs_rows)
+        ):
+            mask[obs_rows, :] = True
+            contributed = True
+
+        target_cols = (
+            self._analysis_full_columns(y_train.mask) if y_train is not None else None
+        )
+        if (
+            target_cols is not None
+            and target_cols.shape[0] == dataset.shape[-1]
+            and np.any(target_cols)
+        ):
+            mask[:, target_cols] = True
+            contributed = True
+
+        dataset._mask = mask if contributed else NOMASK
+        return dataset
+
+    def _apply_analysis_output_geometry(
+        self,
+        dataset,
+        *,
+        role_id,
+        meta_from,
+        direct_x,
+        direct_y,
+        direct_x_kind,
+        direct_y_kind,
+    ):
+        role_id = self._normalize_analysis_role(role_id)
+        x_source = self._analysis_resolve_source_metadata("_X", direct_x_kind, direct_x)
+        y_source = self._analysis_resolve_source_metadata("_Y", direct_y_kind, direct_y)
+
+        if role_id in {
+            "diagnostic",
+            "singular_values",
+            "explained_variance",
+            "explained_variance_ratio",
+            "cumulative_explained_variance",
+        }:
+            return self._analysis_restore_svd_diagnostic_axis(dataset)
+
+        if role_id == "prediction":
+            dataset = self._analysis_prediction_dims_and_coordset(
+                dataset, x_source, y_source
+            )
+            return self._analysis_prediction_mask(dataset, x_source, y_source)
+
+        if (
+            role_id in {"reconstruction", "fitted_data", "residuals"}
+            and direct_x_kind == "arraylike"
+        ):
+            dataset._coordset = None
+            return self._analysis_set_unmasked(dataset)
+
+        geometry_source = self._analysis_reconstruction_geometry_source(
+            role_id,
+            x_source=x_source,
+            direct_x_kind=direct_x_kind,
+        )
+        if geometry_source is not None:
+            return self._analysis_restore_full_geometry(dataset, geometry_source)
+
+        if role_id in {"scores", "concentration_profiles"}:
+            return self._analysis_restore_axis_from_source(dataset, x_source, axis=0)
+
+        if role_id == "y_scores":
+            return self._analysis_restore_axis_from_source(dataset, y_source, axis=0)
+
+        if role_id in {
+            "components",
+            "loadings",
+            "weights",
+            "rotations",
+            "spectral_profiles",
+        }:
+            authority = x_source
+            if role_id in {"loadings", "weights", "rotations"} and meta_from == "_Y":
+                authority = y_source
+            return self._analysis_restore_axis_from_source(dataset, authority, axis=-1)
+
+        return self._analysis_set_unmasked(dataset)
 
     def _apply_analysis_output_metadata(
         self,

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -435,34 +435,6 @@ class AnalysisConfigurable(BaseConfigurable):
         return dataset
 
     def _analysis_restore_svd_diagnostic_axis(self, dataset):
-        if type(self).__name__ != "SVD" or dataset.ndim != 1:
-            return self._analysis_set_unmasked(dataset)
-
-        target_size = min(getattr(self, "_X_shape", dataset.shape))
-        if target_size <= dataset.shape[0]:
-            return self._analysis_set_unmasked(dataset)
-
-        data = np.zeros(target_size, dtype=dataset.dtype)
-        data[: dataset.shape[0]] = np.asarray(dataset.data)
-        dataset.data = data
-
-        if dataset.dims:
-            from spectrochempy.core.dataset.coord import Coord
-
-            dim = dataset.dims[0]
-            title = "components"
-            if dataset.coordset is not None and dataset.coordset[dim] is not None:
-                title = dataset.coordset[dim].title or title
-            dataset.set_coordset(
-                {
-                    dim: Coord(
-                        None,
-                        labels=[f"#{i}" for i in range(target_size)],
-                        title=title,
-                    )
-                }
-            )
-
         return self._analysis_set_unmasked(dataset)
 
     def _analysis_copy_coordset(self, source):

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -1893,8 +1893,9 @@ class Optimize(DecompositionAnalysis):
         # simple and aligned with the PCA / SVD result behaviour.
 
         fitted = self.predict()
+        observed = self.X
         residuals, fit_diagnostics = _compute_fit_diagnostics(
-            self._X,
+            observed,
             fitted,
             getattr(self, "_fit_meta", {}),
             getattr(self, "_model_spec", None),
@@ -1909,7 +1910,7 @@ class Optimize(DecompositionAnalysis):
             direct_y_kind="none",
         )
         covariance = _compute_covariance_matrix(
-            self._X,
+            observed,
             fitted,
             self.jacobian,
             fit_diagnostics,

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -787,41 +787,39 @@ class _set_output:
                         },
                     )
 
-            # eventually restore masks
-            X_transf = obj._restore_masked_data(X_transf, axis=axis)
+            if role_id is None or not hasattr(obj, "_apply_analysis_output_geometry"):
+                # Preserve the legacy generic restoration path for non-analysis outputs.
+                X_transf = obj._restore_masked_data(X_transf, axis=axis)
+
             # Only squeeze if the input was originally 1D (expanded to 2D)
             # This preserves intentionally 2D datasets with shape (1, N)
             if getattr(obj, "_X_original_ndim", 2) == 1:
                 X_transf = X_transf.squeeze()
                 if preserve:
                     X_transf._history = X_transf._history[:-1]
-                if role_id is not None and hasattr(
-                    obj, "_apply_analysis_output_metadata"
-                ):
-                    X_transf = obj._apply_analysis_output_metadata(
-                        X_transf,
-                        role_id=role_id,
-                        meta_from=meta_from,
-                        direct_x=None if direct_X is sentinel else direct_X,
-                        direct_y=None if direct_Y is sentinel else direct_Y,
-                        direct_x_kind=direct_X_kind,
-                        direct_y_kind=direct_Y_kind,
-                    )
-                out.append(X_transf)
-            else:
-                if role_id is not None and hasattr(
-                    obj, "_apply_analysis_output_metadata"
-                ):
-                    X_transf = obj._apply_analysis_output_metadata(
-                        X_transf,
-                        role_id=role_id,
-                        meta_from=meta_from,
-                        direct_x=None if direct_X is sentinel else direct_X,
-                        direct_y=None if direct_Y is sentinel else direct_Y,
-                        direct_x_kind=direct_X_kind,
-                        direct_y_kind=direct_Y_kind,
-                    )
-                out.append(X_transf)
+
+            if role_id is not None and hasattr(obj, "_apply_analysis_output_geometry"):
+                X_transf = obj._apply_analysis_output_geometry(
+                    X_transf,
+                    role_id=role_id,
+                    meta_from=meta_from,
+                    direct_x=None if direct_X is sentinel else direct_X,
+                    direct_y=None if direct_Y is sentinel else direct_Y,
+                    direct_x_kind=direct_X_kind,
+                    direct_y_kind=direct_Y_kind,
+                )
+
+            if role_id is not None and hasattr(obj, "_apply_analysis_output_metadata"):
+                X_transf = obj._apply_analysis_output_metadata(
+                    X_transf,
+                    role_id=role_id,
+                    meta_from=meta_from,
+                    direct_x=None if direct_X is sentinel else direct_X,
+                    direct_y=None if direct_Y is sentinel else direct_Y,
+                    direct_x_kind=direct_X_kind,
+                    direct_y_kind=direct_Y_kind,
+                )
+            out.append(X_transf)
 
         if len(out) == 1:
             return out[0]

--- a/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
@@ -91,3 +91,24 @@ def test_optimize_fitted_and_residuals_preserve_none_units(
     assert result.fitted.units is None
     assert opt.predict().units is None
     assert result.residuals.units is None
+
+
+def test_optimize_fitted_and_residuals_restore_public_geometry_and_mask(
+    synthetic_two_peak_dataset, optimize_script
+):
+    ds = synthetic_two_peak_dataset.copy()
+    ds[40] = scp.MASKED
+
+    opt = scp.Optimize(script=optimize_script).fit(ds)
+    observed = opt.X
+    result = opt.result
+
+    for output in (result.fitted, result.residuals):
+        assert output.shape == observed.shape
+        assert output.dims == observed.dims
+        np.testing.assert_array_equal(output.mask, observed.mask)
+        assert output.coordset is not observed.coordset
+        np.testing.assert_allclose(output.x.data, observed.x.data)
+
+    result.fitted.mask[0, 0] = True
+    assert not observed.mask[0, 0]

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -706,6 +706,141 @@ class TestOptimizeResult:
             2,
         )
 
+    def test_public_diagnostics_match_internal_solver_domain_without_mask(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(synthetic_two_peak_dataset)
+
+        fitted_public = opt.predict()
+        residuals_internal, diagnostics_internal = _compute_fit_diagnostics(
+            opt._X,
+            fitted_public.copy(),
+            getattr(opt, "_fit_meta", {}),
+            getattr(opt, "_model_spec", None),
+        )
+        residuals_public, diagnostics_public = _compute_fit_diagnostics(
+            opt.X,
+            fitted_public,
+            getattr(opt, "_fit_meta", {}),
+            getattr(opt, "_model_spec", None),
+        )
+
+        for key in (
+            "n_observations",
+            "n_varying_parameters",
+            "degrees_of_freedom",
+            "sse",
+            "rss",
+            "rmse",
+            "r_squared",
+            "reduced_chi_square",
+            "adjusted_r_squared",
+            "aic",
+            "bic",
+        ):
+            assert diagnostics_public[key] == pytest.approx(
+                diagnostics_internal[key],
+                nan_ok=True,
+            )
+
+        covariance_internal = _compute_covariance_matrix(
+            opt._X,
+            fitted_public.copy(),
+            opt.jacobian,
+            diagnostics_internal,
+        )
+        covariance_public = _compute_covariance_matrix(
+            opt.X,
+            fitted_public,
+            opt.jacobian,
+            diagnostics_public,
+        )
+
+        np.testing.assert_allclose(
+            np.ma.asarray(residuals_public.masked_data),
+            np.ma.asarray(residuals_internal.masked_data),
+        )
+        np.testing.assert_allclose(covariance_public, covariance_internal)
+
+    def test_public_diagnostics_match_internal_solver_domain_with_mask(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        ds = synthetic_two_peak_dataset.copy()
+        ds[40] = scp.MASKED
+
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fit(ds)
+
+        fitted_public = opt.predict()
+        fitted_internal = scp.NDDataset(
+            np.ma.asarray(fitted_public.masked_data).compressed().reshape(opt._X.shape)
+        )
+        residuals_internal, diagnostics_internal = _compute_fit_diagnostics(
+            opt._X,
+            fitted_internal,
+            getattr(opt, "_fit_meta", {}),
+            getattr(opt, "_model_spec", None),
+        )
+        residuals_public, diagnostics_public = _compute_fit_diagnostics(
+            opt.X,
+            fitted_public,
+            getattr(opt, "_fit_meta", {}),
+            getattr(opt, "_model_spec", None),
+        )
+
+        for key in (
+            "n_observations",
+            "n_varying_parameters",
+            "degrees_of_freedom",
+            "sse",
+            "rss",
+            "rmse",
+            "r_squared",
+            "reduced_chi_square",
+            "adjusted_r_squared",
+            "aic",
+            "bic",
+        ):
+            assert diagnostics_public[key] == pytest.approx(
+                diagnostics_internal[key],
+                nan_ok=True,
+            )
+
+        assert diagnostics_public["n_observations"] == int(
+            np.ma.asarray(opt._X.masked_data).count()
+        )
+        assert (
+            np.ma.asarray(residuals_public.masked_data).count()
+            == diagnostics_public["n_observations"]
+        )
+        assert np.array_equal(np.asarray(residuals_public.mask), np.asarray(opt.X.mask))
+
+        covariance_internal = _compute_covariance_matrix(
+            opt._X,
+            fitted_internal,
+            opt.jacobian,
+            diagnostics_internal,
+        )
+        covariance_public = _compute_covariance_matrix(
+            opt.X,
+            fitted_public,
+            opt.jacobian,
+            diagnostics_public,
+        )
+
+        np.testing.assert_allclose(covariance_public, covariance_internal)
+        np.testing.assert_allclose(
+            np.ma.asarray(residuals_public.masked_data).compressed(),
+            np.ma.asarray(residuals_internal.masked_data).compressed(),
+        )
+
     # ----------------------------------------------------------------------------------
     # Representation
     # ----------------------------------------------------------------------------------

--- a/tests/test_analysis/test_decomposition/test_analysis_output_geometry.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_output_geometry.py
@@ -1,0 +1,314 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+
+"""PR4 geometry and mask policy tests for analysis outputs."""
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.analysis.crossdecomposition.pls import PLSRegression
+from spectrochempy.analysis.decomposition.mcrals import MCRALS
+from spectrochempy.analysis.decomposition.nmf import NMF
+from spectrochempy.analysis.decomposition.pca import PCA
+from spectrochempy.analysis.decomposition.simplisma import SIMPLISMA
+from spectrochempy.analysis.decomposition.svd import SVD
+
+
+@pytest.fixture()
+def geometry_source_dataset():
+    y = scp.Coord(np.arange(6.0), title="obs", units="s")
+    x = scp.Coord(np.arange(5.0), title="feat", units="nm")
+    return scp.NDDataset(
+        np.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0],
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [2.0, 3.0, 4.0, 5.0, 6.0],
+                [3.0, 4.0, 5.0, 6.0, 7.0],
+                [4.0, 5.0, 6.0, 7.0, 8.0],
+                [5.0, 6.0, 7.0, 8.0, 9.0],
+            ]
+        ),
+        coordset=[y, x],
+        title="source",
+        name="source",
+        units="absorbance",
+    )
+
+
+@pytest.fixture()
+def pls_geometry_inputs():
+    rng = np.random.default_rng(0)
+    xobs = scp.Coord(np.arange(6.0) + 10.0, title="train observations")
+    xfeat = scp.Coord(np.arange(5.0) + 50.0, title="x features")
+    yobs = scp.Coord(np.arange(6.0) + 100.0, title="target observations")
+    yfeat = scp.Coord(np.array([700.0, 800.0, 900.0]), title="target variables")
+    X = scp.NDDataset(
+        rng.normal(size=(6, 5)),
+        coordset=[xobs, xfeat],
+        title="X train",
+        name="xtrain",
+    )
+    Y = scp.NDDataset(
+        rng.normal(size=(6, 3)),
+        coordset=[yobs, yfeat],
+        title="Y train",
+        name="ytrain",
+    )
+    return X, Y
+
+
+def test_pca_factor_masks_restore_only_exact_source_axes(geometry_source_dataset):
+    source = geometry_source_dataset
+
+    masked_column = source.copy()
+    masked_column[:, 4] = scp.MASKED
+    pca_column = PCA(n_components=2).fit(masked_column)
+    assert pca_column.scores.mask is np.False_
+    assert pca_column.scores.shape == (6, 2)
+    np.testing.assert_array_equal(pca_column.components.mask, masked_column.mask[:2])
+    assert pca_column.components.shape == (2, 5)
+    np.testing.assert_allclose(pca_column.components.x.data, masked_column.x.data)
+
+    masked_row = source.copy()
+    masked_row[2, :] = scp.MASKED
+    pca_row = PCA(n_components=2).fit(masked_row)
+    np.testing.assert_array_equal(
+        np.all(np.asarray(pca_row.scores.mask), axis=-1),
+        np.all(np.asarray(masked_row.mask), axis=-1),
+    )
+    assert pca_row.components.mask is np.False_
+    np.testing.assert_allclose(pca_row.scores.y.data, masked_row.y.data)
+
+
+def test_pca_reconstruction_restores_exact_full_geometry(geometry_source_dataset):
+    source = geometry_source_dataset
+    masked = source.copy()
+    masked[2, 3] = scp.MASKED
+
+    pca = PCA(n_components=2).fit(masked)
+    reconstruction = pca.inverse_transform()
+
+    assert reconstruction.shape == masked.shape
+    assert reconstruction.dims == masked.dims
+    np.testing.assert_allclose(reconstruction.x.data, masked.x.data)
+    np.testing.assert_allclose(reconstruction.y.data, masked.y.data)
+    np.testing.assert_array_equal(reconstruction.mask, masked.mask)
+
+    reconstruction.mask[0, 0] = True
+    assert not masked.mask[0, 0]
+
+
+def test_reconstruction_direct_input_does_not_leak_fitted_geometry(
+    geometry_source_dataset,
+):
+    source = geometry_source_dataset
+    fitted_source = source.copy()
+    fitted_source[:, 4] = scp.MASKED
+    pca = PCA(n_components=2).fit(fitted_source)
+
+    other = source.copy()
+    other[:, 4] = scp.MASKED
+    other.name = "other"
+    other.y = scp.Coord(np.arange(6.0) + 1000.0, title="other observations")
+    direct_scores = pca.transform(other)
+    direct_reconstruction = pca.inverse_transform(direct_scores)
+    arraylike_reconstruction = pca.inverse_transform(direct_scores.data)
+
+    assert direct_reconstruction.mask is np.False_
+    assert direct_reconstruction.shape == (6, 4)
+    np.testing.assert_allclose(direct_reconstruction.y.data, other.y.data)
+    np.testing.assert_allclose(direct_reconstruction.x.data, fitted_source.x.data[:4])
+    assert arraylike_reconstruction.mask is np.False_
+    assert arraylike_reconstruction.coordset is None
+
+
+def test_nmf_reconstruction_and_components_restore_exact_feature_axis(
+    geometry_source_dataset,
+):
+    source = geometry_source_dataset + 1.0
+    masked = source.copy()
+    masked[:, 4] = scp.MASKED
+
+    nmf = NMF(
+        n_components=2,
+        init="nndsvda",
+        max_iter=500,
+        random_state=0,
+    ).fit(masked)
+
+    np.testing.assert_array_equal(nmf.components.mask, masked.mask[:2])
+    reconstruction = nmf.inverse_transform()
+    np.testing.assert_array_equal(reconstruction.mask, masked.mask)
+    np.testing.assert_allclose(reconstruction.x.data, masked.x.data)
+
+
+def test_profiles_restore_only_exact_supported_axes(geometry_source_dataset):
+    source = geometry_source_dataset + 1.0
+
+    simplisma_input = source.copy()
+    simplisma_input[3, :] = scp.MASKED
+    sma = SIMPLISMA(n_components=2).fit(simplisma_input)
+    np.testing.assert_array_equal(
+        np.all(np.asarray(sma.C.mask), axis=-1),
+        np.all(np.asarray(simplisma_input.mask), axis=-1),
+    )
+    assert sma.St.mask is np.False_
+
+    mcrals_input = source.copy()
+    mcrals_input[:, 4] = scp.MASKED
+    guess = scp.NDDataset(
+        np.abs(np.random.default_rng(1).normal(size=(source.shape[0], 2))),
+        title="guess",
+    )
+    mcr = MCRALS(max_iter=5, tol=1.0e-10, constraints=[]).fit(mcrals_input, guess)
+    assert mcr.C.mask is np.False_
+    np.testing.assert_array_equal(
+        np.all(np.asarray(mcr.St.mask), axis=-2),
+        np.all(np.asarray(mcrals_input.mask), axis=-2),
+    )
+
+
+def test_pls_prediction_assembles_axes_from_xpredict_and_ytrain(
+    pls_geometry_inputs,
+):
+    Xtrain, Ytrain = pls_geometry_inputs
+    pls = PLSRegression(n_components=2).fit(Xtrain, Ytrain)
+
+    Xpredict = scp.NDDataset(
+        np.random.default_rng(1).normal(size=(4, 5)),
+        coordset=[
+            scp.Coord(np.arange(4.0) + 1000.0, title="predict observations"),
+            scp.Coord(np.arange(5.0) + 500.0, title="predict x features"),
+        ],
+        title="X predict",
+        name="xpredict",
+    )
+    prediction = pls.predict(Xpredict)
+
+    assert prediction.shape == (4, 3)
+    assert prediction.dims == ["y", "x"]
+    np.testing.assert_allclose(prediction.y.data, Xpredict.y.data)
+    np.testing.assert_allclose(prediction.x.data, Ytrain.x.data)
+    assert prediction.mask is np.False_
+
+
+def test_pls_prediction_combines_observation_and_target_axis_masks(
+    pls_geometry_inputs,
+):
+    Xtrain, Ytrain = pls_geometry_inputs
+    Ymasked = Ytrain.copy()
+    Ymasked[:, 1] = scp.MASKED
+    pls = PLSRegression(n_components=2).fit(Xtrain, Ymasked)
+
+    Xpredict = scp.NDDataset(
+        np.random.default_rng(2).normal(size=(4, 5)),
+        coordset=[
+            scp.Coord(np.arange(4.0) + 1000.0, title="predict observations"),
+            scp.Coord(np.arange(5.0) + 500.0, title="predict x features"),
+        ],
+        title="X predict",
+        name="xpredict",
+    )
+    Xpredict[1, :] = scp.MASKED
+
+    prediction = pls.predict(Xpredict)
+
+    expected = np.zeros((4, 3), dtype=bool)
+    expected[1, :] = True
+    expected[:, 1] = True
+    np.testing.assert_array_equal(prediction.mask, expected)
+
+
+def test_pls_prediction_arraylike_does_not_reuse_old_xpredict_geometry(
+    pls_geometry_inputs,
+):
+    Xtrain, Ytrain = pls_geometry_inputs
+    pls = PLSRegression(n_components=2).fit(Xtrain, Ytrain)
+
+    Xpredict = scp.NDDataset(
+        np.random.default_rng(3).normal(size=(4, 5)),
+        coordset=[
+            scp.Coord(np.arange(4.0) + 1000.0, title="predict observations"),
+            scp.Coord(np.arange(5.0) + 500.0, title="predict x features"),
+        ],
+        title="X predict",
+        name="xpredict",
+    )
+    Xpredict[1, :] = scp.MASKED
+    _ = pls.predict(Xpredict)
+
+    arraylike_prediction = pls.predict(Xpredict.data)
+
+    assert arraylike_prediction.dims == ["y", "x"]
+    assert arraylike_prediction.mask is np.False_
+    assert arraylike_prediction.coordset is not None
+    assert arraylike_prediction.y.data is None
+    np.testing.assert_allclose(arraylike_prediction.x.data, Ytrain.x.data)
+
+
+def test_pls_prediction_monotarget_uses_public_1d_observation_geometry():
+    rng = np.random.default_rng(4)
+    X = scp.NDDataset(
+        rng.normal(size=(6, 5)),
+        coordset=[scp.Coord(np.arange(6.0), title="obs"), scp.Coord(np.arange(5.0))],
+    )
+    Y = scp.NDDataset(
+        rng.normal(size=(6,)),
+        coordset=[scp.Coord(np.arange(6.0) + 10.0, title="target observations")],
+    )
+    pls = PLSRegression(n_components=2).fit(X, Y)
+    Xpredict = scp.NDDataset(
+        rng.normal(size=(4, 5)),
+        coordset=[scp.Coord(np.arange(4.0) + 100.0, title="predict obs"), scp.Coord(np.arange(5.0) + 50.0)],
+    )
+    Xpredict[2, :] = scp.MASKED
+
+    prediction = pls.predict(Xpredict)
+
+    assert prediction.shape == (4,)
+    assert prediction.dims == ["y"]
+    np.testing.assert_allclose(prediction.y.data, Xpredict.y.data)
+    np.testing.assert_array_equal(prediction.mask, [False, False, True, False])
+
+
+def test_svd_diagnostics_stay_generated_and_unmasked(geometry_source_dataset):
+    svd = SVD().fit(geometry_source_dataset)
+
+    for diagnostic in (
+        svd.singular_values,
+        svd.explained_variance,
+        svd.explained_variance_ratio,
+        svd.cumulative_explained_variance,
+    ):
+        assert diagnostic.mask is np.False_
+        assert diagnostic.dims == ["k"]
+        assert diagnostic.coordset is not None
+        assert diagnostic.coordset["k"].title == "components"
+
+
+def test_svd_diagnostics_restore_public_k_axis_without_source_mask_transfer(
+    geometry_source_dataset,
+):
+    masked = geometry_source_dataset.copy()
+    masked[:, -1] = scp.MASKED
+    masked[-1, :] = scp.MASKED
+
+    svd = SVD().fit(masked)
+
+    for diagnostic in (
+        svd.singular_values,
+        svd.explained_variance,
+        svd.explained_variance_ratio,
+        svd.cumulative_explained_variance,
+    ):
+        assert diagnostic.shape == (5,)
+        assert diagnostic.mask is np.False_
+        assert diagnostic.dims == ["k"]
+        assert diagnostic.coordset is not None
+        assert diagnostic.coordset["k"].title == "components"

--- a/tests/test_analysis/test_decomposition/test_analysis_output_geometry.py
+++ b/tests/test_analysis/test_decomposition/test_analysis_output_geometry.py
@@ -265,7 +265,10 @@ def test_pls_prediction_monotarget_uses_public_1d_observation_geometry():
     pls = PLSRegression(n_components=2).fit(X, Y)
     Xpredict = scp.NDDataset(
         rng.normal(size=(4, 5)),
-        coordset=[scp.Coord(np.arange(4.0) + 100.0, title="predict obs"), scp.Coord(np.arange(5.0) + 50.0)],
+        coordset=[
+            scp.Coord(np.arange(4.0) + 100.0, title="predict obs"),
+            scp.Coord(np.arange(5.0) + 50.0),
+        ],
     )
     Xpredict[2, :] = scp.MASKED
 
@@ -292,7 +295,7 @@ def test_svd_diagnostics_stay_generated_and_unmasked(geometry_source_dataset):
         assert diagnostic.coordset["k"].title == "components"
 
 
-def test_svd_diagnostics_restore_public_k_axis_without_source_mask_transfer(
+def test_svd_diagnostics_keep_natural_length_without_source_mask_transfer(
     geometry_source_dataset,
 ):
     masked = geometry_source_dataset.copy()
@@ -307,7 +310,7 @@ def test_svd_diagnostics_restore_public_k_axis_without_source_mask_transfer(
         svd.explained_variance_ratio,
         svd.cumulative_explained_variance,
     ):
-        assert diagnostic.shape == (5,)
+        assert diagnostic.shape == svd.s.shape
         assert diagnostic.mask is np.False_
         assert diagnostic.dims == ["k"]
         assert diagnostic.coordset is not None

--- a/tests/test_analysis/test_decomposition/test_svd.py
+++ b/tests/test_analysis/test_decomposition/test_svd.py
@@ -77,7 +77,7 @@ def test_svd(low_rank_dataset):
     assert svd.U.shape == (3, 3)
     assert svd.VT.shape == (3, 4)
     assert_allclose(svd.s, [5.0, 3.0, 0.0])
-    assert_allclose(svd.ev_ratio.data, [2500.0 / 34.0, 900.0 / 34.0, 0.0, 0.0])
+    assert_allclose(svd.ev_ratio.data, [2500.0 / 34.0, 900.0 / 34.0, 0.0])
 
     svd.full_matrices = True
     svd.fit(masked)


### PR DESCRIPTION
## Summary

- align analysis-output geometry support with the accepted family-specific rules
- restore exact public X geometry only when source-domain reconstructions and fitted/residual outputs truly match it
- assemble PLS prediction axes by authority from Xpredict and Ytrain instead of copying whole source geometry by shape
- keep diagnostic outputs generated and unmasked while restoring the public SVD k-axis length after masked preprocessing
- add targeted regression coverage for PCA/NMF/PLS/SVD/Optimize support geometry and update the changelog

## Root Cause

The runtime still mixed generic masked-data restoration with analysis-specific output assembly. That left some outputs under-specified, allowed stale coordset leakage across calls, and made support restoration depend on implicit shape heuristics instead of explicit family rules.

## Validation

- pre-commit run --all-files
- python -m pytest tests/test_analysis/test_decomposition/test_analysis_output_geometry.py tests/test_analysis/test_decomposition/test_svd.py -q
- python -m pytest tests/test_analysis/test_curvefitting/test_optimize.py tests/test_analysis/test_curvefitting/test_optimize_result.py tests/test_analysis/test_curvefitting/test_optimize_provenance.py -q
- python -m pytest tests/test_analysis/test_decomposition tests/test_analysis/test_crossdecomposition -q
- python -m pytest tests/test_analysis/test_base/test_base.py -q
- git diff --check
