### PR TITLE
MAINT: validate Optimize constraints against canonical model spec

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -53,3 +53,9 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- The ``Optimize`` structured-validation flow now validates constraint
+  parameter-name references against the canonical ``_FitModelSpec``
+  representation instead of the legacy ``FitParameters`` view (``Optimize.fp``).
+  ``FitParameters`` and ``Optimize.fp`` remain available and unchanged, and the
+  fitting DSL and scientific results are unaffected.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,3 +11,12 @@ What's New in Revision 0.12.4.dev
 
 These are the changes in SpectroChemPy-0.12.4.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Developer
+~~~~~~~~~
+
+- The ``Optimize`` structured-validation flow now validates constraint
+  parameter-name references against the canonical ``_FitModelSpec``
+  representation instead of the legacy ``FitParameters`` view (``Optimize.fp``).
+  ``FitParameters`` and ``Optimize.fp`` remain available and unchanged, and the
+  fitting DSL and scientific results are unaffected.

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -1270,8 +1270,13 @@ class Optimize(DecompositionAnalysis):
         if constraints in (None, {}, []):
             return None
 
-        fit_parameters = self.fp
-        errors = _validate_constraints_content(constraints, fit_parameters)
+        # Validate parameter-name references against the canonical model spec
+        # rather than the legacy FitParameters view. The spec is always kept in
+        # sync with ``self.fp`` by ``_script_validate`` and exposes the same
+        # parameter names, so this removes the only FitParameters dependency of
+        # the structured-validation flow.
+        model_spec = getattr(self, "_model_spec", None)
+        errors = _validate_constraints_content(constraints, model_spec)
         if errors:
             raise ValueError(str(errors[0]))
 

--- a/tests/test_analysis/test_curvefitting/test_optimize.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize.py
@@ -9,8 +9,11 @@ import pytest
 from numpy.testing import assert_allclose
 
 import spectrochempy as scp
+from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.analysis.curvefitting.optimize import ConstraintError
 from spectrochempy.analysis.curvefitting.optimize import ScriptError
+from spectrochempy.analysis.curvefitting.optimize import _modelspec_parameter_names
+from spectrochempy.analysis.curvefitting.optimize import _validate_script_content
 
 
 # -----------------------------------------------------------------------------------
@@ -179,6 +182,25 @@ class TestValidateScript:
         # validate_script must not mutate self.fp
         assert opt.fp is fp_before
 
+    def test_validate_script_repeated_calls_are_stable(self):
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        fp_before = opt.fp
+        first = opt.validate_script()
+        second = opt.validate_script()
+        assert first == second == []
+        # repeated validation must neither mutate fp nor rebuild the spec
+        assert opt.fp is fp_before
+
+    def test_validate_script_invalid_repeated_calls_are_stable(self):
+        opt = scp.Optimize()
+        script = "MODEL: X\nshape: unknownmodel\n"
+        first = opt.validate_script(script)
+        second = opt.validate_script(script)
+        assert len(first) == len(second) == 1
+        assert first[0].message == second[0].message
+        assert "unknownmodel" in first[0].message
+
 
 class TestValidateConstraints:
     """Tests for Optimize.validate_constraints()."""
@@ -292,6 +314,47 @@ class TestValidateConstraints:
                 "limit": 1,
                 "parameters": ["missing_parameter"],
             }
+
+    def test_constraints_trait_validates_against_canonical_spec(self):
+        # Parameter-name validation must rely on the canonical _FitModelSpec
+        # and keep working even when the legacy Optimize.fp view is absent.
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        opt.fp = None
+        with pytest.raises(ValueError, match="Unknown parameter name"):
+            opt.constraints = {
+                "type": "max_connections",
+                "limit": 1,
+                "parameters": ["missing_parameter"],
+            }
+
+    def test_constraint_parameter_names_match_fitparameters_keys(self):
+        # The canonical spec and the legacy FitParameters view expose exactly
+        # the same flat parameter names for constraint-name validation.
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        fp_ref, errors = _validate_script_content(VALID_SCRIPT)
+        assert errors == []
+        assert _modelspec_parameter_names(opt._model_spec) == set(fp_ref.keys())
+
+    def test_fp_matches_historical_parser_output(self):
+        # Optimize.fp keeps its public type and reproduces the historical
+        # _validate_script_content output for the same script.
+        opt = scp.Optimize()
+        opt.script = VALID_SCRIPT
+        fp_ref, errors = _validate_script_content(VALID_SCRIPT)
+        assert errors == []
+        fp = opt.fp
+        assert isinstance(fp, FitParameters)
+        assert fp.models == fp_ref.models
+        assert fp.model == fp_ref.model
+        assert list(fp.keys()) == list(fp_ref.keys())
+        for key in fp_ref.keys():
+            assert fp[key] == fp_ref[key]
+            assert fp.fixed[key] == fp_ref.fixed[key]
+            assert fp.reference[key] == fp_ref.reference[key]
+            assert fp.lob.get(key) == fp_ref.lob.get(key)
+            assert fp.upb.get(key) == fp_ref.upb.get(key)
 
     def test_fit_does_not_crash_when_constraints_are_present(
         self, synthetic_two_peak_dataset, optimize_script


### PR DESCRIPTION
Mechanical first step of the `FitParameters` reduction campaign (roadmap priority 1, ADR `adr-fitparameters-role.md`).

## What changed

`Optimize._constraints_validate` (the `constraints` trait validator) now validates parameter-name references against the canonical `_FitModelSpec` (`self._model_spec`) instead of the legacy `FitParameters` view (`self.fp`). This was the last `FitParameters` dependency of the structured-validation flow.

## Why

- The parser already produces `_FitModelSpec` first; `FitParameters` is only derived for compatibility surfaces (`Optimize.fp`, historical `_validate_script_content` return).
- The canonical spec exposes the same flat parameter names (`_modelspec_parameter_names(spec) == set(fp.keys())`), so behavior is unchanged.
- Per the ADR deprecation strategy step 3, constraints validation should use canonical parameter identifiers derived from the model spec.

## Unchanged

- `FitParameters`, `Optimize.fp`, the DSL, and scientific results are untouched.
- `_validate_script_content` remains the compatibility adapter; `_script_validate` still derives `self.fp` from the spec.
- The execution flow (`_fit`, `_get_modeldata`, `_optimize` fallback, `str(fp)` round-trip) is a future PR boundary.

## Validation

- New regression tests include a migration proof that fails on the previous implementation (validates constraints via spec even with `opt.fp = None`), a spec/fp name-equivalence test, a `Optimize.fp` reconstruction test, and repeated-`validate_script` stability tests.
- Fitting suite: 296 passed.
- `pre-commit run --all-files`: all hooks pass.
- `git diff --check`: clean.

**Checklist**:
- [x] Tests have been added.
- [x] Developer changes (tests, CI, refactoring, tooling) have been documented in the ``Developer`` section of `docs/sources/whatsnew/changelog.rst`.
- [x] Title follows the prefix convention defined in `CONTRIBUTING.md`.
- [x] Changelog entry is present.