### PR TITLE
CI: align release PR title with prefix policy

### DIFF
--- a/.github/workflows/prepare_new_release.yml
+++ b/.github/workflows/prepare_new_release.yml
@@ -182,7 +182,7 @@ jobs:
           Publishing this release will trigger publishing on pypi, anaconda and zenodo.
           EOF
 
-          pr_title="Release version $RELEASE_VERSION"
+          pr_title="REL: Release version $RELEASE_VERSION"
           pr_body="$(cat "$body_file")"
 
           pr_number="$(gh_api_app_only GET \
@@ -219,8 +219,7 @@ jobs:
 
           if ! gh_api_with_fallback POST \
             "repos/${{ github.repository }}/issues/$pr_number/labels" \
-            -f "labels[]=no-changelog" \
-            -f "labels[]=non-standard-prefix" >/dev/null; then
+            -f "labels[]=no-changelog" >/dev/null; then
             echo "::warning::Could not apply labels to release PR $pr_number."
           fi
 

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.12
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.12.3
     v0.12.2
     v0.12.1

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,51 +6,8 @@
 
 :orphan:
 
-What's New in Revision 0.12.3
+What's New in Revision 0.12.4.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.3.
+These are the changes in SpectroChemPy-0.12.4.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
-
-Bug Fixes
-~~~~~~~~~
-
-- Public deprecation warnings no longer promise API removals in ``0.13.0`` for
-  deprecated plotting aliases, the historical ``processing.alignement`` import
-  path, deprecated plugin root aliases, ``concatenate(..., force_stack=True)``,
-  or deprecated writer ``protocol=`` / ``description=`` kwargs. These paths
-  remain available with warnings, and their eventual removal is now governed by
-  the accepted SpectroChemPy deprecation lifecycle policy instead of an expired
-  fixed-version target.
-
-- Analysis and fitting outputs now follow deterministic derived-metadata rules
-  instead of inheriting path-dependent combinations of source identity and
-  wrapper defaults. Single-source outputs preserve the captured scientific
-  provenance from ``fit()`` time while generating canonical derived
-  ``name``/``title``/``description``/``history`` text and clearing
-  ``filename``; direct ``NDDataset`` arguments remain authoritative for that
-  call only, array-like inputs do not leak stale provenance, and input datasets
-  are not mutated. Supervised ``PLSRegression.predict()`` now applies the
-  accepted multi-source provenance order (``Xtrain``, ``Ytrain``, then the
-  prediction input), ``Optimize.result.residuals`` now follows the same
-  canonical derived-output policy as fitted data, latent analysis factors now
-  follow the accepted unitless/default-units policy, source-domain
-  reconstructions and residuals preserve exact source units, supervised
-  predictions preserve exact ``Ytrain`` units, and SVD diagnostic ``NDDataset``
-  outputs now use the common diagnostic metadata contract while raw
-  ``U``/``s``/``VT`` factors remain unchanged.
-
-- Analysis outputs now align their public geometry support with the accepted
-  family-specific rules: latent factors and profiles stay unmasked unless an
-  exact restored full-row/full-column authority exists, source-domain
-  reconstructions and fitted/residual outputs recover the public ``X``
-  coordset and mask only when their geometry matches exactly, ``PLSRegression``
-  predictions rebuild their observation axis from ``Xpredict`` and target axis
-  from ``Ytrain`` without whole-source geometry copies, and diagnostic outputs
-  remain generated and unmasked.
-
-- Sphinx Gallery example pages now use a consistent RST heading hierarchy.
-  Top-level page titles are emitted at the correct level in the generated
-  gallery, and nested section markers were normalized so the HTML navigation is
-  structured consistently. This change is documentation-only and does not alter
-  the scientific behavior of the examples.


### PR DESCRIPTION
## Summary
- create release pull requests with a compliant `REL:` title from the start
- stop relying on the `non-standard-prefix` label for automated core release PRs
- keep the existing `no-changelog` label behavior for generated release PRs
- include the required first post-release regeneration of `docs/sources/whatsnew/latest.rst` and `docs/sources/whatsnew/index.rst`

## Why
The release workflow was opening PRs with titles like `Release version 0.12.3` and only adding `non-standard-prefix` afterward. That made PR Compliance timing-sensitive and forced manual retitling when the initial title check failed before the label path could help.

This branch is also the first post-release commit after `0.12.3`, so the repository-generated whatsnew files must move back to the development state for `0.12.4.dev`.

## Impact
Release PRs now satisfy the normal prefix policy immediately on creation, which removes the brittle dependence on post-creation label application for this path.

The generated whatsnew files are also back in the correct post-release state.

## Validation
- `pre-commit run --all-files`
- `git diff --check`
