### PR TITLE
ENH: add seed parameter to scp.random() and scp.normal()

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,10 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Add ``seed`` parameter to ``scp.random()`` and ``scp.normal()``.
+  The parameter is forwarded to ``numpy.random.default_rng``, making
+  it possible to obtain reproducible random numbers in scripts and
+  gallery examples.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,14 @@ What's New in Revision 0.12.5.dev
 These are the changes in SpectroChemPy-0.12.5.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+New Features
+~~~~~~~~~~~~
+
+- Add ``seed`` parameter to ``scp.random()`` and ``scp.normal()``.
+  The parameter is forwarded to ``numpy.random.default_rng``, making
+  it possible to obtain reproducible random numbers in scripts and
+  gallery examples.
+
 Bug Fixes
 ~~~~~~~~~
 - Fix ``dim`` keyword argument in Savitzky-Golay, smoothing and Whittaker

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -2579,11 +2579,11 @@ class NDMath:
         return cls
 
     @_from_numpy_method
-    def random(cls, size=None, dtype=None, **kwargs):
+    def random(cls, size=None, dtype=None, seed=None, **kwargs):
         r"""
         Return random floats in the half-open interval [0.0, 1.0).
 
-        Results are from the “continuous uniform” distribution over the stated interval.
+        Results are from the "continuous uniform" distribution over the stated interval.
 
         .. note::
             To sample :math:`\\mathrm{Uniform}[a, b)` with :math:`b > a`, multiply the
@@ -2599,6 +2599,10 @@ class NDMath:
         dtype : dtype, optional
             Desired dtype of the result, only float64 and float32 are supported.
             The default value is np.float64.
+        seed : int or SeedSequence or Generator, optional
+            Seed for the random number generator.  Passed to
+            `numpy.random.default_rng`.  Default is `None`, which produces
+            non-reproducible output.
         **kwargs
             Keywords argument used when creating the returned object, such as units,
             name, title, etc...
@@ -2612,12 +2616,12 @@ class NDMath:
         """
         from numpy.random import default_rng
 
-        rng = default_rng()
+        rng = default_rng(seed)
 
         return cls(rng.random(size, dtype), **kwargs)
 
     @_from_numpy_method
-    def normal(cls, loc=0.0, scale=1.0, size=None, dtype=None, **kwargs):
+    def normal(cls, loc=0.0, scale=1.0, size=None, dtype=None, seed=None, **kwargs):
         r"""
         Return samples from a normal (Gaussian) distribution.
 
@@ -2631,6 +2635,10 @@ class NDMath:
             Output shape. Default is None, in which case a single value is returned.
         dtype : dtype, optional
             Desired dtype of the result. The default is ``np.float64``.
+        seed : int or SeedSequence or Generator, optional
+            Seed for the random number generator.  Passed to
+            `numpy.random.default_rng`.  Default is `None`, which produces
+            non-reproducible output.
         **kwargs
             Keyword arguments used when creating the returned object, such as units,
             name, title, etc.
@@ -2642,7 +2650,7 @@ class NDMath:
         """
         from numpy.random import default_rng
 
-        rng = default_rng()
+        rng = default_rng(seed)
         data = rng.normal(loc=loc, scale=scale, size=size)
 
         if dtype is not None:

--- a/tests/test_core/test_dataset/test_mixins/test_ndmath.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndmath.py
@@ -1219,6 +1219,16 @@ def test_random():
     assert ds.x.size == 200
 
 
+def test_random_seed_reproducibility():
+    """Test that seed produces reproducible output."""
+    ds1 = scp.random((10,), seed=42)
+    ds2 = scp.random((10,), seed=42)
+    np.testing.assert_array_equal(ds1.data, ds2.data)
+
+    ds3 = scp.random((10,), seed=123)
+    assert not np.array_equal(ds1.data, ds3.data)
+
+
 def test_normal():
     """Test normal creation function."""
     ds = scp.normal(loc=2.0, scale=0.5, size=(3, 3), units="km")
@@ -1236,6 +1246,16 @@ def test_normal():
     assert ds.shape == (200,)
     assert ds.x.size == 200
     assert abs(ds.mean().m - 1.5) < 0.1
+
+
+def test_normal_seed_reproducibility():
+    """Test that seed produces reproducible output."""
+    ds1 = scp.normal(loc=0.0, scale=1.0, size=(10,), seed=42)
+    ds2 = scp.normal(loc=0.0, scale=1.0, size=(10,), seed=42)
+    np.testing.assert_array_equal(ds1.data, ds2.data)
+
+    ds3 = scp.normal(loc=0.0, scale=1.0, size=(10,), seed=123)
+    assert not np.array_equal(ds1.data, ds3.data)
 
 
 def test_diagonal():


### PR DESCRIPTION
## Objective

Add a `seed` parameter to `scp.random()` and `scp.normal()` so that users can obtain reproducible random numbers in scripts, tests, and gallery examples.

## What changed

- `src/spectrochempy/core/dataset/arraymixins/ndmath.py`:
  - `random()`: new `seed` parameter forwarded to `numpy.random.default_rng`
  - `normal()`: new `seed` parameter forwarded to `numpy.random.default_rng`
  - Docstrings updated for both functions
- `tests/test_core/test_dataset/test_mixins/test_ndmath.py`:
  - `test_random_seed_reproducibility`: verifies identical output with same seed, different output with different seed
  - `test_normal_seed_reproducibility`: same for `normal()`
- `docs/sources/whatsnew/changelog.rst`:
  - New feature entry
- `docs/sources/whatsnew/latest.rst`:
  - Regenerated by pre-commit hook

## Validations

- `test_random`, `test_random_seed_reproducibility`, `test_normal`, `test_normal_seed_reproducibility`: **all pass**
- `pre-commit run --all-files`: **clean**
- `git diff --check`: **clean**

## Scope

- No breaking changes; `seed=None` preserves previous non-deterministic behavior
- No other functions modified
- Gallery example in PR #1555 can be updated to use `scp.normal(..., seed=42)` once this PR is merged
