### PR TITLE
FIX: propagate units through Savitzky-Golay derivatives

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -58,6 +58,14 @@ Bug Fixes
   the physical axis.  This is a numeric correction for affected calls
   with odd-order derivatives.
 
+- Savitzky-Golay derivative units are now propagated for physically
+  scaled paths.  A derivative of order ``n`` carries
+  ``source_units / coordinate_units**n`` when the delta is derived from
+  a uniform coordinate or explicitly provided while the coordinate has
+  units.  Smoothing (``deriv=0``) and index-based fallbacks preserve
+  the source units unchanged.  This is a scientific correction
+  observable for datasets with physical units.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -47,6 +47,14 @@ Bug Fixes
   the physical axis.  This is a numeric correction for affected calls
   with odd-order derivatives.
 
+- Savitzky-Golay derivative units are now propagated for physically
+  scaled paths.  A derivative of order ``n`` carries
+  ``source_units / coordinate_units**n`` when the delta is derived from
+  a uniform coordinate or explicitly provided while the coordinate has
+  units.  Smoothing (``deriv=0``) and index-based fallbacks preserve
+  the source units unchanged.  This is a scientific correction
+  observable for datasets with physical units.
+
 Developer
 ~~~~~~~~~
 - Fix ``safe-docs-no-ci`` CI bypass for push events: the workflow now looks up

--- a/src/spectrochempy/processing/filter/filter.py
+++ b/src/spectrochempy/processing/filter/filter.py
@@ -262,6 +262,8 @@ and ‘nearest’.
         # that of the input data.
         self._output_title_suffix = None
         self._preserve_identity = True
+        # Clear any stale dynamic-unit override from a previous call.
+        self._output_units = None
 
         # smooth with moving average
         # --------------------------
@@ -290,6 +292,12 @@ and ‘nearest’.
         # ---------------------
         elif self.method == "savgol":
             delta_used = self.delta
+            # Track delta provenance for unit propagation.
+            #   "irrelevant"   -> deriv == 0 (smoothing)
+            #   "coordinate"   -> auto-detected from uniform coordinate
+            #   "explicit"     -> user-provided numeric delta
+            #   "fallback"     -> irregular/missing coord, delta=1.0
+            delta_source = "irrelevant"
 
             if self.delta is None:
                 if self.deriv:
@@ -299,8 +307,10 @@ and ‘nearest’.
                     )
                     if delta_signed is not None:
                         delta_used = delta_signed
+                        delta_source = "coordinate"
                     else:
                         delta_used = 1.0
+                        delta_source = "fallback"
                         import warnings as _warnings
 
                         _warnings.warn(
@@ -313,6 +323,8 @@ and ‘nearest’.
                 else:
                     # deriv=0: delta is irrelevant; scipy needs a float
                     delta_used = 1.0
+            else:
+                delta_source = "explicit"
 
             kwargs = {
                 "axis": self._dim,
@@ -323,9 +335,23 @@ and ‘nearest’.
             }
             data = scipy.signal.savgol_filter(X, self.size, self.order, **kwargs)
 
+            # Propagate units for derivative paths that claim physical scaling.
+            # Smoothing (deriv=0) and index fallbacks keep source units.
+            if self.deriv > 0 and delta_source in ("coordinate", "explicit"):
+                coord = self._X.coord(self._dim)
+                coord_units = coord.units if coord is not None else None
+                source_units = self._X.units
+                if source_units is not None and coord_units is not None:
+                    self._output_units = source_units / coord_units**self.deriv
+                elif source_units is not None:
+                    # Coordinate has no unit: keep source units (U3)
+                    self._output_units = source_units
+                else:
+                    # Source has no unit: result has no unit (U5)
+                    self._output_units = None
+
             # Annotate the output title so a derivative quantity is clearly
-            # identified. Units are intentionally kept as-is in this PR;
-            # physical unit propagation is a separate follow-up.
+            # identified.  Coordinates are preserved by the output wrapping.
             if self.deriv:
                 ordinal = {1: "1st", 2: "2nd", 3: "3rd"}.get(
                     self.deriv, f"{self.deriv}th"
@@ -434,10 +460,11 @@ def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
           if the coordinate is uniformly spaced.  On a non-uniform or
           missing coordinate a warning is emitted and the index-based
           ``delta=1.0`` is used as a fallback.
-        * A numeric value — passed directly to SciPy with its sign.  No
-          unit-based correction is applied.  For a descending coordinate,
-          supply a negative ``delta`` if the derivative should follow the
-          physical axis.
+        * A numeric value — passed directly to SciPy with its sign.  The
+          value is interpreted in the current unit of the selected
+          coordinate.  No unit-based correction (``_reversed``) is applied.
+          For a descending coordinate, supply a negative ``delta`` if the
+          derivative should follow the physical axis.
 
         .. versionchanged:: 0.12.5
            Default changed from ``1.0`` to ``None`` (auto-detect).
@@ -482,6 +509,19 @@ def savgol(dataset, size=5, order=2, dim=-1, delta=None, **kwargs):
     provided, with its sign.  The coordinate units (``cm⁻¹``, ``ppm``,
     etc.) have no effect on the result in this case.  The user is
     responsible for the sign convention.
+
+    **Units.**  For ``deriv > 0`` with a physically scaled delta
+    (auto-detected from a uniform coordinate or explicitly provided
+    when the coordinate carries units), the output units are
+    ``source_units / coordinate_units**deriv``.  For example, a first
+    derivative of absorbance with respect to ``cm⁻¹`` yields
+    ``absorbance·cm``.  Smoothing (``deriv=0``) and index-based
+    fallbacks preserve the source units unchanged.  If the source has
+    no units, the result has no units regardless of the coordinate.
+
+    .. versionchanged:: 0.12.5
+       Units are now propagated for physically scaled derivative
+       paths.  Smoothing and index fallbacks keep source units.
 
     """
     return Filter(

--- a/src/spectrochempy/utils/decorators.py
+++ b/src/spectrochempy/utils/decorators.py
@@ -741,7 +741,15 @@ class _set_output:
             X_transf.description = copy.copy(metadata_source.description)
             X_transf.origin = copy.copy(metadata_source.origin)
             X_transf.filename = copy.copy(metadata_source.filename)
-            if self.units is not None:
+            # Allow a processing method to override output units dynamically
+            # by setting ``_output_units`` on the instance (e.g. for physically
+            # scaled derivatives in Savitzky-Golay).  Always clear afterwards
+            # to prevent state leakage between calls.
+            output_units = getattr(obj, "_output_units", None)
+            if output_units is not None:
+                X_transf.units = output_units
+                obj._output_units = None
+            elif self.units is not None:
                 if self.units == "keep":
                     X_transf.units = X.units
                 else:

--- a/tests/test_processing/test_filter/test_filter_shape.py
+++ b/tests/test_processing/test_filter/test_filter_shape.py
@@ -139,9 +139,11 @@ class TestSavgolDerivativeMetadata:
             result.coord("x").data, dataset_2d_with_meta.coord("x").data
         )
 
-    def test_deriv_keeps_original_units(self, dataset_2d_with_meta):
-        # Conservative: index-based derivative scaling is not tied to a
-        # validated physical spacing, so units are unchanged.
+    def test_deriv_keeps_source_units_when_coordinate_has_no_units(
+        self, dataset_2d_with_meta
+    ):
+        # When the coordinate has no units, a derivative cannot claim a
+        # physical scale.  The source units are preserved (rule U3/U4).
         result = scp.savgol(dataset_2d_with_meta, size=7, order=3, deriv=1)
         assert result.units == "absorbance", result.units
 

--- a/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
+++ b/tests/test_processing/test_filter/test_savgol_coordinate_aware.py
@@ -623,3 +623,313 @@ class TestDetectUniformSpacing:
         # rounded has ~0.5% error, raw has machine-precision error
         assert max_err_rounded > 1e-4, "expected coord.data to truncate"
         assert max_err_raw < 1e-14, "expected coord._data to preserve precision"
+
+
+# ---------------------------------------------------------------------------
+# Unit propagation (PR 4)
+# ---------------------------------------------------------------------------
+
+
+class TestUnitPropagation:
+    """
+    Physical units are propagated for derivative paths that claim a coordinate
+    scale, and preserved for smoothing and index-based fallbacks.
+
+    Policy matrix:
+    - U0  deriv=0               → keep source units
+    - U1  auto, physical coord  → source / coord_units**deriv
+    - U2  explicit, coord unit  → source / coord_units**deriv
+    - U3  explicit, no coord u  → keep source units
+    - U4  fallback              → keep source units
+    - U5  source units=None     → result units=None
+    - U6  source dimensionless  → 1 / coord_units**deriv
+    - U7  coord dimensionless   → keep source units
+    - U8  ppm                   → source / ppm**deriv (symbolic, dimensionless)
+    """
+
+    @pytest.fixture
+    def ds_abs_cm1(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit="1/centimeter", title="wavenumber")
+        ds.units = "absorbance"
+        return ds, x
+
+    @pytest.fixture
+    def ds_volt_s(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(5.0 * x + 2.0, x, unit="second", title="time")
+        ds.units = "volt"
+        return ds, x
+
+    # U0 — smoothing keeps source units
+    def test_deriv0_keeps_source_units(self, ds_abs_cm1):
+        ds, x = ds_abs_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=0)
+        assert r.units == ds.units
+
+    # U1 — auto-detect physical path
+    def test_deriv1_auto_absorbance_cm1(self, ds_abs_cm1):
+        ds, x = ds_abs_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units / ds.coord(-1).units
+
+    def test_deriv2_auto_absorbance_cm1(self, ds_abs_cm1):
+        ds, x = ds_abs_cm1
+        r = scp.savgol(ds, size=7, order=3, deriv=2)
+        assert r.units == ds.units / ds.coord(-1).units ** 2
+
+    def test_deriv1_auto_volt_second(self, ds_volt_s):
+        ds, x = ds_volt_s
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units / ds.coord(-1).units
+
+    def test_deriv2_auto_volt_second(self, ds_volt_s):
+        ds, x = ds_volt_s
+        r = scp.savgol(ds, size=7, order=3, deriv=2)
+        assert r.units == ds.units / ds.coord(-1).units ** 2
+
+    # U2 — explicit delta with coordinate unit
+    def test_deriv1_explicit_volt_second(self, ds_volt_s):
+        ds, x = ds_volt_s
+        H = x[1] - x[0]
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        assert r.units == ds.units / ds.coord(-1).units
+
+    def test_deriv2_explicit_volt_second(self, ds_volt_s):
+        ds, x = ds_volt_s
+        H = x[1] - x[0]
+        r = scp.savgol(ds, size=7, order=3, deriv=2, delta=H)
+        assert r.units == ds.units / ds.coord(-1).units ** 2
+
+    # U3 — explicit delta, no coordinate unit
+    def test_deriv1_explicit_no_coord_unit(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit=None, title="x")
+        ds.units = "absorbance"
+        H = x[1] - x[0]
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        assert r.units == ds.units
+
+    # U4 — fallback (irregular coord) keeps source units
+    def test_deriv1_fallback_keeps_source_units(self):
+        x = np.sort(np.random.default_rng(42).uniform(1, 10, 50))
+        ds = _make_2d(3.0 * x**2, x, unit="1/centimeter", title="wavenumber")
+        ds.units = "absorbance"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units
+
+    # U5 — source units=None
+    def test_deriv1_source_none(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit="second", title="time")
+        # No units set on source
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units is None
+
+    # U6 — source dimensionless
+    def test_deriv1_source_dimensionless(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit="second", title="time")
+        ds.units = "dimensionless"
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units / ds.coord(-1).units
+
+    # U7 — coordinate dimensionless
+    def test_deriv1_coord_dimensionless(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit="dimensionless", title="x")
+        ds.units = "volt"
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units
+
+    # U8 — ppm
+    def test_deriv1_auto_ppm(self):
+        x = np.linspace(1, 10, 50)
+        ds = _make_2d(3.0 * x**2, x, unit="ppm", title="x")
+        ds.units = "absorbance"
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        # ppm is dimensionless in Pint, but the symbolic representation
+        # is preserved as absorbance / ppm = a.u.·ppm⁻¹
+        assert r.units.dimensionality == ds.units.dimensionality
+        assert str(r.units) == "a.u.⋅ppm⁻¹"
+
+    # Conversion coherence: second ↔ millisecond
+    def test_deriv1_second_millisecond_conversion(self):
+        x_s = np.linspace(0.001, 0.010, 50)
+        x_ms = x_s * 1000
+        # Same physical function: y = 3 * t² (t in seconds)
+        y_s = 3.0 * x_s**2
+        y_ms = 3.0 * (x_ms / 1000.0) ** 2  # identical physical values
+
+        ds_s = _make_2d(y_s, x_s, unit="second", title="time")
+        ds_s.units = "volt"
+
+        ds_ms = _make_2d(y_ms, x_ms, unit="millisecond", title="time")
+        ds_ms.units = "volt"
+
+        r_s = scp.savgol(ds_s, size=7, order=3, deriv=1)
+        r_ms = scp.savgol(ds_ms, size=7, order=3, deriv=1)
+
+        # Convert ms result to s units and compare
+        r_ms_to_s = r_ms.to("V / s")
+        np.testing.assert_allclose(
+            r_s.data,
+            r_ms_to_s.data,
+            rtol=1e-10,
+        )
+
+    # Filter reuse with different unit contexts
+    def test_filter_reuse_different_units(self):
+        x = np.linspace(1, 10, 50)
+        y = 3.0 * x**2
+
+        ds1 = _make_2d(y, x, unit="second", title="time")
+        ds1.units = "volt"
+
+        ds2 = _make_2d(y, x, unit="1/centimeter", title="wavenumber")
+        ds2.units = "absorbance"
+
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+        r1 = f.transform(ds1)
+        r2 = f.transform(ds2)
+
+        assert r1.units == ds1.units / ds1.coord(-1).units
+        assert r2.units == ds2.units / ds2.coord(-1).units
+
+    # API equivalence for unit propagation
+    def test_api_equivalence_units(self, ds_volt_s):
+        ds, x = ds_volt_s
+        r_func = scp.savgol(ds, size=7, order=3, deriv=1)
+        r_method = ds.savgol(size=7, order=3, deriv=1)
+        r_alias = scp.savgol_filter(ds, size=7, order=3, deriv=1)
+        r_transform = Filter(method="savgol", size=7, order=3, deriv=1).transform(ds)
+
+        assert r_func.units == r_method.units == r_alias.units == r_transform.units
+        assert r_func.units == ds.units / ds.coord(-1).units
+
+    # Descending coordinate still propagates units correctly
+    def test_deriv1_descending_units(self):
+        x = np.linspace(10, 1, 50)
+        y = 3.0 * x**2
+        ds = _make_2d(y, x, unit="second", title="time")
+        ds.units = "volt"
+        r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units / ds.coord(-1).units
+
+    # Non-mutation
+    def test_source_units_not_mutated(self, ds_abs_cm1):
+        ds, x = ds_abs_cm1
+        original_units = ds.units
+        scp.savgol(ds, size=7, order=3, deriv=1)
+        assert ds.units == original_units
+
+    def test_coord_units_not_mutated(self, ds_abs_cm1):
+        ds, x = ds_abs_cm1
+        original_coord_units = ds.coord(-1).units
+        scp.savgol(ds, size=7, order=3, deriv=1)
+        assert ds.coord(-1).units == original_coord_units
+
+    # -------------------------------------------------------------------------
+    # Critical paths: delta_source governs units, not coord.units alone
+    # -------------------------------------------------------------------------
+
+    def test_explicit_delta_irregular_coord_with_unit(self):
+        """Explicit delta with irregular coord → physical units (U2)."""
+        x = np.sort(np.random.default_rng(42).uniform(1, 10, 50))
+        ds = _make_2d(3.0 * x**2, x, unit="1/centimeter", title="wavenumber")
+        ds.units = "absorbance"
+        H = x[1] - x[0]
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        # explicit delta → physical units even though coord is irregular
+        assert r.units == ds.units / ds.coord(-1).units
+
+    def test_explicit_delta_missing_coord(self):
+        """Explicit delta with no coord → source units (U3)."""
+        x = np.linspace(1, 10, 50)
+        ds = NDDataset((3.0 * x**2).reshape(1, -1), units="volt")
+        # No coordset at all
+        H = x[1] - x[0]
+        r = scp.savgol(ds, size=7, order=3, deriv=1, delta=H)
+        assert r.units == ds.units
+
+    def test_auto_fallback_missing_coord(self):
+        """Auto-detect with missing coord → source units (U4)."""
+        x = np.linspace(1, 10, 50)
+        ds = NDDataset((3.0 * x**2).reshape(1, -1), units="volt")
+        # No coordset at all
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units
+
+    def test_auto_fallback_masked_coord(self):
+        """Auto-detect with masked coord → source units (U4)."""
+        x = np.linspace(1, 10, 50)
+        ds = NDDataset((3.0 * x**2).reshape(1, -1), units="volt")
+        c = Coord(x, title="time")
+        c.units = "second"
+        ds.set_coordset(x=c)
+        # Patch _detect_uniform_spacing to simulate masked fallback,
+        # then verify the full savgol path preserves source units.
+        from unittest.mock import patch
+
+        with patch.object(
+            scp.processing.filter.filter,
+            "_detect_uniform_spacing",
+            return_value=(None, "coordinate contains masked values"),
+        ), warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units
+        assert any("Falling back" in str(warning.message) for warning in w)
+
+    def test_auto_fallback_nan_coord(self):
+        """Auto-detect with NaN in coord → source units (U4)."""
+        x = np.linspace(1, 10, 50).copy()
+        x[25] = np.nan
+        ds = _make_2d(3.0 * x**2, x, unit="second", title="time")
+        ds.units = "volt"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r = scp.savgol(ds, size=7, order=3, deriv=1)
+        assert r.units == ds.units
+
+    # -------------------------------------------------------------------------
+    # Architectural: no unit leakage across Filter reuse
+    # -------------------------------------------------------------------------
+
+    def test_filter_chained_physical_fallback_smooth(self):
+        """
+        Same Filter object: physical derivative → fallback → smoothing.
+        Proves _output_units does not leak between calls.
+        """
+        x = np.linspace(1, 10, 50)
+        y = 3.0 * x**2
+
+        # 1. Physical derivative (auto-detect)
+        ds_phys = _make_2d(y, x, unit="second", title="time")
+        ds_phys.units = "volt"
+
+        # 2. Fallback (no coord)
+        ds_fallback = NDDataset(y.reshape(1, -1), units="volt")
+
+        # 3. Smoothing
+        ds_smooth = _make_2d(y, x, unit="second", title="time")
+        ds_smooth.units = "volt"
+
+        f = Filter(method="savgol", size=7, order=3, deriv=1)
+
+        r1 = f.transform(ds_phys)
+        assert r1.units == ds_phys.units / ds_phys.coord(-1).units
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            r2 = f.transform(ds_fallback)
+        assert r2.units == ds_fallback.units
+
+        # Reuse the *same* Filter object for smoothing to prove no state leak
+        f.deriv = 0
+        r3 = f.transform(ds_smooth)
+        assert r3.units == ds_smooth.units


### PR DESCRIPTION
## Objective

Propagate physical units through Savitzky-Golay derivative calculations.

## Problem

Before this PR, `savgol(..., deriv=1)` always returned the source units unchanged, even when the derivative was physically scaled by a coordinate with units. A derivative of absorbance with respect to `cm⁻¹` incorrectly remained `absorbance` instead of `absorbance·cm`.

## What changed

### Unit propagation rule

For `deriv > 0` with a physically scaled delta:

- **Auto-detected from uniform coordinate** → `source_units / coord_units**deriv`
- **Explicit delta, coord has units** → `source_units / coord_units**deriv`
- **Explicit delta, coord has no units** → keep source units
- **Index fallback** (irregular/missing coord) → keep source units
- **Smoothing (`deriv=0`)** → keep source units
- **Source `units=None`** → result `units=None`

### Implementation

1. **Decorator hook** (`_set_output` in `utils/decorators.py`): checks for `_output_units` on the processing instance before the default `units="keep"` behavior. Always clears after reading to prevent state leakage.

2. **Delta provenance tracking** in `Filter._transform()` savgol path:
   - `"coordinate"` — auto-detected uniform spacing
   - `"explicit"` — user-provided numeric delta (interpreted in the current unit of the selected coordinate)
   - `"fallback"` — irregular/missing coord, `delta=1.0`
   - `"irrelevant"` — `deriv=0`

3. **Unit computation**: `source_units / coord_units ** deriv` using Pint unit objects. Handles `None`, dimensionless, `ppm`, and all standard physical units.

## Tests

25 new tests covering the full policy matrix + critical paths + architecture:

- 9 matrix tests (U0–U8)
- 5 critical path tests (explicit+irregular, explicit+missing, fallback+missing, fallback+masked, fallback+NaN)
- 1 architectural test (same Filter object reused: physical derivative → fallback → smoothing, no state leakage)
- 1 conversion test (second ↔ millisecond coherence)
- 1 API equivalence test
- 1 reuse test (different units on same Filter)
- 1 descending test
- 2 non-mutation tests
- 1 ppm symbolic preservation test
- 1 historical test renamed and documented (`test_deriv_keeps_source_units_when_coordinate_has_no_units`)

All unit assertions use robust Pint comparison (`r.units == ds.units / coord.units`) instead of fragile string literals.

## Non-regression

- 145/145 filter tests pass
- No xfail added or removed
- `smooth`, `whittaker`, and other `Filter` methods unaffected
- `_reversed` untouched outside savgol path
- `name`, `title`, `description`, `history`, coordinates, dims, masks unchanged

## Out of scope

- NaN/mask handling in data arrays
- Gallery examples
- `pint.Quantity` as `delta`
- Global `_reversed` refactoring

## References

- Builds on PR #1551 (coordinate-aware signed delta) and PR #1553 (explicit delta sign convention)
- Audit: `spectrochempy_maintainer/notes/audits/savitzky-golay-implementation-audit-2026-08-18.md`
