### PR TITLE
CI: allow safe-docs bypass for whatsnew only

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 - [ ] The new API methods have been included in a section of `docs/sources/reference/index.rst`.
 - [ ] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
 - [ ] Changelog entry is present (or label `no-changelog` is applied).
-- [ ] If this PR changes only safe maintainer/policy docs, the label `safe-docs-no-ci` has been applied; otherwise it has not.
+- [ ] If this PR changes only safe maintainer/policy docs, or only `docs/sources/whatsnew/changelog.rst` plus generated `latest.rst`, the label `safe-docs-no-ci` has been applied; otherwise it has not.
 - [ ] If you are a new contributor, you have added your name (affiliation and ORCID
       if you have one) in the `zenodo.json` in the field contributors field. _Be careful
       not to break the json format (check the content of the file with the

--- a/.github/workflows/scripts/evaluate_pr_bypass.py
+++ b/.github/workflows/scripts/evaluate_pr_bypass.py
@@ -20,6 +20,11 @@ SAFE_EXACT = {
     ".github/PULL_REQUEST_TEMPLATE.md",
 }
 
+SAFE_DOCS_EXACT = {
+    "docs/sources/whatsnew/changelog.rst",
+    "docs/sources/whatsnew/latest.rst",
+}
+
 SAFE_PREFIXES = ("maintainers/",)
 
 UNSAFE_PREFIXES = (
@@ -68,6 +73,8 @@ def is_safe_docs_only(files: list[str]) -> bool:
     if not files:
         return False
     for path in files:
+        if path in SAFE_DOCS_EXACT:
+            continue
         if any(path.startswith(prefix) for prefix in UNSAFE_PREFIXES):
             return False
         if path in SAFE_EXACT:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,11 +453,15 @@ are limited to safe documentation/policy paths such as:
 * root-level `*.md`;
 * `maintainers/**/*.md`;
 * `CONTRIBUTING.md`;
+* `docs/sources/whatsnew/changelog.rst`;
+* generated `docs/sources/whatsnew/latest.rst` when it changes only as the
+  direct companion of `changelog.rst`;
 * the PR template and similar non-executable repository-policy documents.
 
 Do **not** use ``safe-docs-no-ci`` for:
 
-* `docs/` changes, even when the files are non-Python;
+* `docs/` changes outside the narrow `whatsnew/changelog.rst` +
+  generated `latest.rst` exception above, even when the files are non-Python;
 * `examples/` changes;
 * gallery/example/tutorial updates;
 * plugin Markdown such as `plugins/**/README.md`;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,15 @@ documents (`AGENTS.md`, root `*.md`, `maintainers/**/*.md`, PR templates, and
 similar non-executable repository-policy files), maintainers may add the label
 **`safe-docs-no-ci`** to bypass the heavyweight test and docs workflows.
 
+The same label may also be used for the narrow release-notes-only case where
+the changed files are limited to:
+
+* `docs/sources/whatsnew/changelog.rst`
+* generated `docs/sources/whatsnew/latest.rst`
+
 This label must **not** be used for:
 
-* `docs/` changes, even when the files are non-Python;
+* other `docs/` changes, even when the files are non-Python;
 * `examples/` changes;
 * plugin Markdown such as `plugins/**/README.md`;
 * code changes hidden inside a documentation PR;

--- a/tests/test_utils/test_evaluate_pr_bypass.py
+++ b/tests/test_utils/test_evaluate_pr_bypass.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "scripts"
+    / "evaluate_pr_bypass.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("evaluate_pr_bypass", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_safe_docs_bypass_allows_whatsnew_pair_only():
+    module = _load_module()
+
+    assert module.is_safe_docs_only(
+        [
+            "docs/sources/whatsnew/changelog.rst",
+            "docs/sources/whatsnew/latest.rst",
+        ]
+    )
+
+
+def test_safe_docs_bypass_rejects_other_docs_paths():
+    module = _load_module()
+
+    assert not module.is_safe_docs_only(
+        [
+            "docs/sources/whatsnew/changelog.rst",
+            "docs/sources/userguide/plugins_examples.rst",
+        ]
+    )
+
+
+def test_safe_docs_bypass_rejects_gallery_code_changes():
+    module = _load_module()
+
+    assert not module.is_safe_docs_only(
+        [
+            "docs/sources/whatsnew/changelog.rst",
+            "src/spectrochempy/examples/core/d_plotting/plot_styles.py",
+        ]
+    )

--- a/tests/test_utils/test_evaluate_pr_bypass.py
+++ b/tests/test_utils/test_evaluate_pr_bypass.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2]
     / ".github"


### PR DESCRIPTION
## Summary
Refine the `safe-docs-no-ci` bypass so it remains conservative for `docs/` in general while still allowing the narrow release-notes-only case.

## What changed
- allow `safe-docs-no-ci` when a PR changes only `docs/sources/whatsnew/changelog.rst` and its generated companion `docs/sources/whatsnew/latest.rst`
- keep all other `docs/` paths outside the bypass scope
- synchronize the policy text in `AGENTS.md`, `CONTRIBUTING.md`, and the PR template
- add a focused regression test for the bypass classifier

## Why
The previous policy treated a pure release-notes follow-up exactly like executable documentation work, which forced the full heavyweight CI/docs battery for a changelog-only PR. That was too coarse. This change keeps the bypass narrow and exact-path-based instead of weakening it for `docs/` broadly.

## Validation
- `pytest tests/test_utils/test_evaluate_pr_bypass.py`
- `git diff --check`

## Out of scope
- no broader `docs/` bypass
- no change to gallery, examples, tutorials, or Sphinx-executed documentation policy
