### PR TITLE
DOC: use reproducible SpectroChemPy random data in fitting guide

### DIFF
--- a/docs/sources/userguide/analysis/fitting.py
+++ b/docs/sources/userguide/analysis/fitting.py
@@ -34,8 +34,6 @@
 #
 
 # %%
-import numpy as np
-
 import spectrochempy as scp
 from spectrochempy import ur
 
@@ -49,7 +47,8 @@ from spectrochempy import ur
 
 # %%
 def func(t, v, var):
-    d = v * t + (np.random.rand(len(t)) - 0.5) * var
+    noise = scp.random(size=len(t), seed=42)
+    d = v * t + (noise.data - 0.5) * var
     d[0].data = 0.0
     return d
 
@@ -129,7 +128,8 @@ _ = dfit.plot_pen(clear=False, color="g", lw=2, label=" Fitted line", legend="be
 
 # %%
 def func(t, a, var):
-    d = a * (t / 3.0) ** 2 + (np.random.rand(len(t)) - 0.8) * var
+    noise = scp.random(size=len(t), seed=43)
+    d = a * (t / 3.0) ** 2 + (noise.data - 0.8) * var
     for i in range(t.size):
         if d[i].magnitude < 0:
             d[i] = 0.0 * d.units


### PR DESCRIPTION
## Objective

Apply the SpectroChemPy-first principle to the fitting tutorial by replacing non-reproducible `np.random.rand()` with the deterministic `scp.random(..., seed=...)` API introduced in #1556.

## What changed

- `docs/sources/userguide/analysis/fitting.py`:
  - Replaced `np.random.rand(len(t))` in the linear synthetic data generator by `scp.random(size=len(t), seed=42).data`
  - Replaced `np.random.rand(len(t))` in the quadratic synthetic data generator by `scp.random(size=len(t), seed=43).data`
  - Removed `import numpy as np` (no longer used in the file)

## Why this approach

- The two synthetic examples are now deterministic: every Sphinx-Gallery build produces the same figures.
- The tutorial demonstrates a public SpectroChemPy API (`scp.random(seed=...)`) rather than falling back to NumPy.
- The scientific intent (adding noise to synthetic distance data) remains unchanged.
- No runtime changes.

## What this PR does NOT do

- It does not remove NumPy from every example or tutorial. NumPy remains appropriate when the document teaches ufuncs, compares `NDDataset` with `ndarray`, or demonstrates interoperability.
- It does not modify `plot_a_create_dataset.py`, `processing/slicing.py`, or any other file.
- It does not introduce `scp.gaussian` or other profile helpers where they are not the natural fit.
- It does not change the fitting engine (`LSTSQ`, `NNLS`, `Optimize`).

## Validations

- `fitting.py` executed standalone: **OK**
- Reproducibility verified: two calls with `seed=42` produce identical values
- Pre-commit: **clean**
- `git diff --check`: **clean**

## References

- Random seed API: #1556 (`4f400f4d4`)
