### PR TITLE
MAINT: align deprecation warnings with lifecycle policy

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,14 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Public deprecation warnings no longer promise API removals in ``0.13.0`` for
+  deprecated plotting aliases, the historical ``processing.alignement`` import
+  path, deprecated plugin root aliases, ``concatenate(..., force_stack=True)``,
+  or deprecated writer ``protocol=`` / ``description=`` kwargs. These paths
+  remain available with warnings, and their eventual removal is now governed by
+  the accepted SpectroChemPy deprecation lifecycle policy instead of an expired
+  fixed-version target.
+
 - Analysis and fitting outputs now follow deterministic derived-metadata rules
   instead of inheriting path-dependent combinations of source identity and
   wrapper defaults. Single-source outputs preserve the captured scientific

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,14 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- Public deprecation warnings no longer promise API removals in ``0.13.0`` for
+  deprecated plotting aliases, the historical ``processing.alignement`` import
+  path, deprecated plugin root aliases, ``concatenate(..., force_stack=True)``,
+  or deprecated writer ``protocol=`` / ``description=`` kwargs. These paths
+  remain available with warnings, and their eventual removal is now governed by
+  the accepted SpectroChemPy deprecation lifecycle policy instead of an expired
+  fixed-version target.
+
 - Analysis and fitting outputs now follow deterministic derived-metadata rules
   instead of inheriting path-dependent combinations of source identity and
   wrapper defaults. Single-source outputs preserve the captured scientific

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -51,8 +51,6 @@ This module serves as the main entry point for the SpectroChemPy package, provid
 - Dynamic attribute access to NDDataset methods
 """
 
-import warnings
-
 import lazy_loader as _lazy_loader
 
 # --------------------------------------------------------------------------------------
@@ -65,6 +63,7 @@ original_getattr, original_dir, *_ = _lazy_loader.attach_stub(__name__, __file__
 
 from spectrochempy.lazyimport.api_methods import _LAZY_IMPORTS
 from spectrochempy.lazyimport.dataset_methods import _LAZY_DATASETS_IMPORTS
+from spectrochempy.utils.decorators import warn_deprecated
 
 from . import application
 
@@ -168,11 +167,13 @@ def _plugin_root_export(name, namespace_cls):
         if export is None:
             continue
         if export["deprecated"] and name not in _EMITTED_PLUGIN_ROOT_WARNINGS:
-            warnings.warn(
-                f"scp.{name} is deprecated since SpectroChemPy 0.9.0 "
-                f"and will be removed in 0.13.0. "
-                f"Use {export['replacement']} instead.",
-                DeprecationWarning,
+            warn_deprecated(
+                f"scp.{name}",
+                kind="public API alias",
+                replace=export["replacement"],
+                since="0.10.0",
+                policy=True,
+                action="is deprecated",
                 stacklevel=3,
             )
             _EMITTED_PLUGIN_ROOT_WARNINGS.add(name)

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -1419,10 +1419,7 @@ class DecompositionAnalysis(AnalysisConfigurable):
     # Backward compatibility alias
     @deprecated(
         replace="plot_merit",
-        extra_msg=(
-            "Removal will not occur before the SpectroChemPy deprecation policy "
-            "is satisfied."
-        ),
+        policy=True,
     )
     def plotmerit(self, X=None, X_hat=None, **kwargs):
         """
@@ -1758,10 +1755,7 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
     # Backward compatibility alias
     @deprecated(
         replace="plot_parity",
-        extra_msg=(
-            "Removal will not occur before the SpectroChemPy deprecation policy "
-            "is satisfied."
-        ),
+        policy=True,
     )
     def parityplot(
         self, Y=None, Y_hat=None, *, ax=None, clear=True, show=True, **kwargs

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -1417,7 +1417,13 @@ class DecompositionAnalysis(AnalysisConfigurable):
         )
 
     # Backward compatibility alias
-    @deprecated(replace="plot_merit", removed="0.13.0")
+    @deprecated(
+        replace="plot_merit",
+        extra_msg=(
+            "Removal will not occur before the SpectroChemPy deprecation policy "
+            "is satisfied."
+        ),
+    )
     def plotmerit(self, X=None, X_hat=None, **kwargs):
         """
         Backward-compatible alias for :meth:`plot_merit`. Deprecated.
@@ -1750,7 +1756,13 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
         return _plot_parity(Y, Y_hat, ax=ax, clear=clear, show=show, **kwargs)
 
     # Backward compatibility alias
-    @deprecated(replace="plot_parity", removed="0.13.0")
+    @deprecated(
+        replace="plot_parity",
+        extra_msg=(
+            "Removal will not occur before the SpectroChemPy deprecation policy "
+            "is satisfied."
+        ),
+    )
     def parityplot(
         self, Y=None, Y_hat=None, *, ax=None, clear=True, show=True, **kwargs
     ):

--- a/src/spectrochempy/analysis/decomposition/mcrals.py
+++ b/src/spectrochempy/analysis/decomposition/mcrals.py
@@ -16,7 +16,6 @@ __configurables__ = ["MCRALS"]
 
 import base64
 import logging
-import warnings
 from dataclasses import dataclass
 from dataclasses import field
 from types import SimpleNamespace
@@ -35,6 +34,7 @@ from spectrochempy.analysis.decomposition.mcrals_constraints import Constraint
 from spectrochempy.application.application import info_
 from spectrochempy.extern.traittypes import Array
 from spectrochempy.utils.decorators import signature_has_configurable_traits
+from spectrochempy.utils.decorators import warn_deprecated
 
 # --------------------------------------------------------------------------------------
 # Names of legacy traitlet-based constraint parameters.
@@ -1384,29 +1384,40 @@ and `St`.
                 raise ValueError(
                     "Cannot specify both deprecated `tol` and " "`tol_residual_change`."
                 )
-            warnings.warn(
-                "`tol` is deprecated; use `tol_residual_change` with a "
-                "relative value instead (for example, tol=0.1 becomes "
-                "tol_residual_change=1e-3).",
-                FutureWarning,
+            warn_deprecated(
+                "tol",
+                subject="`tol`",
+                replace="tol_residual_change",
+                action="is deprecated",
+                category=FutureWarning,
+                extra_msg=(
+                    "Use a relative value instead (for example, tol=0.1 "
+                    "becomes tol_residual_change=1e-3)."
+                ),
                 stacklevel=2,
             )
             kwargs["tol_residual_change"] = kwargs["tol"] / 100.0
 
         # Detect deprecated solver kwarg names and warn.
         if "solverConc" in kwargs:
-            warnings.warn(
-                "`solverConc` is deprecated; use `solver_C` instead.",
-                FutureWarning,
+            warn_deprecated(
+                "solverConc",
+                subject="`solverConc`",
+                replace="solver_C",
+                action="is deprecated",
+                category=FutureWarning,
                 stacklevel=2,
             )
             if "solver_C" in kwargs:
                 raise ValueError("Cannot specify both `solverConc` and `solver_C`.")
             kwargs["solver_C"] = kwargs.pop("solverConc")
         if "solverSpec" in kwargs:
-            warnings.warn(
-                "`solverSpec` is deprecated; use `solver_St` instead.",
-                FutureWarning,
+            warn_deprecated(
+                "solverSpec",
+                subject="`solverSpec`",
+                replace="solver_St",
+                action="is deprecated",
+                category=FutureWarning,
                 stacklevel=2,
             )
             if "solver_St" in kwargs:
@@ -1416,10 +1427,12 @@ and `St`.
         # Detect legacy constraint traitlet kwargs and warn.
         _legacy_in_kwargs = _LEGACY_CONSTRAINT_TRAITS & set(kwargs)
         if _legacy_in_kwargs:
-            warnings.warn(
-                "Legacy MCR-ALS constraint parameters are deprecated; "
-                "use the `constraints` API instead.",
-                FutureWarning,
+            warn_deprecated(
+                "legacy_constraints",
+                subject="Legacy MCR-ALS constraint parameters",
+                replace="constraints",
+                action="are deprecated",
+                category=FutureWarning,
                 stacklevel=2,
             )
 
@@ -1478,10 +1491,13 @@ and `St`.
         # parameters are assigned on an already-initialized instance.
         init_done = getattr(self, "_init_done", False)
         if name == "tol" and init_done:
-            warnings.warn(
-                "`tol` is deprecated; use `tol_residual_change` with a "
-                "relative value instead.",
-                FutureWarning,
+            warn_deprecated(
+                "tol",
+                subject="`tol`",
+                replace="tol_residual_change",
+                action="is deprecated",
+                category=FutureWarning,
+                extra_msg="Use a relative value instead.",
                 stacklevel=2,
             )
             super().__setattr__(name, value)
@@ -1494,9 +1510,12 @@ and `St`.
             return
         if name in ("solverConc", "solverSpec") and init_done:
             replacement = "solver_C" if name == "solverConc" else "solver_St"
-            warnings.warn(
-                f"`{name}` is deprecated; use `{replacement}` instead.",
-                FutureWarning,
+            warn_deprecated(
+                name,
+                subject=f"`{name}`",
+                replace=replacement,
+                action="is deprecated",
+                category=FutureWarning,
                 stacklevel=2,
             )
         elif name in _LEGACY_CONSTRAINT_TRAITS and init_done:
@@ -1513,10 +1532,12 @@ and `St`.
                     "cannot be used together."
                 )
             object.__getattribute__(self, "_explicit_legacy_traits").add(name)
-            warnings.warn(
-                f"Legacy MCR-ALS constraint parameter `{name}` is deprecated; "
-                "use the `constraints` API instead.",
-                FutureWarning,
+            warn_deprecated(
+                name,
+                subject=f"Legacy MCR-ALS constraint parameter `{name}`",
+                replace="constraints",
+                action="is deprecated",
+                category=FutureWarning,
                 stacklevel=2,
             )
         super().__setattr__(name, value)

--- a/src/spectrochempy/core/writers/exporter.py
+++ b/src/spectrochempy/core/writers/exporter.py
@@ -8,12 +8,11 @@
 __all__ = ["write"]
 __dataset_methods__ = __all__
 
-import warnings
-
 from traitlets import Any
 from traitlets import HasTraits
 
 from spectrochempy.core.readers.filetypes import registry
+from spectrochempy.utils.decorators import warn_deprecated
 from spectrochempy.utils.file import check_filename_to_save
 from spectrochempy.utils.file import pathclean
 from spectrochempy.utils.file import patterns
@@ -21,21 +20,33 @@ from spectrochempy.utils.file import patterns
 
 def _warn_deprecated_writer_kwargs(kwargs):
     if "protocol" in kwargs:
-        warnings.warn(
-            "Writer keyword argument `protocol` is deprecated and will be "
-            "removed in 0.13.0. Writer dispatch is determined by the filename "
-            "suffix or by using an explicit specialized / namespaced writer "
-            "API; `protocol=` does not select the writer.",
-            DeprecationWarning,
+        warn_deprecated(
+            "protocol",
+            subject="Writer keyword argument `protocol`",
+            kind="writer keyword argument",
+            policy=True,
+            action="is deprecated",
+            replace=None,
+            extra_msg=(
+                "Writer dispatch is determined by the filename suffix or by "
+                "using an explicit specialized / namespaced writer API; "
+                "`protocol=` does not select the writer."
+            ),
             stacklevel=4,
         )
     if "description" in kwargs:
-        warnings.warn(
-            "Writer keyword argument `description` is deprecated and will be "
-            "removed in 0.13.0. Exported description metadata comes from "
-            "`dataset.description`, not from a write-time `description=` "
-            "override.",
-            DeprecationWarning,
+        warn_deprecated(
+            "description",
+            subject="Writer keyword argument `description`",
+            kind="writer keyword argument",
+            policy=True,
+            action="is deprecated",
+            replace=None,
+            extra_msg=(
+                "Exported description metadata comes from "
+                "`dataset.description`, not from a write-time "
+                "`description=` override."
+            ),
             stacklevel=4,
         )
 
@@ -145,14 +156,16 @@ def write(dataset, filename=None, **kwargs):
     protocol : {'scp', 'matlab', 'jcamp', 'csv'}, optional
         Deprecated. Writer dispatch is determined by the file name extension or
         by using an explicit specialized writer API. Passing `protocol=` emits
-        a `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
+        a `DeprecationWarning`; removal remains warning-first and is governed
+        by the SpectroChemPy deprecation lifecycle policy.
     directory : str, optional
         Where to write the specified `filename` . If not specified, write in the current directory.
     description: str, optional
         Deprecated. Exported description metadata comes from
         `dataset.description`, not from a write-time override. Passing
-        `description=` emits a `DeprecationWarning` in 0.12 and will raise
-        `TypeError` in 0.13.0.
+        `description=` emits a `DeprecationWarning`; removal remains
+        warning-first and is governed by the SpectroChemPy deprecation
+        lifecycle policy.
     csv_delimiter : str, optional
         Set the column delimiter in CSV file.
         By default it is the one set in SpectroChemPy `Preferences` .

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -38,7 +38,8 @@ def write_csv(*args, **kwargs):
         Additional keyword arguments accepted by the generic writer API.
         This specialized writer always exports CSV files. Deprecated generic
         writer kwargs such as `protocol=` and `description=` still emit a
-        `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
+        `DeprecationWarning`; removal remains warning-first and is governed by
+        the SpectroChemPy deprecation lifecycle policy.
 
     Returns
     -------

--- a/src/spectrochempy/core/writers/write_jcamp.py
+++ b/src/spectrochempy/core/writers/write_jcamp.py
@@ -35,7 +35,8 @@ def write_jcamp(*args, **kwargs):
         Additional keyword arguments accepted by the generic writer API.
         This specialized writer always exports JCAMP-DX files. Deprecated
         generic writer kwargs such as `protocol=` and `description=` still emit
-        a `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
+        a `DeprecationWarning`; removal remains warning-first and is governed
+        by the SpectroChemPy deprecation lifecycle policy.
 
     Returns
     -------

--- a/src/spectrochempy/core/writers/write_matlab.py
+++ b/src/spectrochempy/core/writers/write_matlab.py
@@ -31,7 +31,8 @@ def write_matlab(*args, **kwargs):
         Additional keyword arguments accepted by the generic writer API.
         This specialized writer always exports MATLAB `.mat` files. Deprecated
         generic writer kwargs such as `protocol=` and `description=` still emit
-        a `DeprecationWarning` in 0.12 and will raise `TypeError` in 0.13.0.
+        a `DeprecationWarning`; removal remains warning-first and is governed
+        by the SpectroChemPy deprecation lifecycle policy.
 
     Returns
     -------

--- a/src/spectrochempy/plotting/_methods.py
+++ b/src/spectrochempy/plotting/_methods.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-import warnings
+from spectrochempy.utils.decorators import warn_deprecated
 
 CANONICAL_1D_METHODS = frozenset(
     {
@@ -96,10 +96,12 @@ def normalize_backend_method(
         canonical = _BACKEND_METHOD_ALIASES[method]
         if warned_aliases is not None and method not in warned_aliases:
             warned_aliases.add(method)
-            warnings.warn(
-                f'method="{method}" is deprecated and will be removed in 0.13.0. '
-                f'Use method="{canonical}" instead.',
-                DeprecationWarning,
+            warn_deprecated(
+                f'method="{method}"',
+                kind="plotting alias",
+                replace=f'method="{canonical}"',
+                policy=True,
+                action="is deprecated",
                 stacklevel=stacklevel,
             )
         return canonical

--- a/src/spectrochempy/plotting/composite/parity.py
+++ b/src/spectrochempy/plotting/composite/parity.py
@@ -139,14 +139,20 @@ def plot_parity(
     return ax
 
 
-@deprecated(replace="plot_parity", removed="0.13.0")
+@deprecated(
+    replace="plot_parity",
+    extra_msg=(
+        "Removal will not occur before the SpectroChemPy deprecation policy "
+        "is satisfied."
+    ),
+)
 def parityplot(*args, **kwargs):
     """
     Plot predicted vs measured values (parity plot).
 
-    .. deprecated::
-        Use :func:`plot_parity` instead.  This alias will be removed in
-        version 0.13.0.
+    .. deprecated:: 0.12.0
+        Use :func:`plot_parity` instead. Removal will not occur before the
+        SpectroChemPy deprecation policy is satisfied.
 
     Parameters
     ----------

--- a/src/spectrochempy/plotting/composite/parity.py
+++ b/src/spectrochempy/plotting/composite/parity.py
@@ -141,10 +141,7 @@ def plot_parity(
 
 @deprecated(
     replace="plot_parity",
-    extra_msg=(
-        "Removal will not occur before the SpectroChemPy deprecation policy "
-        "is satisfied."
-    ),
+    policy=True,
 )
 def parityplot(*args, **kwargs):
     """

--- a/src/spectrochempy/processing/alignement/__init__.py
+++ b/src/spectrochempy/processing/alignement/__init__.py
@@ -4,18 +4,20 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 
-import warnings
-
 import lazy_loader as _lazy_loader
+
+from spectrochempy.utils.decorators import warn_deprecated
 
 # --------------------------------------------------------------------------------------
 # Lazy loading of sub-packages
 # --------------------------------------------------------------------------------------
 __getattr__, __dir__, __all__ = _lazy_loader.attach_stub(__name__, __file__)
 
-warnings.warn(
-    "Importing from `spectrochempy.processing.alignement` is deprecated and "
-    "will be removed in 0.13.0. Use `spectrochempy.processing.alignment` instead.",
-    DeprecationWarning,
+warn_deprecated(
+    "spectrochempy.processing.alignement",
+    kind="import path",
+    replace="spectrochempy.processing.alignment",
+    policy=True,
+    action="is deprecated",
     stacklevel=2,
 )

--- a/src/spectrochempy/processing/alignement/align.py
+++ b/src/spectrochempy/processing/alignement/align.py
@@ -5,18 +5,18 @@
 # ======================================================================================
 """Compatibility wrapper for the historical ``processing.alignement`` namespace."""
 
-import warnings
-
 from spectrochempy.processing.alignment.align import align
 from spectrochempy.processing.alignment.align import can_merge_or_align
+from spectrochempy.utils.decorators import warn_deprecated
 
 __all__ = ["align", "can_merge_or_align"]
 __dataset_methods__ = ["align"]
 
-warnings.warn(
-    "Importing from `spectrochempy.processing.alignement.align` is deprecated "
-    "and will be removed in 0.13.0. Use "
-    "`spectrochempy.processing.alignment.align` instead.",
-    DeprecationWarning,
+warn_deprecated(
+    "spectrochempy.processing.alignement.align",
+    kind="import path",
+    replace="spectrochempy.processing.alignment.align",
+    policy=True,
+    action="is deprecated",
     stacklevel=2,
 )

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -86,10 +86,7 @@ def concatenate(*datasets, **kwargs):
         deprecated(
             "force_stack",
             replace="method stack()",
-            extra_msg=(
-                "Removal will not occur before the SpectroChemPy deprecation "
-                "policy is satisfied."
-            ),
+            policy=True,
         )
         return stack(datasets)
 

--- a/src/spectrochempy/processing/transformation/concatenate.py
+++ b/src/spectrochempy/processing/transformation/concatenate.py
@@ -83,7 +83,14 @@ def concatenate(*datasets, **kwargs):
     """
     # check use
     if "force_stack" in kwargs:
-        deprecated("force_stack", replace="method stack()", removed="0.13.0")
+        deprecated(
+            "force_stack",
+            replace="method stack()",
+            extra_msg=(
+                "Removal will not occur before the SpectroChemPy deprecation "
+                "policy is satisfied."
+            ),
+        )
         return stack(datasets)
 
     operation = kwargs.pop("_metadata_operation", "concatenate")

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -132,7 +132,15 @@ def preserve_signature(f):
     return f
 
 
-def deprecated(name=None, *, kind="method", replace="", removed=None, extra_msg=""):
+def deprecated(
+    name=None,
+    *,
+    kind="method",
+    replace="",
+    removed=None,
+    extra_msg="",
+    policy=False,
+):
     """
     Deprecate a function or attribute.
 
@@ -149,6 +157,9 @@ def deprecated(name=None, *, kind="method", replace="", removed=None, extra_msg=
         Additional message.
     removed : str, optional
         Version string when this method will be removed
+    policy : bool, optional
+        If True, express removal timing through the accepted SpectroChemPy
+        deprecation policy instead of a version string.
     """
 
     if name is not None:
@@ -159,6 +170,7 @@ def deprecated(name=None, *, kind="method", replace="", removed=None, extra_msg=
             replace=replace,
             removed=removed,
             extra_msg=extra_msg,
+            policy=policy,
             stacklevel=2,
         )
         return None
@@ -176,6 +188,7 @@ def deprecated(name=None, *, kind="method", replace="", removed=None, extra_msg=
                 replace=replace,
                 removed=removed,
                 extra_msg=extra_msg,
+                policy=policy,
                 stacklevel=2,
             )
             return func(*args, **kwargs)

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -19,6 +19,78 @@ from warnings import warn
 import traitlets as tr
 
 
+def _deprecated_removal_sentence(removed=None, *, policy=False):
+    """Return the removal sentence for a deprecation warning."""
+    if policy:
+        return (
+            "It will not be removed before the SpectroChemPy deprecation policy "
+            "is satisfied."
+        )
+    sremoved = f"version {removed}" if removed else "future version"
+    return f"It will be removed in {sremoved}."
+
+
+def format_deprecated_message(
+    name,
+    *,
+    subject=None,
+    kind="method",
+    replace="",
+    removed=None,
+    extra_msg="",
+    since=None,
+    policy=False,
+    action="is now deprecated",
+):
+    """Return a standardized deprecation message."""
+    if subject is None:
+        subject = f"The `{name}` {kind}" if kind else f"`{name}`"
+    if since:
+        msg = f"{subject} {action} since SpectroChemPy {since}. "
+    else:
+        msg = f"{subject} {action}. "
+
+    if replace:
+        msg += f"Use `{replace}` instead. "
+
+    msg += _deprecated_removal_sentence(removed, policy=policy)
+    if extra_msg:
+        msg += f" {extra_msg.lstrip()}"
+    return msg
+
+
+def warn_deprecated(
+    name,
+    *,
+    subject=None,
+    kind="method",
+    replace="",
+    removed=None,
+    extra_msg="",
+    since=None,
+    policy=False,
+    action="is now deprecated",
+    category=DeprecationWarning,
+    stacklevel=2,
+):
+    """Emit a standardized ``DeprecationWarning``."""
+    warn(
+        format_deprecated_message(
+            name,
+            subject=subject,
+            kind=kind,
+            replace=replace,
+            removed=removed,
+            extra_msg=extra_msg,
+            since=since,
+            policy=policy,
+            action=action,
+        ),
+        category=category,
+        stacklevel=stacklevel,
+    )
+
+
 def preserve_signature(f):
     """
     Preserve the signature of the function being wrapped.
@@ -79,21 +151,16 @@ def deprecated(name=None, *, kind="method", replace="", removed=None, extra_msg=
         Version string when this method will be removed
     """
 
-    def output_warning_message(name, kind, replace, removed, extra_msg):
-        sreplace = f"Use `{replace}` instead. " if replace is not None else ""
-        msg = f" The `{name}` {kind} is now deprecated. {sreplace}"
-        sremoved = f"version {removed}" if removed else "future version"
-        msg += f"`{name}` {kind} will be removed in {sremoved}. "
-        msg += extra_msg
-        warn(
-            msg,
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
     if name is not None:
         kind = "attribute"
-        output_warning_message(name, kind, replace, removed, extra_msg)
+        warn_deprecated(
+            name,
+            kind=kind,
+            replace=replace,
+            removed=removed,
+            extra_msg=extra_msg,
+            stacklevel=2,
+        )
         return None
 
     def deprecation_decorator(func):
@@ -103,7 +170,14 @@ def deprecated(name=None, *, kind="method", replace="", removed=None, extra_msg=
             name = func.__qualname__
             if name.endswith("__init__"):
                 name = name.split(".", maxsplit=1)[0]
-            output_warning_message(name, kind, replace, removed, extra_msg)
+            warn_deprecated(
+                name,
+                kind=kind,
+                replace=replace,
+                removed=removed,
+                extra_msg=extra_msg,
+                stacklevel=2,
+            )
             return func(*args, **kwargs)
 
         return wrapper

--- a/tests/test_core/test_writers/test_exporter.py
+++ b/tests/test_core/test_writers/test_exporter.py
@@ -79,12 +79,15 @@ def test_generic_write_protocol_kwarg_warns_but_keeps_default_scp_save(
     if target.exists():
         target.unlink()
 
-    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated"):
+    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated") as record:
         filename = scp.write(nd, protocol="csv")
 
     assert filename.stem == "synthetic"
     assert filename.suffix == ".scp"
     assert filename.exists()
+    messages = [str(item.message) for item in record]
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
 
     nd2 = NDDataset.load(filename)
     testing.assert_dataset_equal(nd2, nd)
@@ -101,12 +104,17 @@ def test_generic_write_description_kwarg_warns_but_uses_dataset_description(
 
     target = tmp_path / "synthetic.scp"
 
-    with pytest.warns(DeprecationWarning, match="`description` is deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="`description` is deprecated"
+    ) as record:
         filename = scp.write(nd, target, description="custom", confirm=False)
 
     assert filename == target
     assert filename.exists()
     assert nd.description == original_description
+    messages = [str(item.message) for item in record]
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
 
     reloaded = NDDataset.load(filename)
     assert reloaded.description == "source description"

--- a/tests/test_core/test_writers/test_write_csv.py
+++ b/tests/test_core/test_writers/test_write_csv.py
@@ -198,7 +198,7 @@ def test_write_csv_deprecated_protocol_warns_and_still_writes_csv(
     dataset.name = f"real_csv_{api}"
     target = tmp_path / f"{api}.csv"
 
-    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated"):
+    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated") as record:
         if api == "method":
             path = dataset.write_csv(target, protocol="matlab", confirm=False)
         else:
@@ -206,6 +206,9 @@ def test_write_csv_deprecated_protocol_warns_and_still_writes_csv(
 
     assert path == target
     assert path.suffix == ".csv"
+    messages = [str(item.message) for item in record]
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
     text = path.read_text()
     assert "wavenumber / cm^-1,absorbance / a.u." in text
 
@@ -225,7 +228,9 @@ def test_write_csv_deprecated_description_warns_without_overriding_export(
     dataset.description = "source description"
     target = tmp_path / f"{api}.csv"
 
-    with pytest.warns(DeprecationWarning, match="`description` is deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="`description` is deprecated"
+    ) as record:
         if api == "method":
             path = dataset.write_csv(target, description="custom", confirm=False)
         else:
@@ -233,6 +238,9 @@ def test_write_csv_deprecated_description_warns_without_overriding_export(
 
     assert path == target
     assert dataset.description == "source description"
+    messages = [str(item.message) for item in record]
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
     text = path.read_text()
     assert "custom" not in text
     assert "source description" not in text

--- a/tests/test_core/test_writers/test_write_matlab.py
+++ b/tests/test_core/test_writers/test_write_matlab.py
@@ -128,7 +128,9 @@ def test_write_matlab_deprecated_description_warns_but_uses_dataset_description(
     )
     target = tmp_path / f"{api}.mat"
 
-    with pytest.warns(DeprecationWarning, match="`description` is deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="`description` is deprecated"
+    ) as record:
         if api == "method":
             path = dataset.write_matlab(target, description="custom", confirm=False)
         else:
@@ -138,6 +140,9 @@ def test_write_matlab_deprecated_description_warns_but_uses_dataset_description(
 
     assert path == target
     assert dataset.description == "source description"
+    messages = [str(item.message) for item in record]
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
     exported = loadmat(path, simplify_cells=True)
     assert exported["description"] == "source description"
 
@@ -147,12 +152,15 @@ def test_write_matlab_deprecated_protocol_warns_but_still_writes_matlab(tmp_path
     dataset = scp.NDDataset(np.arange(5.0), name="trace")
     target = tmp_path / f"{api}.mat"
 
-    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated"):
+    with pytest.warns(DeprecationWarning, match="`protocol` is deprecated") as record:
         if api == "method":
             path = dataset.write_matlab(target, protocol="csv", confirm=False)
         else:
             path = scp.matlab.write(dataset, target, protocol="csv", confirm=False)
 
     assert path == target
+    messages = [str(item.message) for item in record]
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
     exported = loadmat(path, simplify_cells=True)
     assert np.array_equal(exported["data"], np.arange(5.0))

--- a/tests/test_plotting/test_composite_lifecycle.py
+++ b/tests/test_plotting/test_composite_lifecycle.py
@@ -406,6 +406,15 @@ class TestPlotMeritLifecycle:
         ax = plot_merit(trained_pca, show=False)
         assert isinstance(ax, plt.Axes)
 
+    def test_plotmerit_alias_warns_without_promising_013(self, trained_pca):
+        with pytest.warns(DeprecationWarning, match="plot_merit") as record:
+            ax = trained_pca.plotmerit(show=False)
+
+        assert isinstance(ax, plt.Axes)
+        messages = [str(item.message) for item in record]
+        assert all("0.13.0" not in message for message in messages)
+        assert any("deprecation policy is satisfied" in message for message in messages)
+
 
 # ======================================================================================
 # Undefined lifecycle path tests

--- a/tests/test_plotting/test_method_deprecations.py
+++ b/tests/test_plotting/test_method_deprecations.py
@@ -1,0 +1,27 @@
+# ======================================================================================
+# Copyright (c) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Targeted tests for deprecated plotting method aliases."""
+
+import pytest
+
+from spectrochempy.plotting._methods import normalize_backend_method
+
+
+@pytest.mark.parametrize(
+    ("legacy", "canonical"),
+    [("stack", "lines"), ("map", "contour")],
+)
+def test_backend_method_alias_warns_without_promising_013(legacy, canonical):
+    warned_aliases = set()
+
+    with pytest.warns(DeprecationWarning, match=rf'method="{legacy}"') as record:
+        normalized = normalize_backend_method(legacy, warned_aliases=warned_aliases)
+
+    assert normalized == canonical
+    messages = [str(item.message) for item in record]
+    assert all("0.13.0" not in message for message in messages)
+    assert any(f'method="{canonical}"' in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)

--- a/tests/test_plotting/test_parity.py
+++ b/tests/test_plotting/test_parity.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from spectrochempy import NDDataset
+from spectrochempy.plotting.composite.parity import parityplot
 from spectrochempy.plotting.composite.parity import plot_parity
 
 
@@ -178,4 +179,14 @@ class TestParityPlot:
         assert (
             ax1.figure is not ax2.figure
         ), "without ax, each call must create a new figure (stateless contract)"
+        plt.close("all")
+
+    def test_deprecated_parityplot_alias_warns_without_promising_013(self):
+        with pytest.warns(DeprecationWarning, match="plot_parity") as record:
+            ax = parityplot(self.Y, self.Y_hat, show=False)
+
+        assert isinstance(ax, plt.Axes)
+        messages = [str(item.message) for item in record]
+        assert all("0.13.0" not in message for message in messages)
+        assert any("deprecation policy is satisfied" in message for message in messages)
         plt.close("all")

--- a/tests/test_plugins/test_integration.py
+++ b/tests/test_plugins/test_integration.py
@@ -410,9 +410,15 @@ class TestDeprecatedRootAliases:
             warnings.simplefilter("always")
             obj = scp.IRIS
             assert obj is not None, "IRIS should still be accessible"
+            messages = [str(msg.message) for msg in w]
             assert any(
-                "deprecated" in str(msg.message).lower() for msg in w
-            ), f"No deprecation warning: {[str(m.message) for m in w]}"
+                "deprecated" in message.lower() for message in messages
+            ), f"No deprecation warning: {messages}"
+            assert any("0.10.0" in message for message in messages)
+            assert all("0.13.0" not in message for message in messages)
+            assert any(
+                "deprecation policy is satisfied" in message for message in messages
+            )
 
     @pytest.mark.skipif(not _IRIS_INSTALLED, reason="iris plugin not installed")
     def test_iris_kernel_root_alias_deprecated(self):
@@ -425,7 +431,9 @@ class TestDeprecatedRootAliases:
             warnings.simplefilter("always")
             obj = scp.IrisKernel
             assert obj is not None
-            assert any("deprecated" in str(msg.message).lower() for msg in w)
+            messages = [str(msg.message) for msg in w]
+            assert any("deprecated" in message.lower() for message in messages)
+            assert all("0.13.0" not in message for message in messages)
 
     @pytest.mark.skipif(not _CANTERA_INSTALLED, reason="cantera plugin not installed")
     def test_pfr_root_alias_deprecated(self):
@@ -438,7 +446,9 @@ class TestDeprecatedRootAliases:
             warnings.simplefilter("always")
             obj = scp.PFR
             assert obj is not None
-            assert any("deprecated" in str(msg.message).lower() for msg in w)
+            messages = [str(msg.message) for msg in w]
+            assert any("deprecated" in message.lower() for message in messages)
+            assert all("0.13.0" not in message for message in messages)
 
     @pytest.mark.skipif(not _IRIS_INSTALLED, reason="iris plugin not installed")
     def test_namespaced_access_no_warning(self):
@@ -471,9 +481,11 @@ class TestDeprecatedRootAliases:
             warnings.simplefilter("always")
             obj = scp.CP
             assert obj is not None, "CP should still be accessible"
+            messages = [str(msg.message) for msg in w]
             assert any(
-                "scp.tensor.CP" in str(msg.message) for msg in w
-            ), f"No CP deprecation warning: {[str(m.message) for m in w]}"
+                "scp.tensor.CP" in message for message in messages
+            ), f"No CP deprecation warning: {messages}"
+            assert all("0.13.0" not in message for message in messages)
 
 
 class TestSubmoduleImport:

--- a/tests/test_processing/test_alignement/test_align.py
+++ b/tests/test_processing/test_alignement/test_align.py
@@ -22,11 +22,17 @@ from spectrochempy.utils.exceptions import UnitsCompatibilityError
 
 def test_legacy_align_import_is_deprecated():
     sys.modules.pop("spectrochempy.processing.alignement.align", None)
-    with pytest.deprecated_call(match="processing.alignement.align"):
+    with pytest.deprecated_call(match="processing.alignement.align") as record:
         legacy_module = importlib.import_module(
             "spectrochempy.processing.alignement.align"
         )
     assert legacy_module.align is align
+    messages = [str(item.message) for item in record]
+    assert any(
+        "spectrochempy.processing.alignment.align" in message for message in messages
+    )
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
 
 
 def test_align(ds1, ds2):

--- a/tests/test_processing/test_transformation/test_concatenate.py
+++ b/tests/test_processing/test_transformation/test_concatenate.py
@@ -125,8 +125,12 @@ def test_concatenate(IR_dataset_2D):
     assert s.y.size == s1.y.size
     assert s.x.size == s1.x.size
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="force_stack") as record:
         concatenate(s1, s2, force_stack=True)
+    messages = [str(item.message) for item in record]
+    assert any("method stack()" in message for message in messages)
+    assert all("0.13.0" not in message for message in messages)
+    assert any("deprecation policy is satisfied" in message for message in messages)
 
     # If one of the dimensions is of size one, then this dimension is NOT removed before stacking
     s0 = dataset[0]

--- a/tests/test_utils/test_decorators.py
+++ b/tests/test_utils/test_decorators.py
@@ -40,6 +40,24 @@ class TestDeprecated:
             assert issubclass(w[0].category, DeprecationWarning)
             assert "`old_attr` attribute" in str(w[0].message)
 
+    def test_deprecated_policy_message_replaces_future_version_sentence(self):
+        @deprecated(replace="new_function", policy=True)
+        def old_function():
+            return 42
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = old_function()
+            assert len(w) == 1
+            message = str(w[0].message)
+            assert "future version" not in message
+            assert message.count("deprecation policy is satisfied") == 1
+            assert (
+                "It will not be removed before the SpectroChemPy deprecation "
+                "policy is satisfied."
+            ) in message
+            assert result == 42
+
 
 class TestSignatureHasConfigurableTraits:
     def test_signature_has_configurable_traits(self):


### PR DESCRIPTION
## Summary

This PR aligns active public deprecation warnings with the accepted SpectroChemPy deprecation lifecycle policy.

It removes stale `0.13.0` removal promises from active runtime warning paths without removing any API, and it also factors the warning text generation through shared helpers so decorator-driven and manual deprecations stay in sync.

## What Changed

- repushed active deprecation warnings and docstrings for:
  - plugin root aliases
  - `processing.alignement` compatibility imports
  - plotting method aliases `method="stack"` / `method="map"`
  - `concatenate(..., force_stack=True)`
  - `Analysis.plotmerit()` / `parityplot()` aliases
  - writer `protocol=` / `description=` kwargs
- added shared `format_deprecated_message()` / `warn_deprecated()` helpers and reused them in manual warning sites
- extended that helperization to active `MCRALS` legacy `FutureWarning` paths (`tol`, `solverConc`, `solverSpec`, legacy constraint parameters)
- added and tightened warning-focused tests
- updated `whatsnew/changelog.rst` and regenerated `latest.rst`

## Why

The accepted maintainer policy now requires warning-first deprecations governed by the general lifecycle policy, so active warnings must stop promising removals in `0.13.0` when those removals are not yet policy-compliant.

## Validation

- `micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_exporter.py tests/test_plugins/test_integration.py tests/test_processing/test_alignement/test_align.py tests/test_plotting/test_method_deprecations.py tests/test_plotting/test_parity.py tests/test_plotting/test_composite_lifecycle.py`
- `micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_exporter.py tests/test_plugins/test_integration.py tests/test_processing/test_alignement/test_align.py tests/test_plotting/test_method_deprecations.py tests/test_plotting/test_parity.py tests/test_plotting/test_composite_lifecycle.py tests/test_analysis/test_decomposition/test_mcrals_convergence.py tests/test_analysis/test_decomposition/test_mcrals_constraints_api.py tests/test_analysis/test_decomposition/test_mcrals.py -k "tol or solverConc or solverSpec or constraints or legacy"`
- `pre-commit run --all-files`
- `git diff --check`
