### PR TITLE
FIX: repair docs stable release banner link

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -30,7 +30,7 @@
 <div id="version-popup" class="popup-warning">
     <span class="close-btn" onclick="closePopup()">×</span>
     ⚠️ You are reading the development version documentation.<br />
-    <a href="{{release}}">Read here the documentation of the last stable release</a>.
+    <a href="{{ stable_release_url }}">Read here the documentation of the last stable release</a>.
 </div>
 <script>
     function showPopup() {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -373,12 +373,34 @@ if on_github_actions:
 # get previous versions and save versions dic them in the versions.json file
 # which will be used by versions.js script to display the versions in the sidebar
 previous_versions = os.environ.get("PREVIOUS_VERSIONS", "").split(",")
-last_release = os.environ.get("LAST_RELEASE", "")
+
+
+def _stable_release_version():
+    env_release = os.environ.get("LAST_RELEASE", "")
+    if env_release:
+        return env_release
+
+    whatsnew_versions = []
+    for path in (SRC / "whatsnew").glob("v*.rst"):
+        match = re.fullmatch(r"v(\d+\.\d+\.\d+)\.rst", path.name)
+        if match:
+            whatsnew_versions.append(match.group(1))
+
+    if not whatsnew_versions:
+        return ""
+
+    return max(
+        whatsnew_versions,
+        key=lambda value: tuple(int(part) for part in value.split(".")),
+    )
+
+
+last_release = _stable_release_version()
 
 html_context = {
     "current_version": "stable" if ("dev" not in version) else "latest",
     "latest_version": f"{root}/index.html",
-    "release": f"{root}/{last_release}/index.html",
+    "stable_release_url": f"{root}/{last_release}/index.html" if last_release else "",
     "previous_versions": os.environ.get("PREVIOUS_VERSIONS", "").split(","),  # Added
     # This is for the citing page
     "version": release,

--- a/docs/make.py
+++ b/docs/make.py
@@ -682,7 +682,8 @@ class BuildDocumentation:
     @staticmethod
     def _get_previous_tag():
         # Get the previous core release tag from the git repository.
-        # Keep only plain stable semver tags (e.g., 0.9.0) and exclude
+        # Accept both current prefixed core tags (e.g. spectrochempy-v0.12.3)
+        # and legacy plain semver tags (e.g. 0.9.0), while excluding
         # prereleases such as 0.9.0.dev0.
         # Returns: str - The previous release tag
 
@@ -692,13 +693,13 @@ class BuildDocumentation:
             silent=True,
         )
         if tags:
-            stable_tags = [
-                tag
-                for tag in tags.strip().split("\n")
-                if re.fullmatch(r"\d+\.\d+\.\d+", tag)
-            ]
-            if stable_tags:
-                return stable_tags[0]
+            stable_versions = []
+            for tag in tags.strip().split("\n"):
+                _candidates, version = _canonical_doc_tag(tag)
+                if SEMVER_RE.fullmatch(version):
+                    stable_versions.append(version)
+            if stable_versions:
+                return stable_versions[0]
         return ""
 
     @staticmethod

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -76,6 +76,11 @@ Bug Fixes
   missing observation axis as an empty coordinate instead of raising
   ``KeyError("y")``.
 
+- The documentation warning shown on development builds now links to the
+  actual latest stable release again. Stable-doc discovery now accepts the
+  current prefixed release tags and no longer falls back to obsolete legacy
+  versions such as ``0.8.4``.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -65,6 +65,11 @@ Bug Fixes
   missing observation axis as an empty coordinate instead of raising
   ``KeyError("y")``.
 
+- The documentation warning shown on development builds now links to the
+  actual latest stable release again. Stable-doc discovery now accepts the
+  current prefixed release tags and no longer falls back to obsolete legacy
+  versions such as ``0.8.4``.
+
 Developer
 ~~~~~~~~~
 


### PR DESCRIPTION
## Summary
- repair the development-docs warning so it links to the real latest stable release again
- stop overloading the Sphinx `release` variable in the docs template by using a dedicated `stable_release_url`
- make stable-doc discovery accept current `spectrochempy-v...` release tags and add a fallback from `docs/sources/whatsnew/v*.rst`

## Root cause
The banner template used `{{ release }}`, which is ambiguous in Sphinx because `release` already names the version of the current build. At the same time, the docs build helper only recognized legacy plain-semver tags when computing `LAST_RELEASE`, so modern prefixed tags could be ignored and the link could fall back to obsolete releases such as `0.8.4`.

## Validation
- `micromamba run -n scpy-core python ... docs/conf.py` -> `0.12.3`, `/0.12.3/index.html`
- `PYTHONPATH=docs micromamba run -n scpy-core python ... docs/make.py` -> `0.12.3`
- `pre-commit run --all-files`