### PR TITLE
FIX: honor axis= and dims= keywords in NDDataset reductions

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -81,6 +81,15 @@ Bug Fixes
   current prefixed release tags and no longer falls back to obsolete legacy
   versions such as ``0.8.4``.
 
+- Passing ``axis=`` or ``dims=`` to NDDataset reduction methods (``sum``,
+  ``mean``, ``std``, ``var``, ``ptp``, ``amax``/``max``, ``amin``/``min``,
+  ``argmax``, ``argmin``, ``average``, ``coordmax``, ``coordmin``,
+  ``cumsum``, ``all``, ``any``) now correctly reduces along the requested
+  axis instead of computing a global reduction. ``axis=`` and ``dims=`` are
+  accepted as aliases of ``dim=``; passing more than one dimension selector
+  simultaneously raises ``TypeError``. Unrecognised keyword arguments now
+  raise ``TypeError`` instead of being silently stored as attributes.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -70,6 +70,15 @@ Bug Fixes
   current prefixed release tags and no longer falls back to obsolete legacy
   versions such as ``0.8.4``.
 
+- Passing ``axis=`` or ``dims=`` to NDDataset reduction methods (``sum``,
+  ``mean``, ``std``, ``var``, ``ptp``, ``amax``/``max``, ``amin``/``min``,
+  ``argmax``, ``argmin``, ``average``, ``coordmax``, ``coordmin``,
+  ``cumsum``, ``all``, ``any``) now correctly reduces along the requested
+  axis instead of computing a global reduction. ``axis=`` and ``dims=`` are
+  accepted as aliases of ``dim=``; passing more than one dimension selector
+  simultaneously raises ``TypeError``. Unrecognised keyword arguments now
+  raise ``TypeError`` instead of being silently stored as attributes.
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -32,6 +32,14 @@ __dataset_methods__ = []
 ArrayLike = np.ndarray | NDArray
 DType = TypeVar("DType", bound=np.dtype[Any])
 
+# Keyword arguments accepted but ignored by reduction methods. They belong to
+# the numpy reduction protocol (``numpy.all``, ``numpy.sum``, ... forward them
+# to the underlying ``.all()``/``.sum()`` methods) and are not supported by the
+# spectrochempy reductions, which return new objects.
+_NUMPY_REDUCTION_KWARGS = frozenset(
+    {"keepdims", "out", "initial", "where", "returned"},
+)
+
 
 def _reduce_method(method: Callable) -> Callable:
     # Decorator that sets the reduce flag to true for _from_numpy decorator.
@@ -100,6 +108,7 @@ class _from_numpy_method:
                             new = NDDataset(dataset)
 
             argpos = []
+            dim_pos = None
 
             for par in pars.values():
                 if par.name in [
@@ -108,6 +117,8 @@ class _from_numpy_method:
                     "kwargs",
                 ]:  # or (par.name == 'dataset' and instance is not None):
                     continue
+                if par.name == "dim" and par.default is None:
+                    dim_pos = len(argpos)
                 argpos.append(
                     args.pop(0) if args else kwargs.pop(par.name, par.default),
                 )
@@ -137,6 +148,35 @@ class _from_numpy_method:
             # -----------------------------
             # Create from an existing array
             # ------------------------------
+            # For methods declaring a `dim` selector (default None), `axis`
+            # and `dims` keywords are aliases of `dim`. Only one effective
+            # (non-None) selector is allowed, and unknown keywords raise
+            # instead of being silently stored as attributes.
+            if dim_pos is not None:
+                for keyword in ("axis", "dims"):
+                    if keyword in kwargs:
+                        selector = kwargs.pop(keyword)
+                        if argpos[dim_pos] is not None and selector is not None:
+                            raise TypeError(
+                                f"{method}() got conflicting dimension selectors: "
+                                f"`{keyword}` cannot be used together with `dim` "
+                                f"(got `dim={argpos[dim_pos]!r}` and "
+                                f"`{keyword}={selector!r}`). Use only one of "
+                                "`dim`, `dims` or `axis`.",
+                            )
+                        if selector is not None:
+                            argpos[dim_pos] = selector
+                unknown = [
+                    k
+                    for k in kwargs
+                    if k not in new._attributes_() and k not in _NUMPY_REDUCTION_KWARGS
+                ]
+                if unknown:
+                    raise TypeError(
+                        f"{method}() got an unexpected keyword argument "
+                        f"{unknown[0]!r}",
+                    )
+
             # Replace some attribute according to the kwargs
             for k, v in list(kwargs.items())[:]:
                 if k != "units":

--- a/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
@@ -734,3 +734,178 @@ class TestBareDatasetReduction:
     def test_argmax_bare(self, bare_dataset):
         am = bare_dataset.argmax()
         assert am == 2
+
+
+# ======================================================================================
+# AXIS/DIMS KEYWORD ROUTING
+# ======================================================================================
+
+
+class TestAxisKeywordRouting:
+    """Characterize the axis=/dims= -> dim routing for reduction methods.
+
+    These tests verify the FIX applied to the _from_numpy_method descriptor:
+    ``axis`` and ``dims`` keywords are routed into ``dim`` for all reduction
+    methods that declare a ``dim`` parameter with default None.
+    """
+
+    def test_mean_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.mean(axis=0)
+        r_dim = reduction_dataset.mean(dim="y")
+        assert isinstance(r_axis, NDDataset)
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+        assert list(r_axis.dims) == list(r_dim.dims)
+
+    def test_mean_axis_1_equivalent_to_dim_x(self, reduction_dataset):
+        r_axis = reduction_dataset.mean(axis=1)
+        r_dim = reduction_dataset.mean(dim="x")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_sum_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.sum(axis=0)
+        r_dim = reduction_dataset.sum(dim="y")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+        assert list(r_axis.dims) == list(r_dim.dims)
+
+    def test_std_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.std(axis=0)
+        r_dim = reduction_dataset.std(dim="y")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_var_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.var(axis=0)
+        r_dim = reduction_dataset.var(dim="y")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_amax_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.amax(axis=0)
+        r_dim = reduction_dataset.amax(dim="y")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_amin_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.amin(axis=0)
+        r_dim = reduction_dataset.amin(dim="y")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_ptp_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.ptp(axis=0)
+        r_dim = reduction_dataset.ptp(dim="y")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_argmax_axis_0(self, reduction_dataset):
+        r_axis = reduction_dataset.argmax(axis=0)
+        r_dim = reduction_dataset.argmax(dim="y")
+        assert np.array_equal(r_axis, r_dim)
+
+    def test_argmin_axis_0(self, reduction_dataset):
+        r_axis = reduction_dataset.argmin(axis=0)
+        r_dim = reduction_dataset.argmin(dim="y")
+        assert np.array_equal(r_axis, r_dim)
+
+    def test_cumsum_axis_0_equivalent_to_dim_y(self, reduction_dataset):
+        r_axis = reduction_dataset.cumsum(axis=0)
+        r_dim = reduction_dataset.cumsum(dim="y")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_axis_negative_index(self, reduction_dataset):
+        r_axis = reduction_dataset.sum(axis=-1)
+        r_dim = reduction_dataset.sum(dim="x")
+        np.testing.assert_allclose(r_axis.data, r_dim.data)
+
+    def test_axis_none_is_global(self, reduction_dataset):
+        r_axis = reduction_dataset.sum(axis=None)
+        r_dim = reduction_dataset.sum(dim=None)
+        assert np.isclose(r_axis, r_dim)
+
+    def test_dims_keyword_routes(self, reduction_dataset):
+        r_dims = reduction_dataset.mean(dims="y")
+        r_dim = reduction_dataset.mean(dim="y")
+        np.testing.assert_allclose(r_dims.data, r_dim.data)
+
+    def test_axis_and_dim_same_value_conflict(self, reduction_dataset):
+        with pytest.raises(TypeError, match="conflicting dimension selectors"):
+            reduction_dataset.mean(dim="y", axis=0)
+
+    def test_axis_and_dim_different_value_conflict(self, reduction_dataset):
+        with pytest.raises(TypeError, match="conflicting dimension selectors"):
+            reduction_dataset.mean(dim="y", axis=1)
+
+    def test_dims_and_dim_same_value_conflict(self, reduction_dataset):
+        with pytest.raises(TypeError, match="conflicting dimension selectors"):
+            reduction_dataset.mean(dim="y", dims="y")
+
+    def test_unknown_kwarg_raises(self, reduction_dataset):
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            reduction_dataset.mean(axis=0, some_typo=True)
+
+    def test_axis_coordset_reduced(self, reduction_dataset):
+        r = reduction_dataset.sum(axis=0)
+        assert r.coordset is not None
+        assert r.coordset.names == ["x"]
+
+    def test_axis_coordset_surviving_preserved(self, reduction_dataset):
+        r = reduction_dataset.sum(axis=0)
+        assert r["x"].title == "wavenumber"
+        assert "cm" in str(r["x"].units)
+
+    def test_axis_keepdims(self, reduction_dataset):
+        r = reduction_dataset.sum(axis=0, keepdims=True)
+        assert r.shape == (1, 7)
+
+    def test_axis_preserves_metadata(self, reduction_dataset):
+        r = reduction_dataset.mean(axis=0)
+        assert r.title == reduction_dataset.title
+        assert r.name == reduction_dataset.name
+        assert r.author == reduction_dataset.author
+
+    def test_axis_source_not_mutated(self, reduction_dataset):
+        data_before = reduction_dataset.data.copy()
+        reduction_dataset.mean(axis=0)
+        np.testing.assert_array_equal(reduction_dataset.data, data_before)
+
+    def test_axis_masked_data(self):
+        arr = np.ma.MaskedArray(
+            np.arange(35.0).reshape(5, 7), mask=np.zeros((5, 7), dtype=bool)
+        )
+        arr[0, 0] = np.ma.masked
+        ds = NDDataset(arr)
+        r = ds.mean(axis=0)
+        assert isinstance(r, NDDataset)
+        assert r.shape == (7,)
+
+    def test_axis_classmethod(self, reduction_dataset):
+        r = NDDataset.mean(reduction_dataset, axis=0)
+        r_dim = reduction_dataset.mean(dim="y")
+        np.testing.assert_allclose(r.data, r_dim.data)
+
+    def test_axis_api_path(self, reduction_dataset):
+        r = reduction_dataset.mean(axis=0)
+        assert isinstance(r, NDDataset)
+
+    def test_axis_negative_coordset(self, reduction_dataset):
+        r = reduction_dataset.sum(axis=-1)
+        assert r.coordset is not None
+        assert r.coordset.names == ["y"]
+
+    def test_axis_bool_all(self, reduction_dataset):
+        r = reduction_dataset.all(axis=0)
+        assert isinstance(r, np.ndarray)
+        assert r.shape == (7,)
+
+    def test_axis_bool_any(self, reduction_dataset):
+        r = reduction_dataset.any(axis=0)
+        assert isinstance(r, np.ndarray)
+        assert r.shape == (7,)
+
+    def test_axis_average(self, reduction_dataset):
+        r = reduction_dataset.average(axis=0)
+        r_dim = reduction_dataset.average(dim="y")
+        np.testing.assert_allclose(r.data, r_dim.data)
+
+    def test_coordmax_axis(self, reduction_dataset):
+        r = reduction_dataset.coordmax(axis=0)
+        assert r is not None
+
+    def test_coordmin_axis(self, reduction_dataset):
+        r = reduction_dataset.coordmin(axis=0)
+        assert r is not None

--- a/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_reduction_semantics_baseline.py
@@ -742,7 +742,8 @@ class TestBareDatasetReduction:
 
 
 class TestAxisKeywordRouting:
-    """Characterize the axis=/dims= -> dim routing for reduction methods.
+    """
+    Characterize the axis=/dims= -> dim routing for reduction methods.
 
     These tests verify the FIX applied to the _from_numpy_method descriptor:
     ``axis`` and ``dims`` keywords are routed into ``dim`` for all reduction


### PR DESCRIPTION
## Summary

The `_from_numpy_method` descriptor absorbed unrecognized kwargs via `setattr()`, so `axis=` was silently ignored and the global reduction was computed instead of the requested axis reduction (e.g. `mean(axis=0)` computed the global mean instead of reducing along axis 0).

## Changes

**`ndmath.py` — descriptor fix:**
- Route `axis=` and `dims=` keywords into `dim=` for all reduction methods that declare a `dim` parameter with default None
- Raise `TypeError` on conflicting selectors (`dim + axis`, `dim + dims`)
- Reject unknown keywords instead of silently storing them as attributes
- Accept numpy protocol keywords (`keepdims`, `out`, `initial`, `where`, `returned`) without error

**`test_reduction_semantics_baseline.py` — 32 new tests:**
- `TestAxisKeywordRouting`: equivalence of `axis=`/`dims=`/`dim=` for all 15 reduction families, negative indices, global, conflicts, unknown kwargs, coordset, keepdims, metadata, non-mutation, masked data, classmethod path

## Test Results

- 1571/1571 dataset tests pass
- 44/44 integration tests pass
- 0 regressions

## Scope

This is **PR 1** of the [Dimension Selection Runtime Alignment campaign](https://github.com/spectrochempy/spectrochempy_maintainer/blob/master/notes/audits/dimension-selection-runtime-alignment-2026-08-16.md). PR 2 will add tuple/list multi-dimension selector support.
