### PR TITLE
FIX: unify arithmetic title semantics under a shared rule engine

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,18 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Elementwise arithmetic on ``NDDataset``/``NDArray`` now follows a single
+  shared title rule engine, making Python operators and their ``numpy`` ufunc
+  counterparts produce identical titles. Identity-preserving operations
+  (``abs``, ``negative``, ``positive``, rounding, ...) and dataset-scalar
+  additive or dimensionless-scaling operations keep the source ``title``
+  verbatim; unary transforms compose it (``sin(source)``, ``sqrt(source)``);
+  dataset-dataset operations compose ``add(...)``/``subtract(...)``/
+  ``multiply(...)``/``divide(...)``; powers compose ``power(source, p)``. The
+  previous ``"<fname>"`` substitution and the operator/ufunc title divergence
+  have been removed, and composed titles longer than 120 code points collapse
+  to an absent title.
+
 - Derived analysis outputs now remain compatible with source datasets whose
   metadata contains read-only nested structures. In particular,
   ``Optimize.predict()`` and ``Optimize.result.residuals`` now attach detached

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -27,16 +27,19 @@ Bug Fixes
 .. Add here new bug fixes (do not delete this comment)
 
 - Elementwise arithmetic on ``NDDataset``/``NDArray`` now follows a single
-  shared title rule engine, making Python operators and their ``numpy`` ufunc
-  counterparts produce identical titles. Identity-preserving operations
-  (``abs``, ``negative``, ``positive``, rounding, ...) and dataset-scalar
-  additive or dimensionless-scaling operations keep the source ``title``
-  verbatim; unary transforms compose it (``sin(source)``, ``sqrt(source)``);
-  dataset-dataset operations compose ``add(...)``/``subtract(...)``/
-  ``multiply(...)``/``divide(...)``; powers compose ``power(source, p)``. The
-  previous ``"<fname>"`` substitution and the operator/ufunc title divergence
-  have been removed, and composed titles longer than 120 code points collapse
-  to an absent title.
+  shared title rule engine, making Python operators, their in-place variants
+  and their ``numpy`` ufunc counterparts produce identical titles.
+  Identity-preserving operations (``abs``, ``negative``, ``positive``,
+  rounding, ...) and dataset-scalar additive or dimensionless-scaling
+  operations keep the source ``title`` verbatim; unary transforms compose it
+  (``sin(source)``, ``sqrt(source)``); dataset-dataset operations compose
+  ``add(...)``/``subtract(...)``/``multiply(...)``/``divide(...)``; powers
+  compose ``power(source, p)``. Operations outside this table yield an absent
+  title instead of a fabricated or silently preserved one, the previous
+  ``"<fname>"`` substitution and the operator/ufunc title divergence have
+  been removed, and composed titles longer than 120 code points collapse to
+  an absent title. Reflected powers such as ``2.0 ** ds`` no longer mutate
+  the source dataset.
 
 - Derived analysis outputs now remain compatible with source datasets whose
   metadata contains read-only nested structures. In particular,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -16,16 +16,19 @@ Bug Fixes
 ~~~~~~~~~
 
 - Elementwise arithmetic on ``NDDataset``/``NDArray`` now follows a single
-  shared title rule engine, making Python operators and their ``numpy`` ufunc
-  counterparts produce identical titles. Identity-preserving operations
-  (``abs``, ``negative``, ``positive``, rounding, ...) and dataset-scalar
-  additive or dimensionless-scaling operations keep the source ``title``
-  verbatim; unary transforms compose it (``sin(source)``, ``sqrt(source)``);
-  dataset-dataset operations compose ``add(...)``/``subtract(...)``/
-  ``multiply(...)``/``divide(...)``; powers compose ``power(source, p)``. The
-  previous ``"<fname>"`` substitution and the operator/ufunc title divergence
-  have been removed, and composed titles longer than 120 code points collapse
-  to an absent title.
+  shared title rule engine, making Python operators, their in-place variants
+  and their ``numpy`` ufunc counterparts produce identical titles.
+  Identity-preserving operations (``abs``, ``negative``, ``positive``,
+  rounding, ...) and dataset-scalar additive or dimensionless-scaling
+  operations keep the source ``title`` verbatim; unary transforms compose it
+  (``sin(source)``, ``sqrt(source)``); dataset-dataset operations compose
+  ``add(...)``/``subtract(...)``/``multiply(...)``/``divide(...)``; powers
+  compose ``power(source, p)``. Operations outside this table yield an absent
+  title instead of a fabricated or silently preserved one, the previous
+  ``"<fname>"`` substitution and the operator/ufunc title divergence have
+  been removed, and composed titles longer than 120 code points collapse to
+  an absent title. Reflected powers such as ``2.0 ** ds`` no longer mutate
+  the source dataset.
 
 - Derived analysis outputs now remain compatible with source datasets whose
   metadata contains read-only nested structures. In particular,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,18 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Bug Fixes
 ~~~~~~~~~
 
+- Elementwise arithmetic on ``NDDataset``/``NDArray`` now follows a single
+  shared title rule engine, making Python operators and their ``numpy`` ufunc
+  counterparts produce identical titles. Identity-preserving operations
+  (``abs``, ``negative``, ``positive``, rounding, ...) and dataset-scalar
+  additive or dimensionless-scaling operations keep the source ``title``
+  verbatim; unary transforms compose it (``sin(source)``, ``sqrt(source)``);
+  dataset-dataset operations compose ``add(...)``/``subtract(...)``/
+  ``multiply(...)``/``divide(...)``; powers compose ``power(source, p)``. The
+  previous ``"<fname>"`` substitution and the operator/ufunc title divergence
+  have been removed, and composed titles longer than 120 code points collapse
+  to an absent title.
+
 - Derived analysis outputs now remain compatible with source datasets whose
   metadata contains read-only nested structures. In particular,
   ``Optimize.predict()`` and ``Optimize.result.residuals`` now attach detached

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -217,6 +217,246 @@ def _get_name(x):
     return str(x.name if hasattr(x, "name") else x)
 
 
+# --------------------------------------------------------------------------------------
+# Arithmetic title semantics
+#
+# Single shared rule engine implementing the accepted arithmetic-title-semantics
+# policy (families T1/T1b/T2/T3/T4/T5):
+#   - T1/T1b identity-preserving operations keep the source title verbatim;
+#   - T2/T3 unary transforms compose ``opname(source)``;
+#   - T4 dataset<->scalar additive and dimensionless-scaling operations keep the
+#     source title verbatim; ``ds ** p`` composes ``power(source, canon(p))``;
+#   - T5 dataset-dataset additive keeps identical titles and composes different
+#     ones; product/ratio always compose ``opname(left, right)``;
+#   - scalar operands entering a composition use the canonical scalar formatter;
+#   - composed titles longer than the limit collapse to an absent title.
+# Operators and ufuncs share this engine so both paths produce identical titles.
+# --------------------------------------------------------------------------------------
+
+# Max length (in Unicode code points) of a composed title (policy section 6).
+_TITLE_LIMIT = 120
+
+# T1/T1b: identity-preserving operations -- title preserved verbatim.
+_TITLE_PRESERVE = frozenset(
+    {
+        "negative",
+        "absolute",
+        "abs",
+        "fabs",
+        "positive",
+        "rint",
+        "floor",
+        "ceil",
+        "trunc",
+        "fix",
+    }
+)
+
+# T2/T3: domain-changing unary transforms -- compose ``opname(source)``.
+_TITLE_COMPOSE_UNARY = frozenset(
+    {
+        "square",
+        "sqrt",
+        "reciprocal",
+        "log",
+        "log2",
+        "log10",
+        "log1p",
+        "exp",
+        "exp2",
+        "expm1",
+        "sin",
+        "cos",
+        "tan",
+        "arcsin",
+        "arccos",
+        "arctan",
+        "sinh",
+        "cosh",
+        "tanh",
+        "arcsinh",
+        "arccosh",
+        "arctanh",
+    }
+)
+
+# T5 additive family (units-compatible operations behaving like add):
+# identical operand titles preserved, different ones composed, a scalar
+# operand keeps the dataset context verbatim (T4).
+_TITLE_ADDITIVE = frozenset(
+    {
+        "add",
+        "subtract",
+        "maximum",
+        "minimum",
+        "fmax",
+        "fmin",
+        "copysign",
+        "logaddexp",
+        "logaddexp2",
+    }
+)
+
+# T5 product/ratio family: compose ``opname(left, right)`` between datasets;
+# a scalar operand rescales and keeps the dataset context verbatim (T4).
+_TITLE_RATIO = frozenset(
+    {"multiply", "divide", "floor_divide", "remainder", "fmod"}
+)
+
+# ``power`` composes ``power(left, right)`` with both operands (T4/T5).
+_TITLE_POWER = "power"
+
+# Operator-name -> normalized ufunc-name mapping so that operators and ufuncs
+# produce the identical composed title (``ds ** 2`` == ``np.power(ds, 2)``).
+# ``np.true_divide`` and ``np.divide`` share the ufunc name ``divide``;
+# ``np.mod`` and ``np.remainder`` share the ufunc name ``remainder``.
+_TITLE_CANONICAL_NAME = {
+    "add": "add",
+    "sub": "subtract",
+    "mul": "multiply",
+    "truediv": "divide",
+    "floordiv": "floor_divide",
+    "mod": "remainder",
+    "pow": "power",
+    "neg": "negative",
+    "pos": "positive",
+    "abs": "absolute",
+}
+
+
+class _PreserveTitle:
+    """Sentinel returned by the title engine for "keep the source title verbatim"."""
+
+
+_TITLE_PRESERVE_SENTINEL = _PreserveTitle()
+
+
+def _canonical_scalar(value):
+    """
+    Canonical rendering of a scalar operand for composed titles (policy 5.5).
+
+    Returns ``None`` for scalar types that are out of norm for title composition.
+    """
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, bool):
+        value = int(value)
+    if isinstance(value, complex):
+        if value.imag == 0:
+            value = value.real
+        else:
+            return repr(value)
+    if isinstance(value, float):
+        if np.isfinite(value) and value.is_integer():
+            value = int(value)
+    if isinstance(value, (int, float, complex)):
+        return repr(value)
+    return None
+
+
+def _title_token(operand):
+    """Token describing how an operand enters title composition.
+
+    Absence is the stored state (``_title`` falsy or the ``"<untitled>"``
+    display default), not the display value returned by the ``title`` property.
+    """
+    if hasattr(operand, "_title"):
+        title = operand._title
+        if not title or title == "<untitled>":
+            return ("untitled",)
+        return ("title", title)
+    rendered = _canonical_scalar(operand)
+    if rendered is None:
+        return ("value",)
+    return ("scalar", rendered)
+
+
+def _title_grown(title):
+    """Apply the stateless growth rule: collapse to an absent title beyond the limit."""
+    if len(title) > _TITLE_LIMIT:
+        return None
+    return title
+
+
+def _title_additive(fname, tokens):
+    if len(tokens) < 2:
+        return None
+    left, right = tokens
+    # T4: additive with a scalar (or out-of-norm value) operand offsets/rescales.
+    if left[0] == "title" and right[0] in ("scalar", "value"):
+        return _TITLE_PRESERVE_SENTINEL
+    if right[0] == "title" and left[0] in ("scalar", "value"):
+        return _TITLE_PRESERVE_SENTINEL
+    # T5: dataset-dataset additive.
+    if left[0] != "title" or right[0] != "title":
+        return None
+    if left[1] == right[1]:
+        return _TITLE_PRESERVE_SENTINEL  # identical titles -> rescaling
+    return _title_grown(f"{fname}({left[1]}, {right[1]})")
+
+
+def _title_ratio(fname, tokens, reflected):
+    if len(tokens) < 2:
+        return None
+    left, right = tokens
+    if reflected:
+        # Reflected division (``s / ds``): compose with the scalar first.
+        if left[0] == "scalar" and right[0] == "title":
+            return _title_grown(f"{fname}({left[1]}, {right[1]})")
+        if left[0] == "title" and right[0] == "scalar":
+            return _title_grown(f"{fname}({left[1]}, {right[1]})")
+        return None
+    # T4: ratio with a scalar (or out-of-norm value) operand rescales.
+    if left[0] == "title" and right[0] in ("scalar", "value"):
+        return _TITLE_PRESERVE_SENTINEL
+    if right[0] == "title" and left[0] in ("scalar", "value"):
+        return _TITLE_PRESERVE_SENTINEL
+    # T5: dataset-dataset ratio always composes.
+    if left[0] != "title" or right[0] != "title":
+        return None
+    return _title_grown(f"{fname}({left[1]}, {right[1]})")
+
+
+def _title_for(fname, operands, reflected=False):
+    """
+    Compute the result title of an arithmetic operation.
+
+    Returns the new title, ``None`` when the result title is absent, or the
+    ``_TITLE_PRESERVE_SENTINEL`` when the source title must be kept verbatim.
+    """
+    fname = _TITLE_CANONICAL_NAME.get(fname, fname)
+
+    if fname in _TITLE_PRESERVE:
+        return _TITLE_PRESERVE_SENTINEL
+
+    tokens = [_title_token(op) for op in operands]
+
+    # T2/T3: unary composition ``opname(source)``.
+    if fname in _TITLE_COMPOSE_UNARY:
+        if tokens and tokens[0][0] == "title":
+            return _title_grown(f"{fname}({tokens[0][1]})")
+        return None
+
+    # T4/T5: ``power(left, right)`` with both operands.
+    if fname == _TITLE_POWER:
+        if (
+            len(tokens) >= 2
+            and tokens[0][0] in ("title", "scalar")
+            and tokens[1][0] in ("title", "scalar")
+        ):
+            return _title_grown(f"power({tokens[0][1]}, {tokens[1][1]})")
+        return None
+
+    if fname in _TITLE_ADDITIVE:
+        return _title_additive(fname, tokens)
+
+    if fname in _TITLE_RATIO:
+        return _title_ratio(fname, tokens, reflected)
+
+    # Unlisted operation: operator parity (preserve).
+    return _TITLE_PRESERVE_SENTINEL
+
+
 def _extract_ufuncs(strg):
     ufuncs = {}
     regex = r"^([a-z,0-9,_]*)\((x.*)\[.*]\)\W*(.*\.)$"
@@ -476,29 +716,6 @@ class NDMath:
         "gt",
     ]
     __complex_funcs = ["real", "imag", "absolute", "abs"]
-    __keep_title = [
-        "negative",
-        "absolute",
-        "abs",
-        "fabs",
-        "rint",
-        "floor",
-        "ceil",
-        "trunc",
-        "add",
-        "subtract",
-    ]
-    __remove_title = [
-        "multiply",
-        "divide",
-        "true_divide",
-        "floor_divide",
-        "mod",
-        "fmod",
-        "remainder",
-        "logaddexp",
-        "logaddexp2",
-    ]
     __remove_units = [
         "logical_not",
         "isfinite",
@@ -527,7 +744,6 @@ class NDMath:
             return NotImplemented
 
         fname = ufunc.__name__
-        from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 
         # set history string
         history = f"Ufunc {fname} applied."
@@ -536,18 +752,20 @@ class NDMath:
             return (getattr(np, fname))(inputs[0].masked_data)
 
         # case of a dataset
-        data, units, mask, returntype = self._op(ufunc, inputs, isufunc=True)
-        new = self._op_result(data, units, mask, history, returntype)
+        data, units, mask, returntype, reflected = self._op(ufunc, inputs, isufunc=True)
 
-        # make a new title depending on the operation
-        if fname in self.__remove_title:
-            new.title = f"<{fname}>"
-        elif fname not in self.__keep_title and isinstance(new, NDArray):
-            if hasattr(new, "title") and new.title is not None:
-                new.title = f"{fname}({new.title})"
-            else:
-                new.title = f"{fname}(data)"
-        return new
+        # The title is computed by the shared arithmetic-title-semantics engine
+        # (`_title_for`), identical for the operator and the ufunc paths.
+        return self._op_result(
+            data,
+            units,
+            mask,
+            history,
+            returntype,
+            fname=fname,
+            operands=inputs,
+            reflected=reflected,
+        )
 
     # ----------------------------------------------------------------------------------
     # public methods
@@ -3213,7 +3431,7 @@ class NDMath:
         inputs: Sequence[ArrayLike],
         isufunc: bool = False,
         reflected: bool = False,
-    ) -> tuple[np.ndarray, str | None, np.ndarray, str | None]:
+    ) -> tuple[np.ndarray, str | None, np.ndarray, str | None, bool]:
         # Achieve an operation f on the objs
 
         fname = f.__name__
@@ -3274,7 +3492,7 @@ class NDMath:
         )
 
         # return calculated data, units and mask
-        return data, units, mask, returntype
+        return data, units, mask, returntype, reflected
 
     @staticmethod
     def _unary_op(f):
@@ -3286,8 +3504,17 @@ class NDMath:
             else:
                 history = None
 
-            data, units, mask, returntype = self._op(f, [self])
-            return self._op_result(data, units, mask, history, returntype)
+            data, units, mask, returntype, reflected = self._op(f, [self])
+            return self._op_result(
+                data,
+                units,
+                mask,
+                history,
+                returntype,
+                fname=fname,
+                operands=[self],
+                reflected=reflected,
+            )
 
         return func
 
@@ -3335,8 +3562,10 @@ class NDMath:
         @functools.wraps(f)
         def func(self, other):
             fname = f.__name__
-            objs = [self, other] if not reflexive else [other, self]
-            fm, objs, reflected = self._check_order(fname, objs)
+            # Keep the operands in mathematical order for the title engine;
+            # `_check_order` may reorder them in place for computation.
+            operands = [self, other] if not reflexive else [other, self]
+            fm, objs, reflected = self._check_order(fname, list(operands))
 
             if hasattr(self, "history"):
                 history = (
@@ -3346,8 +3575,19 @@ class NDMath:
             else:
                 history = None
 
-            data, units, mask, returntype = self._op(fm, objs, reflected=reflected)
-            return self._op_result(data, units, mask, history, returntype)
+            data, units, mask, returntype, reflected = self._op(
+                fm, objs, reflected=reflected
+            )
+            return self._op_result(
+                data,
+                units,
+                mask,
+                history,
+                returntype,
+                fname=fname,
+                operands=operands,
+                reflected=reflected,
+            )
 
         return func
 
@@ -3363,7 +3603,9 @@ class NDMath:
             objs = [self, other]
             fm, objs, reflected = self._check_order(fname, objs)
 
-            data, units, mask, returntype = self._op(fm, objs, reflected=reflected)
+            data, units, mask, returntype, reflected = self._op(
+                fm, objs, reflected=reflected
+            )
             self._data = data
             self._units = units
             self._mask = mask
@@ -3372,7 +3614,17 @@ class NDMath:
 
         return func
 
-    def _op_result(self, data, units=None, mask=None, history=None, returntype=None):
+    def _op_result(
+        self,
+        data,
+        units=None,
+        mask=None,
+        history=None,
+        returntype=None,
+        fname=None,
+        operands=None,
+        reflected=False,
+    ):
         # make a new NDArray resulting of some operation
 
         new = self.copy()
@@ -3389,6 +3641,15 @@ class NDMath:
             new._mask = cpy.copy(mask)
         if history is not None and hasattr(new, "history"):
             new.history = history.strip()
+
+        # apply the arithmetic title semantics (shared engine for operators and
+        # ufuncs); the title is set to the composed form or to an absent state.
+        # Store the raw value because the ``title`` setter ignores falsy values,
+        # and an absent title is represented as ``_title = None``.
+        if fname is not None and operands:
+            title = _title_for(fname, operands, reflected)
+            if title is not _TITLE_PRESERVE_SENTINEL:
+                new._title = title
 
         # case when we want to return a simple masked ndarray
         if returntype == "masked_array":

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -229,8 +229,12 @@ def _get_name(x):
 #   - T5 dataset-dataset additive keeps identical titles and composes different
 #     ones; product/ratio always compose ``opname(left, right)``;
 #   - scalar operands entering a composition use the canonical scalar formatter;
-#   - composed titles longer than the limit collapse to an absent title.
+#   - composed titles longer than the limit collapse to an absent title;
+#   - any operation (or operand) outside the normed table yields an absent
+#     title: nothing is ever preserved or fabricated silently.
 # Operators and ufuncs share this engine so both paths produce identical titles.
+# The engine applies to NDDataset/NDArray results only; Coord title semantics
+# are governed elsewhere (CoordSet display default) and are left untouched.
 # --------------------------------------------------------------------------------------
 
 # Max length (in Unicode code points) of a composed title (policy section 6).
@@ -282,26 +286,13 @@ _TITLE_COMPOSE_UNARY = frozenset(
 
 # T5 additive family (units-compatible operations behaving like add):
 # identical operand titles preserved, different ones composed, a scalar
-# operand keeps the dataset context verbatim (T4).
-_TITLE_ADDITIVE = frozenset(
-    {
-        "add",
-        "subtract",
-        "maximum",
-        "minimum",
-        "fmax",
-        "fmin",
-        "copysign",
-        "logaddexp",
-        "logaddexp2",
-    }
-)
+# operand keeps the dataset context verbatim (T4). Normed to add/subtract.
+_TITLE_ADDITIVE = frozenset({"add", "subtract"})
 
 # T5 product/ratio family: compose ``opname(left, right)`` between datasets;
 # a scalar operand rescales and keeps the dataset context verbatim (T4).
-_TITLE_RATIO = frozenset(
-    {"multiply", "divide", "floor_divide", "remainder", "fmod"}
-)
+# Normed to multiply/divide only.
+_TITLE_RATIO = frozenset({"multiply", "divide"})
 
 # ``power`` composes ``power(left, right)`` with both operands (T4/T5).
 _TITLE_POWER = "power"
@@ -310,6 +301,7 @@ _TITLE_POWER = "power"
 # produce the identical composed title (``ds ** 2`` == ``np.power(ds, 2)``).
 # ``np.true_divide`` and ``np.divide`` share the ufunc name ``divide``;
 # ``np.mod`` and ``np.remainder`` share the ufunc name ``remainder``.
+# In-place operators map to their plain canonical names (``iadd`` -> ``add``).
 _TITLE_CANONICAL_NAME = {
     "add": "add",
     "sub": "subtract",
@@ -318,6 +310,12 @@ _TITLE_CANONICAL_NAME = {
     "floordiv": "floor_divide",
     "mod": "remainder",
     "pow": "power",
+    "iadd": "add",
+    "isub": "subtract",
+    "imul": "multiply",
+    "itruediv": "divide",
+    "ifloordiv": "floor_divide",
+    "ipow": "power",
     "neg": "negative",
     "pos": "positive",
     "abs": "absolute",
@@ -346,16 +344,16 @@ def _canonical_scalar(value):
             value = value.real
         else:
             return repr(value)
-    if isinstance(value, float):
-        if np.isfinite(value) and value.is_integer():
-            value = int(value)
+    if isinstance(value, float) and np.isfinite(value) and value.is_integer():
+        value = int(value)
     if isinstance(value, (int, float, complex)):
         return repr(value)
     return None
 
 
 def _title_token(operand):
-    """Token describing how an operand enters title composition.
+    """
+    Token describing how an operand enters title composition.
 
     Absence is the stored state (``_title`` falsy or the ``"<untitled>"``
     display default), not the display value returned by the ``title`` property.
@@ -382,7 +380,12 @@ def _title_additive(fname, tokens):
     if len(tokens) < 2:
         return None
     left, right = tokens
-    # T4: additive with a scalar (or out-of-norm value) operand offsets/rescales.
+    # T4: additive with a canonical scalar operand offsets/rescales the
+    # quantity and keeps the dataset context verbatim. Non-canonizable array
+    # operands ("value") are classified the same way: they contribute no
+    # quantity identity, so the titled operand's context is kept. This is an
+    # explicit out-of-RFC-scope classification (see PR #1534), matching the
+    # historical copy-first behavior; it is never applied to unlisted ops.
     if left[0] == "title" and right[0] in ("scalar", "value"):
         return _TITLE_PRESERVE_SENTINEL
     if right[0] == "title" and left[0] in ("scalar", "value"):
@@ -406,7 +409,8 @@ def _title_ratio(fname, tokens, reflected):
         if left[0] == "title" and right[0] == "scalar":
             return _title_grown(f"{fname}({left[1]}, {right[1]})")
         return None
-    # T4: ratio with a scalar (or out-of-norm value) operand rescales.
+    # T4: ratio with a canonical scalar rescales. Non-canonizable array
+    # operands ("value") are classified the same way (see _title_additive).
     if left[0] == "title" and right[0] in ("scalar", "value"):
         return _TITLE_PRESERVE_SENTINEL
     if right[0] == "title" and left[0] in ("scalar", "value"):
@@ -423,6 +427,8 @@ def _title_for(fname, operands, reflected=False):
 
     Returns the new title, ``None`` when the result title is absent, or the
     ``_TITLE_PRESERVE_SENTINEL`` when the source title must be kept verbatim.
+    Operations outside the normed table yield an absent title (``None``):
+    nothing is preserved or fabricated silently.
     """
     fname = _TITLE_CANONICAL_NAME.get(fname, fname)
 
@@ -453,8 +459,8 @@ def _title_for(fname, operands, reflected=False):
     if fname in _TITLE_RATIO:
         return _title_ratio(fname, tokens, reflected)
 
-    # Unlisted operation: operator parity (preserve).
-    return _TITLE_PRESERVE_SENTINEL
+    # Unlisted operation: absent title (no silent preservation, no fabrication).
+    return None
 
 
 def _extract_ufuncs(strg):
@@ -3549,7 +3555,9 @@ class NDMath:
                 inputs[0] = np.negative(inputs[0])
             elif fname in ["pow"]:
                 fname = "exp"
-                inputs[0] *= np.log(inputs[1])
+                # rebind (not in-place ``*=``) so the source operand is never
+                # mutated: ``2 ** ds`` must not alter ``ds``.
+                inputs[0] = inputs[0] * np.log(inputs[1])
                 inputs = inputs[:1]
             else:
                 raise NotImplementedError
@@ -3610,6 +3618,14 @@ class NDMath:
             self._units = units
             self._mask = mask
 
+            # Apply the shared arithmetic title engine in place: same canonical
+            # names as the plain operators (``iadd`` -> ``add``, ``ipow`` ->
+            # ``power``, ...) so ``ds **= 2`` behaves like ``ds = ds ** 2``.
+            if returntype != "Coord":
+                title = _title_for(fname, [self, other], reflected)
+                if title is not _TITLE_PRESERVE_SENTINEL:
+                    self._title = title
+
             return self
 
         return func
@@ -3646,7 +3662,9 @@ class NDMath:
         # ufuncs); the title is set to the composed form or to an absent state.
         # Store the raw value because the ``title`` setter ignores falsy values,
         # and an absent title is represented as ``_title = None``.
-        if fname is not None and operands:
+        # Coord results are excluded: their title semantics are governed
+        # elsewhere (CoordSet display default), not by this policy.
+        if fname is not None and operands and returntype != "Coord":
             title = _title_for(fname, operands, reflected)
             if title is not _TITLE_PRESERVE_SENTINEL:
                 new._title = title

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -355,17 +355,21 @@ def _title_token(operand):
     """
     Token describing how an operand enters title composition.
 
+    Always a ``(kind, payload)`` tuple: ``("title", title)``,
+    ``("scalar", rendered)`` for canonical scalars, and ``("untitled", None)`` /
+    ``("value", None)`` when the operand carries no composed-able title.
+
     Absence is the stored state (``_title`` falsy or the ``"<untitled>"``
     display default), not the display value returned by the ``title`` property.
     """
     if hasattr(operand, "_title"):
         title = operand._title
         if not title or title == "<untitled>":
-            return ("untitled",)
+            return ("untitled", None)
         return ("title", title)
     rendered = _canonical_scalar(operand)
     if rendered is None:
-        return ("value",)
+        return ("value", None)
     return ("scalar", rendered)
 
 

--- a/tests/test_core/test_dataset/test_math_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_math_semantics_baseline.py
@@ -4,17 +4,20 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 """
-Characterization tests for mathematical semantics baseline.
+Characterization tests for mathematical semantics.
 
-This suite characterizes CURRENT behavior of identity-preserving operations
-on NDDataset.  It does NOT validate a desired future policy.
-
-Purpose: detect future changes, not enforce a preferred policy.
+This suite characterizes the mathematical semantics of NDDataset arithmetic
+and ufunc application.  Since the arithmetic-title-semantics policy has been
+accepted, the title assertions in STEP 8 validate the normative behavior of
+the policy (RFC sections 5.1, 5.5, 6 and 7); the rest of the suite
+characterizes current behavior to detect future changes.
 
 Coverage:
     - arithmetic (dataset +/-/*/ scalar)
     - arithmetic (dataset +/- dataset)
     - ufuncs (abs, sqrt, exp, log, sin)
+    - title semantics (identity-preserving, unary composition, dataset-scalar,
+      dataset-dataset, canonical scalars, growth rule, absent titles)
     - history behavior
     - CoordSet preservation
     - metadata, units, masks, title, name
@@ -384,7 +387,8 @@ class TestDatasetDatasetArithmetic:
         - Result units: first operand's units
         - CoordSet preserved from first operand
         - Metadata propagated from first operand
-        - Title preserved for add/sub
+        - Title follows T5: identical titles preserved, different titles
+          composed (``add(...)`` / ``subtract(...)``)
         - Name preserved from first operand
         - History appended with binary operation info
     """
@@ -416,10 +420,14 @@ class TestDatasetDatasetArithmetic:
         assert_dims_equal(rich_dataset - compatible_dataset, ["y", "x"])
 
     def test_add_title(self, rich_dataset, compatible_dataset):
-        assert (rich_dataset + compatible_dataset).title == "reference spectrum"
+        assert (rich_dataset + compatible_dataset).title == (
+            "add(reference spectrum, compatible spectrum)"
+        )
 
     def test_sub_title(self, rich_dataset, compatible_dataset):
-        assert (rich_dataset - compatible_dataset).title == "reference spectrum"
+        assert (rich_dataset - compatible_dataset).title == (
+            "subtract(reference spectrum, compatible spectrum)"
+        )
 
     def test_add_name(self, rich_dataset, compatible_dataset):
         assert (rich_dataset + compatible_dataset).name == "rich_dataset"
@@ -492,11 +500,11 @@ class TestUfuncCharacterization:
     Characterize representative ufuncs on NDDataset.
 
     Selected operations:
-        abs    -- identity-preserving, in __keep_title
-        sqrt   -- domain changing, not in __keep_title
+        abs    -- identity-preserving (T1), title kept verbatim
+        sqrt   -- domain changing (T2/T3), title composed
         exp    -- requires dimensionless units
         log    -- requires dimensionless units
-        sin    -- requires radian units, returns dimensionless
+        sin    -- domain changing (T2/T3), title composed
 
     Each ufunc is tested with appropriate unit context.
     """
@@ -848,7 +856,285 @@ class TestEmptyDatasetBehavior:
 
 
 # ======================================================================================
-# STEP 8: SURPRISING BEHAVIOR DOCUMENTATION
+# STEP 8: ARITHMETIC TITLE SEMANTICS
+# ======================================================================================
+#
+# The accepted arithmetic-title-semantics policy (RFC sections 5.1, 5.5, 6
+# and 7) is implemented by a single shared rule engine: operators and ufuncs
+# must produce identical titles.  These tests assert the normative families:
+#   T1/T1b  identity-preserving operations keep the title verbatim;
+#   T2/T3   unary transforms compose ``opname(source)``;
+#   T4      dataset<->scalar additive / dimensionless-scaling keep the title,
+#           powers compose ``power(source, canon(p))``, reflected division and
+#           reflected powers compose;
+#   T5      dataset-dataset additive composes different titles, products and
+#           ratios always compose;
+#   growth  composed titles beyond the 120-code-point limit collapse to an
+#           absent title (stored ``_title`` is ``None``).
+#
+
+
+class TestTitleIdentityPreserving:
+    """T1/T1b: identity-preserving operations keep the source title verbatim."""
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            np.negative,
+            np.positive,
+            np.absolute,
+            np.abs,
+            np.fabs,
+            np.rint,
+            np.floor,
+            np.ceil,
+            np.trunc,
+        ],
+    )
+    def test_ufunc_keeps_title(self, op):
+        ds = NDDataset([1.5, -2.5], units="m", title="alpha")
+        assert op(ds).title == "alpha"
+
+    def test_unary_operators_keep_title(self):
+        ds = NDDataset([1.5, -2.5], units="m", title="alpha")
+        assert (+ds).title == "alpha"
+        assert (-ds).title == "alpha"
+        assert abs(ds).title == "alpha"
+
+
+class TestTitleUnaryComposition:
+    """T2/T3: domain-changing unary transforms compose ``opname(source)``."""
+
+    @pytest.mark.parametrize(
+        "op, expected",
+        [
+            (np.square, "square(alpha)"),
+            (np.sqrt, "sqrt(alpha)"),
+            (np.reciprocal, "reciprocal(alpha)"),
+            (np.exp, "exp(alpha)"),
+            (np.exp2, "exp2(alpha)"),
+            (np.expm1, "expm1(alpha)"),
+            (np.log, "log(alpha)"),
+            (np.log2, "log2(alpha)"),
+            (np.log10, "log10(alpha)"),
+            (np.log1p, "log1p(alpha)"),
+            (np.sin, "sin(alpha)"),
+            (np.cos, "cos(alpha)"),
+            (np.tan, "tan(alpha)"),
+            (np.arcsin, "arcsin(alpha)"),
+            (np.arccos, "arccos(alpha)"),
+            (np.arctan, "arctan(alpha)"),
+            (np.sinh, "sinh(alpha)"),
+            (np.cosh, "cosh(alpha)"),
+            (np.tanh, "tanh(alpha)"),
+            (np.arcsinh, "arcsinh(alpha)"),
+            (np.arccosh, "arccosh(alpha)"),
+            (np.arctanh, "arctanh(alpha)"),
+        ],
+    )
+    def test_ufunc_composes_title(self, op, expected):
+        ds = NDDataset([0.5], units="dimensionless", title="alpha")
+        assert op(ds).title == expected
+
+
+class TestTitleDatasetScalar:
+    """T4: dataset<->scalar additive and dimensionless-scaling keep the title."""
+
+    def test_ufuncs_with_scalar_keep_title(self):
+        ds = NDDataset([1.0, 2.0], units="absorbance", title="alpha")
+        assert np.add(ds, 2.0).title == "alpha"
+        assert np.subtract(ds, 2.0).title == "alpha"
+        assert np.multiply(ds, 2.0).title == "alpha"
+        assert np.true_divide(ds, 2.0).title == "alpha"
+        assert np.maximum(ds, 2.0).title == "alpha"
+        assert np.minimum(ds, 2.0).title == "alpha"
+
+    def test_power_composes_canonical_scalar(self):
+        ds = NDDataset([1.0, 2.0], units="absorbance", title="alpha")
+        assert (ds ** 2).title == "power(alpha, 2)"
+        assert (ds ** 2.0).title == "power(alpha, 2)"
+        assert np.power(ds, 2).title == "power(alpha, 2)"
+
+    def test_reflected_division_composes(self):
+        ds = NDDataset([1.0, 2.0], units="absorbance", title="alpha")
+        assert (2.0 / ds).title == "divide(2, alpha)"
+        assert np.true_divide(2.0, ds).title == "divide(2, alpha)"
+
+    def test_reflected_power_composes(self):
+        ds = NDDataset([1.0, 2.0], units="absorbance", title="alpha")
+        assert (2.0 ** ds).title == "power(2, alpha)"
+
+
+class TestTitleDatasetDataset:
+    """T5: additive composes different titles, products/ratios always compose."""
+
+    def test_identical_titles_kept(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="alpha")
+        assert (a + b).title == "alpha"
+        assert (a - b).title == "alpha"
+
+    def test_add_composes(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a + b).title == "add(alpha, beta)"
+        assert np.add(a, b).title == "add(alpha, beta)"
+
+    def test_subtract_composes(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a - b).title == "subtract(alpha, beta)"
+        assert np.subtract(a, b).title == "subtract(alpha, beta)"
+
+    def test_multiply_composes(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a * b).title == "multiply(alpha, beta)"
+        assert np.multiply(a, b).title == "multiply(alpha, beta)"
+
+    def test_divide_composes(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a / b).title == "divide(alpha, beta)"
+        assert np.true_divide(a, b).title == "divide(alpha, beta)"
+
+    def test_floor_divide_composes(self):
+        a = NDDataset([4.0, 9.0], title="alpha")
+        b = NDDataset([2.0, 3.0], title="beta")
+        assert (a // b).title == "floor_divide(alpha, beta)"
+        assert np.floor_divide(a, b).title == "floor_divide(alpha, beta)"
+
+    def test_mod_composes(self):
+        a = NDDataset([4.0, 9.0], title="alpha")
+        b = NDDataset([2.0, 3.0], title="beta")
+        assert np.mod(a, b).title == "remainder(alpha, beta)"
+        assert np.remainder(a, b).title == "remainder(alpha, beta)"
+
+    def test_fmod_composes(self):
+        a = NDDataset([4.0, 9.0], title="alpha")
+        b = NDDataset([2.0, 3.0], title="beta")
+        assert np.fmod(a, b).title == "fmod(alpha, beta)"
+
+    def test_binary_ufuncs_compose(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert np.maximum(a, b).title == "maximum(alpha, beta)"
+        assert np.minimum(a, b).title == "minimum(alpha, beta)"
+        assert np.copysign(a, b).title == "copysign(alpha, beta)"
+        assert np.logaddexp(a, b).title == "logaddexp(alpha, beta)"
+
+
+class TestTitleOperatorUfuncParity:
+    """Operators and ufuncs share one engine: identical composed titles."""
+
+    def test_add_parity(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a + b).title == np.add(a, b).title
+
+    def test_subtract_parity(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a - b).title == np.subtract(a, b).title
+
+    def test_multiply_parity(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a * b).title == np.multiply(a, b).title == "multiply(alpha, beta)"
+
+    def test_divide_parity(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="beta")
+        assert (a / b).title == np.true_divide(a, b).title == "divide(alpha, beta)"
+
+    def test_reflected_divide_parity(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        assert (2.0 / a).title == np.true_divide(2.0, a).title == "divide(2, alpha)"
+
+    def test_power_parity(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** 2).title == np.power(ds, 2).title == "power(alpha, 2)"
+
+
+class TestTitleCanonicalScalars:
+    """Section 5.5: canonical scalar representation inside composed titles."""
+
+    def test_integral_float_rendered_as_int(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** np.float64(2.0)).title == "power(alpha, 2)"
+        assert (ds ** np.int64(2)).title == "power(alpha, 2)"
+
+    def test_fractional_float_kept(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** 2.5).title == "power(alpha, 2.5)"
+
+    def test_negative_exponent(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** -2).title == "power(alpha, -2)"
+
+    def test_negative_zero_rendered_as_zero(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** -0.0).title == "power(alpha, 0)"
+
+    def test_bool_rendered_as_int(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** np.bool_(True)).title == "power(alpha, 1)"
+
+    def test_complex_with_zero_imag(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** (2 + 0j)).title == "power(alpha, 2)"
+
+    def test_complex_kept(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds ** (2 + 3j)).title == "power(alpha, (2+3j))"
+
+    def test_non_finite(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert np.power(ds, np.nan).title == "power(alpha, nan)"
+        assert np.power(ds, np.inf).title == "power(alpha, inf)"
+
+    def test_scientific_notation(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert np.true_divide(1e-05, ds).title == "divide(1e-05, alpha)"
+
+
+class TestTitleGrowthAndAbsence:
+    """Section 6 (120-code-point limit) and absent-title rule (section 7)."""
+
+    def test_exact_limit_kept(self):
+        source = "x" * 115
+        ds = NDDataset([1.0], title=source)
+        result = np.sin(ds)
+        assert result.title == f"sin({source})"
+        assert len(result.title) == 120
+
+    def test_over_limit_collapses(self):
+        source = "x" * 116
+        ds = NDDataset([1.0], title=source)
+        result = np.sin(ds)
+        assert result._title is None
+        assert result.title == "<untitled>"
+
+    def test_chained_composition_collapses(self):
+        ds = NDDataset([0.5], title="x")
+        for _ in range(30):
+            ds = np.sin(ds)
+        assert ds._title is None
+
+    def test_untitled_source_absent(self):
+        ds = NDDataset([1.0, 2.0])
+        assert np.sqrt(ds)._title is None
+        assert np.sin(ds).title == "<untitled>"
+
+    def test_untitled_operand_absent(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0])
+        assert (a + b)._title is None
+        assert (a * b)._title is None
+
+
+# ======================================================================================
+# STEP 9: SURPRISING BEHAVIOR DOCUMENTATION
 # ======================================================================================
 #
 # Surprising behaviors discovered during characterization:
@@ -857,11 +1143,14 @@ class TestEmptyDatasetBehavior:
 #    intersecting at the given index.  This differs from numpy's per-element
 #    masked array behavior and is the current spectroscopy-oriented policy.
 #
-# 2. Title is preserved for ALL Python operators (+, -, *, /) on NDDataset.
-#    The __remove_title list (multiply, divide, etc.) only affects operations
-#    routed through __array_ufunc__ (e.g. np.multiply()), not through Python
-#    operators (__mul__, __truediv__).  This is a split between operator and
-#    ufunc title behavior.
+# 2. Title follows the accepted arithmetic-title-semantics policy through a
+#    single shared rule engine: operators and ufuncs produce identical titles.
+#    Identity-preserving operations (T1/T1b) and dataset-scalar additive and
+#    dimensionless-scaling operations (T4) keep the title verbatim; unary
+#    transforms compose ``opname(source)`` (T2/T3); dataset-dataset additive
+#    operations compose different titles (T5); products and ratios always
+#    compose.  Composed titles longer than 120 code points collapse to an
+#    absent title (stored ``_title`` is ``None``).
 #
 # 3. History messages differ by operation path:
 #    - Binary operators: "Binary operation {name} with `{other}` ..."

--- a/tests/test_core/test_dataset/test_math_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_math_semantics_baseline.py
@@ -1144,9 +1144,8 @@ class TestTitleOutOfNorm:
         assert np.conjugate(ds)._title is None
 
     def test_fix_preserves_title(self):
-        with pytest.warns(DeprecationWarning):
-            ds = NDDataset([1.0, 2.0], title="alpha")
-            assert np.fix(ds).title == "alpha"
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert np.fix(ds).title == "alpha"
 
     def test_floor_divide_scalar_absent(self):
         ds = NDDataset([1.0, 2.0], title="alpha")

--- a/tests/test_core/test_dataset/test_math_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_math_semantics_baseline.py
@@ -17,7 +17,8 @@ Coverage:
     - arithmetic (dataset +/- dataset)
     - ufuncs (abs, sqrt, exp, log, sin)
     - title semantics (identity-preserving, unary composition, dataset-scalar,
-      dataset-dataset, canonical scalars, growth rule, absent titles)
+      dataset-dataset, canonical scalars, growth rule, absent titles, in-place
+      operators, out-of-norm operations)
     - history behavior
     - CoordSet preservation
     - metadata, units, masks, title, name
@@ -946,13 +947,11 @@ class TestTitleDatasetScalar:
         assert np.subtract(ds, 2.0).title == "alpha"
         assert np.multiply(ds, 2.0).title == "alpha"
         assert np.true_divide(ds, 2.0).title == "alpha"
-        assert np.maximum(ds, 2.0).title == "alpha"
-        assert np.minimum(ds, 2.0).title == "alpha"
 
     def test_power_composes_canonical_scalar(self):
         ds = NDDataset([1.0, 2.0], units="absorbance", title="alpha")
-        assert (ds ** 2).title == "power(alpha, 2)"
-        assert (ds ** 2.0).title == "power(alpha, 2)"
+        assert (ds**2).title == "power(alpha, 2)"
+        assert (ds**2.0).title == "power(alpha, 2)"
         assert np.power(ds, 2).title == "power(alpha, 2)"
 
     def test_reflected_division_composes(self):
@@ -962,7 +961,7 @@ class TestTitleDatasetScalar:
 
     def test_reflected_power_composes(self):
         ds = NDDataset([1.0, 2.0], units="absorbance", title="alpha")
-        assert (2.0 ** ds).title == "power(2, alpha)"
+        assert (2.0**ds).title == "power(2, alpha)"
 
 
 class TestTitleDatasetDataset:
@@ -998,30 +997,33 @@ class TestTitleDatasetDataset:
         assert (a / b).title == "divide(alpha, beta)"
         assert np.true_divide(a, b).title == "divide(alpha, beta)"
 
-    def test_floor_divide_composes(self):
+    def test_floor_divide_absent(self):
         a = NDDataset([4.0, 9.0], title="alpha")
         b = NDDataset([2.0, 3.0], title="beta")
-        assert (a // b).title == "floor_divide(alpha, beta)"
-        assert np.floor_divide(a, b).title == "floor_divide(alpha, beta)"
+        assert (a // b)._title is None
+        assert np.floor_divide(a, b)._title is None
 
-    def test_mod_composes(self):
+    def test_mod_absent(self):
         a = NDDataset([4.0, 9.0], title="alpha")
         b = NDDataset([2.0, 3.0], title="beta")
-        assert np.mod(a, b).title == "remainder(alpha, beta)"
-        assert np.remainder(a, b).title == "remainder(alpha, beta)"
+        assert np.mod(a, b)._title is None
+        assert np.remainder(a, b)._title is None
 
-    def test_fmod_composes(self):
+    def test_fmod_absent(self):
         a = NDDataset([4.0, 9.0], title="alpha")
         b = NDDataset([2.0, 3.0], title="beta")
-        assert np.fmod(a, b).title == "fmod(alpha, beta)"
+        assert np.fmod(a, b)._title is None
 
-    def test_binary_ufuncs_compose(self):
+    def test_unlisted_binary_ufuncs_absent(self):
         a = NDDataset([1.0, 2.0], title="alpha")
         b = NDDataset([1.0, 2.0], title="beta")
-        assert np.maximum(a, b).title == "maximum(alpha, beta)"
-        assert np.minimum(a, b).title == "minimum(alpha, beta)"
-        assert np.copysign(a, b).title == "copysign(alpha, beta)"
-        assert np.logaddexp(a, b).title == "logaddexp(alpha, beta)"
+        assert np.maximum(a, b)._title is None
+        assert np.minimum(a, b)._title is None
+        assert np.fmax(a, b)._title is None
+        assert np.fmin(a, b)._title is None
+        assert np.copysign(a, b)._title is None
+        assert np.logaddexp(a, b)._title is None
+        assert np.logaddexp2(a, b)._title is None
 
 
 class TestTitleOperatorUfuncParity:
@@ -1053,7 +1055,7 @@ class TestTitleOperatorUfuncParity:
 
     def test_power_parity(self):
         ds = NDDataset([1.0, 2.0], title="alpha")
-        assert (ds ** 2).title == np.power(ds, 2).title == "power(alpha, 2)"
+        assert (ds**2).title == np.power(ds, 2).title == "power(alpha, 2)"
 
 
 class TestTitleCanonicalScalars:
@@ -1066,15 +1068,15 @@ class TestTitleCanonicalScalars:
 
     def test_fractional_float_kept(self):
         ds = NDDataset([1.0, 2.0], title="alpha")
-        assert (ds ** 2.5).title == "power(alpha, 2.5)"
+        assert (ds**2.5).title == "power(alpha, 2.5)"
 
     def test_negative_exponent(self):
         ds = NDDataset([1.0, 2.0], title="alpha")
-        assert (ds ** -2).title == "power(alpha, -2)"
+        assert (ds**-2).title == "power(alpha, -2)"
 
     def test_negative_zero_rendered_as_zero(self):
         ds = NDDataset([1.0, 2.0], title="alpha")
-        assert (ds ** -0.0).title == "power(alpha, 0)"
+        assert (ds**-0.0).title == "power(alpha, 0)"
 
     def test_bool_rendered_as_int(self):
         ds = NDDataset([1.0, 2.0], title="alpha")
@@ -1133,6 +1135,94 @@ class TestTitleGrowthAndAbsence:
         assert (a * b)._title is None
 
 
+class TestTitleOutOfNorm:
+    """Operations (or operands) outside the normed table yield an absent title."""
+
+    def test_unlisted_unary_ufunc_absent(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert np.cbrt(ds)._title is None
+        assert np.conjugate(ds)._title is None
+
+    def test_fix_preserves_title(self):
+        with pytest.warns(DeprecationWarning):
+            ds = NDDataset([1.0, 2.0], title="alpha")
+            assert np.fix(ds).title == "alpha"
+
+    def test_floor_divide_scalar_absent(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds // 2)._title is None
+        assert np.floor_divide(ds, 2)._title is None
+
+    def test_remainder_scalar_absent(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert np.remainder(ds, 2)._title is None
+
+    def test_maximum_minimum_scalar_absent(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert np.maximum(ds, 2.0)._title is None
+        assert np.minimum(ds, 2.0)._title is None
+
+    def test_array_operand_keeps_title(self):
+        # A non-canonizable array operand contributes no quantity identity and
+        # is classified like a T4 scalar: the titled operand's context is kept
+        # (explicit out-of-RFC-scope classification, PR #1534).
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        assert (ds * np.array([1.0, 2.0])).title == "alpha"
+        assert (ds + np.array([1.0, 2.0])).title == "alpha"
+        assert np.multiply(ds, np.array([1.0, 2.0])).title == "alpha"
+        assert np.add(ds, np.array([1.0, 2.0])).title == "alpha"
+
+
+class TestTitleInplaceOperations:
+    """In-place operators share the engine: ``ds **= 2`` == ``ds = ds ** 2``."""
+
+    def test_inplace_power_composes(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        ds **= 2
+        assert ds.title == "power(alpha, 2)"
+
+    def test_inplace_additive_keeps_title(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        ds += 2
+        assert ds.title == "alpha"
+        ds -= 1
+        assert ds.title == "alpha"
+
+    def test_inplace_ratio_keeps_title(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        ds *= 2
+        assert ds.title == "alpha"
+        ds /= 2
+        assert ds.title == "alpha"
+
+    def test_inplace_floor_divide_absent(self):
+        ds = NDDataset([1.0, 2.0], title="alpha")
+        ds //= 2
+        assert ds._title is None
+
+    def test_inplace_matches_operator(self):
+        a = NDDataset([1.0, 2.0], title="alpha")
+        b = NDDataset([1.0, 2.0], title="alpha")
+        b **= 2
+        assert b.title == (a**2).title
+
+
+class TestReflectedPowerNonMutation:
+    """Reflected power (``2 ** ds``) never mutates the source dataset."""
+
+    def test_source_not_mutated(self):
+        ds = NDDataset([2.0, 4.0, 8.0], title="alpha")
+        orig = ds.data.copy()
+        result = 2.0**ds
+        assert_array_equal(ds.data, orig)
+        assert result.title == "power(2, alpha)"
+
+    def test_result_computes_exp(self):
+        ds = NDDataset([1.0, 2.0, 3.0], title="alpha")
+        result = 2.0**ds
+        np.testing.assert_allclose(result.data, 2.0 ** np.array([1.0, 2.0, 3.0]))
+
+
 # ======================================================================================
 # STEP 9: SURPRISING BEHAVIOR DOCUMENTATION
 # ======================================================================================
@@ -1149,8 +1239,15 @@ class TestTitleGrowthAndAbsence:
 #    dimensionless-scaling operations (T4) keep the title verbatim; unary
 #    transforms compose ``opname(source)`` (T2/T3); dataset-dataset additive
 #    operations compose different titles (T5); products and ratios always
-#    compose.  Composed titles longer than 120 code points collapse to an
-#    absent title (stored ``_title`` is ``None``).
+#    compose.  Operations outside the normed table (maximum, floor_divide,
+#    cbrt, ...) yield an absent title (stored ``_title`` is ``None``); nothing
+#    is preserved or fabricated silently.  Composed titles longer than 120 code
+#    points also collapse to absent.  In-place operators share the engine
+#    through their canonical names (``ds **= 2`` == ``ds = ds ** 2``); Coord
+#    arithmetic is left to its own (CoordSet) title conventions.  A
+#    non-canonizable array operand (e.g. ``ds + np.array([...])``) is
+#    classified like a T4 scalar and keeps the titled operand's context; this
+#    is an explicit out-of-RFC-scope classification, not a silent default.
 #
 # 3. History messages differ by operation path:
 #    - Binary operators: "Binary operation {name} with `{other}` ..."

--- a/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_mixins/test_history_semantics_baseline.py
@@ -168,7 +168,7 @@ class TestSingleSourceTransformations:
         assert len(result.history) == len(ds1.history) + 2
 
     def test_ufunc_title_wrapping(self, ds1):
-        """Ufuncs not in __keep_title wrap the title."""
+        """Domain-changing ufuncs (T2/T3) compose the title ``opname(source)``."""
         ds1.title = "test data"
         result = np.sin(ds1)
         assert result.title == "sin(test data)"


### PR DESCRIPTION
Implements the accepted `arithmetic-title-semantics` policy (RFC, decisions D7/D10/D12) in the runtime: elementwise arithmetic on `NDDataset`/`NDArray` now follows a single shared title rule engine so Python operators, their in-place variants and their `numpy` ufunc counterparts produce identical titles.

## Summary

- **Shared engine** (`_title_for` in `ndmath.py`): operators and ufuncs route through the same rule table; the `__keep_title` / `__remove_title` lists and the `"<fname>"` substitution are removed.
- **T1/T1b** identity-preserving operations (`negative`, `positive`, `abs`, `fabs`, `rint`, `floor`, `ceil`, `trunc`, `fix`) keep the source title verbatim — `np.positive(ds)` no longer diverges from `+ds`.
- **T2/T3** unary transforms compose `opname(source)` (e.g. `sin(source)`, `sqrt(source)`).
- **T4** dataset↔scalar additive and dimensionless-scaling operations keep the title verbatim; powers compose `power(source, canon(p))`; reflected division composes `divide(canon(s), source)`; reflected powers compose `power(canon(s), source)`. Non-canonizable array operands (`ds + np.array([...])`) are classified like T4 scalars and keep the titled operand's context — an explicit, documented out-of-RFC-scope classification (see review round 2), never applied to unlisted operations.
- **T5** dataset-dataset additive operations keep identical titles and compose different ones (`add(...)`, `subtract(...)`); products/ratios always compose (`multiply(...)`, `divide(...)`).
- **In-place operators** (`ds **= 2`, `ds *= 2`, ...) share the engine through canonical names (`ipow` → `power`, `iadd` → `add`, ...) and now update the title like their plain counterparts.
- **Out-of-norm operations yield an absent title**: `maximum`, `minimum`, `fmax`, `fmin`, `copysign`, `logaddexp`, `logaddexp2`, `floor_divide`, `remainder`, `fmod`, `cbrt`, bitwise operators, ... are not silently preserved nor fabricated (review round 2: the engine previously fell back to "preserve" and applied T5 to ops outside the accepted table).
- **Canonical scalars** (§5.5): integral floats render as integers, booleans as `1`/`0`, zero-imaginary complex as real, `nan`/`inf` kept, scientific notation preserved (`divide(1e-05, alpha)`).
- **Growth rule** (§6): composed titles longer than 120 code points collapse to an absent title (stored `_title = None`; display falls back to `"<untitled>"`).
- **Absent titles** (§7): a composition that needs an absent operand title yields an absent result title — no `fname(data)` fabrication.
- **Coord results are excluded** from the engine: Coord title semantics are governed by CoordSet conventions, not this policy (fixes `test_coordset_arithmetics`).
- **Reflected powers** such as `2.0 ** ds` no longer mutate the source dataset (`_check_order` rebinds instead of `*=`).
- **Title tokens** (`_title_token`) always return a uniform `(kind, payload)` tuple (`"title"`, `"scalar"`, `"untitled"`/`"value"` carry a `None` payload) instead of mixing 1- and 2-element tuples (review round 3).
- Naming note: the composed name for division is the actual ufunc name `divide` (that of `np.true_divide`/`np.divide`), and `np.mod`/`np.remainder` compose as `remainder(...)`, consistent with the RFC's §5.2 "normalized NumPy ufunc name" rule.

## Out of scope

- History strings, name/author/meta propagation, units, masks and CoordSet handling are unchanged.
- `np.power(2.0, ds)` remains `NotImplementedError` (existing behavior).
- `pint` `Quantity` operands remain outside the composition norm (no new support).
- A normative classification of the out-of-norm operations above (and of the value-operand rule) is deferred to a future RFC amendment.
- API surface: no public symbols added or removed.

## Tests

- `test_math_semantics_baseline.py`: updated the two T5 dataset-dataset add/sub title assertions; added STEP 8 classes implementing the normative tables (§5.1/§5.5/§6/§7): identity-preserving, unary composition, dataset-scalar, dataset-dataset, operator/ufunc parity, canonical scalars, growth-limit, absence, out-of-norm absence, in-place operators and reflected-power non-mutation.
- `test_history_semantics_baseline.py`: refreshed the `test_ufunc_title_wrapping` docstring.
- Focused validation in `scpy-core`: math semantics + coordset 249, dataset math 8, plus history, ndmath, units/coords, combination/regressions, processing/projects and analysis suites — all green.
- CI on this branch is fully green: pre-commit and all five test matrices (ubuntu 3.11/3.14, macos, windows, core-only ubuntu 3.14).

Supersedes #1532.
