### PR TITLE
FIX: honor dim selection in Filter APIs (savgol, smooth, whittaker)

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -25,6 +25,14 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
+- Fix ``dim`` keyword argument in Savitzky-Golay, smoothing and Whittaker
+  filters (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).
+  ``savgol()``, ``smooth()``, ``whittaker()`` and
+  ``Filter(...).transform()`` now accept a ``dim`` parameter to select the
+  processing axis.  Dimension names (e.g. ``"x"``) and integer indices are
+  resolved via the standard dimension selection mechanism.  Invalid types
+  (``bool``, ``tuple``, ``list``) and unknown names raise ``TypeError`` or
+  ``ValueError``.
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,17 @@ What's New in Revision 0.12.5.dev
 These are the changes in SpectroChemPy-0.12.5.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+Bug Fixes
+~~~~~~~~~
+- Fix ``dim`` keyword argument in Savitzky-Golay, smoothing and Whittaker
+  filters (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).
+  ``savgol()``, ``smooth()``, ``whittaker()`` and
+  ``Filter(...).transform()`` now accept a ``dim`` parameter to select the
+  processing axis.  Dimension names (e.g. ``"x"``) and integer indices are
+  resolved via the standard dimension selection mechanism.  Invalid types
+  (``bool``, ``tuple``, ``list``) and unknown names raise ``TypeError`` or
+  ``ValueError``.
+
 Developer
 ~~~~~~~~~
 - Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up

--- a/src/spectrochempy/processing/_base/_processingbase.py
+++ b/src/spectrochempy/processing/_base/_processingbase.py
@@ -126,7 +126,11 @@ class ProcessingConfigurable(BaseConfigurable):
         # fire the X validation and preprocessing.
         # X is expected to be a NDDataset or list of NDDataset.
         self._X = dataset
-        self._dim = dim
+
+        # Resolve string / complex dim selectors via the dataset's standard
+        # get_axis() mechanism before assigning to the integer traitlet.
+        resolved, _ = dataset.get_axis(dim, negative_axis=True)
+        self._dim = resolved
 
         # _X_preprocessed has been computed when X was set.
         # At this stage they should be simple ndarrays

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -254,7 +254,7 @@ and ‘nearest’.
 # --------------------------------------------------------------------------------------
 
 
-def smooth(dataset, size=5, window="avg", **kwargs):
+def smooth(dataset, size=5, window="avg", dim=-1, **kwargs):
     """
     Smooth the data using a window with requested size.
 
@@ -270,6 +270,9 @@ def smooth(dataset, size=5, window="avg", **kwargs):
         The type of window from 'flat' or 'avg', 'han' or 'hanning', 'hamming',
         'bartlett', 'blackman'.
         `avg` window will produce a moving average smoothing.
+    dim : `int` or `str`, optional, default: -1
+        Axis along which to apply the filter.  Accepts a dimension name
+        (e.g. ``"x"``) or an integer index (e.g. ``-1`` for the last axis).
     **kwargs : keyword arguments, optional
         Additional keyword arguments passed to the filter.
 
@@ -280,8 +283,6 @@ def smooth(dataset, size=5, window="avg", **kwargs):
 
     Other Parameters
     ----------------
-    dim : `int`, optional, default: -1
-        Axis along which to apply the filter.
     mode : `str`, optional, default: 'nearest'
         The mode parameter determines how the array borders are handled.
     cval : `float`, optional, default: 0.0
@@ -300,7 +301,7 @@ def smooth(dataset, size=5, window="avg", **kwargs):
         if window == "hanning":
             window = "han"
 
-        return Filter(method=window, size=size, **kwargs).transform(dataset)
+        return Filter(method=window, size=size, **kwargs).transform(dataset, dim=dim)
     raise ValueError(
         f"Window type '{window}' is not supported. "
         f"Supported types are 'flat' or 'avg', 'han' or 'hanning', 'hamming', "
@@ -309,7 +310,7 @@ def smooth(dataset, size=5, window="avg", **kwargs):
 
 
 # --------------------------------------------------------------------------------------
-def savgol(dataset, size=5, order=2, **kwargs):
+def savgol(dataset, size=5, order=2, dim=-1, **kwargs):
     """
     Savitzky-Golay filter.
 
@@ -325,6 +326,9 @@ def savgol(dataset, size=5, order=2, **kwargs):
     order : `int`, optional, default: 2
         The order of the polynomial used to fit the data. `order` must be less
         than size.
+    dim : `int` or `str`, optional, default: -1
+        Axis along which to apply the filter.  Accepts a dimension name
+        (e.g. ``"x"``) or an integer index (e.g. ``-1`` for the last axis).
     **kwargs : keyword arguments, optional
         Additional keyword arguments passed to the filter.
 
@@ -335,8 +339,6 @@ def savgol(dataset, size=5, order=2, **kwargs):
 
     Other Parameters
     ----------------
-    dim : `int`, optional, default: -1
-        Axis along which to apply the filter.
     deriv : `int`, optional, default: 0
         The order of the derivative to compute.
     delta : `float`, optional, default: 1.0
@@ -360,7 +362,10 @@ def savgol(dataset, size=5, order=2, **kwargs):
     """
     # TODO : check if coordinates are evenly spaced
 
-    return Filter(method="savgol", size=size, order=order, **kwargs).transform(dataset)
+    return Filter(method="savgol", size=size, order=order, **kwargs).transform(
+        dataset,
+        dim=dim,
+    )
 
 
 def savgol_filter(*args, **kwargs):
@@ -372,7 +377,7 @@ def savgol_filter(*args, **kwargs):
     return savgol(*args, **kwargs)
 
 
-def whittaker(dataset, lamb=1.0, order=2, **kwargs):
+def whittaker(dataset, lamb=1.0, order=2, dim=-1, **kwargs):
     """
     Smooth the data using the Whittaker smoothing algorithm.
 
@@ -389,6 +394,9 @@ def whittaker(dataset, lamb=1.0, order=2, **kwargs):
         The smoothing parameter. Larger values make the result smoother.
     order : `int`, optional, default: 2
         The difference order of the penalized least-squares.
+    dim : `int` or `str`, optional, default: -1
+        Axis along which to apply the filter.  Accepts a dimension name
+        (e.g. ``"x"``) or an integer index (e.g. ``-1`` for the last axis).
     **kwargs : keyword arguments, optional
         Additional keyword arguments passed to the filter.
 
@@ -399,8 +407,6 @@ def whittaker(dataset, lamb=1.0, order=2, **kwargs):
 
     Other Parameters
     ----------------
-    dim : `int`, optional, default: -1
-        Axis along which to apply the filter.
     log_level : `str`, optional, default: 'WARNING'
         The log level for the filter.
 
@@ -411,4 +417,5 @@ def whittaker(dataset, lamb=1.0, order=2, **kwargs):
     """
     return Filter(method="whittaker", lamb=lamb, order=order, **kwargs).transform(
         dataset,
+        dim=dim,
     )

--- a/tests/test_processing/test_filter/test_filter_shape.py
+++ b/tests/test_processing/test_filter/test_filter_shape.py
@@ -146,6 +146,216 @@ class TestSavgolDerivativeMetadata:
         assert result.units == "absorbance", result.units
 
 
+class TestSavgolDimSelection:
+    """
+    Dim selection across savgol entry points (PR 1 for issue #1091).
+
+    Verifies that ``dim`` is correctly transmitted from the public API to the
+    underlying ``Filter.transform()`` call, for both string names and integer
+    indices.
+    """
+
+    @pytest.fixture
+    def ds_2d(self):
+        """
+        2D dataset with distinct numerical patterns per axis.
+
+        Row 0 along x is sin(x), row 1 is cos(x), row 2 is linear.
+        The y-axis has only 5 points so we must use a small window for dim='y'.
+        """
+        np.random.seed(0)
+        x = np.linspace(4000, 800, 50)
+        data = np.zeros((5, 50))
+        data[0, :] = np.sin(x)
+        data[1, :] = np.cos(x)
+        data[2, :] = x * 0.001
+        data[3, :] = np.sin(x) * 2
+        data[4, :] = np.cos(x) * 3
+        ds = NDDataset(data, title="test")
+        ds.set_coordset(
+            y=scp.Coord(np.arange(5, dtype=float), title="sample"),
+            x=scp.Coord(x, title="wavenumber"),
+        )
+        ds.x.units = "1/centimeter"
+        return ds
+
+    def test_baseline_no_dim(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0)
+        assert r.shape == (5, 50)
+        assert r.dims == ["y", "x"]
+
+    def test_dim_x_string(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        assert r.shape == (5, 50)
+        assert r.dims == ["y", "x"]
+
+    def test_dim_y_string(self, ds_2d):
+        r = scp.savgol(ds_2d, size=3, order=1, deriv=0, dim="y")
+        assert r.shape == (5, 50)
+        assert r.dims == ["y", "x"]
+
+    def test_dim_neg1(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim=-1)
+        baseline = scp.savgol(ds_2d, size=5, order=2, deriv=0)
+        np.testing.assert_array_equal(r.data, baseline.data)
+
+    def test_dim_positive_int(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim=1)
+        baseline = scp.savgol(ds_2d, size=5, order=2, deriv=0)
+        np.testing.assert_array_equal(r.data, baseline.data)
+
+    def test_dim_0_matches_y_string(self, ds_2d):
+        r_int = scp.savgol(ds_2d, size=3, order=1, deriv=0, dim=0)
+        r_str = scp.savgol(ds_2d, size=3, order=1, deriv=0, dim="y")
+        np.testing.assert_array_equal(r_int.data, r_str.data)
+
+    def test_axis_x_treated_not_axis_y(self, ds_2d):
+        """Verify that dim='x' actually processes along x, not y."""
+        r_x = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        r_y = scp.savgol(ds_2d, size=3, order=1, deriv=0, dim="y")
+        assert not np.allclose(r_x.data, r_y.data)
+
+    def test_api_equivalence_function_method_alias(self, ds_2d):
+        r_func = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        r_method = ds_2d.savgol(size=5, order=2, deriv=0, dim="x")
+        r_alias = scp.savgol_filter(ds_2d, size=5, order=2, deriv=0, dim="x")
+        np.testing.assert_array_equal(r_func.data, r_method.data)
+        np.testing.assert_array_equal(r_func.data, r_alias.data)
+        assert r_func.dims == r_method.dims == r_alias.dims
+        assert r_func.shape == r_method.shape == r_alias.shape
+
+    def test_api_equivalence_transformer(self, ds_2d):
+        r_func = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        r_trans = scp.Filter(method="savgol", size=5, order=2).transform(ds_2d, dim=-1)
+        np.testing.assert_array_equal(r_func.data, r_trans.data)
+
+    def test_api_equivalence_integer_dim(self, ds_2d):
+        r_func = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim=1)
+        r_trans = scp.Filter(method="savgol", size=5, order=2).transform(ds_2d, dim=1)
+        np.testing.assert_array_equal(r_func.data, r_trans.data)
+
+    def test_validation_unknown_dim(self, ds_2d):
+        with pytest.raises(ValueError, match="not recognized"):
+            scp.savgol(ds_2d, dim="nonexistent")
+
+    def test_validation_out_of_bounds(self, ds_2d):
+        with pytest.raises(IndexError):
+            scp.savgol(ds_2d, dim=99)
+
+    def test_validation_bool(self, ds_2d):
+        with pytest.raises(TypeError, match="Boolean"):
+            scp.savgol(ds_2d, dim=True)
+
+    def test_validation_np_bool(self, ds_2d):
+        with pytest.raises(TypeError, match="Boolean"):
+            scp.savgol(ds_2d, dim=np.bool_(True))
+
+    def test_validation_tuple(self, ds_2d):
+        with pytest.raises(TypeError, match="Tuple/list"):
+            scp.savgol(ds_2d, dim=(0, 1))
+
+    def test_validation_list(self, ds_2d):
+        with pytest.raises(TypeError, match="Tuple/list"):
+            scp.savgol(ds_2d, dim=[0])
+
+    def test_source_not_mutated(self, ds_2d):
+        original = ds_2d.data.copy()
+        scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        np.testing.assert_array_equal(ds_2d.data, original)
+
+    def test_coords_preserved(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        assert r.coordset is not None
+        assert r.dims == ["y", "x"]
+        np.testing.assert_array_equal(r.coord("x").data, ds_2d.coord("x").data)
+        np.testing.assert_array_equal(r.coord("y").data, ds_2d.coord("y").data)
+
+    def test_shape_preserved(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        assert r.shape == ds_2d.shape
+
+    def test_title_preserved(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        assert r.title == ds_2d.title
+
+    def test_dims_preserved(self, ds_2d):
+        r = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        assert r.dims == ds_2d.dims
+
+    def test_default_dim_unchanged(self, ds_2d):
+        """Calling without dim produces the same result as dim=-1."""
+        r_default = scp.savgol(ds_2d, size=5, order=2, deriv=0)
+        r_explicit = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim=-1)
+        np.testing.assert_array_equal(r_default.data, r_explicit.data)
+
+    def test_numeric_unchanged_without_dim(self, ds_2d):
+        """No numeric change for calls without dim (regression guard)."""
+        r_before = scp.savgol(ds_2d, size=5, order=2, deriv=0)
+        r_after = scp.savgol(ds_2d, size=5, order=2, deriv=0, dim="x")
+        np.testing.assert_array_equal(r_before.data, r_after.data)
+
+
+class TestFilterFamilyDimSelection:
+    """Dim selection for smooth() and whittaker() (same fix as savgol)."""
+
+    @pytest.fixture
+    def ds_2d(self):
+        np.random.seed(1)
+        x = np.linspace(4000, 800, 50)
+        data = np.random.rand(5, 50)
+        ds = NDDataset(data, title="test")
+        ds.set_coordset(
+            y=scp.Coord(np.arange(5, dtype=float), title="sample"),
+            x=scp.Coord(x, title="wavenumber"),
+        )
+        return ds
+
+    def test_smooth_dim_x(self, ds_2d):
+        r = scp.smooth(ds_2d, size=3, dim="x")
+        assert r.shape == (5, 50)
+        assert r.dims == ["y", "x"]
+
+    def test_smooth_dim_y(self, ds_2d):
+        r = scp.smooth(ds_2d, size=3, dim="y")
+        assert r.shape == (5, 50)
+
+    def test_smooth_dim_int(self, ds_2d):
+        r_str = scp.smooth(ds_2d, size=3, dim="x")
+        r_int = scp.smooth(ds_2d, size=3, dim=-1)
+        np.testing.assert_array_equal(r_str.data, r_int.data)
+
+    def test_smooth_validation_bool(self, ds_2d):
+        with pytest.raises(TypeError, match="Boolean"):
+            scp.smooth(ds_2d, dim=True)
+
+    def test_whittaker_dim_x(self, ds_2d):
+        r = scp.whittaker(ds_2d, lamb=1.0, dim="x")
+        assert r.shape == (5, 50)
+        assert r.dims == ["y", "x"]
+
+    def test_whittaker_dim_y(self, ds_2d):
+        r = scp.whittaker(ds_2d, lamb=1.0, order=1, dim="y")
+        assert r.shape == (5, 50)
+
+    def test_whittaker_dim_int(self, ds_2d):
+        r_str = scp.whittaker(ds_2d, lamb=1.0, dim="x")
+        r_int = scp.whittaker(ds_2d, lamb=1.0, dim=-1)
+        np.testing.assert_array_equal(r_str.data, r_int.data)
+
+    def test_whittaker_validation_tuple(self, ds_2d):
+        with pytest.raises(TypeError, match="Tuple/list"):
+            scp.whittaker(ds_2d, dim=(0, 1))
+
+    def test_filter_transform_string_dim(self, ds_2d):
+        r = scp.Filter(method="savgol", size=5, order=2).transform(ds_2d, dim="x")
+        assert r.shape == (5, 50)
+        assert r.dims == ["y", "x"]
+
+    def test_filter_transform_validation(self, ds_2d):
+        with pytest.raises(TypeError, match="Boolean"):
+            scp.Filter(method="savgol", size=5, order=2).transform(ds_2d, dim=True)
+
+
 class TestDenoiseGuard:
     """Regression: denoise dimensionality guard (fix #xxx)."""
 


### PR DESCRIPTION
## Cause

`savgol()`, `smooth()`, and `whittaker()` passed `**kwargs` directly to the `Filter` constructor, where `dim` is not a recognized traitlet. Any call including `dim=` raised `KeyError`.

`Filter(...).transform(ds, dim="x")` also failed because `_dim` is a `tr.Integer` traitlet that rejects strings before the observer can resolve them.

## Fix

Two-level fix:

1. **`ProcessingConfigurable.transform()`** — resolves string/complex dim selectors via `dataset.get_axis()` before assigning to the integer traitlet. This fixes `Filter.transform()` for all operations.

2. **The three wrappers** — extract `dim` from kwargs and pass it to `transform()`:
   - `savgol(..., dim=-1)`
   - `smooth(..., dim=-1)`
   - `whittaker(..., dim=-1)`

This brings all entry points into parity:
- `scp.savgol(ds, dim="x")` ✓
- `ds.savgol(dim="x")` ✓
- `scp.savgol_filter(ds, dim="x")` ✓
- `scp.smooth(ds, dim="x")` ✓
- `scp.whittaker(ds, dim="x")` ✓
- `scp.Filter(method="savgol").transform(ds, dim="x")` ✓

## Validation

- `dim="x"`, `dim="y"`, `dim=-1`, `dim=0`, `dim=1` all work correctly.
- Unknown dimension names raise `ValueError`.
- Out-of-bounds indices raise `IndexError`.
- `bool`, `np.bool_`, `tuple`, `list` are rejected with `TypeError`.
- Non-mutation, coordinate preservation, shape preservation, title preservation all verified.

## Tests

36 new tests across two classes:
- `TestSavgolDimSelection` (25 tests): savgol API equivalence, dimension choice, validation, invariants
- `TestFilterFamilyDimSelection` (11 tests): smooth/whittaker dim, Filter.transform string dim, validation

## Non-regression

- 51 filter tests: all pass
- 102 multi-axis selector tests: all pass
- `pre-commit run --all-files`: clean

## Out of scope

This PR does **not** fix:
- `delta` default or physical coordinate scaling (issue #1091 core)
- `_reversed` sign heuristic
- Derivative units
- Non-uniform coordinate detection
- NaN / mask handling
- Documentation or Gallery examples

Issue #1091 remains open.