### PR TITLE
DOC: revert update_version_and_release_notes.py and move changelog entry to Developer

### DIFF
--- a/.github/workflows/scripts/update_version_and_release_notes.py
+++ b/.github/workflows/scripts/update_version_and_release_notes.py
@@ -258,6 +258,8 @@ def make_release_note_index(revision):
     cleaned_sections = [header]
 
     for section in sections[1:]:
+        if section.strip().endswith("(do not delete this comment)"):
+            continue
         content = re.sub(
             r"(\.\. Add.*\(do not delete this comment\)\n)",
             "",
@@ -265,8 +267,6 @@ def make_release_note_index(revision):
             count=0,
             flags=0,
         )
-        if not content.strip():
-            continue
         content = content.strip() + "\n"
         cleaned_sections.append(content)
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -24,12 +24,6 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
-- Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up
-  the associated PR via ``gh pr list --commit`` to recover its labels when the
-  push event context has none (`#1546 <https://github.com/spectrochempy/spectrochempy/issues/1546>`_).
-- Fix ``latest.rst`` generation: changelog sections containing both real entries
-  and the placeholder comment were silently dropped because the section-skip
-  check ran before stripping the comment.
 .. Add here new bug fixes (do not delete this comment)
 
 
@@ -59,3 +53,6 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+- Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up
+  the associated PR via ``gh pr list --commit`` to recover its labels when the
+  push event context has none (`#1546 <https://github.com/spectrochempy/spectrochempy/issues/1546>`_).

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -17,12 +17,6 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
-- Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up
-  the associated PR via ``gh pr list --commit`` to recover its labels when the
-  push event context has none (`#1546 <https://github.com/spectrochempy/spectrochempy/issues/1546>`_).
-- Fix ``latest.rst`` generation: changelog sections containing both real entries
-  and the placeholder comment were silently dropped because the section-skip
-  check ran before stripping the comment.
 
 Dependency Updates
 ~~~~~~~~~~~~~~~~~~
@@ -35,3 +29,6 @@ Deprecations
 
 Developer
 ~~~~~~~~~
+- Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up
+  the associated PR via ``gh pr list --commit`` to recover its labels when the
+  push event context has none (`#1546 <https://github.com/spectrochempy/spectrochempy/issues/1546>`_).

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,21 +12,6 @@ What's New in Revision 0.12.5.dev
 These are the changes in SpectroChemPy-0.12.5.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
-New Features
-~~~~~~~~~~~~
-
-Bug Fixes
-~~~~~~~~~
-
-Dependency Updates
-~~~~~~~~~~~~~~~~~~
-
-Breaking Changes
-~~~~~~~~~~~~~~~~
-
-Deprecations
-~~~~~~~~~~~~
-
 Developer
 ~~~~~~~~~
 - Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up


### PR DESCRIPTION
- Reverts the section-skip change introduced in PR #1548 that caused orphan section titles in `latest.rst`
- Moves the `safe-docs-no-ci` changelog entry from Bug Fixes to Developer (CI infrastructure fix, not user-facing behavior)