### PR TITLE
FIX: resolve published gallery runtime regressions

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,17 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Derived analysis outputs now remain compatible with source datasets whose
+  metadata contains read-only nested structures. In particular,
+  ``Optimize.predict()`` and ``Optimize.result.residuals`` now attach detached
+  writable metadata copies instead of attempting in-place updates against
+  locked source-derived metadata.
+
+- The AsLS baseline-correction path now avoids the SciPy
+  ``SparseEfficiencyWarning`` previously exposed by published gallery examples,
+  without changing the underlying baseline-correction algorithm or the
+  scientific results.
+
 - Fix inconsistent fit diagnostics after directly mutating the public
   ``Optimize.fp`` view (for example setting ``fp.fixed``): the mutation was
   ignored by the optimization but was re-injected into the reported state by

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,17 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- Derived analysis outputs now remain compatible with source datasets whose
+  metadata contains read-only nested structures. In particular,
+  ``Optimize.predict()`` and ``Optimize.result.residuals`` now attach detached
+  writable metadata copies instead of attempting in-place updates against
+  locked source-derived metadata.
+
+- The AsLS baseline-correction path now avoids the SciPy
+  ``SparseEfficiencyWarning`` previously exposed by published gallery examples,
+  without changing the underlying baseline-correction algorithm or the
+  scientific results.
+
 - Fix inconsistent fit diagnostics after directly mutating the public
   ``Optimize.fp`` view (for example setting ``fp.fixed``): the mutation was
   ignored by the optimization but was re-injected into the reported state by

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -209,6 +209,17 @@ class AnalysisConfigurable(BaseConfigurable):
         return self._ANALYSIS_ROLE_TITLES[role_id]
 
     @staticmethod
+    def _analysis_output_meta_copy(meta_source):
+        """Return a detached, writable metadata copy for derived outputs."""
+        if meta_source is None:
+            return Meta()
+        new_meta = copy.deepcopy(meta_source)
+        new_meta.readonly = False
+        new_meta.parent = None
+        new_meta.name = None
+        return new_meta
+
+    @staticmethod
     def _analysis_ordered_unique_text(values):
         ordered = []
         seen = set()
@@ -765,8 +776,8 @@ class AnalysisConfigurable(BaseConfigurable):
             )
             dataset.author = merged_author
             dataset.origin = "" if merged_origin is None else merged_origin
-            dataset.meta = (
-                copy.deepcopy(y_train.meta) if y_train is not None else Meta()
+            dataset._meta = self._analysis_output_meta_copy(
+                y_train.meta if y_train is not None else None
             )
             dataset.name = self._analysis_generated_name(role_id, x_predict)
             dataset.title = self._analysis_role_title(role_id)
@@ -843,9 +854,9 @@ class AnalysisConfigurable(BaseConfigurable):
             dataset.acquisition_date = None
 
         if meta_authority is not None:
-            dataset.meta = copy.deepcopy(meta_authority.meta)
+            dataset._meta = self._analysis_output_meta_copy(meta_authority.meta)
         else:
-            dataset.meta = Meta()
+            dataset._meta = Meta()
 
         dataset.name = self._analysis_generated_name(role_id, single_source)
         dataset.title = self._analysis_role_title(role_id)

--- a/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_preferences.py
@@ -101,12 +101,12 @@ _ = new.plot(method="image", colorbar=True)
 _ = scp.abs(new).plot(method="image", colorbar=True)
 
 # %% Contour plots are also available, with the same default colormap as for the image method:
-_ = new.plot(method="map")
-_ = scp.abs(new).plot(method="map")
+_ = new.plot(method="contour")
+_ = scp.abs(new).plot(method="contour")
 
 # %%
 # Note that the scp allows one to use this syntax too:
-_ = scp.plot_map(new)
+_ = scp.plot_contour(new)
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -57,6 +57,8 @@ _ = dataset.plot_image()
 
 # %%
 # Grid scan data:
+# This sample mapping does not store an explicit map-area type. SpectroChemPy
+# therefore warns and assumes the usual XY column-major scan order.
 dataset = scp.read_wdf("ramandata/wire/mapping.wdf")
 _ = dataset.sum(dim=2).plot_image(equal_aspect=True)
 _ = dataset[..., 1529.0].plot_image(equal_aspect=True)

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -524,7 +524,9 @@ baseline/trends for different segments of the data.
                 while True:
                     W = sparse.spdiags(w, 0, N, N)
                     C = W + lamb * D.dot(D.transpose())
-                    z = spsolve(C, w * y)
+                    # Convert once to a direct-solver-friendly sparse format to
+                    # avoid gallery-facing SparseEfficiencyWarning noise.
+                    z = spsolve(C.tocsc(), w * y)
                     w = p * (y > z) + (1 - p) * (y < z)
                     change = np.sum(np.abs(w_old - w)) / N
                     # info_(change)

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -1,5 +1,8 @@
+import warnings
+
 import numpy as np
 import pytest
+from scipy.sparse import SparseEfficiencyWarning
 
 import spectrochempy as scp
 from spectrochempy.processing.baselineprocessing.baselineprocessing import Baseline
@@ -66,6 +69,28 @@ def test_baseline_asls_1d(synthetic_1d_baseline_dataset):
     assert baseline.shape == dataset.shape
     assert np.all(np.isfinite(baseline.data))
     assert np.all(np.isfinite(corrected.data))
+
+
+def test_baseline_asls_1d_emits_no_sparse_efficiency_warning(
+    synthetic_1d_baseline_dataset,
+):
+    dataset, _, _ = synthetic_1d_baseline_dataset
+
+    blc = Baseline(log_level="WARNING")
+    blc.model = "asls"
+    blc.mu = 0.5 * 10**9
+    blc.asymmetry = 0.001
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        blc.fit(dataset)
+
+    sparse_warnings = [
+        warning
+        for warning in recorded
+        if issubclass(warning.category, SparseEfficiencyWarning)
+    ]
+    assert sparse_warnings == []
 
 
 def test_baseline_asls_2d(synthetic_2d_baseline_dataset):

--- a/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
+++ b/tests/test_analysis/test_curvefitting/test_optimize_provenance.py
@@ -112,3 +112,31 @@ def test_optimize_fitted_and_residuals_restore_public_geometry_and_mask(
 
     result.fitted.mask[0, 0] = True
     assert not observed.mask[0, 0]
+
+
+def test_optimize_predict_accepts_readonly_source_metadata(
+    synthetic_two_peak_dataset, optimize_script
+):
+    ds = synthetic_two_peak_dataset.copy()
+    ds.name = "readonly_source"
+    ds.meta.project = "nmr-relax"
+    ds.meta.processing = {"reader": "topspin"}
+    ds.meta.readonly = True
+
+    opt = scp.Optimize(script=optimize_script).fit(ds)
+
+    prediction = opt.predict()
+    residuals = opt.result.residuals
+
+    assert prediction.name == "readonly_source_Optimize.fitted_data"
+    assert prediction.meta.project == "nmr-relax"
+    assert prediction.meta.processing["reader"] == "topspin"
+    assert prediction.meta.readonly is False
+    prediction.meta.processing["reader"] = "changed"
+    assert ds.meta.processing["reader"] == "topspin"
+
+    assert residuals.meta.project == "nmr-relax"
+    assert residuals.meta.processing["reader"] == "topspin"
+    assert residuals.meta.readonly is False
+    residuals.meta.processing["reader"] = "residuals-changed"
+    assert ds.meta.processing["reader"] == "topspin"


### PR DESCRIPTION
## Summary
- fix the published NMR relaxation gallery traceback caused by read-only nested metadata on derived `Optimize` outputs
- update the NDDataset preferences gallery example away from the deprecated `method="map"` alias
- avoid AsLS `SparseEfficiencyWarning` noise visible in the published baseline-related gallery examples
- document the legitimate Renishaw mapping warning directly in the example text

## Why
A gallery-focused review of the published documentation found one real runtime failure and several avoidable example issues:
- the published NMR relaxation example failed on `fitter.predict()` with `ValueError: This dictionary is read-only`
- `plot_preferences.py` still demonstrated the deprecated `method="map"` alias
- the published baseline and Raman examples exposed `SparseEfficiencyWarning` from the AsLS solver path
- the Renishaw example emitted a legitimate mapping warning without explaining it in the surrounding narrative

## What changed
- `AnalysisConfigurable` now attaches a detached writable metadata copy to derived analysis outputs instead of updating an existing potentially read-only metadata object in place
- added a regression test covering `Optimize.predict()` and residual outputs when the fit source metadata is read-only
- converted the AsLS sparse system to CSC before `spsolve()` and added a regression test ensuring the covered path emits no `SparseEfficiencyWarning`
- replaced the deprecated contour-map alias usage in the gallery example with canonical contour terminology
- added an explanatory comment in the Renishaw example for the default scan-order assumption warning

## Validation
- `pre-commit run --all-files`
- `PYTHONPATH=/private/tmp/scpy-gallery-fixes/src:/private/tmp/scpy-gallery-fixes/plugins/spectrochempy-nmr/src ~/.local/bin/micromamba run -n scpy-core python -m pytest tests/test_analysis/test_curvefitting/test_optimize_provenance.py -q`
- `PYTHONPATH=/private/tmp/scpy-gallery-fixes/src:/private/tmp/scpy-gallery-fixes/plugins/spectrochempy-nmr/src ~/.local/bin/micromamba run -n scpy-core python -m pytest tests/test_analysis/test_baseline/test_baseline.py -q`
- `git diff --check`
