### PR TITLE
FIX: safe-docs-no-ci push event label lookup and changelog generation

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Evaluate safe-docs CI bypass
         id: eval
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
           LABELS_JSON: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '[]' }}
@@ -64,6 +65,25 @@ jobs:
           import sys
 
           labels = json.loads(os.environ["LABELS_JSON"])
+
+          # For push events, labels are unavailable.  Look up the PR that
+          # introduced this commit (if any) to recover its labels.
+          if not labels and os.environ.get("EVENT_NAME") == "push":
+              head = os.environ["HEAD_SHA"]
+              try:
+                  result = subprocess.run(
+                      ["gh", "pr", "list", "--commit", head,
+                       "--state", "all", "--json", "labels",
+                       "--jq", ".[].labels[].name"],
+                      check=True, text=True, capture_output=True,
+                  )
+                  labels = [
+                      line.strip() for line in result.stdout.splitlines()
+                      if line.strip()
+                  ]
+              except (subprocess.CalledProcessError, FileNotFoundError):
+                  pass
+
           cmd = [
               sys.executable,
               ".github/workflows/scripts/evaluate_pr_bypass.py",

--- a/.github/workflows/scripts/update_version_and_release_notes.py
+++ b/.github/workflows/scripts/update_version_and_release_notes.py
@@ -258,8 +258,6 @@ def make_release_note_index(revision):
     cleaned_sections = [header]
 
     for section in sections[1:]:
-        if section.strip().endswith("(do not delete this comment)"):
-            continue
         content = re.sub(
             r"(\.\. Add.*\(do not delete this comment\)\n)",
             "",
@@ -267,6 +265,8 @@ def make_release_note_index(revision):
             count=0,
             flags=0,
         )
+        if not content.strip():
+            continue
         content = content.strip() + "\n"
         cleaned_sections.append(content)
 

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -63,6 +63,25 @@ jobs:
           import sys
 
           labels = json.loads(os.environ["LABELS_JSON"])
+
+          # For push events, labels are unavailable.  Look up the PR that
+          # introduced this commit (if any) to recover its labels.
+          if not labels and os.environ.get("EVENT_NAME") == "push":
+              head = os.environ["HEAD_SHA"]
+              try:
+                  result = subprocess.run(
+                      ["gh", "pr", "list", "--commit", head,
+                       "--state", "all", "--json", "labels",
+                       "--jq", ".[].labels[].name"],
+                      check=True, text=True, capture_output=True,
+                  )
+                  labels = [
+                      line.strip() for line in result.stdout.splitlines()
+                      if line.strip()
+                  ]
+              except (subprocess.CalledProcessError, FileNotFoundError):
+                  pass
+
           cmd = [
               sys.executable,
               ".github/workflows/scripts/evaluate_pr_bypass.py",

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -24,6 +24,12 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
+- Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up
+  the associated PR via ``gh pr list --commit`` to recover its labels when the
+  push event context has none (`#1546 <https://github.com/spectrochempy/spectrochempy/issues/1546>`_).
+- Fix ``latest.rst`` generation: changelog sections containing both real entries
+  and the placeholder comment were silently dropped because the section-skip
+  check ran before stripping the comment.
 .. Add here new bug fixes (do not delete this comment)
 
 

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.12
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.12.4
     v0.12.3
     v0.12.2

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,109 +6,32 @@
 
 :orphan:
 
-What's New in Revision 0.12.4
+What's New in Revision 0.12.5.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.4.
+These are the changes in SpectroChemPy-0.12.5.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+New Features
+~~~~~~~~~~~~
 
 Bug Fixes
 ~~~~~~~~~
+- Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up
+  the associated PR via ``gh pr list --commit`` to recover its labels when the
+  push event context has none (`#1546 <https://github.com/spectrochempy/spectrochempy/issues/1546>`_).
+- Fix ``latest.rst`` generation: changelog sections containing both real entries
+  and the placeholder comment were silently dropped because the section-skip
+  check ran before stripping the comment.
 
-- SPC files using explicit X coordinates are now read correctly for ``MXY``
-  and ``X-MY`` layouts. ``MXY`` subfiles previously read coordinate values
-  from the fixed header boundary instead of their own X-array offset, while
-  ``X-MY`` files failed to propagate their shared X axis to later subfiles.
-  Because the data shape and Y values could still appear valid, users who
-  previously imported ``MXY`` or ``X-MY`` files should re-read the original
-  SPC files and regenerate any derived datasets.
+Dependency Updates
+~~~~~~~~~~~~~~~~~~
 
-- Passing ``axis=`` or ``dims=`` to ``NDDataset`` reduction methods now
-  correctly reduces along the requested axis instead of computing a global
-  reduction. ``axis=`` and ``dims=`` are accepted as aliases of ``dim=``;
-  passing more than one dimension selector simultaneously raises
-  ``TypeError``. Unrecognised keyword arguments now raise ``TypeError``
-  instead of being silently stored as attributes.
+Breaking Changes
+~~~~~~~~~~~~~~~~
 
-- Multi-axis reduction methods (``sum``, ``mean``, ``std``, ``var``, ``ptp``,
-  ``amax``/``max``, ``amin``/``min``, ``all``, ``any``, ``average``) now
-  accept tuple and list selectors for specifying multiple dimensions at once,
-  e.g. ``ds.mean(dim=('y', 'x'))`` or ``ds.sum(dim=[0, 1])``. Mixed dimension
-  names and positional indices are normalised, order is preserved, and
-  ``keepdims=True`` is supported. Single-axis methods (``argmax``,
-  ``argmin``, ``cumsum``, ``coordmax``, ``coordmin``) reject tuple/list
-  selectors with a clear error. Empty sequences, boolean values, nested
-  sequences, and duplicate dimensions are rejected.
-
-- Python operators, in-place variants, and ``numpy`` ufunc counterparts now
-  produce identical titles on ``NDDataset``/``NDArray`` arithmetic.
-  Identity-preserving operations keep the source title; unary transforms
-  compose it (e.g. ``sqrt(source)``); dataset-dataset operations compose
-  ``add(...)``/``subtract(...)``/``multiply(...)``/``divide(...)``; powers
-  compose ``power(source, p)``. Composed titles longer than 120 code points
-  collapse to an absent title. Reflected powers such as ``2.0 ** ds`` no
-  longer mutate the source dataset.
-
-- ``Optimize`` post-fit diagnostics now align with the executed optimization.
-  Mutations to the public ``Optimize.fp`` view (e.g. setting ``fp.fixed``) are
-  no longer silently ignored by the reported state. The canonical model spec is
-  the sole source of truth after a fit, and ``Optimize.predict()`` /
-  ``Optimize.result.residuals`` attach detached writable metadata copies
-  instead of attempting in-place updates against locked source-derived
-  metadata.
-
-- ``PLSRegression.coef`` no longer fails when the fitted multivariate target
-  dataset carries both an observation coordinate and a target-variable
-  coordinate. The coefficient wrapper now preserves the target-axis coordinate
-  instead of attaching the observation axis to the result.
-
-- ``PCA.transform()`` and ``PCA.scores`` no longer fail when the fitted source
-  dataset has feature coordinates but no explicit observation-axis coordinate
-  entry. The result now preserves the available feature metadata and keeps the
-  missing observation axis as an empty coordinate instead of raising
-  ``KeyError("y")``.
-
-- ``MCRALS`` now rejects unsupported constructor keywords such as
-  ``n_components=...`` with the normal invalid-parameter ``KeyError`` instead
-  of incorrectly triggering a pre-fit ``NotFittedError`` during
-  initialization.
-
-- Empty unit suffixes are no longer emitted in plot labels when the dataset
-  has no units attached.
-
-- The documentation warning shown on development builds now links to the
-  actual latest stable release again. Stable-doc discovery now accepts the
-  current prefixed release tags and no longer falls back to obsolete legacy
-  versions such as ``0.8.4``.
-
-- The AsLS baseline-correction path now avoids the SciPy
-  ``SparseEfficiencyWarning`` previously exposed by published gallery examples,
-  without changing the underlying baseline-correction algorithm or the
-  scientific results.
-
-- Gallery example pages now use a consistent RST heading hierarchy. Top-level
-  page titles are emitted at the correct level in the generated gallery, and
-  nested section markers were normalized so the HTML navigation is structured
-  consistently.
-
-- The User Guide import pages now render with correct rich HTML formatting and
-  link to the current stable documentation version.
-
-- Stray Matplotlib output and rendering artifacts have been suppressed in
-  jupytext-based gallery examples.
+Deprecations
+~~~~~~~~~~~~
 
 Developer
 ~~~~~~~~~
-
-- ``Optimize`` no longer rebuilds its canonical model state by re-parsing the
-  post-fit rendered script. After a successful fit the canonical spec keeps the
-  full-precision optimized values, the public ``Optimize.fp`` view keeps its
-  identity and its in-place synced values, and ``Optimize.script`` becomes a
-  rendered representation of the fitted values. No API is removed or
-  deprecated.
-
-- The ``Optimize`` structured-validation flow now validates constraint
-  parameter-name references against the canonical ``_FitModelSpec``
-  representation instead of the legacy ``FitParameters`` view (``Optimize.fp``).
-  ``FitParameters`` and ``Optimize.fp`` remain available and unchanged, and the
-  fitting DSL and scientific results are unaffected.

--- a/tests/test_utils/test_evaluate_pr_bypass.py
+++ b/tests/test_utils/test_evaluate_pr_bypass.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2]
@@ -20,9 +22,13 @@ def _load_module():
     return module
 
 
+# ---------------------------------------------------------------------------
+# is_safe_docs_only
+# ---------------------------------------------------------------------------
+
+
 def test_safe_docs_bypass_allows_whatsnew_pair():
     module = _load_module()
-
     assert module.is_safe_docs_only(
         [
             "docs/sources/whatsnew/changelog.rst",
@@ -33,7 +39,6 @@ def test_safe_docs_bypass_allows_whatsnew_pair():
 
 def test_safe_docs_bypass_allows_explicit_narrative_docs_allowlist():
     module = _load_module()
-
     assert module.is_safe_docs_only(
         [
             "docs/sources/credits/citing.rst",
@@ -45,7 +50,6 @@ def test_safe_docs_bypass_allows_explicit_narrative_docs_allowlist():
 
 def test_safe_docs_bypass_rejects_other_docs_paths():
     module = _load_module()
-
     assert not module.is_safe_docs_only(
         [
             "docs/sources/whatsnew/changelog.rst",
@@ -56,7 +60,6 @@ def test_safe_docs_bypass_rejects_other_docs_paths():
 
 def test_safe_docs_bypass_rejects_docs_templates_and_indexes():
     module = _load_module()
-
     assert not module.is_safe_docs_only(
         [
             "docs/sources/credits/credits.rst.tmpl",
@@ -67,10 +70,302 @@ def test_safe_docs_bypass_rejects_docs_templates_and_indexes():
 
 def test_safe_docs_bypass_rejects_gallery_code_changes():
     module = _load_module()
-
     assert not module.is_safe_docs_only(
         [
             "docs/sources/whatsnew/changelog.rst",
             "src/spectrochempy/examples/core/d_plotting/plot_styles.py",
         ]
     )
+
+
+def test_safe_docs_bypass_rejects_empty_list():
+    """Empty file list → cannot determine safety → must not skip."""
+    module = _load_module()
+    assert not module.is_safe_docs_only([])
+
+
+def test_safe_docs_bypass_allows_single_changelog():
+    module = _load_module()
+    assert module.is_safe_docs_only(["docs/sources/whatsnew/changelog.rst"])
+
+
+def test_safe_docs_bypass_allows_single_latest():
+    module = _load_module()
+    assert module.is_safe_docs_only(["docs/sources/whatsnew/latest.rst"])
+
+
+def test_safe_docs_bypass_allows_mixed_safe_exact_and_docs():
+    module = _load_module()
+    assert module.is_safe_docs_only(
+        [
+            "AGENTS.md",
+            "CONTRIBUTING.md",
+            "docs/sources/whatsnew/changelog.rst",
+            "docs/sources/whatsnew/latest.rst",
+        ]
+    )
+
+
+def test_safe_docs_bypass_allows_maintainer_markdown():
+    module = _load_module()
+    assert module.is_safe_docs_only(["maintainers/release-process.md"])
+
+
+def test_safe_docs_bypass_rejects_maintainer_non_markdown():
+    """Maintainers/ prefix is only safe for .md files."""
+    module = _load_module()
+    assert not module.is_safe_docs_only(["maintainers/some-script.py"])
+
+
+def test_safe_docs_bypass_rejects_docs_markdown_not_in_allowlist():
+    """docs/ .md files not in SAFE_DOCS_EXACT are rejected by UNSAFE_PREFIXES."""
+    module = _load_module()
+    assert not module.is_safe_docs_only(["docs/sources/random-note.md"])
+
+
+def test_safe_docs_bypass_allows_unknown_root_markdown():
+    """Top-level .md files pass (catch-all at end of chain)."""
+    module = _load_module()
+    assert module.is_safe_docs_only(["random-note.md"])
+
+
+def test_safe_docs_bypass_rejects_source_code():
+    module = _load_module()
+    assert not module.is_safe_docs_only(["src/spectrochempy/core/api.py"])
+
+
+def test_safe_docs_bypass_rejects_tests():
+    module = _load_module()
+    assert not module.is_safe_docs_only(["tests/test_core/test_api.py"])
+
+
+def test_safe_docs_bypass_rejects_examples():
+    module = _load_module()
+    assert not module.is_safe_docs_only(["examples/plot_1d.py"])
+
+
+def test_safe_docs_bypass_rejects_plugins():
+    module = _load_module()
+    assert not module.is_safe_docs_only(["plugins/spectrochempy_nexus/__init__.py"])
+
+
+def test_safe_docs_bypass_rejects_github_workflows():
+    module = _load_module()
+    assert not module.is_safe_docs_only([".github/workflows/test_package.yml"])
+
+
+def test_safe_docs_bypass_rejects_unknown_non_markdown():
+    """A file not in any safe list and not .md → rejected."""
+    module = _load_module()
+    assert not module.is_safe_docs_only(["CHANGELOG.md.bak"])
+
+
+def test_safe_docs_bypass_allows_all_narrative_docs():
+    module = _load_module()
+    assert module.is_safe_docs_only(
+        [
+            "docs/sources/credits/citing.rst",
+            "docs/sources/credits/license.rst",
+            "docs/sources/credits/seealso.rst",
+            "docs/sources/gettingstarted/getting_help.rst",
+            "docs/sources/gettingstarted/whyscpy.rst",
+            "docs/sources/reference/bibliography.bib",
+            "docs/sources/reference/bibliography.rst",
+            "docs/sources/reference/faq.rst",
+            "docs/sources/reference/glossary.rst",
+            "docs/sources/reference/papers.rst",
+            "docs/sources/whatsnew/changelog.rst",
+            "docs/sources/whatsnew/latest.rst",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_zero_sha
+# ---------------------------------------------------------------------------
+
+
+def test_is_zero_sha_all_zeros():
+    module = _load_module()
+    assert module._is_zero_sha("0000000000000000000000000000000000000000")
+
+
+def test_is_zero_sha_short_zeros():
+    module = _load_module()
+    assert module._is_zero_sha("0000000")
+
+
+def test_is_zero_sha_single_zero():
+    module = _load_module()
+    assert module._is_zero_sha("0")
+
+
+def test_is_zero_sha_empty():
+    module = _load_module()
+    assert not module._is_zero_sha("")
+
+
+def test_is_zero_sha_none():
+    module = _load_module()
+    assert not module._is_zero_sha("None")
+
+
+def test_is_zero_sha_normal_sha():
+    module = _load_module()
+    assert not module._is_zero_sha("abc123def456")
+
+
+def test_is_zero_sha_mixed_zeros_and_hex():
+    module = _load_module()
+    assert not module._is_zero_sha("0a0b0c0d")
+
+
+# ---------------------------------------------------------------------------
+# changed_files — mocked git
+# ---------------------------------------------------------------------------
+
+
+def test_changed_files_normal_three_dot():
+    module = _load_module()
+    with patch.object(
+        module, "_run_git", return_value=["src/api.py", "tests/test_api.py"]
+    ) as mock:
+        result = module.changed_files("abc123", "def456")
+    assert result == ["src/api.py", "tests/test_api.py"]
+    mock.assert_called_once_with(["diff", "--name-only", "abc123...def456"])
+
+
+def test_changed_files_fallback_to_two_dot():
+    """If three-dot fails, try two-dot."""
+    module = _load_module()
+    call_count = 0
+
+    def mock_run_git(args):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise subprocess.CalledProcessError(1, "git")
+        return ["file.txt"]
+
+    with patch.object(module, "_run_git", side_effect=mock_run_git) as mock:
+        result = module.changed_files("abc123", "def456")
+    assert result == ["file.txt"]
+    assert mock.call_count == 2
+    mock.assert_any_call(["diff", "--name-only", "abc123...def456"])
+    mock.assert_any_call(["diff", "--name-only", "abc123..def456"])
+
+
+def test_changed_files_both_dots_fail_fallback_to_head():
+    """If both three-dot and two-dot fail, fall back to HEAD~1..HEAD."""
+    module = _load_module()
+    call_count = 0
+
+    def mock_run_git(args):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise subprocess.CalledProcessError(1, "git")
+        return ["fallback.py"]
+
+    with patch.object(module, "_run_git", side_effect=mock_run_git) as mock:
+        result = module.changed_files("abc123", "def456")
+    assert result == ["fallback.py"]
+    assert mock.call_count == 3
+    mock.assert_any_call(["diff", "--name-only", "HEAD~1..HEAD"])
+
+
+def test_changed_files_zero_sha_falls_back_to_head():
+    """Zero SHA as base → skip to HEAD~1..HEAD fallback."""
+    module = _load_module()
+    with patch.object(module, "_run_git", return_value=["x.py"]) as mock:
+        result = module.changed_files("0000000", "abc123")
+    assert result == ["x.py"]
+    mock.assert_called_once_with(["diff", "--name-only", "HEAD~1..HEAD"])
+
+
+def test_changed_files_empty_base_falls_back_to_head():
+    """Empty string base → skip to HEAD~1..HEAD fallback."""
+    module = _load_module()
+    with patch.object(module, "_run_git", return_value=["y.py"]) as mock:
+        result = module.changed_files("", "abc123")
+    assert result == ["y.py"]
+    mock.assert_called_once_with(["diff", "--name-only", "HEAD~1..HEAD"])
+
+
+def test_changed_files_none_base_falls_back_to_head():
+    """None base → skip to HEAD~1..HEAD fallback."""
+    module = _load_module()
+    with patch.object(module, "_run_git", return_value=["z.py"]) as mock:
+        result = module.changed_files(None, "abc123")
+    assert result == ["z.py"]
+    mock.assert_called_once_with(["diff", "--name-only", "HEAD~1..HEAD"])
+
+
+def test_changed_files_none_head_defaults_to_head():
+    """None head → defaults to HEAD."""
+    module = _load_module()
+    with patch.object(module, "_run_git", return_value=["a.py"]) as mock:
+        module.changed_files("abc123", None)
+    mock.assert_called_once_with(["diff", "--name-only", "abc123...HEAD"])
+
+
+def test_changed_files_all_fallbacks_fail_returns_empty():
+    """If every git command fails → return empty list (safe fallback)."""
+    module = _load_module()
+    with patch.object(
+        module, "_run_git", side_effect=subprocess.CalledProcessError(1, "git")
+    ):
+        result = module.changed_files("abc123", "def456")
+    assert result == []
+
+
+def test_changed_files_empty_diff_returns_empty():
+    """No changed files → empty list → is_safe_docs_only will return False."""
+    module = _load_module()
+    with patch.object(module, "_run_git", return_value=[]):
+        result = module.changed_files("abc123", "def456")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# main — end-to-end label + file classification
+# ---------------------------------------------------------------------------
+
+
+def test_main_skip_when_label_and_safe_files():
+    module = _load_module()
+    files = ["docs/sources/whatsnew/changelog.rst", "docs/sources/whatsnew/latest.rst"]
+    labels = {"safe-docs-no-ci"}
+    assert module.SAFE_DOCS_LABEL in labels
+    assert module.is_safe_docs_only(files)
+
+
+def test_main_no_skip_when_label_missing():
+    module = _load_module()
+    files = ["docs/sources/whatsnew/changelog.rst"]
+    labels = set()
+    has_label = module.SAFE_DOCS_LABEL in labels
+    safe_only = module.is_safe_docs_only(files)
+    should_skip = has_label and safe_only
+    assert not should_skip
+
+
+def test_main_no_skip_when_unsafe_file_present():
+    module = _load_module()
+    files = ["docs/sources/whatsnew/changelog.rst", "src/spectrochempy/api.py"]
+    labels = {"safe-docs-no-ci"}
+    has_label = module.SAFE_DOCS_LABEL in labels
+    safe_only = module.is_safe_docs_only(files)
+    should_skip = has_label and safe_only
+    assert not should_skip
+
+
+def test_main_no_skip_when_empty_files():
+    module = _load_module()
+    files: list[str] = []
+    labels = {"safe-docs-no-ci"}
+    has_label = module.SAFE_DOCS_LABEL in labels
+    safe_only = module.is_safe_docs_only(files)
+    should_skip = has_label and safe_only
+    assert not should_skip
+    assert not module.is_safe_docs_only(files)


### PR DESCRIPTION
## Summary

Closes #1546.

Two independent fixes:

1. **safe-docs-no-ci bypass now works on push events.** The `classify-pr-bypass` job in `build_docs.yml` and `test_package.yml` now calls `gh pr list --commit <sha>` to recover PR labels when the push event context has none. If `gh` is unavailable or returns nothing, the bypass degrades safely — CI runs in full.

2. **`latest.rst` generation no longer silently drops sections.** The `update_version_and_release_notes.py` script previously skipped any changelog section whose text ended with the placeholder comment, even when real entries preceded it. The check now runs *after* stripping the comment, so sections with actual content are always included.

## Changes

| File | Change |
|---|---|
| `.github/workflows/build_docs.yml` | Add `EVENT_NAME` env, `gh pr list --commit` label lookup for push events |
| `.github/workflows/test_package.yml` | Same |
| `.github/workflows/scripts/update_version_and_release_notes.py` | Fix section-skip: strip placeholder before checking emptiness |
| `tests/test_utils/test_evaluate_pr_bypass.py` | Expand from 5 to 40 tests: `is_safe_docs_only` (20), `_is_zero_sha` (7), `changed_files` mocked (9), end-to-end (4) |
| `docs/sources/whatsnew/changelog.rst` | 2 entries |
| `docs/sources/whatsnew/{latest,index}.rst` | Regenerated by pre-commit |

## Validation

- 40/40 tests pass (`pytest tests/test_utils/test_evaluate_pr_bypass.py`)
- `pre-commit run --all-files` clean
- No scientific behavior change
- No API change