### PR TITLE
CI: expand safe-docs exact allowlist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 - [ ] The new API methods have been included in a section of `docs/sources/reference/index.rst`.
 - [ ] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
 - [ ] Changelog entry is present (or label `no-changelog` is applied).
-- [ ] If this PR changes only safe maintainer/policy docs, or only `docs/sources/whatsnew/changelog.rst` plus generated `latest.rst`, the label `safe-docs-no-ci` has been applied; otherwise it has not.
+- [ ] If this PR changes only safe maintainer/policy docs, or only files from the explicit safe-docs allowlist in `CONTRIBUTING.md`, the label `safe-docs-no-ci` has been applied; otherwise it has not.
 - [ ] If you are a new contributor, you have added your name (affiliation and ORCID
       if you have one) in the `zenodo.json` in the field contributors field. _Be careful
       not to break the json format (check the content of the file with the

--- a/.github/workflows/scripts/evaluate_pr_bypass.py
+++ b/.github/workflows/scripts/evaluate_pr_bypass.py
@@ -21,6 +21,16 @@ SAFE_EXACT = {
 }
 
 SAFE_DOCS_EXACT = {
+    "docs/sources/credits/citing.rst",
+    "docs/sources/credits/license.rst",
+    "docs/sources/credits/seealso.rst",
+    "docs/sources/gettingstarted/getting_help.rst",
+    "docs/sources/gettingstarted/whyscpy.rst",
+    "docs/sources/reference/bibliography.bib",
+    "docs/sources/reference/bibliography.rst",
+    "docs/sources/reference/faq.rst",
+    "docs/sources/reference/glossary.rst",
+    "docs/sources/reference/papers.rst",
     "docs/sources/whatsnew/changelog.rst",
     "docs/sources/whatsnew/latest.rst",
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,6 +453,16 @@ are limited to safe documentation/policy paths such as:
 * root-level `*.md`;
 * `maintainers/**/*.md`;
 * `CONTRIBUTING.md`;
+* `docs/sources/credits/citing.rst`;
+* `docs/sources/credits/license.rst`;
+* `docs/sources/credits/seealso.rst`;
+* `docs/sources/gettingstarted/getting_help.rst`;
+* `docs/sources/gettingstarted/whyscpy.rst`;
+* `docs/sources/reference/bibliography.bib`;
+* `docs/sources/reference/bibliography.rst`;
+* `docs/sources/reference/faq.rst`;
+* `docs/sources/reference/glossary.rst`;
+* `docs/sources/reference/papers.rst`;
 * `docs/sources/whatsnew/changelog.rst`;
 * generated `docs/sources/whatsnew/latest.rst` when it changes only as the
   direct companion of `changelog.rst`;
@@ -460,8 +470,8 @@ are limited to safe documentation/policy paths such as:
 
 Do **not** use ``safe-docs-no-ci`` for:
 
-* `docs/` changes outside the narrow `whatsnew/changelog.rst` +
-  generated `latest.rst` exception above, even when the files are non-Python;
+* `docs/` changes outside the explicit safe-file allowlist above, even when
+  the files are non-Python;
 * `examples/` changes;
 * gallery/example/tutorial updates;
 * plugin Markdown such as `plugins/**/README.md`;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,18 @@ documents (`AGENTS.md`, root `*.md`, `maintainers/**/*.md`, PR templates, and
 similar non-executable repository-policy files), maintainers may add the label
 **`safe-docs-no-ci`** to bypass the heavyweight test and docs workflows.
 
-The same label may also be used for the narrow release-notes-only case where
-the changed files are limited to:
+The same label may also be used for the narrow exact-path allowlist below:
 
+* `docs/sources/credits/citing.rst`
+* `docs/sources/credits/license.rst`
+* `docs/sources/credits/seealso.rst`
+* `docs/sources/gettingstarted/getting_help.rst`
+* `docs/sources/gettingstarted/whyscpy.rst`
+* `docs/sources/reference/bibliography.bib`
+* `docs/sources/reference/bibliography.rst`
+* `docs/sources/reference/faq.rst`
+* `docs/sources/reference/glossary.rst`
+* `docs/sources/reference/papers.rst`
 * `docs/sources/whatsnew/changelog.rst`
 * generated `docs/sources/whatsnew/latest.rst`
 

--- a/tests/test_utils/test_evaluate_pr_bypass.py
+++ b/tests/test_utils/test_evaluate_pr_bypass.py
@@ -20,13 +20,25 @@ def _load_module():
     return module
 
 
-def test_safe_docs_bypass_allows_whatsnew_pair_only():
+def test_safe_docs_bypass_allows_whatsnew_pair():
     module = _load_module()
 
     assert module.is_safe_docs_only(
         [
             "docs/sources/whatsnew/changelog.rst",
             "docs/sources/whatsnew/latest.rst",
+        ]
+    )
+
+
+def test_safe_docs_bypass_allows_explicit_narrative_docs_allowlist():
+    module = _load_module()
+
+    assert module.is_safe_docs_only(
+        [
+            "docs/sources/credits/citing.rst",
+            "docs/sources/reference/faq.rst",
+            "docs/sources/reference/bibliography.bib",
         ]
     )
 
@@ -38,6 +50,17 @@ def test_safe_docs_bypass_rejects_other_docs_paths():
         [
             "docs/sources/whatsnew/changelog.rst",
             "docs/sources/userguide/plugins_examples.rst",
+        ]
+    )
+
+
+def test_safe_docs_bypass_rejects_docs_templates_and_indexes():
+    module = _load_module()
+
+    assert not module.is_safe_docs_only(
+        [
+            "docs/sources/credits/credits.rst.tmpl",
+            "docs/sources/index.rst",
         ]
     )
 


### PR DESCRIPTION
## Summary
Expand the `safe-docs-no-ci` bypass from the minimal `whatsnew` exception to a slightly broader but still exact-path-based allowlist of non-executable narrative/reference documentation files.

## What changed
- keep the existing safe maintainer/policy-doc paths
- keep the `docs/sources/whatsnew/changelog.rst` + generated `latest.rst` exception
- add an explicit exact-path allowlist for a small set of narrative/reference docs:
  - `docs/sources/credits/citing.rst`
  - `docs/sources/credits/license.rst`
  - `docs/sources/credits/seealso.rst`
  - `docs/sources/gettingstarted/getting_help.rst`
  - `docs/sources/gettingstarted/whyscpy.rst`
  - `docs/sources/reference/bibliography.bib`
  - `docs/sources/reference/bibliography.rst`
  - `docs/sources/reference/faq.rst`
  - `docs/sources/reference/glossary.rst`
  - `docs/sources/reference/papers.rst`
- keep all other `docs/` paths outside the bypass scope
- add regression tests proving the classifier accepts only the explicit allowlist and still rejects templates, indexes, userguide docs, and gallery/example changes

## Why
The narrow `whatsnew` fix addresses the immediate release-notes case, but there are a few other clearly non-executable, non-gallery docs that have the same low-risk profile. This PR broadens the allowlist carefully without turning `safe-docs-no-ci` into a general `docs/` bypass.

## Validation
- `pytest tests/test_utils/test_evaluate_pr_bypass.py`
- `git diff --check`

## Out of scope
- no wildcard allowlist for large `docs/` subtrees
- no change to gallery, examples, notebooks, generated API docs, templates, or build-driving index/toctree files
- does not supersede the principle that most `docs/` changes should still run normal docs/test CI
