### PR TITLE
DOC: suppress stray Matplotlib outputs in jupytext examples

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -613,7 +613,7 @@ components = f1.result.components
 # %%
 _ = ndOHcorr.plot()
 ax = (components[:]).plot(clear=False)
-ax.autoscale(enable=True, axis="y")
+_ = ax.autoscale(enable=True, axis="y")
 
 # %% [markdown]
 # `plot_merit()` overlays the experimental spectrum, the fitted profile, and the

--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -82,7 +82,7 @@ nd_oh_corr = scp.basc(
 )
 ax = nd_oh.plot(label="Synthetic spectrum")
 _ = nd_oh_corr.plot(clear=False, label="Baseline-corrected spectrum")
-ax.legend()
+_ = ax.legend()
 
 # %% [markdown]
 # ## Detect peaks and inspect the structured result
@@ -263,7 +263,7 @@ components = fit_result.components
 # %%
 _ = nd_oh_corr.plot()
 ax = components[:].plot(clear=False)
-ax.autoscale(enable=True, axis="y")
+_ = ax.autoscale(enable=True, axis="y")
 
 # %% [markdown]
 # `plot_merit()` overlays the corrected spectrum, the fitted profile, and the

--- a/docs/sources/userguide/analysis/pls.py
+++ b/docs/sources/userguide/analysis/pls.py
@@ -147,7 +147,7 @@ pls.plot_parity(
     label="validation",
     clear=False,
 )
-ax.legend(loc="lower right")
+_ = ax.legend(loc="lower right")
 
 # %% [markdown]
 # The goodness of fit (as expressed by R-squared) can also be obtained using the `score()` method. For the training dataset

--- a/docs/sources/userguide/plotting/advanced.py
+++ b/docs/sources/userguide/plotting/advanced.py
@@ -33,11 +33,11 @@ ds1 = ds[0]
 
 # %%
 ax = ds1.plot()
-ax.set_title(r"NH$_4$Y Activation - $\nu_{NH}$ Region")
-ax.set_xlabel(r"Wavenumber (cm$^{-1}$)")
-ax.set_ylabel("Absorbance (a.u.)")
-ax.set_xlim(3500, 2800)
-ax.annotate(
+_ = ax.set_title(r"NH$_4$Y Activation - $\nu_{NH}$ Region")
+_ = ax.set_xlabel(r"Wavenumber (cm$^{-1}$)")
+_ = ax.set_ylabel("Absorbance (a.u.)")
+_ = ax.set_xlim(3500, 2800)
+_ = ax.annotate(
     "NH stretch",
     xy=(3250, 0.6),
     xytext=(3400, 0.7),
@@ -84,9 +84,9 @@ _ = ds.plot_image(cmap="RdBu_r", norm=norm, colorbar=True)
 
 # %%
 ax = ds1.plot()
-ax.set_xlabel(r"$ \tilde{\nu}$ (cm$^{-1}$)")
-ax.set_ylabel(r"$ \epsilon$ (mol$^{-1}$·L·cm$^{-1}$)")
-ax.set_title(r"Beer-Lambert: $A = \epsilon c l$")
+_ = ax.set_xlabel(r"$ \tilde{\nu}$ (cm$^{-1}$)")
+_ = ax.set_ylabel(r"$ \epsilon$ (mol$^{-1}$·L·cm$^{-1}$)")
+_ = ax.set_title(r"Beer-Lambert: $A = \epsilon c l$")
 
 # %% [markdown]
 # ## Reproducibility

--- a/docs/sources/userguide/plotting/customization.py
+++ b/docs/sources/userguide/plotting/customization.py
@@ -107,9 +107,9 @@ _ = ds.plot(figsize=(10, 4))
 
 # %%
 ax = ds.plot()
-ax.set_title("NH4Y Activation Spectrum")
-ax.set_xlabel("Wavenumber (cm⁻¹)")
-ax.set_ylabel("Absorbance (a.u.)")
+_ = ax.set_title("NH4Y Activation Spectrum")
+_ = ax.set_xlabel("Wavenumber (cm⁻¹)")
+_ = ax.set_ylabel("Absorbance (a.u.)")
 
 # %% [markdown]
 # ## Grid

--- a/docs/sources/userguide/processing/baseline.py
+++ b/docs/sources/userguide/processing/baseline.py
@@ -383,7 +383,7 @@ R1 = R.detrend()
 _ = R.plot(label="original")
 _ = R1.plot(label="detrended", clear=False)
 ax = (R - R1).plot(label="trend", clear=False, cmap=None, color="red", ls=":")
-ax.legend(loc="upper left")
+_ = ax.legend(loc="upper left")
 _ = ax.set_ylim([-0.3, 0.8])
 
 # %% [markdown]

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
@@ -72,7 +72,7 @@ m = St.ptp()
 for i in range(St.shape[0]):
     St.data[i] -= i * m / 2
 ax = St.plot(title="Components", colormap=None, legend=St.k.labels)
-ax.set_yticks([])
+_ = ax.set_yticks([])
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -88,7 +88,7 @@ _ = pca.plot_score(color_mapping="labels")
 # The 3D score plot (first 3 PCs) shows that a third PC does not further
 # distinguish versicolor from virginica:
 ax = pca.plot_score(components=(1, 2, 3), color_mapping="labels")
-ax.view_init(10, 75)
+_ = ax.view_init(10, 75)
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_synthetic_profiles.py
@@ -40,7 +40,7 @@ profiles.title = "relative concentration"
 
 # %%
 ax = profiles.T.plot()
-ax.legend()
+_ = ax.legend()
 
 # %%
 # Use built-in Gaussian line-shape helper
@@ -60,4 +60,4 @@ profiles_gaussian.title = "relative concentration"
 
 # %%
 ax = profiles_gaussian.T.plot()
-ax.legend()
+_ = ax.legend()

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -80,7 +80,7 @@ if ds_list is not None:
         label="validation",
         clear=False,
     )
-    ax.legend(loc="lower right")
+    _ = ax.legend(loc="lower right")
 
 # %%
 # This ends the example ! The following line can be uncommented if no plot shows when

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -86,7 +86,7 @@ _ = f1.fit(ndOH)
 scp.info_(f"numbers of components: {f1.n_components}")
 _ = ndOH.plot()
 ax = (f1.components[:]).plot(clear=False)
-ax.autoscale(enable=True, axis="y")
+_ = ax.autoscale(enable=True, axis="y")
 
 # %%
 # Fit the model
@@ -98,7 +98,7 @@ _ = f1.fit(ndOH)
 # Show the result
 _ = ndOH.plot()
 ax = (f1.components[:]).plot(clear=False)
-ax.autoscale(enable=True, axis="y")
+_ = ax.autoscale(enable=True, axis="y")
 
 # %%
 # Evaluate the fit quality

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
@@ -45,7 +45,7 @@ _ = plt.plot(time, distance_fitted, ":r", label="Linear regression output")
 plt.xlabel("time / h")
 plt.ylabel("distance / km")
 plt.title(f"Linear regression, $R^2={rsquare:.3f}$")
-plt.legend()
+_ = plt.legend()
 
 # %%
 # Using NDDatasets as input (X and Y)

--- a/src/spectrochempy/examples/processing/filtering/plot_filter.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_filter.py
@@ -32,8 +32,8 @@ ax = Xm.plot(clear=False, color="r", ls="-", lw=1.5, label="SG filter")
 diff = X - Xm
 s = round(diff.std(dim=-1).values, 2)
 ax = diff.plot(clear=False, ls="-", lw=1, label=f"difference (std={s})")
-ax.legend(loc="best", fontsize=10)
-ax.set_title("Savitzky-Golay filter (size=7, order=2)")
+_ = ax.legend(loc="best", fontsize=10)
+_ = ax.set_title("Savitzky-Golay filter (size=7, order=2)")
 
 # %%
 # Whittaker-Eilers smoothing
@@ -45,5 +45,5 @@ ax = Xm.plot(clear=False, color="r", ls="-", lw=1.5, label="WE filter")
 diff = X - Xm
 s = round(diff.std(dim=-1).values, 2)
 ax = diff.plot(clear=False, ls="-", lw=1, label=f"difference (std={s})")
-ax.legend(loc="best", fontsize=10)
-ax.set_title("Whittaker-Eiler filter (order=2, lamb=1.5)")
+_ = ax.legend(loc="best", fontsize=10)
+_ = ax.set_title("Whittaker-Eiler filter (order=2, lamb=1.5)")


### PR DESCRIPTION
## Summary

Suppress stray Matplotlib return-value outputs in jupytext-backed examples and user-guide pages when those return values are not intentionally used.

## Problem

Some examples and user-guide notebook cells ended with bare calls such as `ax.legend(...)`, which caused rendered notebook/docs output to show parasitic objects like `Legend(...)`. The same pattern also appeared with other Matplotlib methods that return non-rich objects, such as titles, labels, annotations, tick lists, or autoscale/view calls.

## What changed

- replace bare ignored `ax.legend(...)` / `plt.legend()` calls with `_ = ...`
- extend the cleanup to similar top-level `ax.<method>(...)` calls in jupytext cells where the return value is not reused and would only create noisy output
- keep untouched the cases inside helper function definitions or non-terminal notebook-cell contexts where no parasitic rendered output is produced

## Scope

Touched files include examples and user-guide sources in:

- filtering
- decomposition and PLS examples
- curve-fitting examples
- plotting customization/advanced pages
- fitting / PLS / baseline / peak-analysis user-guide pages

## Validation

- ran `pre-commit run --all-files` before the final push
- result: all hooks passed, including `ruff` and `ruff-format`
- re-scanned `docs/sources` and `src/spectrochempy/examples` to review remaining bare `ax.<method>(...)` sites and keep only the harmless/non-terminal cases unchanged

## Risk

Low risk: this only suppresses notebook cell outputs and does not alter plotted content or analysis behavior.