### PR TITLE
FIX: omit empty unit suffixes from plot labels

### DIFF
--- a/src/spectrochempy/utils/mplutils.py
+++ b/src/spectrochempy/utils/mplutils.py
@@ -312,22 +312,20 @@ def make_label(ss, lab="<no_axe_label>", use_mpl=True):
     if "<untitled>" in label:
         label = "values"
 
+    has_display_units = ss.units is not None and str(ss.units) not in [
+        "dimensionless",
+        "absolute_transmittance",
+    ]
+
     if use_mpl:
-        if ss.units is not None and str(ss.units) not in [
-            "dimensionless",
-            "absolute_transmittance",
-        ]:
+        if has_display_units:
             units = rf"/\ {ss.units:~L}"
             if pint_version < 24:
                 units = units.replace("%", r"\%")
-        else:
-            units = ""
-        label = rf"{label} $\mathrm{{{units}}}$"
+            label = rf"{label} $\mathrm{{{units}}}$"
     else:
-        if ss.units is not None and str(ss.units) != "dimensionless":
+        if has_display_units:
             units = rf"{ss.units:~H}"
-        else:
-            units = ""
-        label = rf"{label} / {units}"
+            label = rf"{label} / {units}"
 
     return label

--- a/tests/test_plotting/test_units_labeling.py
+++ b/tests/test_plotting/test_units_labeling.py
@@ -27,9 +27,9 @@ def assert_dataset_state_unchanged(dataset_before, dataset_after):
     new_keys = set(after_dict.keys()) - set(before_dict.keys())
     plotting_keys = new_keys - internal_attrs
 
-    assert (
-        not plotting_keys
-    ), f"Dataset mutated by plotting with new attributes: {plotting_keys}"
+    assert not plotting_keys, (
+        f"Dataset mutated by plotting with new attributes: {plotting_keys}"
+    )
     assert not hasattr(dataset_after, "fig")
     assert not hasattr(dataset_after, "ndaxes")
 
@@ -119,9 +119,9 @@ class TestUnitsLabeling:
         # Should not have unit suffixes
         assert "Position" in xlabel, "Should contain coordinate title"
         # Should not have things like "/dimensionless" or similar
-        assert (
-            "/dimensionless" not in xlabel
-        ), "Should not contain unit suffix for unitless"
+        assert "/dimensionless" not in xlabel, (
+            "Should not contain unit suffix for unitless"
+        )
 
         # Y-axis should have data title without unit suffix
         assert "Test Signal" in ylabel, "Should contain data title"
@@ -141,7 +141,11 @@ class TestUnitsLabeling:
         from spectrochempy import NDDataset
 
         x_coord = Coord(data=np.linspace(0, 10, 20), title="Position")
-        dataset = NDDataset(np.random.random(20), title="Apodization curve", coordset=[x_coord])
+        dataset = NDDataset(
+            np.random.random(20),
+            title="Apodization curve",
+            coordset=[x_coord],
+        )
 
         assert make_label(x_coord, "x") == "Position"
         assert make_label(dataset, "values") == "Apodization curve"

--- a/tests/test_plotting/test_units_labeling.py
+++ b/tests/test_plotting/test_units_labeling.py
@@ -27,9 +27,9 @@ def assert_dataset_state_unchanged(dataset_before, dataset_after):
     new_keys = set(after_dict.keys()) - set(before_dict.keys())
     plotting_keys = new_keys - internal_attrs
 
-    assert not plotting_keys, (
-        f"Dataset mutated by plotting with new attributes: {plotting_keys}"
-    )
+    assert (
+        not plotting_keys
+    ), f"Dataset mutated by plotting with new attributes: {plotting_keys}"
     assert not hasattr(dataset_after, "fig")
     assert not hasattr(dataset_after, "ndaxes")
 
@@ -119,9 +119,9 @@ class TestUnitsLabeling:
         # Should not have unit suffixes
         assert "Position" in xlabel, "Should contain coordinate title"
         # Should not have things like "/dimensionless" or similar
-        assert "/dimensionless" not in xlabel, (
-            "Should not contain unit suffix for unitless"
-        )
+        assert (
+            "/dimensionless" not in xlabel
+        ), "Should not contain unit suffix for unitless"
 
         # Y-axis should have data title without unit suffix
         assert "Test Signal" in ylabel, "Should contain data title"

--- a/tests/test_plotting/test_units_labeling.py
+++ b/tests/test_plotting/test_units_labeling.py
@@ -10,6 +10,8 @@ Tests automatic axis labeling from coordinates,
 unit formatting, and unitless coordinate handling.
 """
 
+from spectrochempy.utils.mplutils import make_label
+
 
 def assert_dataset_state_unchanged(dataset_before, dataset_after):
     """Verify dataset was not mutated by plotting."""
@@ -123,6 +125,25 @@ class TestUnitsLabeling:
 
         # Y-axis should have data title without unit suffix
         assert "Test Signal" in ylabel, "Should contain data title"
+        assert r"\mathrm{}" not in xlabel
+        assert r"\mathrm{}" not in ylabel
+        assert " / " not in xlabel
+        assert " / " not in ylabel
 
         # Verify dataset unchanged
         assert_dataset_state_unchanged(ds_before, dataset)
+
+    def test_make_label_omits_empty_unit_suffixes(self):
+        """Unitless labels should not include empty unit wrappers or slashes."""
+        import numpy as np
+
+        from spectrochempy import Coord
+        from spectrochempy import NDDataset
+
+        x_coord = Coord(data=np.linspace(0, 10, 20), title="Position")
+        dataset = NDDataset(np.random.random(20), title="Apodization curve", coordset=[x_coord])
+
+        assert make_label(x_coord, "x") == "Position"
+        assert make_label(dataset, "values") == "Apodization curve"
+        assert make_label(x_coord, "x", use_mpl=False) == "Position"
+        assert make_label(dataset, "values", use_mpl=False) == "Apodization curve"


### PR DESCRIPTION
## Summary

Fix plot axis labels for unitless datasets and coordinates so generated labels no longer carry an empty unit suffix.

## Problem

In the user-guide `apodization.py` example, some generated plot labels showed the title followed by an orphan separator when no unit existed. The issue was not apodization-specific: it came from the shared plotting label helper.

## Root cause

`make_label()` in `spectrochempy.utils.mplutils` always interpolated a unit wrapper into the final label template, even when there was no displayable unit. That produced labels such as:

- `Position $\\mathrm{}$`
- `values $\\mathrm{}$`
- `Position / ` in plain-text formatting

## What changed

- add a shared `has_display_units` guard in `make_label()`
- only append formatted unit suffixes when a displayable unit is actually present
- add regression coverage for unitless coordinates and datasets to ensure labels omit both empty `\\mathrm{}` wrappers and trailing ` / ` suffixes

## Validation

- `PYTHONPATH=/private/tmp/spectrochempy-apodization-label/src MPLCONFIGDIR=/private/tmp/mpl-scpy /Users/christian/micromamba/envs/scpy-core/bin/python -m pytest tests/test_plotting/test_units_labeling.py -q`
- direct reproduction of the `apodization.py` symptom after the fix confirmed the y-label now renders as `values`

## Impact

This is a localized plotting-label fix. Labels with actual units keep the existing formatting path; only unitless labels change.