### PR TITLE
DOC: tune baseline gallery comparison parameters

### DIFF
--- a/docs/sources/userguide/processing/baseline.py
+++ b/docs/sources/userguide/processing/baseline.py
@@ -220,8 +220,8 @@ _ = blc.plot()
 
 # %%
 blc.model = "asls"
-blc.lamb = 10**9
-blc.asymmetry = 0.002
+blc.lamb = 3 * 10**8
+blc.asymmetry = 0.001
 _ = blc.fit(X)
 X6 = blc.transform()
 _ = X6.plot()
@@ -233,7 +233,7 @@ _ = X6.plot()
 
 # %%
 blc.model = "snip"
-blc.snip_width = 200
+blc.snip_width = 180
 _ = blc.fit(X)
 X7 = blc.transform()
 _ = X7.plot()

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -127,12 +127,14 @@ _ = corrected.plot()
 # Try the AsLS model
 # -------------------
 # The Asymmetric Least Squares model (Eilers and Boelens, 2005) offers
-# a different trade-off. The ``mu`` parameter controls smoothness and
-# ``asymmetry`` controls the weighting.
+# a different trade-off. The ``lamb`` parameter controls smoothness and
+# ``asymmetry`` controls the weighting. Here we use a stiffer baseline and a
+# lower asymmetry than the original gallery values so the result stays closer
+# to the multivariate polynomial reference.
 blc.multivariate = False
 blc.model = "asls"
-blc.mu = 10**9
-blc.asymmetry = 0.002
+blc.lamb = 3 * 10**8
+blc.asymmetry = 0.001
 _ = blc.fit(ndp)
 
 # %%
@@ -155,10 +157,11 @@ _ = corrected.plot()
 # %%
 # Try the SNIP model
 # -------------------
-# The Statistics-sensitive Non-linear Iterative Peak-clipping method:
+# The Statistics-sensitive Non-linear Iterative Peak-clipping method. A slightly
+# narrower window follows the polynomial reference more closely on this dataset.
 blc.multivariate = False
 blc.model = "snip"
-blc.snip_width = 200
+blc.snip_width = 180
 _ = blc.fit(ndp)
 
 # %%


### PR DESCRIPTION
## Summary

Tune the baseline gallery comparison example so the sequential AsLS and SNIP demonstrations better track the multivariate polynomial reference on `nh4y-activation.spg`.

## What changed

- switch the gallery AsLS example from `mu` to the actual `lamb` Baseline parameter
- tune the gallery AsLS settings to `lamb = 3 * 10**8` and `asymmetry = 0.001`
- tune the gallery and user-guide SNIP setting to `snip_width = 180`
- clarify in the example comments why these values were chosen for this dataset

## Why

The current gallery comparison makes AsLS look much worse than expected for this dataset. On inspection, the example assigns `blc.mu`, while the public `Baseline` API exposes `lamb`, so the smoothing setting used in the example was not aligned with the documented parameter. Tightening the documented settings also makes the comparison with the multivariate polynomial baseline more representative.

## Validation

- ran a targeted `scpy-core` sanity check on representative spectra from `nh4y-activation.spg`
- verified sequential AsLS with `lamb = 3 * 10**8`, `asymmetry = 0.001`
- verified sequential SNIP with `snip_width = 180`

## Notes

- branch name uses the `docs/` prefix so the repository's GitHub Pages branch-preview workflow can publish generated docs for this PR