### PR TITLE
FIX: preserve title through elementwise ufuncs

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Elementwise ufunc results on ``NDDataset`` and ``NDArray`` now preserve the
+  source ``title``, consistent with Python arithmetic operators (``+``, ``-``,
+  ``*``, ``/``). Previously some ufunc paths replaced the title (for example
+  ``"<multiply>"``) or wrapped it (for example ``"sin(...)"``); this
+  operator/ufunc title divergence has been removed.
+
 - Derived analysis outputs now remain compatible with source datasets whose
   metadata contains read-only nested structures. In particular,
   ``Optimize.predict()`` and ``Optimize.result.residuals`` now attach detached

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,12 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- Elementwise ufunc results on ``NDDataset`` and ``NDArray`` now preserve the
+  source ``title``, consistent with Python arithmetic operators (``+``, ``-``,
+  ``*``, ``/``). Previously some ufunc paths replaced the title (for example
+  ``"<multiply>"``) or wrapped it (for example ``"sin(...)"``); this
+  operator/ufunc title divergence has been removed.
+
 - Derived analysis outputs now remain compatible with source datasets whose
   metadata contains read-only nested structures. In particular,
   ``Optimize.predict()`` and ``Optimize.result.residuals`` now attach detached

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -476,29 +476,6 @@ class NDMath:
         "gt",
     ]
     __complex_funcs = ["real", "imag", "absolute", "abs"]
-    __keep_title = [
-        "negative",
-        "absolute",
-        "abs",
-        "fabs",
-        "rint",
-        "floor",
-        "ceil",
-        "trunc",
-        "add",
-        "subtract",
-    ]
-    __remove_title = [
-        "multiply",
-        "divide",
-        "true_divide",
-        "floor_divide",
-        "mod",
-        "fmod",
-        "remainder",
-        "logaddexp",
-        "logaddexp2",
-    ]
     __remove_units = [
         "logical_not",
         "isfinite",
@@ -527,7 +504,6 @@ class NDMath:
             return NotImplemented
 
         fname = ufunc.__name__
-        from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 
         # set history string
         history = f"Ufunc {fname} applied."
@@ -537,17 +513,10 @@ class NDMath:
 
         # case of a dataset
         data, units, mask, returntype = self._op(ufunc, inputs, isufunc=True)
-        new = self._op_result(data, units, mask, history, returntype)
 
-        # make a new title depending on the operation
-        if fname in self.__remove_title:
-            new.title = f"<{fname}>"
-        elif fname not in self.__keep_title and isinstance(new, NDArray):
-            if hasattr(new, "title") and new.title is not None:
-                new.title = f"{fname}({new.title})"
-            else:
-                new.title = f"{fname}(data)"
-        return new
+        # Category A (preserve geometry) ufuncs preserve the source title;
+        # `_op_result` carries it over from the source dataset.
+        return self._op_result(data, units, mask, history, returntype)
 
     # ----------------------------------------------------------------------------------
     # public methods

--- a/tests/test_core/test_dataset/test_math_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_math_semantics_baseline.py
@@ -262,8 +262,8 @@ class TestDatasetScalarArithmetic:
         assert_masked_values(rich_dataset / 2.0, (0, 0))
 
     # ---- title behavior ----
-    # Current: ALL Python operators (+, -, *, /) preserve the title.
-    # Title overwriting only happens via __array_ufunc__ for ufunc paths.
+    # Category A arithmetic preserves the title for BOTH the operator path
+    # (+, -, *, /) and the elementwise ufunc path (np.add, np.multiply, ...).
 
     def test_add_title(self, rich_dataset):
         assert (rich_dataset + 2.0).title == "reference spectrum"
@@ -276,6 +276,12 @@ class TestDatasetScalarArithmetic:
 
     def test_truediv_title(self, rich_dataset):
         assert (rich_dataset / 2.0).title == "reference spectrum"
+
+    def test_mul_ufunc_title(self, rich_dataset):
+        assert np.multiply(rich_dataset, 2.0).title == "reference spectrum"
+
+    def test_add_ufunc_title(self, rich_dataset):
+        assert np.add(rich_dataset, 2.0).title == "reference spectrum"
 
     # ---- name behavior ----
 
@@ -492,12 +498,13 @@ class TestUfuncCharacterization:
     Characterize representative ufuncs on NDDataset.
 
     Selected operations:
-        abs    -- identity-preserving, in __keep_title
-        sqrt   -- domain changing, not in __keep_title
+        abs    -- identity-preserving
+        sqrt   -- domain changing
         exp    -- requires dimensionless units
         log    -- requires dimensionless units
         sin    -- requires radian units, returns dimensionless
 
+    Category A (preserve geometry) ufuncs preserve the source title.
     Each ufunc is tested with appropriate unit context.
     """
 
@@ -542,7 +549,7 @@ class TestUfuncCharacterization:
     def test_sqrt_title(self):
         ds = NDDataset([1.0, 4.0], title="test")
         result = np.sqrt(ds)
-        assert result.title == "sqrt(test)"
+        assert result.title == "test"
 
     def test_sqrt_name(self):
         ds = NDDataset([1.0, 4.0], name="myname")
@@ -591,7 +598,7 @@ class TestUfuncCharacterization:
     def test_sin_title(self):
         ds = NDDataset([0.0, 1.0], title="angle", units="radian")
         result = np.sin(ds)
-        assert result.title == "sin(angle)"
+        assert result.title == "angle"
 
     def test_sin_name(self):
         ds = NDDataset([0.0, 1.0], name="angle_data", units="radian")
@@ -857,11 +864,11 @@ class TestEmptyDatasetBehavior:
 #    intersecting at the given index.  This differs from numpy's per-element
 #    masked array behavior and is the current spectroscopy-oriented policy.
 #
-# 2. Title is preserved for ALL Python operators (+, -, *, /) on NDDataset.
-#    The __remove_title list (multiply, divide, etc.) only affects operations
-#    routed through __array_ufunc__ (e.g. np.multiply()), not through Python
-#    operators (__mul__, __truediv__).  This is a split between operator and
-#    ufunc title behavior.
+# 2. Title is preserved for ALL elementwise arithmetic, both through Python
+#    operators (+, -, *, /) and through elementwise ufuncs (np.multiply,
+#    np.sin, np.sqrt, ...).  The ufunc path previously replaced the title
+#    (e.g. "<multiply>") or wrapped it (e.g. "sin(...)") for some operations;
+#    this divergence from the operator path was removed (G1).
 #
 # 3. History messages differ by operation path:
 #    - Binary operators: "Binary operation {name} with `{other}` ..."

--- a/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
@@ -167,11 +167,11 @@ class TestSingleSourceTransformations:
         result = np.sin(np.exp(ds1))
         assert len(result.history) == len(ds1.history) + 2
 
-    def test_ufunc_title_wrapping(self, ds1):
-        """Ufuncs not in __keep_title wrap the title."""
+    def test_ufunc_preserves_title(self, ds1):
+        """Ufuncs preserve the source title (Category A semantics)."""
         ds1.title = "test data"
         result = np.sin(ds1)
-        assert result.title == "sin(test data)"
+        assert result.title == "test data"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Elementwise ufunc results on `NDDataset` / `NDArray` now preserve the source `title`, consistent with Python arithmetic operators (`+`, `-`, `*`, `/`).

Previously `__array_ufunc__` in `ndmath.py` mutated the title:
- binary ufuncs in the `__remove_title` list replaced it (`np.multiply(ds, 2)` → `"<multiply>"`),
- other ufuncs wrapped it in parentheses (`np.sin(ds)` → `"sin(My title)"`).

This diverged from the operator path, which always preserved the title. The accepted Metadata Contract v1 (Category A, `title: preserve`) makes the operator behavior normative, so the ufunc path is now aligned by relying on the existing `_op_result` copy instead of rewriting the title.

## Changes

- `src/spectrochempy/core/dataset/arraymixins/ndmath.py`: remove the `__keep_title` / `__remove_title` lists and the title mutation block in `__array_ufunc__`; the result now inherits the source title via `_op_result`.
- Tests updated/added in `test_math_semantics_baseline.py` (`test_sqrt_title`, `test_sin_title`, new `test_mul_ufunc_title`, `test_add_ufunc_title`, characterization docstring and STEP 8 note) and `test_history_semantics_baseline.py` (`test_ufunc_preserves_title`).
- Changelog entry (Bug Fixes) added; `latest.rst` regenerated via the standard workflow.

## Validation

- 212 passed (`test_math_semantics_baseline.py` + `test_history_semantics_baseline.py`), 260 passed (`test_ndmath.py` + `test_dataset_math.py`), 5 passed (`test_dataset_complex.py`).
- Probes: `np.multiply`/`np.true_divide`/`np.add`/`np.subtract`/`np.sin`/`np.sqrt`/`np.exp`/`np.negative`/`np.abs`, Python operators, and reflected ops (`2.0 * ds`, `2.0 / ds`) all preserve the title; non-`__call__` ufunc methods are still rejected.
- `pre-commit run --all-files` passes.