### PR TITLE
DOC: normalize gallery heading hierarchy

### DIFF
--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -46,7 +46,7 @@ _ = efa1.fit(dataset)
 
 # %%
 # Forward and backward evolution
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Forward evolution of the first 5 components
 f = efa1.f_ev[:, :5]
 _ = f.T.plot(yscale="log", legend=f.k.labels)

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -25,7 +25,7 @@ import spectrochempy as scp
 # Generate a test dataset
 # -----------------------
 # 1) simulated chromatogram
-# *************************
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 t = scp.Coord.arange(15, units="minutes", title="time")  # time coordinates
 c = scp.Coord(range(2), title="components")  # component coordinates
@@ -38,7 +38,7 @@ _ = dsc.plot(title="concentration")
 
 # %%
 # 2) absorption spectra
-# **********************
+# ~~~~~~~~~~~~~~~~~~~~~~
 
 spec = np.array([[2.0, 3.0, 4.0, 2.0], [3.0, 4.0, 2.0, 1.0]])
 w = scp.Coord.arange(1, 5, 1, units="nm", title="wavelength")
@@ -48,7 +48,7 @@ _ = dss.plot(title="spectra")
 
 # %%
 # 3) simulated data matrix
-# ************************
+# ~~~~~~~~~~~~~~~~~~~~~~~~
 
 dataset = scp.dot(dsc.T, dss)
 dataset += scp.normal(scale=0.1, size=dataset.shape)
@@ -58,7 +58,7 @@ _ = dataset.plot(title="calculated dataset")
 
 # %%
 # 4) evolving factor analysis (EFA)
-# *********************************
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 efa = scp.EFA()
 _ = efa.fit(dataset)
 

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -6,7 +6,7 @@
 # ruff: noqa
 """
 PCA example (iris dataset)
---------------------------
+==========================
 In this example, we perform the PCA dimensionality reduction of the classical `iris`
 dataset (Ronald A. Fisher.
 "The Use of Multiple Measurements in Taxonomic Problems. Annals of Eugenics, 7, pp.179-188, 1936).

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
@@ -6,7 +6,7 @@
 # ruff: noqa
 """
 PCA analysis example
---------------------
+====================
 In this example, we perform the PCA dimensionality reduction of a spectra
 dataset
 
@@ -46,7 +46,7 @@ scores
 
 # %%
 # Display the results graphically
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # First we can set some preferences for the plot
 prefs = scp.preferences

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
@@ -7,7 +7,7 @@
 # ruff: noqa
 """
 SIMPLISMA example
------------------
+=================
 In this example, we perform the PCA dimensionality reduction of a spectra
 dataset
 

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -6,7 +6,7 @@
 # ruff: noqa
 """
 PLS regression example
-----------------------
+======================
 In this example, we perform a PLS regression to predict the moisture of corn samples
 from their NIR spectra.
 

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -8,7 +8,7 @@
 """
 
 Fitting 1D dataset
-------------------
+==================
 In this example, we find the least  square solution of a simple linear
 equation.
 

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lineshapes.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lineshapes.py
@@ -7,7 +7,7 @@
 # ruff: noqa
 """
 Built-in line-shape helpers
----------------------------
+===========================
 
 This example shows the direct top-level helpers for generating common 1D
 profiles without instantiating fitting models explicitly.

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
@@ -54,7 +54,7 @@ peaks.x.values
 
 # %%
 # Visualize detected peaks
-# ^^^^^^^^^^^^^^^^^^^^^^^^^
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
 ax = last.plot_pen()
 markers = peaks + 0.015
 _ = markers.plot_scatter(

--- a/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
@@ -27,7 +27,7 @@ import spectrochempy as scp
 
 # %%
 # Coordinates
-# +++++++++++
+# ~~~~~~~~~~~
 # The `Coord` object allows creating an array of coordinates directly with
 # ``Coord.linspace``, attaching metadata (units, labels, title) in a single
 # step — no separate numpy array needed.
@@ -50,7 +50,7 @@ print(a)
 
 # %%
 # Data and nd-Dataset
-# +++++++++++++++++++
+# ~~~~~~~~~~~~~~~~~~~
 # ``scp.fromfunction`` builds an NDDataset directly from a Python function.
 # The function receives the coordinate arrays and returns the intensity values.
 def synth_func(temperature, time, wavenumber):

--- a/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
@@ -25,7 +25,7 @@ import spectrochempy as scp
 
 # %%
 # Coordinates
-# +++++++++++
+# ~~~~~~~~~~~
 # The `Coord` object allows creating an array of coordinates directly with
 # ``Coord.linspace``, attaching metadata (units, labels, title) in a single
 # step — no separate numpy array needed.
@@ -48,7 +48,7 @@ print(a)
 
 # %%
 # Data and nd-Dataset
-# +++++++++++++++++++
+# ~~~~~~~~~~~~~~~~~~~
 # ``scp.fromfunction`` builds an NDDataset directly from a Python function.
 # The function receives the coordinate arrays and returns the intensity values.
 def synth_func(temperature, time, wavenumber):

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -30,7 +30,7 @@ _ = dataset.plot(method="image")
 
 # %%
 # Handle diverging colormaps
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
 # A diverging colormap is triggered when negative values are present.
 # Enforce a sequential colormap explicitly:
 _ = dataset.plot_image(cmap="cividis")


### PR DESCRIPTION
## Summary
Normalize heading markers across the Sphinx Gallery example scripts so the generated sidebar uses a consistent hierarchy.

## What changed
- promote gallery page titles to the proper top-level `=` heading where a few examples were still using `-`
- standardize internal gallery section levels to use `-` for first-level sections and `~` for the level below
- leave plugin examples unchanged because this repository snapshot does not contain plugin `plot_*.py` gallery scripts

## Why
A few examples were rendering with the wrong heading level in the HTML gallery sidebar because their page title or nested section markers used inconsistent RST adornments.

## Validation
- targeted scan of `src/spectrochempy/examples/plot_*.py` heading markers
- `git diff --check`
