### PR TITLE
FIX: scale Savitzky-Golay derivatives from coordinates

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -34,6 +34,18 @@ Bug Fixes
   (``bool``, ``tuple``, ``list``) and unknown names raise ``TypeError`` or
   ``ValueError``.
 
+- Savitzky-Golay derivatives now automatically use the signed spacing of a
+  uniformly spaced coordinate when ``delta`` is omitted
+  (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).
+  For ``deriv > 0``, the ``savgol()`` wrapper detects the coordinate along the
+  processed axis and derives a signed delta.  An ascending coordinate yields a
+  positive delta, a descending one yields a negative delta.  The derivative
+  sign therefore conforms to the physical variable carried by the coordinate
+  without relying on the unit-based ``_reversed`` heuristic.  An explicit
+  ``delta`` has priority and disables auto-detection.  On a non-uniform
+  or missing coordinate a warning is emitted and the index-based ``delta=1.0``
+  is used as a fallback.  ``deriv=0`` is unchanged.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -23,6 +23,18 @@ Bug Fixes
   (``bool``, ``tuple``, ``list``) and unknown names raise ``TypeError`` or
   ``ValueError``.
 
+- Savitzky-Golay derivatives now automatically use the signed spacing of a
+  uniformly spaced coordinate when ``delta`` is omitted
+  (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).
+  For ``deriv > 0``, the ``savgol()`` wrapper detects the coordinate along the
+  processed axis and derives a signed delta.  An ascending coordinate yields a
+  positive delta, a descending one yields a negative delta.  The derivative
+  sign therefore conforms to the physical variable carried by the coordinate
+  without relying on the unit-based ``_reversed`` heuristic.  An explicit
+  ``delta`` has priority and disables auto-detection.  On a non-uniform
+  or missing coordinate a warning is emitted and the index-based ``delta=1.0``
+  is used as a fallback.  ``deriv=0`` is unchanged.
+
 Developer
 ~~~~~~~~~
 - Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up

--- a/src/spectrochempy/processing/_base/_processingbase.py
+++ b/src/spectrochempy/processing/_base/_processingbase.py
@@ -5,16 +5,12 @@
 # ======================================================================================
 """Module implementing the base abstract classes to define estimators such as PCA, ..."""
 
-import logging
-
 import traitlets as tr
 
 from spectrochempy.application.application import app
 from spectrochempy.utils.baseconfigurable import BaseConfigurable
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
 from spectrochempy.utils.exceptions import NotTransformedError
-
-logger = logging.getLogger(__name__)
 
 
 # ======================================================================================
@@ -148,9 +144,6 @@ class ProcessingConfigurable(BaseConfigurable):
         self._transformed = True
         return Xt
 
-    # ------------------------------------------------------------------
-    # Coordinate spacing detection (used by savgol for auto-delta)
-    # ------------------------------------------------------------------
     @property
     def log(self):
         """Return ``log`` output."""

--- a/src/spectrochempy/processing/_base/_processingbase.py
+++ b/src/spectrochempy/processing/_base/_processingbase.py
@@ -5,12 +5,17 @@
 # ======================================================================================
 """Module implementing the base abstract classes to define estimators such as PCA, ..."""
 
+import logging
+
+import numpy as np
 import traitlets as tr
 
 from spectrochempy.application.application import app
 from spectrochempy.utils.baseconfigurable import BaseConfigurable
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
 from spectrochempy.utils.exceptions import NotTransformedError
+
+logger = logging.getLogger(__name__)
 
 
 # ======================================================================================
@@ -143,6 +148,67 @@ class ProcessingConfigurable(BaseConfigurable):
         # methods which need to be applied will be possibly used.
         self._transformed = True
         return Xt
+
+    # ------------------------------------------------------------------
+    # Coordinate spacing detection (used by savgol for auto-delta)
+    # ------------------------------------------------------------------
+    def _detect_uniform_spacing(self, dataset, dim):
+        """
+        Detect uniform spacing from the coordinate along *dim*.
+
+        Returns ``(delta_signed, message)`` where *delta_signed* is a float
+        when the coordinate is uniformly spaced, or ``None`` when detection
+        fails (in which case *message* explains why).
+
+        The returned delta carries the sign of the real storage order:
+        an ascending coordinate yields a positive delta, a descending one
+        yields a negative delta.
+
+        Detection uses ``numpy.diff`` and checks that the range of
+        spacings is within a relative tolerance of 1% of the mean
+        spacing.  This accommodates the limited precision of coordinate
+        storage while remaining far below physically meaningful spacing
+        variations.  No median or implicit fallback is produced.
+
+        Parameters
+        ----------
+        dataset : `NDDataset`
+            The dataset whose coordinate is inspected.
+        dim : int
+            The resolved integer axis index.
+
+        Returns
+        -------
+        delta_signed : float or None
+        message : str or None
+        """
+        try:
+            coord = dataset.coord(dim)
+        except Exception:
+            return None, "no coordinate available"
+
+        if coord is None:
+            return None, "coordinate is None"
+
+        values = np.asarray(coord.data, dtype=float)
+
+        if values.ndim != 1 or values.size < 2:
+            return None, "coordinate has fewer than 2 points"
+
+        if not np.all(np.isfinite(values)):
+            return None, "coordinate contains non-finite values (NaN or Inf)"
+
+        diffs = np.diff(values)
+
+        if np.all(diffs == 0):
+            return None, "coordinate is degenerate (all values identical)"
+
+        mean_diff = np.mean(diffs)
+        spread = np.ptp(diffs)
+        if spread / np.abs(mean_diff) > 0.01:
+            return None, "coordinate is not uniformly spaced"
+
+        return float(diffs[0]), None
 
     @property
     def log(self):

--- a/src/spectrochempy/processing/_base/_processingbase.py
+++ b/src/spectrochempy/processing/_base/_processingbase.py
@@ -7,7 +7,6 @@
 
 import logging
 
-import numpy as np
 import traitlets as tr
 
 from spectrochempy.application.application import app
@@ -152,64 +151,6 @@ class ProcessingConfigurable(BaseConfigurable):
     # ------------------------------------------------------------------
     # Coordinate spacing detection (used by savgol for auto-delta)
     # ------------------------------------------------------------------
-    def _detect_uniform_spacing(self, dataset, dim):
-        """
-        Detect uniform spacing from the coordinate along *dim*.
-
-        Returns ``(delta_signed, message)`` where *delta_signed* is a float
-        when the coordinate is uniformly spaced, or ``None`` when detection
-        fails (in which case *message* explains why).
-
-        The returned delta carries the sign of the real storage order:
-        an ascending coordinate yields a positive delta, a descending one
-        yields a negative delta.
-
-        Detection uses ``numpy.diff`` and checks that the range of
-        spacings is within a relative tolerance of 1% of the mean
-        spacing.  This accommodates the limited precision of coordinate
-        storage while remaining far below physically meaningful spacing
-        variations.  No median or implicit fallback is produced.
-
-        Parameters
-        ----------
-        dataset : `NDDataset`
-            The dataset whose coordinate is inspected.
-        dim : int
-            The resolved integer axis index.
-
-        Returns
-        -------
-        delta_signed : float or None
-        message : str or None
-        """
-        try:
-            coord = dataset.coord(dim)
-        except Exception:
-            return None, "no coordinate available"
-
-        if coord is None:
-            return None, "coordinate is None"
-
-        values = np.asarray(coord.data, dtype=float)
-
-        if values.ndim != 1 or values.size < 2:
-            return None, "coordinate has fewer than 2 points"
-
-        if not np.all(np.isfinite(values)):
-            return None, "coordinate contains non-finite values (NaN or Inf)"
-
-        diffs = np.diff(values)
-
-        if np.all(diffs == 0):
-            return None, "coordinate is degenerate (all values identical)"
-
-        mean_diff = np.mean(diffs)
-        spread = np.ptp(diffs)
-        if spread / np.abs(mean_diff) > 0.01:
-            return None, "coordinate is not uniformly spaced"
-
-        return float(diffs[0]), None
-
     @property
     def log(self):
         """Return ``log`` output."""

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -124,8 +124,16 @@ class Filter(ProcessingConfigurable):
 
     delta = tr.Float(
         default_value=1.0,
+        allow_none=True,
         help="The spacing of the samples to which the filter will be applied. "
-        "This is only used if deriv > 0.",
+        "This is only used if deriv > 0.\n\n"
+        "When ``None`` (the default for the ``savgol()`` wrapper), the spacing "
+        "is automatically derived from the coordinate of the processed axis "
+        "if the coordinate is uniformly spaced.  If the coordinate is missing, "
+        "non-uniform, or non-numeric, the index-based delta of 1.0 is used "
+        "with a warning.\n\n"
+        "When set to a numeric value, that value is used as-is and no "
+        "automatic coordinate detection is performed.",
     ).tag(config=True)
 
     mode = tr.Enum(
@@ -211,17 +219,53 @@ and ‘nearest’.
         # Savitzky-Golay filter
         # ---------------------
         elif self.method == "savgol":
+            # ------------------------------------------------------------------
+            # Coordinate-aware delta: when delta is None (auto-detect) and a
+            # derivative is requested, derive the signed spacing from the
+            # coordinate.  The sign naturally handles ascending/descending
+            # coordinates so no _reversed correction is needed.
+            # ------------------------------------------------------------------
+            delta_used = self.delta
+            _auto_detected = False
+
+            if self.delta is None:
+                if self.deriv:
+                    delta_signed, msg = self._detect_uniform_spacing(
+                        self._X,
+                        self._dim,
+                    )
+                    if delta_signed is not None:
+                        delta_used = delta_signed
+                        _auto_detected = True
+                    else:
+                        delta_used = 1.0
+                        import warnings as _warnings
+
+                        _warnings.warn(
+                            f"Savitzky-Golay derivative requested but {msg}. "
+                            "Falling back to index-based delta=1.0. "
+                            "To obtain physically scaled derivatives, provide "
+                            "a uniformly spaced coordinate or set delta explicitly.",
+                            stacklevel=2,
+                        )
+                else:
+                    # deriv=0: delta is irrelevant; scipy needs a float
+                    delta_used = 1.0
+
             kwargs = {
                 "axis": self._dim,
                 "deriv": self.deriv,
-                "delta": self.delta,
+                "delta": delta_used,
                 "mode": self.mode,
                 "cval": self.cval,
             }
             data = scipy.signal.savgol_filter(X, self.size, self.order, **kwargs)
 
-            # Change derived data sign if we have reversed coordinate axis
-            if self._reversed and self.deriv:
+            # _reversed correction: ONLY when an explicit delta was used
+            # (the user supplied delta=1.0 or another value).  When the
+            # delta was auto-detected from the coordinate the sign is
+            # already correct and no further correction must be applied.
+            if not _auto_detected and self._reversed and self.deriv:
                 data = data * (-1) ** self.deriv
 
             # Annotate the output title so a derivative quantity is clearly
@@ -310,7 +354,7 @@ def smooth(dataset, size=5, window="avg", dim=-1, **kwargs):
 
 
 # --------------------------------------------------------------------------------------
-def savgol(dataset, size=5, order=2, dim=-1, **kwargs):
+def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
     """
     Savitzky-Golay filter.
 
@@ -329,6 +373,20 @@ def savgol(dataset, size=5, order=2, dim=-1, **kwargs):
     dim : `int` or `str`, optional, default: -1
         Axis along which to apply the filter.  Accepts a dimension name
         (e.g. ``"x"``) or an integer index (e.g. ``-1`` for the last axis).
+    delta : `float` or ``None``, optional, default: ``None``
+        Sample spacing of the coordinate to which the filter is applied.
+
+        * ``None`` (default) — when ``deriv > 0``, the signed spacing is
+          automatically derived from the coordinate of the processed axis
+          if the coordinate is uniformly spaced.  On a non-uniform or
+          missing coordinate a warning is emitted and the index-based
+          ``delta=1.0`` is used as a fallback.
+        * A numeric value — used as-is; no automatic coordinate detection
+          is performed.
+
+        .. versionchanged:: 0.13.0
+           Default changed from ``1.0`` to ``None`` (auto-detect).
+
     **kwargs : keyword arguments, optional
         Additional keyword arguments passed to the filter.
 
@@ -341,8 +399,6 @@ def savgol(dataset, size=5, order=2, dim=-1, **kwargs):
     ----------------
     deriv : `int`, optional, default: 0
         The order of the derivative to compute.
-    delta : `float`, optional, default: 1.0
-        The spacing of the samples to which the filter will be applied.
     mode : `str`, optional, default: 'nearest'
         The mode parameter determines how the array borders are handled.
     cval : `float`, optional, default: 0.0
@@ -362,7 +418,9 @@ def savgol(dataset, size=5, order=2, dim=-1, **kwargs):
     """
     # TODO : check if coordinates are evenly spaced
 
-    return Filter(method="savgol", size=size, order=order, **kwargs).transform(
+    return Filter(
+        method="savgol", size=size, order=order, delta=delta, **kwargs
+    ).transform(
         dataset,
         dim=dim,
     )

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -48,12 +48,23 @@ def _detect_uniform_spacing(dataset, dim):
     """
     try:
         coord = dataset.coord(dim)
-    except Exception:
+    except AttributeError:
         return None, "no coordinate available"
 
     if coord is None:
         return None, "coordinate is None"
 
+    if coord.is_masked or (
+        hasattr(coord, "_mask")
+        and isinstance(coord._mask, np.ndarray)
+        and np.any(coord._mask)
+    ):
+        return None, "coordinate contains masked values"
+
+    # Use coord._data (raw float64 storage) rather than coord.data.
+    # The public .data property applies a rounding layer that truncates
+    # float64 to ~4 significant digits, destroying the uniform-spacing
+    # signal.  _data preserves the original precision.
     try:
         values = np.asarray(coord._data, dtype=float)
     except (TypeError, ValueError):
@@ -469,14 +480,13 @@ def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
 
     Notes
     -----
-    When ``delta`` is ``None`` (the default), the Savitzky-Golay filter
-    automatically detects the coordinate spacing.  Be aware that the
-    Savitzky-Golay algorithm is fundamentally index-based; coordinate-aware
-    scaling is applied as a post-processing step.
+    When ``delta`` is ``None`` (the default), the sample spacing is
+    detected from the coordinate and passed directly to
+    ``scipy.signal.savgol_filter``.  The Savitzky-Golay algorithm is
+    fundamentally index-based; the detected delta scales the derivative
+    coefficients during the convolution.
 
     """
-    # TODO : check if coordinates are evenly spaced
-
     return Filter(
         method="savgol", size=size, order=order, delta=delta, **kwargs
     ).transform(

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -21,6 +21,63 @@ __dataset_methods__ = [
 __configurables__ = ["Filter"]
 __all__ = __dataset_methods__ + __configurables__
 
+
+def _detect_uniform_spacing(dataset, dim):
+    """
+    Detect uniform spacing from the coordinate along *dim*.
+
+    Uses the raw float64 storage (``coord._data``) to avoid precision loss
+    from the ``Coord`` rounding layer.  All successive differences are
+    compared to their mean with ``numpy.allclose(rtol=1e-10, atol=0)``.
+    The mean signed delta is returned (not ``diffs[0]``).
+
+    Parameters
+    ----------
+    dataset : `NDDataset`
+        The dataset whose coordinate is inspected.
+    dim : int
+        The resolved integer axis index.
+
+    Returns
+    -------
+    delta_signed : float or None
+        The mean signed spacing when the coordinate is uniformly spaced,
+        or ``None`` when detection fails.
+    message : str or None
+        Explanation when *delta_signed* is ``None``, else ``None``.
+    """
+    try:
+        coord = dataset.coord(dim)
+    except Exception:
+        return None, "no coordinate available"
+
+    if coord is None:
+        return None, "coordinate is None"
+
+    try:
+        values = np.asarray(coord._data, dtype=float)
+    except (TypeError, ValueError):
+        return None, "coordinate is not numeric"
+
+    if values.ndim != 1 or values.size < 2:
+        return None, "coordinate has fewer than 2 points"
+
+    if not np.all(np.isfinite(values)):
+        return None, "coordinate contains non-finite values (NaN or Inf)"
+
+    diffs = np.diff(values)
+
+    if np.all(diffs == 0):
+        return None, "coordinate is degenerate (all values identical)"
+
+    mean_diff = np.mean(diffs)
+
+    if not np.allclose(diffs, mean_diff, rtol=1e-10, atol=0):
+        return None, "coordinate is not uniformly spaced"
+
+    return float(mean_diff), None
+
+
 _common_see_also = """
 See Also
 --------
@@ -123,11 +180,11 @@ class Filter(ProcessingConfigurable):
     ).tag(config=True)
 
     delta = tr.Float(
-        default_value=1.0,
+        default_value=None,
         allow_none=True,
         help="The spacing of the samples to which the filter will be applied. "
         "This is only used if deriv > 0.\n\n"
-        "When ``None`` (the default for the ``savgol()`` wrapper), the spacing "
+        "When ``None`` (the default), the spacing "
         "is automatically derived from the coordinate of the processed axis "
         "if the coordinate is uniformly spaced.  If the coordinate is missing, "
         "non-uniform, or non-numeric, the index-based delta of 1.0 is used "
@@ -230,7 +287,7 @@ and ‘nearest’.
 
             if self.delta is None:
                 if self.deriv:
-                    delta_signed, msg = self._detect_uniform_spacing(
+                    delta_signed, msg = _detect_uniform_spacing(
                         self._X,
                         self._dim,
                     )
@@ -384,7 +441,7 @@ def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
         * A numeric value — used as-is; no automatic coordinate detection
           is performed.
 
-        .. versionchanged:: 0.13.0
+        .. versionchanged:: 0.12.5
            Default changed from ``1.0`` to ``None`` (auto-detect).
 
     **kwargs : keyword arguments, optional
@@ -412,8 +469,10 @@ def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
 
     Notes
     -----
-    Even spacing of the axis coordinates is NOT checked.
-    Be aware that Savitzky-Golay algorithm is based on indexes, not on coordinates.
+    When ``delta`` is ``None`` (the default), the Savitzky-Golay filter
+    automatically detects the coordinate spacing.  Be aware that the
+    Savitzky-Golay algorithm is fundamentally index-based; coordinate-aware
+    scaling is applied as a post-processing step.
 
     """
     # TODO : check if coordinates are evenly spaced

--- a/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
+++ b/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
@@ -7,10 +7,12 @@ Covers:
 - unit-independent sign (cm⁻¹, ppm, unitless)
 - delta=None auto-detect vs explicit delta
 - irregular coordinate warning
-- missing / degenerate / non-finite coordinate fallback
+- missing / degenerate / non-finite / non-numeric coordinate fallback
 - deriv=0 invariance
 - invariants (non-mutation, shape, coords, title)
 - API equivalence after PR 1 dim fix
+- Filter object reuse (no delta leak)
+- explicit delta + _reversed interaction (cm⁻¹/ppm)
 """
 
 import warnings
@@ -22,6 +24,7 @@ import spectrochempy as scp
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.processing.filter.filter import Filter
+from spectrochempy.processing.filter.filter import _detect_uniform_spacing
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -101,11 +104,10 @@ class TestDerivative1Analytic:
         r = scp.savgol(ds, size=7, order=3, deriv=1)
         expected = 6.0 * x[MID]
         actual = float(r.data[0, MID])
-        # Savitzky-Golay interior error is dominated by the filter approximation,
-        # not by our delta derivation.  Allow generous tolerance for edge effects.
+        # With _data precision the auto-detected delta is exact to ~1e-14.
         assert (
-            abs(actual - expected) < 0.15
-        ), f"{fixture_name}: deriv=1 auto: actual={actual:.4f}, expected={expected:.4f}"
+            abs(actual - expected) < 1e-12
+        ), f"{fixture_name}: deriv=1 auto: actual={actual:.10f}, expected={expected:.10f}"
 
     def test_deriv1_sign_ascending(self, ds_asc):
         ds, x = ds_asc
@@ -130,9 +132,7 @@ class TestDerivative1Analytic:
     def test_deriv1_explicit_delta_matches_scipy(self, ds_asc):
         ds, x = ds_asc
         r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
-        sp = scp.Filter(method="savgol", size=7, order=3, deriv=1, delta=H).transform(
-            ds
-        )
+        sp = Filter(method="savgol", size=7, order=3, deriv=1, delta=H).transform(ds)
         np.testing.assert_allclose(r.data, sp.data, atol=1e-14)
 
 
@@ -153,8 +153,8 @@ class TestDerivative2Analytic:
         r = scp.savgol(ds, size=7, order=3, deriv=2)
         actual = float(r.data[0, MID])
         assert (
-            abs(actual - 6.0) < 0.05
-        ), f"{fixture_name}: deriv=2 auto: actual={actual:.4f}, expected=6.0000"
+            abs(actual - 6.0) < 1e-12
+        ), f"{fixture_name}: deriv=2 auto: actual={actual:.10f}, expected=6.0000000000"
 
 
 # ---------------------------------------------------------------------------
@@ -205,19 +205,24 @@ class TestDeltaPriority:
         np.testing.assert_allclose(r.data, expected, atol=1e-14)
 
     def test_filter_reuse_no_delta_leak(self):
-        """Two successive transforms with different coords via the wrapper."""
+        """Single Filter object reused on two datasets with different coords."""
         x1 = np.linspace(1, 10, 50)
         x2 = np.linspace(1, 20, 50)
         ds1 = _make_2d(3.0 * x1**2, x1)
         ds2 = _make_2d(3.0 * x2**2, x2)
 
-        r1 = scp.savgol(ds1, size=7, order=3, deriv=1)
-        r2 = scp.savgol(ds2, size=7, order=3, deriv=1)
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+        r1 = f.transform(ds1)
+        r2 = f.transform(ds2)
 
         expected1 = 6.0 * x1[MID]
         expected2 = 6.0 * x2[MID]
-        assert abs(float(r1.data[0, MID]) - expected1) < 0.15
-        assert abs(float(r2.data[0, MID]) - expected2) < 0.15
+        assert (
+            abs(float(r1.data[0, MID]) - expected1) < 1e-12
+        ), f"ds1: actual={float(r1.data[0,MID]):.6f}, expected={expected1:.6f}"
+        assert (
+            abs(float(r2.data[0, MID]) - expected2) < 1e-12
+        ), f"ds2: actual={float(r2.data[0,MID]):.6f}, expected={expected2:.6f}"
 
 
 # ---------------------------------------------------------------------------
@@ -258,12 +263,12 @@ class TestIrregularCoordinate:
 
 
 # ---------------------------------------------------------------------------
-# Missing / degenerate / non-finite coordinate
+# Missing / degenerate / non-finite / non-numeric coordinate
 # ---------------------------------------------------------------------------
 
 
 class TestEdgeCoordinateCases:
-    """Missing, degenerate, or non-finite coordinates trigger fallback."""
+    """Missing, degenerate, non-finite, or non-numeric coordinates trigger fallback."""
 
     def test_no_coord(self):
         ds = NDDataset(np.random.rand(1, 50))
@@ -293,15 +298,6 @@ class TestEdgeCoordinateCases:
             coord_warnings = [x for x in w if "non-finite" in str(x.message).lower()]
             assert len(coord_warnings) >= 1
 
-    def test_too_few_points(self):
-        ds = NDDataset(np.ones((1, 2)))
-        ds.set_coordset(x=Coord(np.array([5.0, 5.0]), title="x"))
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            scp.savgol(ds, size=1, order=0, deriv=1)
-            coord_warnings = [x for x in w if "degenerate" in str(x.message).lower()]
-            assert len(coord_warnings) >= 1
-
     def test_repeated_values_giving_zero_diff(self):
         x = np.ones(50)
         x[0] = 1.0
@@ -311,8 +307,76 @@ class TestEdgeCoordinateCases:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             scp.savgol(ds, size=7, order=3, deriv=1)
-            # Should either warn about degenerate or non-uniform
-            assert len(w) >= 0  # at minimum no crash
+            # non-uniform → must warn about falling back
+            coord_warnings = [x for x in w if "falling back" in str(x.message).lower()]
+            assert len(coord_warnings) >= 1
+
+    def test_non_numeric_coord(self):
+        """
+        A non-numeric coord triggers a fallback warning.
+
+        String coords cannot be created through the normal Coord API, so
+        this tests the helper directly with a mock whose _data is string.
+        """
+        from unittest.mock import MagicMock
+
+        mock_ds = MagicMock()
+        mock_coord = MagicMock()
+        mock_coord._data = np.array(["a", "b", "c", "d", "e"])
+        mock_ds.coord.return_value = mock_coord
+        delta, msg = _detect_uniform_spacing(mock_ds, -1)
+        assert delta is None
+        assert "not numeric" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Explicit delta + _reversed interaction (cm⁻¹/ppm)
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitDeltaReversed:
+    """
+    When an explicit delta is given, _reversed still applies (backward compat).
+
+    These tests document the existing behavior: for cm⁻¹/ppm coords with
+    explicit positive delta, _reversed flips the sign of odd-order
+    derivatives.  This is an existing limitation preserved for backward
+    compatibility.
+    """
+
+    def test_explicit_delta_cm1_ascending_positive(self, ds_asc_cm1):
+        """Explicit delta=H with ascending cm⁻¹ → _reversed flips sign."""
+        ds, x = ds_asc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        # _reversed is True for cm⁻¹, so sign is flipped
+        assert float(r.data[0, MID]) < 0
+
+    def test_explicit_delta_cm1_descending_positive(self, ds_desc_cm1):
+        """Explicit delta=H with descending cm⁻¹ → _reversed flips twice (net positive)."""
+        ds, x = ds_desc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        # descending → negative delta → _reversed flips → positive
+        assert float(r.data[0, MID]) > 0
+
+    def test_explicit_delta_cm1_negative(self, ds_asc_cm1):
+        """Explicit negative delta with ascending cm⁻¹ → _reversed flips."""
+        ds, x = ds_asc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=-H)
+        # negative delta + _reversed flips for odd deriv
+        assert float(r.data[0, MID]) > 0
+
+    def test_auto_delta_cm1_ascending_positive(self, ds_asc_cm1):
+        """Auto-detected delta with ascending cm⁻¹ → correct positive sign."""
+        ds, x = ds_asc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert float(r.data[0, MID]) > 0
+
+    def test_auto_delta_cm1_descending_negative(self, ds_desc_cm1):
+        """Auto-detected delta with descending cm⁻¹ → negative sign (correct)."""
+        ds, x = ds_desc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        # descending coord → negative auto-delta → correct negative derivative sign
+        assert float(r.data[0, MID]) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -362,12 +426,11 @@ class TestAPIEquivalence:
         np.testing.assert_allclose(r_func.data, r_method.data, atol=1e-14)
         np.testing.assert_allclose(r_func.data, r_alias.data, atol=1e-14)
 
-    def test_transformer(self, ds_asc):
+    def test_transformer_default_delta(self, ds_asc):
+        """Filter(method='savgol') with default delta=None must match savgol()."""
         ds, x = ds_asc
         r_func = scp.savgol(ds, size=7, order=3, deriv=1)
-        r_trans = Filter(
-            method="savgol", size=7, order=3, deriv=1, delta=None
-        ).transform(ds)
+        r_trans = Filter(method="savgol", size=7, order=3, deriv=1).transform(ds)
         np.testing.assert_allclose(r_func.data, r_trans.data, atol=1e-14)
 
     def test_dim_string(self, ds_asc):
@@ -383,38 +446,44 @@ class TestAPIEquivalence:
 
 
 class TestDetectUniformSpacing:
-    """Direct tests on the helper method."""
+    """Direct tests on the module-level helper function."""
 
     def test_uniform_ascending(self):
         x = np.linspace(1, 10, 50)
         ds = _make_2d(np.ones(50), x)
-        f = Filter(method="savgol", size=7, order=3, deriv=1)
-        delta, msg = f._detect_uniform_spacing(ds, -1)
+        delta, msg = _detect_uniform_spacing(ds, -1)
         assert delta is not None
         assert delta > 0
+        assert abs(delta - H) < 1e-14
         assert msg is None
 
     def test_uniform_descending(self):
         x = np.linspace(10, 1, 50)
         ds = _make_2d(np.ones(50), x)
-        f = Filter(method="savgol", size=7, order=3, deriv=1)
-        delta, msg = f._detect_uniform_spacing(ds, -1)
+        delta, msg = _detect_uniform_spacing(ds, -1)
         assert delta is not None
         assert delta < 0
+        assert abs(delta - (-H)) < 1e-14
         assert msg is None
+
+    def test_returns_mean_not_first(self):
+        """Return value must be the mean signed delta, not diffs[0]."""
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(np.ones(50), x)
+        delta, msg = _detect_uniform_spacing(ds, -1)
+        # mean of raw diffs = H exactly
+        assert delta == pytest.approx(H, abs=1e-14)
 
     def test_irregular(self):
         x = np.sort(np.random.default_rng(42).uniform(1, 10, 50))
         ds = _make_2d(np.ones(50), x)
-        f = Filter(method="savgol", size=7, order=3, deriv=1)
-        delta, msg = f._detect_uniform_spacing(ds, -1)
+        delta, msg = _detect_uniform_spacing(ds, -1)
         assert delta is None
         assert "not uniformly spaced" in msg
 
     def test_no_coord(self):
         ds = NDDataset(np.ones((1, 50)))
-        f = Filter(method="savgol", size=7, order=3, deriv=1)
-        delta, msg = f._detect_uniform_spacing(ds, -1)
+        delta, msg = _detect_uniform_spacing(ds, -1)
         assert delta is None
         assert "no coordinate" in msg.lower() or "none" in msg.lower()
 
@@ -422,7 +491,24 @@ class TestDetectUniformSpacing:
         x = np.linspace(1, 10, 50)
         x[10] = np.nan
         ds = _make_2d(np.ones(50), x)
-        f = Filter(method="savgol", size=7, order=3, deriv=1)
-        delta, msg = f._detect_uniform_spacing(ds, -1)
+        delta, msg = _detect_uniform_spacing(ds, -1)
         assert delta is None
         assert "non-finite" in msg.lower()
+
+    def test_single_point_coord(self):
+        ds = NDDataset(np.ones((1, 1)))
+        ds.set_coordset(x=Coord(np.array([5.0]), title="x"))
+        delta, msg = _detect_uniform_spacing(ds, -1)
+        assert delta is None
+        assert "fewer than 2" in msg.lower()
+
+    def test_non_numeric_coord(self):
+        from unittest.mock import MagicMock
+
+        mock_ds = MagicMock()
+        mock_coord = MagicMock()
+        mock_coord._data = np.array(["a", "b", "c", "d", "e"])
+        mock_ds.coord.return_value = mock_coord
+        delta, msg = _detect_uniform_spacing(mock_ds, -1)
+        assert delta is None
+        assert "not numeric" in msg.lower()

--- a/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
+++ b/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
@@ -153,7 +153,7 @@ class TestDerivative2Analytic:
         r = scp.savgol(ds, size=7, order=3, deriv=2)
         actual = float(r.data[0, MID])
         assert (
-            abs(actual - 6.0) < 1e-12
+            abs(actual - 6.0) < 1e-10
         ), f"{fixture_name}: deriv=2 auto: actual={actual:.10f}, expected=6.0000000000"
 
 

--- a/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
+++ b/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
@@ -1,0 +1,428 @@
+"""
+Tests for coordinate-aware Savitzky-Golay derivatives (PR 2, issue #1091).
+
+Covers:
+- analytic accuracy on y = 3x² (deriv=1 → 6x, deriv=2 → 6)
+- ascending / descending uniform coordinates
+- unit-independent sign (cm⁻¹, ppm, unitless)
+- delta=None auto-detect vs explicit delta
+- irregular coordinate warning
+- missing / degenerate / non-finite coordinate fallback
+- deriv=0 invariance
+- invariants (non-mutation, shape, coords, title)
+- API equivalence after PR 1 dim fix
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.core.dataset.coord import Coord
+from spectrochempy.core.dataset.nddataset import NDDataset
+from spectrochempy.processing.filter.filter import Filter
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+H = 0.18367346938775511  # (10-1)/49  — spacing of linspace(1, 10, 50)
+
+
+def _make_2d(data_1d, coord_values, unit=None, title="wavenumber"):
+    ds = NDDataset(data_1d.reshape(1, -1))
+    c = Coord(coord_values, title=title)
+    if unit:
+        c.units = unit
+    ds.set_coordset(x=c)
+    return ds
+
+
+@pytest.fixture
+def ds_asc():
+    """Ascending uniform coordinate, y = 3x², no unit."""
+    x = np.linspace(1, 10, 50)
+    return _make_2d(3.0 * x**2, x, unit=None, title="x"), x
+
+
+@pytest.fixture
+def ds_desc():
+    """Descending uniform coordinate, y = 3x², no unit."""
+    x = np.linspace(10, 1, 50)
+    return _make_2d(3.0 * x**2, x, unit=None, title="x"), x
+
+
+@pytest.fixture
+def ds_asc_cm1():
+    """Ascending uniform coordinate with wavenumber unit."""
+    x = np.linspace(1, 10, 50)
+    return _make_2d(3.0 * x**2, x, unit="1/centimeter"), x
+
+
+@pytest.fixture
+def ds_desc_cm1():
+    """Descending uniform coordinate with wavenumber unit."""
+    x = np.linspace(10, 1, 50)
+    return _make_2d(3.0 * x**2, x, unit="1/centimeter"), x
+
+
+@pytest.fixture
+def ds_asc_ppm():
+    """Ascending uniform coordinate with ppm unit."""
+    x = np.linspace(1, 10, 50)
+    return _make_2d(3.0 * x**2, x, unit="ppm"), x
+
+
+@pytest.fixture
+def ds_irreg():
+    """Irregular coordinate."""
+    x = np.sort(np.random.default_rng(42).uniform(1, 10, 50))
+    return _make_2d(3.0 * x**2, x, title="x"), x
+
+
+MID = 25  # midpoint index for 50-point arrays (away from edges)
+
+
+# ---------------------------------------------------------------------------
+# Analytic accuracy — deriv=1
+# ---------------------------------------------------------------------------
+
+
+class TestDerivative1Analytic:
+    """y = 3x² → y' = 6x."""
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["ds_asc", "ds_desc", "ds_asc_cm1", "ds_desc_cm1", "ds_asc_ppm"],
+    )
+    def test_deriv1_auto_delta(self, fixture_name, request):
+        ds, x = request.getfixturevalue(fixture_name)
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        expected = 6.0 * x[MID]
+        actual = float(r.data[0, MID])
+        # Savitzky-Golay interior error is dominated by the filter approximation,
+        # not by our delta derivation.  Allow generous tolerance for edge effects.
+        assert (
+            abs(actual - expected) < 0.15
+        ), f"{fixture_name}: deriv=1 auto: actual={actual:.4f}, expected={expected:.4f}"
+
+    def test_deriv1_sign_ascending(self, ds_asc):
+        ds, x = ds_asc
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.data[0, MID] > 0, "ascending deriv=1 should be positive"
+
+    def test_deriv1_sign_descending(self, ds_desc):
+        ds, x = ds_desc
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.data[0, MID] > 0, "descending deriv=1 should be positive (6x > 0)"
+
+    def test_deriv1_sign_cm1_ascending(self, ds_asc_cm1):
+        ds, x = ds_asc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.data[0, MID] > 0, "ascending cm-1 deriv=1 should be positive"
+
+    def test_deriv1_sign_cm1_descending(self, ds_desc_cm1):
+        ds, x = ds_desc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.data[0, MID] > 0, "descending cm-1 deriv=1 should be positive"
+
+    def test_deriv1_explicit_delta_matches_scipy(self, ds_asc):
+        ds, x = ds_asc
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        sp = scp.Filter(method="savgol", size=7, order=3, deriv=1, delta=H).transform(
+            ds
+        )
+        np.testing.assert_allclose(r.data, sp.data, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# Analytic accuracy — deriv=2
+# ---------------------------------------------------------------------------
+
+
+class TestDerivative2Analytic:
+    """y = 3x² → y'' = 6."""
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["ds_asc", "ds_desc", "ds_asc_cm1", "ds_desc_cm1", "ds_asc_ppm"],
+    )
+    def test_deriv2_auto_delta(self, fixture_name, request):
+        ds, x = request.getfixturevalue(fixture_name)
+        r = scp.savgol(ds, size=7, order=3, deriv=2)
+        actual = float(r.data[0, MID])
+        assert (
+            abs(actual - 6.0) < 0.05
+        ), f"{fixture_name}: deriv=2 auto: actual={actual:.4f}, expected=6.0000"
+
+
+# ---------------------------------------------------------------------------
+# deriv=0 invariance
+# ---------------------------------------------------------------------------
+
+
+class TestDeriv0Invariance:
+    """deriv=0 must be bit-identical to the input (no delta detection triggered)."""
+
+    def test_deriv0_unchanged(self, ds_asc):
+        ds, x = ds_asc
+        r = scp.savgol(ds, size=7, order=3, deriv=0)
+        np.testing.assert_allclose(r.data, ds.data, atol=1e-14)
+
+    def test_deriv0_no_warning(self, ds_asc):
+        ds, x = ds_asc
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=7, order=3, deriv=0)
+            coord_warnings = [
+                x for x in w if "uniformly spaced" in str(x.message).lower()
+            ]
+            assert len(coord_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Delta priority
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaPriority:
+    """Explicit delta must take precedence over auto-detection."""
+
+    def test_explicit_delta_overrides_auto(self, ds_asc):
+        ds, x = ds_asc
+        r_auto = scp.savgol(ds, size=7, order=3, deriv=1)
+        r_explicit = scp.savgol(ds, size=7, order=3, deriv=1, delta=1.0)
+        # auto uses h, explicit uses 1.0 → different numerical results
+        assert not np.allclose(r_auto.data, r_explicit.data, atol=1e-6)
+
+    def test_explicit_delta_h_matches_scipy(self, ds_asc):
+        ds, x = ds_asc
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        import scipy.signal
+
+        expected = scipy.signal.savgol_filter(ds.data, 7, 3, axis=-1, deriv=1, delta=H)
+        np.testing.assert_allclose(r.data, expected, atol=1e-14)
+
+    def test_filter_reuse_no_delta_leak(self):
+        """Two successive transforms with different coords via the wrapper."""
+        x1 = np.linspace(1, 10, 50)
+        x2 = np.linspace(1, 20, 50)
+        ds1 = _make_2d(3.0 * x1**2, x1)
+        ds2 = _make_2d(3.0 * x2**2, x2)
+
+        r1 = scp.savgol(ds1, size=7, order=3, deriv=1)
+        r2 = scp.savgol(ds2, size=7, order=3, deriv=1)
+
+        expected1 = 6.0 * x1[MID]
+        expected2 = 6.0 * x2[MID]
+        assert abs(float(r1.data[0, MID]) - expected1) < 0.15
+        assert abs(float(r2.data[0, MID]) - expected2) < 0.15
+
+
+# ---------------------------------------------------------------------------
+# Irregular coordinate
+# ---------------------------------------------------------------------------
+
+
+class TestIrregularCoordinate:
+    """Non-uniform coordinate must trigger a warning and fall back to delta=1.0."""
+
+    def test_warning_emitted(self, ds_irreg):
+        ds, x = ds_irreg
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=7, order=3, deriv=1)
+            coord_warnings = [
+                x for x in w if "uniformly spaced" in str(x.message).lower()
+            ]
+            assert len(coord_warnings) >= 1
+
+    def test_fallback_to_index_based(self, ds_irreg):
+        ds, x = ds_irreg
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("ignore")
+            r_auto = scp.savgol(ds, size=7, order=3, deriv=1)
+        r_explicit = scp.savgol(ds, size=7, order=3, deriv=1, delta=1.0)
+        np.testing.assert_allclose(r_auto.data, r_explicit.data, atol=1e-14)
+
+    def test_explicit_delta_suppresses_warning(self, ds_irreg):
+        ds, x = ds_irreg
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=7, order=3, deriv=1, delta=1.0)
+            coord_warnings = [
+                x for x in w if "uniformly spaced" in str(x.message).lower()
+            ]
+            assert len(coord_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Missing / degenerate / non-finite coordinate
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCoordinateCases:
+    """Missing, degenerate, or non-finite coordinates trigger fallback."""
+
+    def test_no_coord(self):
+        ds = NDDataset(np.random.rand(1, 50))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=7, order=3, deriv=1)
+            coord_warnings = [x for x in w if "falling back" in str(x.message).lower()]
+            assert len(coord_warnings) >= 1
+
+    def test_degenerate_coord(self):
+        ds = NDDataset(np.random.rand(1, 50))
+        ds.set_coordset(x=Coord(np.ones(50), title="x"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=7, order=3, deriv=1)
+            coord_warnings = [x for x in w if "degenerate" in str(x.message).lower()]
+            assert len(coord_warnings) >= 1
+
+    def test_nan_in_coord(self):
+        x = np.linspace(1, 10, 50)
+        x[25] = np.nan
+        ds = NDDataset(np.random.rand(1, 50))
+        ds.set_coordset(x=Coord(x, title="x"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=7, order=3, deriv=1)
+            coord_warnings = [x for x in w if "non-finite" in str(x.message).lower()]
+            assert len(coord_warnings) >= 1
+
+    def test_too_few_points(self):
+        ds = NDDataset(np.ones((1, 2)))
+        ds.set_coordset(x=Coord(np.array([5.0, 5.0]), title="x"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=1, order=0, deriv=1)
+            coord_warnings = [x for x in w if "degenerate" in str(x.message).lower()]
+            assert len(coord_warnings) >= 1
+
+    def test_repeated_values_giving_zero_diff(self):
+        x = np.ones(50)
+        x[0] = 1.0
+        x[-1] = 2.0
+        ds = NDDataset(np.random.rand(1, 50))
+        ds.set_coordset(x=Coord(x, title="x"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            scp.savgol(ds, size=7, order=3, deriv=1)
+            # Should either warn about degenerate or non-uniform
+            assert len(w) >= 0  # at minimum no crash
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+class TestInvariants:
+    """Non-mutation, shape, coords, title preservation."""
+
+    def test_source_not_mutated(self, ds_asc):
+        ds, x = ds_asc
+        original_data = ds.data.copy()
+        scp.savgol(ds, size=7, order=3, deriv=1)
+        np.testing.assert_array_equal(ds.data, original_data)
+
+    def test_coord_not_mutated(self, ds_asc):
+        ds, x = ds_asc
+        original_coord = ds.coord(-1).data.copy()
+        scp.savgol(ds, size=7, order=3, deriv=1)
+        np.testing.assert_array_equal(ds.coord(-1).data, original_coord)
+
+    def test_shape_preserved(self, ds_asc):
+        ds, x = ds_asc
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.shape == ds.shape
+
+    def test_dims_preserved(self, ds_asc):
+        ds, x = ds_asc
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.dims == ds.dims
+
+
+# ---------------------------------------------------------------------------
+# API equivalence
+# ---------------------------------------------------------------------------
+
+
+class TestAPIEquivalence:
+    """All entry points produce identical results for coordinate-aware path."""
+
+    def test_function_method_alias(self, ds_asc):
+        ds, x = ds_asc
+        r_func = scp.savgol(ds, size=7, order=3, deriv=1)
+        r_method = ds.savgol(size=7, order=3, deriv=1)
+        r_alias = scp.savgol_filter(ds, size=7, order=3, deriv=1)
+        np.testing.assert_allclose(r_func.data, r_method.data, atol=1e-14)
+        np.testing.assert_allclose(r_func.data, r_alias.data, atol=1e-14)
+
+    def test_transformer(self, ds_asc):
+        ds, x = ds_asc
+        r_func = scp.savgol(ds, size=7, order=3, deriv=1)
+        r_trans = Filter(
+            method="savgol", size=7, order=3, deriv=1, delta=None
+        ).transform(ds)
+        np.testing.assert_allclose(r_func.data, r_trans.data, atol=1e-14)
+
+    def test_dim_string(self, ds_asc):
+        ds, x = ds_asc
+        r_int = scp.savgol(ds, size=7, order=3, deriv=1, dim=-1)
+        r_str = scp.savgol(ds, size=7, order=3, deriv=1, dim="x")
+        np.testing.assert_allclose(r_int.data, r_str.data, atol=1e-14)
+
+
+# ---------------------------------------------------------------------------
+# _detect_uniform_spacing helper
+# ---------------------------------------------------------------------------
+
+
+class TestDetectUniformSpacing:
+    """Direct tests on the helper method."""
+
+    def test_uniform_ascending(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(np.ones(50), x)
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+        delta, msg = f._detect_uniform_spacing(ds, -1)
+        assert delta is not None
+        assert delta > 0
+        assert msg is None
+
+    def test_uniform_descending(self):
+        x = np.linspace(10, 1, 50)
+        ds = _make_2d(np.ones(50), x)
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+        delta, msg = f._detect_uniform_spacing(ds, -1)
+        assert delta is not None
+        assert delta < 0
+        assert msg is None
+
+    def test_irregular(self):
+        x = np.sort(np.random.default_rng(42).uniform(1, 10, 50))
+        ds = _make_2d(np.ones(50), x)
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+        delta, msg = f._detect_uniform_spacing(ds, -1)
+        assert delta is None
+        assert "not uniformly spaced" in msg
+
+    def test_no_coord(self):
+        ds = NDDataset(np.ones((1, 50)))
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+        delta, msg = f._detect_uniform_spacing(ds, -1)
+        assert delta is None
+        assert "no coordinate" in msg.lower() or "none" in msg.lower()
+
+    def test_nan_coord(self):
+        x = np.linspace(1, 10, 50)
+        x[10] = np.nan
+        ds = _make_2d(np.ones(50), x)
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+        delta, msg = f._detect_uniform_spacing(ds, -1)
+        assert delta is None
+        assert "non-finite" in msg.lower()

--- a/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
+++ b/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
@@ -322,6 +322,8 @@ class TestEdgeCoordinateCases:
 
         mock_ds = MagicMock()
         mock_coord = MagicMock()
+        mock_coord.is_masked = False
+        mock_coord._mask = False
         mock_coord._data = np.array(["a", "b", "c", "d", "e"])
         mock_ds.coord.return_value = mock_coord
         delta, msg = _detect_uniform_spacing(mock_ds, -1)
@@ -336,46 +338,56 @@ class TestEdgeCoordinateCases:
 
 class TestExplicitDeltaReversed:
     """
-    When an explicit delta is given, _reversed still applies (backward compat).
+    Explicit delta + _reversed interaction documents a known bug.
 
-    These tests document the existing behavior: for cm⁻¹/ppm coords with
-    explicit positive delta, _reversed flips the sign of odd-order
-    derivatives.  This is an existing limitation preserved for backward
-    compatibility.
+    For cm⁻¹/ppm coords with explicit positive delta, _reversed flips
+    the sign of odd-order derivatives.  xfail(strict=True) ensures the
+    test fails if the bug is ever fixed, prompting an update.
     """
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Explicit delta with cm-1 ascending: _reversed incorrectly "
+        "flips sign. Expected positive. See #1091 follow-up.",
+    )
     def test_explicit_delta_cm1_ascending_positive(self, ds_asc_cm1):
-        """Explicit delta=H with ascending cm⁻¹ → _reversed flips sign."""
         ds, x = ds_asc_cm1
         r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
-        # _reversed is True for cm⁻¹, so sign is flipped
-        assert float(r.data[0, MID]) < 0
-
-    def test_explicit_delta_cm1_descending_positive(self, ds_desc_cm1):
-        """Explicit delta=H with descending cm⁻¹ → _reversed flips twice (net positive)."""
-        ds, x = ds_desc_cm1
-        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
-        # descending → negative delta → _reversed flips → positive
+        # Currently returns negative due to _reversed; correct is positive
         assert float(r.data[0, MID]) > 0
 
+    def test_explicit_delta_cm1_descending_correct(self, ds_desc_cm1):
+        """Explicit delta=H with descending cm-1 → _reversed cancels correctly."""
+        ds, x = ds_desc_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        expected = 6.0 * x[MID]
+        # For descending coords, _reversed happens to correct the sign
+        # and the magnitude matches.
+        assert float(r.data[0, MID]) > 0
+        assert abs(float(r.data[0, MID]) - expected) < 1e-12
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Explicit negative delta with cm-1 ascending: _reversed "
+        "flips sign. Expected negative. See #1091 follow-up.",
+    )
     def test_explicit_delta_cm1_negative(self, ds_asc_cm1):
-        """Explicit negative delta with ascending cm⁻¹ → _reversed flips."""
         ds, x = ds_asc_cm1
         r = scp.savgol(ds, size=7, order=3, deriv=1, delta=-H)
-        # negative delta + _reversed flips for odd deriv
-        assert float(r.data[0, MID]) > 0
+        # Correct result: negative (descending direction)
+        assert float(r.data[0, MID]) < 0
 
     def test_auto_delta_cm1_ascending_positive(self, ds_asc_cm1):
-        """Auto-detected delta with ascending cm⁻¹ → correct positive sign."""
+        """Auto-detected delta with ascending cm-1 → correct positive sign."""
         ds, x = ds_asc_cm1
         r = scp.savgol(ds, size=7, order=3, deriv=1)
         assert float(r.data[0, MID]) > 0
 
-    def test_auto_delta_cm1_descending_negative(self, ds_desc_cm1):
-        """Auto-detected delta with descending cm⁻¹ → negative sign (correct)."""
+    def test_auto_delta_cm1_descending_positive(self, ds_desc_cm1):
+        """Auto-detected delta with descending cm-1 → correct positive sign."""
         ds, x = ds_desc_cm1
         r = scp.savgol(ds, size=7, order=3, deriv=1)
-        # descending coord → negative auto-delta → correct negative derivative sign
+        # descending coord → negative auto-delta → y=3x², 6x > 0
         assert float(r.data[0, MID]) > 0
 
 
@@ -507,8 +519,41 @@ class TestDetectUniformSpacing:
 
         mock_ds = MagicMock()
         mock_coord = MagicMock()
+        mock_coord.is_masked = False
+        mock_coord._mask = False
         mock_coord._data = np.array(["a", "b", "c", "d", "e"])
         mock_ds.coord.return_value = mock_coord
         delta, msg = _detect_uniform_spacing(mock_ds, -1)
         assert delta is None
         assert "not numeric" in msg.lower()
+
+    def test_masked_coord(self):
+        """A coordinate with masked values triggers fallback."""
+        from unittest.mock import MagicMock
+
+        mock_ds = MagicMock()
+        mock_coord = MagicMock()
+        mock_coord.is_masked = True
+        mock_coord._mask = np.array([False, False, True, False, False])
+        mock_ds.coord.return_value = mock_coord
+        delta, msg = _detect_uniform_spacing(mock_ds, -1)
+        assert delta is None
+        assert "masked" in msg.lower()
+
+    def test_data_precision_vs_raw(self):
+        """
+        coord.data truncates float64; coord._data preserves it.
+
+        This test justifies using the private _data attribute:
+        the public .data property rounds values to ~4 significant digits,
+        which destroys the uniform-spacing signal for linspace coords.
+        """
+        x = np.linspace(1, 10, 50)
+        c = Coord(x, title="x")
+        data_rounded = np.asarray(c.data, dtype=float)
+        data_raw = np.asarray(c._data, dtype=float)
+        max_err_rounded = np.max(np.abs(data_rounded - x))
+        max_err_raw = np.max(np.abs(data_raw - x))
+        # rounded has ~0.5% error, raw has machine-precision error
+        assert max_err_rounded > 1e-4, "expected coord.data to truncate"
+        assert max_err_raw < 1e-14, "expected coord._data to preserve precision"


### PR DESCRIPTION
## Issue

Closes #1091.

## Problem

Savitzky-Golay derivatives with `deriv > 0` used `delta=1.0` regardless of the actual coordinate spacing. The derivative magnitude was wrong by a factor of the coordinate spacing, and the sign was determined by a unit-based `_reversed` heuristic rather than the actual coordinate direction.

## What changed

### Auto-detected delta (default)

When `delta` is omitted (default in both `savgol()` wrapper and `Filter`), the signed sample spacing is derived from the coordinate of the processed axis:

- **Uniform ascending coordinate** → positive delta
- **Uniform descending coordinate** → negative delta
- **Non-uniform, missing, non-finite, or masked coordinate** → warning + fallback to `delta=1.0`
- **`deriv=0`** → unchanged, delta irrelevant

### Explicit delta

An explicit `delta` (e.g. `delta=1.0`, `delta=0.5`) takes priority and disables auto-detection. The existing `_reversed` correction is preserved for backward compatibility on this path.

### Implementation

1. **`_detect_uniform_spacing()`** — private module-level function in `filter.py`. Uses `coord._data` (raw float64 storage, bypasses the `Coord` rounding layer that truncates to ~4 significant digits). Checks uniformity via `np.allclose(diffs, mean_diff, rtol=1e-10, atol=0)`. Returns the mean signed delta or None + a message.

2. **`Filter.delta` trait** — default changed from `1.0` to `None` (`allow_none=True`). Both `savgol()` wrapper and `Filter(method="savgol")` default to auto-detection.

3. **`Filter._transform()` savgol path** — when `delta is None` and `deriv > 0`, calls `_detect_uniform_spacing()`. If uniform: passes the signed delta directly to `scipy.signal.savgol_filter` and skips `_reversed` correction. If not: warns and uses `delta=1.0`.

4. **Masked coordinate handling** — coordinates with masked values are detected and trigger the same fallback as non-uniform coordinates.

## Accuracy

Analytic test on y = 3x², size=7, order=3 (MID index):

| Scenario | Before (delta=1.0) | After (auto-detected) |
|---|---|---|
| deriv=1, ascending | 6.16 (err 27.4) | **33.55** (err ~1e-14) |
| deriv=1, descending | -5.96 (err 38.4) | **32.45** (err ~1e-14) |
| deriv=2, any | ~6.00 (err ~1e-5) | **6.00** (err ~2e-12) |

The previous ~0.06 error was caused by `Coord.data` rounding float64 to ~4 significant digits. Using `coord._data` (raw storage) restores machine-precision accuracy.

## Tests

50 tests in `test_savgol_coordinate_aware.py` (2 xfail for known _reversed bug):
- Analytic accuracy (deriv=1, deriv=2, 5 coordinate scenarios, tolerance 1e-12 / 1e-10)
- Sign correctness (ascending, descending, cm⁻¹, ppm)
- Delta priority (explicit overrides auto, scipy match)
- Filter reuse: single Filter object on two datasets with different spacings
- Irregular coordinate (warning, fallback, explicit suppresses warning)
- Edge cases (no coord, degenerate, NaN, repeated values)
- Non-numeric coord (mock-based)
- Masked coord (mock-based)
- Explicit delta + _reversed: ascending cm⁻¹ xfail(strict=True), descending cm⁻¹ correct
- _data vs data precision: test justifying why private _data is used
- Invariants (non-mutation, shape, coords, dims)
- API equivalence (function, method, alias, transformer with default delta, dim string)
- Helper tests (uniform, irregular, no coord, NaN, single-point, non-numeric, masked)

## Non-regression

- 130 filter/policy tests: all pass
- 2 xfailed (known _reversed bug on explicit delta + ascending cm⁻¹)
- `pre-commit run --all-files`: clean

## Out of scope

- Unit propagation (`source_units / coordinate_units**deriv`)
- `_reversed` global refactoring
- NaN/mask handling in data arrays
- Gallery examples

The `_reversed` correction is still applied when an explicit `delta` is provided with `cm⁻¹`/`ppm` coordinates, which can flip the sign of odd-order derivatives on ascending coordinates. This existing bug is documented by 2 xfail(strict=True) tests and will be addressed separately.
