### PR TITLE
FIX: honor explicit delta sign in Savitzky-Golay derivatives

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -46,6 +46,18 @@ Bug Fixes
   or missing coordinate a warning is emitted and the index-based ``delta=1.0``
   is used as a fallback.  ``deriv=0`` is unchanged.
 
+- Fix sign of Savitzky-Golay derivatives when an explicit ``delta`` is
+  provided with ``cm⁻¹`` or ``ppm`` coordinates
+  (`#1552 <https://github.com/spectrochempy/spectrochempy/issues/1552>`_).
+  The former ``_reversed`` correction applied ``(-1)**deriv`` on the
+  Savitzky-Golay path when the coordinate carried ``cm⁻¹`` or ``ppm``
+  units, flipping the sign of odd-order derivatives on ascending
+  coordinates.  An explicit ``delta`` is now passed to SciPy with its
+  sign; no unit-based correction is applied.  For a descending
+  coordinate, supply a negative ``delta`` if the derivative should follow
+  the physical axis.  This is a numeric correction for affected calls
+  with odd-order derivatives.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -35,6 +35,18 @@ Bug Fixes
   or missing coordinate a warning is emitted and the index-based ``delta=1.0``
   is used as a fallback.  ``deriv=0`` is unchanged.
 
+- Fix sign of Savitzky-Golay derivatives when an explicit ``delta`` is
+  provided with ``cm⁻¹`` or ``ppm`` coordinates
+  (`#1552 <https://github.com/spectrochempy/spectrochempy/issues/1552>`_).
+  The former ``_reversed`` correction applied ``(-1)**deriv`` on the
+  Savitzky-Golay path when the coordinate carried ``cm⁻¹`` or ``ppm``
+  units, flipping the sign of odd-order derivatives on ascending
+  coordinates.  An explicit ``delta`` is now passed to SciPy with its
+  sign; no unit-based correction is applied.  For a descending
+  coordinate, supply a negative ``delta`` if the derivative should follow
+  the physical axis.  This is a numeric correction for affected calls
+  with odd-order derivatives.
+
 Developer
 ~~~~~~~~~
 - Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -193,15 +193,17 @@ class Filter(ProcessingConfigurable):
     delta = tr.Float(
         default_value=None,
         allow_none=True,
-        help="The spacing of the samples to which the filter will be applied. "
+        help="The signed sample spacing passed to ``scipy.signal.savgol_filter``. "
         "This is only used if deriv > 0.\n\n"
-        "When ``None`` (the default), the spacing "
+        "When ``None`` (the default), the signed spacing "
         "is automatically derived from the coordinate of the processed axis "
-        "if the coordinate is uniformly spaced.  If the coordinate is missing, "
-        "non-uniform, or non-numeric, the index-based delta of 1.0 is used "
-        "with a warning.\n\n"
-        "When set to a numeric value, that value is used as-is and no "
-        "automatic coordinate detection is performed.",
+        "if the coordinate is uniformly spaced.  On a non-uniform or "
+        "missing coordinate a warning is emitted and the index-based "
+        "``delta=1.0`` is used as a fallback.\n\n"
+        "When set to a numeric value, that value is passed directly to "
+        "SciPy with its sign.  No unit-based correction (``_reversed``) "
+        "is applied.  For a descending coordinate, supply a negative "
+        "``delta`` if the derivative should follow the physical axis.",
     ).tag(config=True)
 
     mode = tr.Enum(
@@ -287,14 +289,7 @@ and ‘nearest’.
         # Savitzky-Golay filter
         # ---------------------
         elif self.method == "savgol":
-            # ------------------------------------------------------------------
-            # Coordinate-aware delta: when delta is None (auto-detect) and a
-            # derivative is requested, derive the signed spacing from the
-            # coordinate.  The sign naturally handles ascending/descending
-            # coordinates so no _reversed correction is needed.
-            # ------------------------------------------------------------------
             delta_used = self.delta
-            _auto_detected = False
 
             if self.delta is None:
                 if self.deriv:
@@ -304,7 +299,6 @@ and ‘nearest’.
                     )
                     if delta_signed is not None:
                         delta_used = delta_signed
-                        _auto_detected = True
                     else:
                         delta_used = 1.0
                         import warnings as _warnings
@@ -329,18 +323,9 @@ and ‘nearest’.
             }
             data = scipy.signal.savgol_filter(X, self.size, self.order, **kwargs)
 
-            # _reversed correction: ONLY when an explicit delta was used
-            # (the user supplied delta=1.0 or another value).  When the
-            # delta was auto-detected from the coordinate the sign is
-            # already correct and no further correction must be applied.
-            if not _auto_detected and self._reversed and self.deriv:
-                data = data * (-1) ** self.deriv
-
             # Annotate the output title so a derivative quantity is clearly
-            # identified. Units are intentionally kept as-is (the Savitzky-Golay
-            # path is index-based and does not validate even spacing, so we do
-            # not claim physically transformed units) and coordinates are
-            # preserved by the output wrapping.
+            # identified. Units are intentionally kept as-is in this PR;
+            # physical unit propagation is a separate follow-up.
             if self.deriv:
                 ordinal = {1: "1st", 2: "2nd", 3: "3rd"}.get(
                     self.deriv, f"{self.deriv}th"
@@ -442,18 +427,25 @@ def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
         Axis along which to apply the filter.  Accepts a dimension name
         (e.g. ``"x"``) or an integer index (e.g. ``-1`` for the last axis).
     delta : `float` or ``None``, optional, default: ``None``
-        Sample spacing of the coordinate to which the filter is applied.
+        Sample spacing passed to ``scipy.signal.savgol_filter``.
 
         * ``None`` (default) — when ``deriv > 0``, the signed spacing is
           automatically derived from the coordinate of the processed axis
           if the coordinate is uniformly spaced.  On a non-uniform or
           missing coordinate a warning is emitted and the index-based
           ``delta=1.0`` is used as a fallback.
-        * A numeric value — used as-is; no automatic coordinate detection
-          is performed.
+        * A numeric value — passed directly to SciPy with its sign.  No
+          unit-based correction is applied.  For a descending coordinate,
+          supply a negative ``delta`` if the derivative should follow the
+          physical axis.
 
         .. versionchanged:: 0.12.5
            Default changed from ``1.0`` to ``None`` (auto-detect).
+
+        .. versionchanged:: 0.12.5
+           Explicit ``delta`` is now passed to SciPy with its sign.
+           The former ``_reversed`` unit-based correction is no longer
+           applied when ``delta`` is explicitly provided.
 
     **kwargs : keyword arguments, optional
         Additional keyword arguments passed to the filter.
@@ -485,6 +477,11 @@ def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
     ``scipy.signal.savgol_filter``.  The Savitzky-Golay algorithm is
     fundamentally index-based; the detected delta scales the derivative
     coefficients during the convolution.
+
+    When ``delta`` is a numeric value, it is passed to SciPy exactly as
+    provided, with its sign.  The coordinate units (``cm⁻¹``, ``ppm``,
+    etc.) have no effect on the result in this case.  The user is
+    responsible for the sign convention.
 
     """
     return Filter(

--- a/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
+++ b/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
@@ -19,6 +19,7 @@ import warnings
 
 import numpy as np
 import pytest
+import scipy.signal
 
 import spectrochempy as scp
 from spectrochempy.core.dataset.coord import Coord
@@ -338,43 +339,30 @@ class TestEdgeCoordinateCases:
 
 class TestExplicitDeltaReversed:
     """
-    Explicit delta + _reversed interaction documents a known bug.
+    Explicit delta + coordinate unit interaction.
 
-    For cm⁻¹/ppm coords with explicit positive delta, _reversed flips
-    the sign of odd-order derivatives.  xfail(strict=True) ensures the
-    test fails if the bug is ever fixed, prompting an update.
+    Since #1552, an explicit delta is passed to SciPy with its sign and
+    the ``_reversed`` correction is no longer applied.  All tests pass
+    without xfail.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Explicit delta with cm-1 ascending: _reversed incorrectly "
-        "flips sign. Expected positive. See #1091 follow-up.",
-    )
     def test_explicit_delta_cm1_ascending_positive(self, ds_asc_cm1):
         ds, x = ds_asc_cm1
         r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
-        # Currently returns negative due to _reversed; correct is positive
-        assert float(r.data[0, MID]) > 0
+        expected = scipy.signal.savgol_filter(3.0 * x**2, 7, 3, deriv=1, delta=H)[MID]
+        assert abs(float(r.data[0, MID]) - expected) < 1e-10
 
-    def test_explicit_delta_cm1_descending_correct(self, ds_desc_cm1):
-        """Explicit delta=H with descending cm-1 → _reversed cancels correctly."""
+    def test_explicit_delta_cm1_descending_positive(self, ds_desc_cm1):
         ds, x = ds_desc_cm1
         r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
-        expected = 6.0 * x[MID]
-        # For descending coords, _reversed happens to correct the sign
-        # and the magnitude matches.
-        assert float(r.data[0, MID]) > 0
-        assert abs(float(r.data[0, MID]) - expected) < 1e-12
+        expected = scipy.signal.savgol_filter(3.0 * x**2, 7, 3, deriv=1, delta=H)[MID]
+        assert abs(float(r.data[0, MID]) - expected) < 1e-10
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Explicit negative delta with cm-1 ascending: _reversed "
-        "flips sign. Expected negative. See #1091 follow-up.",
-    )
     def test_explicit_delta_cm1_negative(self, ds_asc_cm1):
         ds, x = ds_asc_cm1
         r = scp.savgol(ds, size=7, order=3, deriv=1, delta=-H)
-        # Correct result: negative (descending direction)
+        expected = scipy.signal.savgol_filter(3.0 * x**2, 7, 3, deriv=1, delta=-H)[MID]
+        assert abs(float(r.data[0, MID]) - expected) < 1e-10
         assert float(r.data[0, MID]) < 0
 
     def test_auto_delta_cm1_ascending_positive(self, ds_asc_cm1):
@@ -389,6 +377,84 @@ class TestExplicitDeltaReversed:
         r = scp.savgol(ds, size=7, order=3, deriv=1)
         # descending coord → negative auto-delta → y=3x², 6x > 0
         assert float(r.data[0, MID]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Explicit delta sign matrix (#1552)
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitDeltaSignMatrix:
+    """
+    Explicit delta is authoritative: sign, magnitude, and unit-independence.
+
+    For every (direction, unit, delta_sign) combination, the result must
+    match ``scipy.signal.savgol_filter`` with the same delta.
+    """
+
+    @pytest.mark.parametrize(
+        "unit",
+        [None, "1/centimeter", "ppm", "meter"],
+        ids=["none", "cm-1", "ppm", "meter"],
+    )
+    @pytest.mark.parametrize(
+        "direction",
+        ["ascending", "descending"],
+        ids=["asc", "desc"],
+    )
+    def test_positive_delta_matches_scipy(self, direction, unit):
+        x = (
+            np.linspace(1, 10, 50)
+            if direction == "ascending"
+            else np.linspace(10, 1, 50)
+        )
+        y = 3.0 * x**2
+        ds = _make_2d(y, x, unit=unit)
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        expected = scipy.signal.savgol_filter(y, 7, 3, deriv=1, delta=H)[MID]
+        assert abs(float(r.data[0, MID]) - expected) < 1e-10
+
+    @pytest.mark.parametrize(
+        "unit",
+        [None, "1/centimeter", "ppm", "meter"],
+        ids=["none", "cm-1", "ppm", "meter"],
+    )
+    @pytest.mark.parametrize(
+        "direction",
+        ["ascending", "descending"],
+        ids=["asc", "desc"],
+    )
+    def test_negative_delta_matches_scipy(self, direction, unit):
+        x = (
+            np.linspace(1, 10, 50)
+            if direction == "ascending"
+            else np.linspace(10, 1, 50)
+        )
+        y = 3.0 * x**2
+        ds = _make_2d(y, x, unit=unit)
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=-H)
+        expected = scipy.signal.savgol_filter(y, 7, 3, deriv=1, delta=-H)[MID]
+        assert abs(float(r.data[0, MID]) - expected) < 1e-10
+
+    def test_positive_delta_ascending_sign(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit="1/centimeter")
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        assert float(r.data[0, MID]) > 0
+
+    def test_negative_delta_ascending_sign(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit="1/centimeter")
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=-H)
+        assert float(r.data[0, MID]) < 0
+
+    def test_deriv2_unaffected_by_sign_convention(self):
+        x = np.linspace(1, 10, 50)
+        y = 3.0 * x**2
+        ds = _make_2d(y, x, unit="1/centimeter")
+        r = scp.savgol(ds, size=7, order=3, deriv=2, delta=H)
+        expected = scipy.signal.savgol_filter(y, 7, 3, deriv=2, delta=H)[MID]
+        assert abs(float(r.data[0, MID]) - expected) < 1e-10
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue

Closes #1552.

## Problem

When an explicit `delta` is provided to `savgol()` or `Filter(delta=h).transform()` for `cm⁻¹` or `ppm` coordinates, the `_reversed` correction applies `(-1)**deriv` to the output, flipping the sign of odd-order derivatives on ascending coordinates.

## Root cause

The Savitzky-Golay path contained an `_reversed` block that applied a unit-based sign correction whenever `self._reversed` was `True` (which it is for `cm⁻¹` and `ppm`). This block ran on explicit-delta calls, double-correcting the sign already encoded in the user's delta.

## What changed

Removed the `_reversed` correction entirely from the `Filter._transform()` savgol path. The `_auto_detected` flag is also removed since it is no longer needed.

The convention is now:

- `delta=None` (auto-detect): signed spacing derived from the coordinate; no `_reversed` correction (unchanged from #1551).
- `delta` numeric: passed directly to SciPy with its sign. No unit-based correction. The user is responsible for the sign convention.

## Accuracy

All 16 combinations of 4 units × 2 directions × 2 delta signs now match `scipy.signal.savgol_filter` to machine precision (< 1e-10).

## Tests

69 tests in `test_savgol_coordinate_aware.py` (0 xfail):

- 2 former `xfail(strict=True)` tests now pass normally
- 16 new sign matrix tests (4 units × 2 directions × 2 delta signs + sign assertion + deriv=2)
- All existing #1551 tests continue to pass

## Non-regression

- 120/120 filter tests pass
- No xfail remaining for #1552
- Auto-detected path unchanged
- `smooth`, `whittaker`, and other Filter methods unaffected
- `_reversed` untouched outside the savgol path

## Out of scope

- Unit propagation
- `Coord.reversed` global refactoring
- NaN/mask handling in data arrays
- Gallery examples
