### PR TITLE
FIX: align post-fit diagnostics with the executed optimization

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,14 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fix inconsistent fit diagnostics after directly mutating the public
+  ``Optimize.fp`` view (for example setting ``fp.fixed``): the mutation was
+  ignored by the optimization but was re-injected into the reported state by
+  the post-fit script round-trip, so ``n_varying_parameters``,
+  ``degrees_of_freedom`` and the rendered script could disagree with what was
+  actually optimized. The canonical model spec is now the sole source of truth
+  after a fit.
+
 
 .. section
 
@@ -53,6 +61,16 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- ``Optimize`` no longer rebuilds its canonical model state by re-parsing the
+  post-fit rendered script. After a successful fit the canonical spec keeps the
+  full-precision optimized values, the public ``Optimize.fp`` view keeps its
+  identity and its in-place synced values, and ``Optimize.script`` becomes a
+  rendered representation of the fitted values: the display precision of the
+  render no longer limits the precision of the internal fitted state, and the
+  rendered text is never re-injected into the canonical model.
+  ``FitParameters`` and ``Optimize.fp`` are unchanged, the fp-only entry path is
+  preserved, and no API is removed or deprecated.
 
 - The ``Optimize`` structured-validation flow now validates constraint
   parameter-name references against the canonical ``_FitModelSpec``

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,8 +12,29 @@ What's New in Revision 0.12.4.dev
 These are the changes in SpectroChemPy-0.12.4.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+Bug Fixes
+~~~~~~~~~
+
+- Fix inconsistent fit diagnostics after directly mutating the public
+  ``Optimize.fp`` view (for example setting ``fp.fixed``): the mutation was
+  ignored by the optimization but was re-injected into the reported state by
+  the post-fit script round-trip, so ``n_varying_parameters``,
+  ``degrees_of_freedom`` and the rendered script could disagree with what was
+  actually optimized. The canonical model spec is now the sole source of truth
+  after a fit.
+
 Developer
 ~~~~~~~~~
+
+- ``Optimize`` no longer rebuilds its canonical model state by re-parsing the
+  post-fit rendered script. After a successful fit the canonical spec keeps the
+  full-precision optimized values, the public ``Optimize.fp`` view keeps its
+  identity and its in-place synced values, and ``Optimize.script`` becomes a
+  rendered representation of the fitted values: the display precision of the
+  render no longer limits the precision of the internal fitted state, and the
+  rendered text is never re-injected into the canonical model.
+  ``FitParameters`` and ``Optimize.fp`` are unchanged, the fp-only entry path is
+  preserved, and no API is removed or deprecated.
 
 - The ``Optimize`` structured-validation flow now validates constraint
   parameter-name references against the canonical ``_FitModelSpec``

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -1197,9 +1197,14 @@ class Optimize(DecompositionAnalysis):
         self._fit_config = fit_config
         self._solver_artifacts = solver_artifacts
 
-        # replace the previous script with new fp parameters
-        self.script = str(fp)
-        self._model_spec = _FitModelSpec.from_fitparameters(self.fp)
+        # Replace the previous script with a rendered view of the new parameter
+        # values without re-parsing it into canonical state (see maintainer
+        # decision recorded in the FitParameters ADR amendment, 2026-08-13).
+        # The canonical spec keeps the full-precision optimized values and the
+        # public fp view keeps its identity and synced values. Writing the
+        # render directly into trait storage bypasses the script validator,
+        # which would otherwise rebuild the spec from the rounded text.
+        self._trait_values["script"] = str(fp)
 
         # log.info the results
         display.clear_output(wait=True)

--- a/src/spectrochempy/analysis/curvefitting/optimize.py
+++ b/src/spectrochempy/analysis/curvefitting/optimize.py
@@ -288,20 +288,27 @@ def _modelspec_internal_vector(spec):
 
 
 def _sync_fitparameters_from_modelspec(fp, spec):
-    """Update a FitParameters object with values from a model spec."""
-    for name, ps in spec.common_params.items():
-        if ps.reference is not None:
-            continue
-        if name in fp:
-            fp.data[name] = ps.value
+    """
+    Reset a ``FitParameters`` view in place to faithfully reflect a spec.
 
-    for comp in spec.components:
-        for name, ps in comp.params.items():
-            if ps.reference is not None:
-                continue
-            key = f"{name}_{comp.label}"
-            if key in fp:
-                fp.data[key] = ps.value
+    Preserves the object identity of *fp* while rebuilding its full view from
+    the canonical model spec: values, ``fixed``/``vary`` flags, bounds,
+    reference flags, model structure and experiment metadata are all restored.
+    Direct legacy-view mutations (``fp.fixed``, ``fp.lob``/``fp.upb``,
+    ``fp.reference``, ...) therefore cannot survive into the public
+    ``Optimize.fp`` after a fit when they are not authoritative.
+    """
+    view = spec.to_fitparameters()
+    fp.data = view.data
+    fp.lob = view.lob
+    fp.upb = view.upb
+    fp.fixed = view.fixed
+    fp.reference = view.reference
+    fp.common = view.common
+    fp.model = view.model
+    fp.models = view.models
+    fp.expvars = view.expvars
+    fp.expnumber = view.expnumber
     return fp
 
 
@@ -1201,10 +1208,11 @@ class Optimize(DecompositionAnalysis):
         # values without re-parsing it into canonical state (see maintainer
         # decision recorded in the FitParameters ADR amendment, 2026-08-13).
         # The canonical spec keeps the full-precision optimized values and the
-        # public fp view keeps its identity and synced values. Writing the
-        # render directly into trait storage bypasses the script validator,
-        # which would otherwise rebuild the spec from the rounded text.
-        self._trait_values["script"] = str(fp)
+        # public fp view keeps its identity and synced values. The render is
+        # written without running the script validator (which would rebuild the
+        # spec from the rounded text) but observers of ``script`` are still
+        # notified as for a normal assignment.
+        self._set_rendered_script(str(fp))
 
         # log.info the results
         display.clear_output(wait=True)
@@ -1268,6 +1276,23 @@ class Optimize(DecompositionAnalysis):
         self._model_spec = spec
         self.fp = spec.to_fitparameters()
         return proposal.value
+
+    # ----------------------------------------------------------------------------------
+    def _set_rendered_script(self, value):
+        """
+        Assign the ``script`` trait without re-parsing it into canonical state.
+
+        The post-fit script is a rendered representation of the fitted values;
+        the canonical spec and the ``fp`` view already reflect the executed
+        optimization. Unlike a regular assignment, the script validator (which
+        would rebuild the canonical state from the rendered text) is bypassed,
+        but observers of ``script`` are still notified as for a normal
+        assignment (see traitlets ``TraitType.set`` semantics).
+        """
+        old = self.script  # materialize the default value when needed
+        self._trait_values["script"] = value
+        if old != value:
+            self._notify_trait("script", old, value)
 
     @tr.validate("constraints")
     def _constraints_validate(self, proposal):

--- a/tests/test_analysis/test_curvefitting/test_optimize.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize.py
@@ -12,6 +12,9 @@ import spectrochempy as scp
 from spectrochempy.analysis.curvefitting._parameters import FitParameters
 from spectrochempy.analysis.curvefitting.optimize import ConstraintError
 from spectrochempy.analysis.curvefitting.optimize import ScriptError
+from spectrochempy.analysis.curvefitting.optimize import (
+    _extract_varying_parameter_values,
+)
 from spectrochempy.analysis.curvefitting.optimize import _modelspec_parameter_names
 from spectrochempy.analysis.curvefitting.optimize import _validate_script_content
 
@@ -400,3 +403,163 @@ def test_fit_single_dataset(synthetic_two_peak_dataset, optimize_script):
         rtol=0.02,
         atol=3.0,
     )
+
+
+# -----------------------------------------------------------------------------------
+# post-fit fp / script contract (round-trip alignment)
+# -----------------------------------------------------------------------------------
+def test_fit_preserves_fp_identity_and_type(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # The canonical spec is the source of truth and the public fp view is kept
+    # in place after a fit: identity is preserved and the type is unchanged.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    fp_before = opt.fp
+    opt.fit(synthetic_two_peak_dataset)
+    assert opt.fp is fp_before
+    assert isinstance(opt.fp, FitParameters)
+
+
+def test_fit_syncs_full_precision_values_into_fp(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # The synced fp view mirrors the canonical spec exactly (full precision);
+    # it is not rebuilt from the 4-decimal rendered script.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fit(synthetic_two_peak_dataset)
+    spec = opt._model_spec
+    for key, ps in spec._iter_varying():
+        assert opt.fp[key] == ps.value
+
+
+def test_fit_renders_script_at_display_precision(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # The post-fit script is a rendered public representation of the fitted
+    # values: syntactically valid, models, references and the COMMON block
+    # survive, and values approximate the internal full-precision state to the
+    # historical 4-decimal display precision.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fit(synthetic_two_peak_dataset)
+
+    assert "COMMON" in opt.script
+    assert "MODEL: line_1" in opt.script
+    assert "MODEL: line_2" in opt.script
+    assert "> ratio:gratio" in opt.script
+    assert opt.validate_script(opt.script) == []
+
+    rendered_fp, errors = _validate_script_content(opt.script)
+    assert errors == []
+    for key in rendered_fp.keys():
+        if isinstance(opt.fp[key], str) or isinstance(rendered_fp[key], str):
+            continue
+        assert float(rendered_fp[key]) == pytest.approx(float(opt.fp[key]), abs=1e-4)
+
+
+def test_explicit_script_assignment_after_fit_rebuilds_canonical_state(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # Only an explicit user assignment of a new script is authoritative: it
+    # rebuilds the canonical spec and the fp view.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fit(synthetic_two_peak_dataset)
+
+    new_script = """
+MODEL: X
+shape: gaussianmodel
+    $ ampl: 1.0, 0.0, none
+    $ pos:  500, 0, 1000
+    $ width: 10, 0, 100
+"""
+    opt.script = new_script
+    assert opt.fp["pos_x"] == 500.0
+    assert opt._model_spec.components[0].params["pos"].value == 500.0
+
+
+def test_direct_fp_fixed_mutation_does_not_corrupt_reported_state(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # Direct fp-view mutations are not authoritative: the canonical spec wins.
+    # The reported state must stay consistent with what was actually optimized
+    # (9 varying parameters), not with the ignored fp.fixed mutation.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fp.fixed["pos_line_1"] = True
+    opt.fit(synthetic_two_peak_dataset)
+
+    diag = opt.result.diagnostics
+    assert diag["n_varying_parameters"] == 9
+    assert opt._model_spec.components[0].params["pos"].vary is True
+
+
+def test_direct_fp_value_mutation_does_not_change_fit(
+    synthetic_two_peak_dataset, optimize_script
+):
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fp["pos_line_1"] = (3500.0, 3400.0, 3700.0)  # ignored by the canonical spec
+    opt.fit(synthetic_two_peak_dataset)
+
+    assert opt.result.diagnostics["n_varying_parameters"] == 9
+    assert opt._model_spec.components[0].params["pos"].value == pytest.approx(
+        3620.0, abs=3.0
+    )
+
+
+def test_fp_only_entry_fits_and_preserves_identity(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # The fp-only legacy entry path remains live: a FitParameters view can be
+    # fitted directly, the same public object is kept, and the post-fit script
+    # is rendered.
+    ref = scp.Optimize()
+    ref.script = optimize_script
+    ref.autobase = True
+    ref.max_iter = 10
+    ref.fit(synthetic_two_peak_dataset)
+
+    opt = scp.Optimize()
+    fp = ref.fp.copy()
+    opt.fp = fp
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fit(synthetic_two_peak_dataset)
+
+    assert opt.fp is fp
+    assert isinstance(opt.fp, FitParameters)
+    assert opt.result.diagnostics["n_varying_parameters"] == 9
+    assert opt.fp["pos_line_1"] == pytest.approx(3620.0, abs=3.0)
+    assert "MODEL" in opt.script
+    assert_allclose(
+        opt._model_spec.extract_varying_values(),
+        _extract_varying_parameter_values(opt.fp),
+    )
+
+
+def test_successive_fits_are_stable(synthetic_two_peak_dataset, optimize_script):
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fit(synthetic_two_peak_dataset)
+    first_cost = opt.result.diagnostics["cost"]
+    first_pos = opt.fp["pos_line_1"]
+    opt.fit(synthetic_two_peak_dataset)
+    assert opt.result.diagnostics["cost"] == pytest.approx(first_cost, rel=1e-6)
+    assert opt.fp["pos_line_1"] == pytest.approx(first_pos, rel=1e-6)

--- a/tests/test_analysis/test_curvefitting/test_optimize.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize.py
@@ -491,9 +491,11 @@ shape: gaussianmodel
 def test_direct_fp_fixed_mutation_does_not_corrupt_reported_state(
     synthetic_two_peak_dataset, optimize_script
 ):
-    # Direct fp-view mutations are not authoritative: the canonical spec wins.
-    # The reported state must stay consistent with what was actually optimized
-    # (9 varying parameters), not with the ignored fp.fixed mutation.
+    # Direct fp-view mutations are not authoritative: the canonical spec wins
+    # and the whole public view is re-synced from it after the fit. The
+    # reported diagnostics, the fp view and the rendered script must all stay
+    # consistent with what was actually optimized (9 varying parameters), not
+    # with the ignored fp.fixed mutation.
     opt = scp.Optimize()
     opt.script = optimize_script
     opt.autobase = True
@@ -504,6 +506,9 @@ def test_direct_fp_fixed_mutation_does_not_corrupt_reported_state(
     diag = opt.result.diagnostics
     assert diag["n_varying_parameters"] == 9
     assert opt._model_spec.components[0].params["pos"].vary is True
+    assert opt.fp.fixed["pos_line_1"] is False
+    assert "$ pos" in opt.script
+    assert "* pos" not in opt.script
 
 
 def test_direct_fp_value_mutation_does_not_change_fit(
@@ -513,13 +518,83 @@ def test_direct_fp_value_mutation_does_not_change_fit(
     opt.script = optimize_script
     opt.autobase = True
     opt.max_iter = 10
-    opt.fp["pos_line_1"] = (3500.0, 3400.0, 3700.0)  # ignored by the canonical spec
+    opt.fp["pos_line_1"] = (3500.0, 3000.0, 4000.0)  # ignored by the canonical spec
     opt.fit(synthetic_two_peak_dataset)
 
     assert opt.result.diagnostics["n_varying_parameters"] == 9
     assert opt._model_spec.components[0].params["pos"].value == pytest.approx(
         3620.0, abs=3.0
     )
+    assert opt.fp["pos_line_1"] == pytest.approx(3620.0, abs=3.0)
+    assert opt.fp.lob["pos_line_1"] == pytest.approx(3400.0)
+    assert opt.fp.upb["pos_line_1"] == pytest.approx(3700.0)
+
+
+def test_direct_fp_bounds_mutation_does_not_survive_in_view(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # Direct bound mutations in the fp view are not authoritative: the bounds
+    # are restored from the canonical spec after the fit.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fp.lob["pos_line_1"] = 3000.0
+    opt.fp.upb["pos_line_1"] = 4000.0
+    opt.fit(synthetic_two_peak_dataset)
+
+    assert opt.fp.lob["pos_line_1"] == pytest.approx(3400.0)
+    assert opt.fp.upb["pos_line_1"] == pytest.approx(3700.0)
+    assert opt._model_spec.components[0].params["pos"].bounds == (3400.0, 3700.0)
+
+
+def test_direct_fp_reference_mutation_does_not_survive_in_view(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # Reference flags are part of the canonical structure: replacing the
+    # ``ratio_line_2`` reference by an inline value in the fp view must not
+    # survive the fit.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    opt.autobase = True
+    opt.max_iter = 10
+    assert opt.fp.reference["ratio_line_2"] is True
+    opt.fp.reference["ratio_line_2"] = False
+    opt.fp.data["ratio_line_2"] = 0.25
+    opt.fp.fixed["ratio_line_2"] = False
+    opt.fp.lob["ratio_line_2"] = 0.0
+    opt.fp.upb["ratio_line_2"] = 1.0
+    opt.fit(synthetic_two_peak_dataset)
+
+    assert opt.fp.reference["ratio_line_2"] is True
+    assert opt.fp.data["ratio_line_2"] == "gratio"
+    assert opt.fp.fixed["ratio_line_2"] is True
+    assert "> ratio:gratio" in opt.script
+
+
+def test_postfit_script_assignment_notifies_observers(
+    synthetic_two_peak_dataset, optimize_script
+):
+    # The post-fit script render is an observable change of the ``script``
+    # trait: observers are notified as for a normal assignment, even though
+    # the rendered text is never re-parsed into canonical state.
+    opt = scp.Optimize()
+    opt.script = optimize_script
+    changes = []
+    opt.observe(
+        lambda c: changes.append((c["name"], c["old"], c["new"])), names="script"
+    )
+    opt.autobase = True
+    opt.max_iter = 10
+    opt.fit(synthetic_two_peak_dataset)
+
+    assert len(changes) == 1
+    name, old, new = changes[0]
+    assert name == "script"
+    assert old == optimize_script
+    assert new == opt.script
+    assert "MODEL: line_1" in new
+    assert "MODEL: line_2" in new
 
 
 def test_fp_only_entry_fits_and_preserves_identity(

--- a/tests/test_analysis/test_curvefitting/test_optimize_result.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_result.py
@@ -403,6 +403,26 @@ class TestOptimizeResult:
 
         assert opt.result.diagnostics["n_varying_parameters"] == 9
 
+    def test_postfit_diagnostics_reflect_executed_optimization(
+        self, synthetic_two_peak_dataset, optimize_script
+    ):
+        # Direct fp-view mutations are not authoritative for the canonical spec.
+        # The reported diagnostics must match the executed optimization (9
+        # varying parameters) instead of the ignored fp.fixed mutation.
+        opt = scp.Optimize()
+        opt.script = optimize_script
+        opt.autobase = True
+        opt.max_iter = 10
+        opt.fp.fixed["pos_line_1"] = True
+        opt.fit(synthetic_two_peak_dataset)
+
+        diag = opt.result.diagnostics
+        assert diag["n_varying_parameters"] == 9
+        assert diag["degrees_of_freedom"] == (
+            diag["n_observations"] - diag["n_varying_parameters"]
+        )
+        assert np.isfinite(diag["rss"])
+
     def test_fit_stores_modelspec_synced_with_fitparameters(
         self, synthetic_two_peak_dataset, optimize_script
     ):


### PR DESCRIPTION
Closes #1528.

## Summary

Removes the post-fit script round-trip in `Optimize._fit`: the 4-decimal
rendered view of the fitted parameters is no longer re-parsed back into
canonical model state.

## Why

Direct mutations of the public `Optimize.fp` view (e.g. `opt.fp.fixed[...] = True`)
are ignored by the optimization (the canonical `_FitModelSpec` is authoritative)
but were previously re-injected by the post-fit `str(fp)` round-trip. As a result
`n_varying_parameters`, `degrees_of_freedom` and the rendered script could
disagree with what was actually optimized (#1528).

## Behavior

- The canonical spec keeps the full-precision optimized values after a fit
  (no longer truncated to the 4-decimal render).
- The public `Optimize.fp` view keeps its identity and is synced in place at
  full precision (was previously rebuilt through a re-parse).
- `Optimize.script` becomes a rendered representation of the fitted values and
  is never re-injected into the canonical model. The rendered text is
  byte-identical to the historical output for a normal fit.
- The fp-only entry path is preserved; no API is removed or deprecated.

## Tests

8 new tests in `test_optimize.py` plus 1 diagnostics-consistency test in
`test_optimize_result.py`, covering fp identity/type preservation, full-
precision sync, render fidelity, explicit script reassignment, direct fp
mutation semantics, fp-only entry and successive-fit stability. The three
discriminating tests fail on master and pass on this branch. Full
`tests/test_analysis/test_curvefitting` suite: 437 passed, 1 skipped.

## Changelog

Bug Fixes + Developer entries added to `changelog.rst`; `latest.rst`
regenerated via the `update_version_and_release_notes` hook.