### PR TITLE
DOC: add 0.12.3 gallery changelog note

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -60,6 +60,12 @@ Bug Fixes
   from ``Ytrain`` without whole-source geometry copies, and diagnostic outputs
   remain generated and unmasked.
 
+- Sphinx Gallery example pages now use a consistent RST heading hierarchy.
+  Top-level page titles are emitted at the correct level in the generated
+  gallery, and nested section markers were normalized so the HTML navigation is
+  structured consistently. This change is documentation-only and does not alter
+  the scientific behavior of the examples.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -48,3 +48,9 @@ Bug Fixes
   predictions rebuild their observation axis from ``Xpredict`` and target axis
   from ``Ytrain`` without whole-source geometry copies, and diagnostic outputs
   remain generated and unmasked.
+
+- Sphinx Gallery example pages now use a consistent RST heading hierarchy.
+  Top-level page titles are emitted at the correct level in the generated
+  gallery, and nested section markers were normalized so the HTML navigation is
+  structured consistently. This change is documentation-only and does not alter
+  the scientific behavior of the examples.


### PR DESCRIPTION
## Summary
Add the missing `0.12.3` release-note entry for the gallery heading hierarchy cleanup that was merged on `master` in `#1522`.

## What changed
- extend `docs/sources/whatsnew/changelog.rst` with a release-oriented note for the Sphinx Gallery heading hierarchy normalization
- regenerate `docs/sources/whatsnew/latest.rst` with the project script so the rendered unreleased notes stay in sync

## Why
`master` is now green and includes `#1522`, but the pending `0.12.3` patch-release notes were still missing the gallery/documentation item. This follow-up keeps the changelog aligned with the actual release scope before the maintainer manually runs the official release-preparation workflow.

## Validation
- `.github/workflows/scripts/update_version_and_release_notes.py unreleased`
- `pre-commit run --all-files`
- `git diff --check`

## Label note
I did not apply `safe-docs-no-ci` because the repository policy explicitly excludes `docs/` changes from that bypass label, and this PR modifies `docs/sources/whatsnew/*`.
