### PR TITLE
FIX: reject invalid MCRALS constructor parameters cleanly

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -65,6 +65,11 @@ Bug Fixes
   coordinate. The coefficient wrapper now preserves the target-axis coordinate
   instead of attaching the observation axis to the result.
 
+- ``MCRALS`` now rejects unsupported constructor keywords such as
+  ``n_components=...`` with the normal invalid-parameter ``KeyError`` instead
+  of incorrectly triggering a pre-fit ``NotFittedError`` during
+  initialization.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -54,6 +54,11 @@ Bug Fixes
   coordinate. The coefficient wrapper now preserves the target-axis coordinate
   instead of attaching the observation axis to the result.
 
+- ``MCRALS`` now rejects unsupported constructor keywords such as
+  ``n_components=...`` with the normal invalid-parameter ``KeyError`` instead
+  of incorrectly triggering a pre-fit ``NotFittedError`` during
+  initialization.
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -1023,7 +1023,7 @@ class AnalysisConfigurable(BaseConfigurable):
 
         """
         for key, value in params.items():
-            if not hasattr(self, key):
+            if not self._has_writable_public_parameter(key):
                 raise SpectroChemPyError(
                     f"Invalid parameter '{key}' for {self.__class__.__name__}."
                 )

--- a/src/spectrochempy/utils/baseconfigurable.py
+++ b/src/spectrochempy/utils/baseconfigurable.py
@@ -12,6 +12,7 @@ Implements the base abstract classes to define models and estimators.
 import logging
 from contextlib import suppress
 from copy import copy
+from inspect import getattr_static
 
 import numpy as np
 import traitlets as tr
@@ -110,7 +111,6 @@ class BaseConfigurable(MetaConfigurable):
         # ---------------------
         # Reset all config parameters to default, if not warm_start
         defaults = self.params(default=True)
-        default_keys = set(defaults)
         configkw = {} if self._warm_start else defaults.copy()
 
         # Eventually take parameters from kwargs
@@ -119,7 +119,7 @@ class BaseConfigurable(MetaConfigurable):
         # Now update all configuration parameters
         # if an item k is not in the config parameters, an error is raised.
         for k, v in configkw.items():
-            if k in default_keys:
+            if self._has_writable_public_parameter(k):
                 current = getattr(self, k)
                 # Handle array comparison
                 if isinstance(current, np.ndarray) or isinstance(v, np.ndarray):
@@ -141,6 +141,12 @@ class BaseConfigurable(MetaConfigurable):
     # ----------------------------------------------------------------------------------
     # Private methods
     # ----------------------------------------------------------------------------------
+    def _has_writable_public_parameter(self, name):
+        if self.has_trait(name):
+            return True
+        descriptor = getattr_static(type(self), name, None)
+        return isinstance(descriptor, property) and descriptor.fset is not None
+
     def _make_dataset(self, d):
         # Transform an array-like object to NDDataset
         # or a list of array-like to a list of NDQataset

--- a/src/spectrochempy/utils/baseconfigurable.py
+++ b/src/spectrochempy/utils/baseconfigurable.py
@@ -110,7 +110,8 @@ class BaseConfigurable(MetaConfigurable):
         # ---------------------
         # Reset all config parameters to default, if not warm_start
         defaults = self.params(default=True)
-        configkw = {} if self._warm_start else defaults
+        default_keys = set(defaults)
+        configkw = {} if self._warm_start else defaults.copy()
 
         # Eventually take parameters from kwargs
         configkw.update(kwargs)
@@ -118,7 +119,7 @@ class BaseConfigurable(MetaConfigurable):
         # Now update all configuration parameters
         # if an item k is not in the config parameters, an error is raised.
         for k, v in configkw.items():
-            if hasattr(self, k) and k in defaults:
+            if k in default_keys:
                 current = getattr(self, k)
                 # Handle array comparison
                 if isinstance(current, np.ndarray) or isinstance(v, np.ndarray):

--- a/tests/test_analysis/test_decomposition/test_mcrals.py
+++ b/tests/test_analysis/test_decomposition/test_mcrals.py
@@ -434,6 +434,11 @@ def test_MCRALS_errors(model, data):
     except KeyError as exc:
         assert "'nonexistent' is not a valid" in exc.args[0]
 
+    try:
+        _ = MCRALS(n_components=3, log_level="DEBUG")
+    except KeyError as exc:
+        assert "'n_components' is not a valid" in exc.args[0]
+
     # guess with wrong size of dimensions
     try:
         mcr.fit(


### PR DESCRIPTION
## Summary
Fix the `MCRALS(n_components=...)` constructor-path bug so unsupported keywords fail with the normal invalid-parameter error instead of triggering a pre-fit `NotFittedError`.

## What Changed
- copy the default configuration mapping before merging constructor kwargs in `BaseConfigurable`
- validate shared parameter writes through declared traitlets or writable public properties with setters
- keep read-only computed properties such as `n_components` out of the writable-parameter path
- align `AnalysisConfigurable.set_params()` with the same writable-parameter rule
- extend the MCRALS error regression test to cover `n_components=...`
- add a changelog entry and commit the generated `docs/sources/whatsnew/latest.rst`

## Root Cause
Shared parameter validation in the configurable base classes mixed two concerns:
- it reused the mutable dictionary returned by `self.params(default=True)` during constructor setup;
- it relied on generic attribute access patterns that did not distinguish writable public parameters from read-only computed properties.

For `MCRALS(n_components=...)`, that path ended up evaluating the inherited pre-fit `n_components` property and raised `NotFittedError`. The final fix preserves valid writable public aliases such as `solver_C` and `solver_St` while still rejecting unsupported read-only names like `n_components`.

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_decomposition/test_mcrals.py -q -k MCRALS_errors`
- `micromamba run -n scpy-core python -m pytest tests/test_utils/test_baseconfigurable.py -q`
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_decomposition/test_mcrals.py tests/test_utils/test_baseconfigurable.py tests/test_analysis/test_base/test_sklearn_compat.py -q`
- `micromamba run -n scpy-core pre-commit run --all-files`

## Notes
This PR intentionally keeps `MCRALS` constructor semantics unchanged: `n_components` remains unsupported at construction time and is now rejected cleanly as an invalid parameter.