### PR TITLE
FIX: preserve PCA scores for partial coordsets

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -70,6 +70,12 @@ Bug Fixes
   of incorrectly triggering a pre-fit ``NotFittedError`` during
   initialization.
 
+- ``PCA.transform()`` and ``PCA.scores`` no longer fail when the fitted source
+  dataset has feature coordinates but no explicit observation-axis coordinate
+  entry. The result now preserves the available feature metadata and keeps the
+  missing observation axis as an empty coordinate instead of raising
+  ``KeyError("y")``.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -59,6 +59,12 @@ Bug Fixes
   of incorrectly triggering a pre-fit ``NotFittedError`` during
   initialization.
 
+- ``PCA.transform()`` and ``PCA.scores`` no longer fail when the fitted source
+  dataset has feature coordinates but no explicit observation-axis coordinate
+  entry. The result now preserves the available feature metadata and keeps the
+  missing observation axis as an empty coordinate instead of raising
+  ``KeyError("y")``.
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -473,9 +473,19 @@ class AnalysisConfigurable(BaseConfigurable):
         if source.coordset is None or dataset.coordset is None:
             return dataset
         if axis == 0:
-            dataset.coordset[dataset.dims[0]] = source.coordset[source.dims[0]].copy()
+            try:
+                coord = source.coordset[source.dims[0]]
+            except KeyError:
+                coord = None
+            if coord is not None:
+                dataset.coordset[dataset.dims[0]] = coord.copy()
         elif axis == -1:
-            dataset.coordset[dataset.dims[-1]] = source.coordset[source.dims[-1]].copy()
+            try:
+                coord = source.coordset[source.dims[-1]]
+            except KeyError:
+                coord = None
+            if coord is not None:
+                dataset.coordset[dataset.dims[-1]] = coord.copy()
         return dataset
 
     def _analysis_apply_full_axis_mask(self, dataset, full_mask, axis):

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -766,9 +766,21 @@ class _set_output:
             # make coordset
             M, N = X.shape
 
+            def _coord_or_none(dataset, axis):
+                if dataset.coordset is None:
+                    return None
+                try:
+                    dim = dataset.dims[axis]
+                    coord = dataset.coordset[dim]
+                except (KeyError, IndexError, TypeError, ValueError):
+                    return None
+                return coord.copy() if coord is not None else None
+
             if X_transf.shape == X.shape and self.typex is None and self.typey is None:
                 X_transf.dims = X.dims
-                X_transf.set_coordset({X.dims[0]: X.coord(0), X.dims[1]: X.coord(1)})
+                X_transf.set_coordset(
+                    {X.dims[0]: _coord_or_none(X, 0), X.dims[1]: _coord_or_none(X, 1)}
+                )
             else:
                 # Resolve component labels — defer to analysis subclasses
                 # (e.g. PCA → PC1, PC2, …).
@@ -806,9 +818,7 @@ class _set_output:
                     X_transf.dims = [X.dims[1], "k"]
                     X_transf.set_coordset(
                         {
-                            X.dims[1]: (
-                                X.coord(1).copy() if X.coord(1) is not None else None
-                            ),
+                            X.dims[1]: _coord_or_none(X, 1),
                             "k": Coord(
                                 None,
                                 labels=_component_labels(X_transf.shape[-1]),
@@ -825,18 +835,14 @@ class _set_output:
                                 labels=_component_labels(X_transf.shape[0]),
                                 title="components",
                             ),
-                            X.dims[1]: (
-                                X.coord(1).copy() if X.coord(-1) is not None else None
-                            ),
+                            X.dims[1]: _coord_or_none(X, 1),
                         },
                     )
                 elif self.typex == "components":
                     X_transf.dims = [X.dims[0], "k"]
                     X_transf.set_coordset(
                         {
-                            X.dims[0]: (
-                                X.coord(0).copy() if X.coord(0) is not None else None
-                            ),
+                            X.dims[0]: _coord_or_none(X, 0),
                             # cannot use X.y in case of transposed X
                             "k": Coord(
                                 None,
@@ -854,18 +860,14 @@ class _set_output:
                                 labels=[f"#{i}" for i in range(X_transf.shape[-1])],
                                 title="components",
                             ),
-                            X.dims[1]: (
-                                X.coord(1).copy() if X.coord(1) is not None else None
-                            ),
+                            X.dims[1]: _coord_or_none(X, 1),
                         },
                     )
                 elif self.typey == "features":
                     X_transf.dims = [X.dims[1], "k"]
                     X_transf.set_coordset(
                         {
-                            X.dims[1]: (
-                                X.coord(1).copy() if X.coord(1) is not None else None
-                            ),
+                            X.dims[1]: _coord_or_none(X, 1),
                             "k": Coord(
                                 None,
                                 labels=[f"#{i}" for i in range(X_transf.shape[-1])],

--- a/tests/test_analysis/test_decomposition/test_pca.py
+++ b/tests/test_analysis/test_decomposition/test_pca.py
@@ -17,6 +17,7 @@ from numpy.testing import assert_allclose
 import spectrochempy as scp
 from spectrochempy.analysis._base._analysisbase import NotFittedError
 from spectrochempy.analysis.decomposition.pca import PCA
+from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.utils import docutils as chd
 from spectrochempy.utils import testing
@@ -142,6 +143,35 @@ def test_pca_transform_fit_transform_and_inverse(low_rank_pca_dataset):
     assert X_hat.title == "reconstruction"
     assert X_hat.units == dataset.units
     assert X_hat.dims == dataset.dims
+
+
+def test_pca_transform_handles_partial_coordset_without_observation_axis():
+    x = scp.Coord(np.linspace(400.0, 700.0, 4), title="wavelength", units="nm")
+    dataset = scp.NDDataset(
+        np.array(
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [1.0, 2.0, 3.0, 4.0],
+                [2.0, 3.0, 4.0, 5.0],
+            ]
+        ),
+        units="absorbance",
+    )
+    dataset.coordset = CoordSet(x=x)
+
+    pca = PCA(n_components=2).fit(dataset)
+
+    scores = pca.transform()
+    assert scores.shape == (3, 2)
+    assert scores.dims == ["y", "k"]
+    assert scores.coordset is not None
+    assert scores.y.is_empty
+    assert scores.k.title == "components"
+
+    scores_prop = pca.scores
+    assert scores_prop.shape == (3, 2)
+    assert scores_prop.y.is_empty
+    assert_allclose(scores_prop.data, scores.data)
 
 
 def test_pca_reporting(low_rank_pca_dataset):


### PR DESCRIPTION
## Summary
- preserve PCA score wrapping when the fitted dataset has only a feature-axis coordinate entry
- treat missing observation-axis coordset entries as absent geometry instead of hard failures
- add a regression test and changelog entry for the partial-coordset PCA path

## Root cause
The generic analysis-output wrapping path assumed that both source axes had coordset entries. For PCA scores, a dataset with only `x` defined triggered the logging `coord()` lookup on `y`, then failed again while restoring the missing axis from the source coordset.

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_decomposition/test_pca.py -q`
- `pre-commit run --all-files`