### PR TITLE
FIX: preserve PLS coef target coordinates

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -60,6 +60,11 @@ Bug Fixes
   actually optimized. The canonical model spec is now the sole source of truth
   after a fit.
 
+- ``PLSRegression.coef`` no longer fails when the fitted multivariate target
+  dataset carries both an observation coordinate and a target-variable
+  coordinate. The coefficient wrapper now preserves the target-axis coordinate
+  instead of attaching the observation axis to the result.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -49,6 +49,11 @@ Bug Fixes
   actually optimized. The canonical model spec is now the sole source of truth
   after a fit.
 
+- ``PLSRegression.coef`` no longer fails when the fitted multivariate target
+  dataset carries both an observation coordinate and a target-variable
+  coordinate. The coefficient wrapper now preserves the target-axis coordinate
+  instead of attaching the observation axis to the result.
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/crossdecomposition/pls.py
+++ b/src/spectrochempy/analysis/crossdecomposition/pls.py
@@ -274,7 +274,9 @@ class PLSRegression(CrossDecompositionAnalysis):
         coef = NDDataset(self._coef)
         coef.dims = ["x", "y"]
         try:
-            y_coord = self._Y.y
+            y_coord = None
+            if self._Y.coordset is not None and self._Y.ndim > 1:
+                y_coord = self._Y.coordset[self._Y.dims[-1]].copy()
         except (AttributeError, IndexError, TypeError):
             y_coord = None
         coef.set_coordset(

--- a/tests/test_analysis/test_crossdecomposition/test_pls_result.py
+++ b/tests/test_analysis/test_crossdecomposition/test_pls_result.py
@@ -201,6 +201,39 @@ class TestPLSRegressionResult:
     def test_coef_is_nddataset(self, pls_fitted):
         assert hasattr(pls_fitted.coef, "shape")
 
+    def test_coef_uses_target_coordinate_when_y_has_observation_axis(self):
+        import spectrochempy as scp
+
+        rng = np.random.default_rng(0)
+        X = scp.NDDataset(
+            rng.normal(size=(8, 5)),
+            coordset=[
+                scp.Coord(np.arange(8), title="samples"),
+                scp.Coord(np.linspace(1000.0, 2000.0, 5), title="wavelength"),
+            ],
+        )
+        Y = scp.NDDataset(
+            rng.normal(size=(8, 2)),
+            coordset=[
+                scp.Coord(np.arange(8), title="observations"),
+                scp.Coord([10, 20], title="targets", labels=["a", "b"]),
+            ],
+        )
+
+        pls = PLSRegression(n_components=2)
+        pls.fit(X, Y)
+
+        coef = pls.coef
+        assert coef.shape == (5, 2)
+        assert coef.x.size == 5
+        assert coef.y.size == 2
+        assert coef.y.title == "targets"
+        assert list(coef.y.labels) == ["a", "b"]
+        assert_allclose(
+            pls.result.outputs["coef"].data,
+            coef.data,
+        )
+
     def test_all_outputs_are_nddataset(self, pls_fitted):
         for key, value in pls_fitted.result.outputs.items():
             assert hasattr(value, "shape"), f"{key} is not an NDDataset"


### PR DESCRIPTION
## Summary
Fix `PLSRegression.coef` when the fitted `Y` dataset carries both observation and target-variable coordinates.

## What Changed
- copy the target-axis coordinate from the fitted `Y` dataset when building `coef`
- keep the existing public `coef` shape and dims contract unchanged
- add a focused regression test for multivariate `Y` with an observation axis
- add a changelog entry and commit the generated `docs/sources/whatsnew/latest.rst`

## Root Cause
`coef` attached the observation coordinate from `Y` to the result target axis. For multivariate targets this produced a coordinate-size mismatch (`n_obs` vs `n_targets`) and raised a `ValueError`.

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_crossdecomposition/test_pls_result.py -q`
- `micromamba run -n scpy-core pre-commit run --all-files`

## Notes
This PR only fixes the target-coordinate wrapping bug. It does not change `coef` units or its metadata policy surface.