### PR TITLE
DOC: simplify and stabilize Gallery examples

### DIFF
--- a/docs/sources/userguide/plugins/hypercomplex.rst
+++ b/docs/sources/userguide/plugins/hypercomplex.rst
@@ -70,9 +70,8 @@ An ordinary complex dataset stores one complex number per point:
 .. code-block:: python
 
     import spectrochempy as scp
-    import numpy as np
 
-    c = scp.NDDataset(np.array([1+2j, 3+4j]))
+    c = scp.NDDataset([1+2j, 3+4j])
 
 A **hypercomplex** dataset stores *two* complex numbers per point,
 typically written as a quaternion:

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -15,8 +15,6 @@ In this example, we perform the Evolving Factor Analysis of a TEST dataset
 """
 
 # %%
-import numpy as np
-
 import spectrochempy as scp
 
 # sphinx_gallery_thumbnail_number = 5
@@ -30,7 +28,7 @@ import spectrochempy as scp
 t = scp.Coord.arange(15, units="minutes", title="time")  # time coordinates
 c = scp.Coord(range(2), title="components")  # component coordinates
 
-dsc = scp.zeros((2, 15), dtype=np.float64, coords=[c, t])
+dsc = scp.zeros((2, 15), coords=[c, t])
 dsc[0, 3:8] = [1, 3, 6, 3, 1]  # compound 1
 dsc[1, 5:11] = [1, 3, 5, 3, 1, 0.5]  # compound 2
 
@@ -40,7 +38,7 @@ _ = dsc.plot(title="concentration")
 # 2) absorption spectra
 # ~~~~~~~~~~~~~~~~~~~~~~
 
-spec = np.array([[2.0, 3.0, 4.0, 2.0], [3.0, 4.0, 2.0, 1.0]])
+spec = [[2.0, 3.0, 4.0, 2.0], [3.0, 4.0, 2.0, 1.0]]
 w = scp.Coord.arange(1, 5, 1, units="nm", title="wavelength")
 
 dss = scp.NDDataset(data=spec, coords=[c, w])
@@ -51,7 +49,7 @@ _ = dss.plot(title="spectra")
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 
 dataset = scp.dot(dsc.T, dss)
-dataset += scp.normal(scale=0.1, size=dataset.shape)
+dataset += scp.normal(scale=0.1, size=dataset.shape, seed=42)
 dataset.title = "intensity"
 
 _ = dataset.plot(title="calculated dataset")

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -19,8 +19,6 @@ For convenience, this dataset is also available in the SpectroChemPy test-data
 directory as ``matlabdata/METING9.MAT``.
 """
 
-import numpy as np
-
 import spectrochempy as scp
 
 # %%
@@ -69,7 +67,7 @@ _ = mcr_1.St.plot()
 # roughly estimated rate constants:
 reactions = ("A -> B", "B -> C")
 species_concentrations = {"A": 5.0, "B": 0.0, "C": 0.0}
-k0 = np.array((0.5, 0.05))
+k0 = [0.5, 0.05]
 kin = scp.ActionMassKinetics(reactions, species_concentrations, k0)
 
 # %%

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -42,10 +42,7 @@ _ = dataset.plot(method="image", diverging_margin=0.1)
 # %%
 # Filter blank spectra
 # --------------------
-import numpy as np
-
-keep_rows = np.where(dataset.data.mean(axis=1) > 0)[0]
-dataset = dataset[keep_rows]
+dataset = dataset[dataset.data.mean(axis=1) > 0]
 _ = dataset.plot_image()
 
 # %%


### PR DESCRIPTION
## Objective

Consolidate the SpectroChemPy-first campaign by grouping the deterministic noise improvement (category A) with trivial NumPy simplifications (category B) into a single PR.

## Category A — scientific improvement

### EFA Keller-Massart example ()

The synthetic noise added to the simulated dataset was non-reproducible ( without seed). Every Sphinx-Gallery build produced different figures.

**Fix:** add `seed=42` to `scp.normal()`. The dataset and all downstream EFA results (eigenvalues, concentration profiles) are now deterministic. Verified by running the example twice and confirming exact equality.

## Category B — ergonomic simplifications

| File | Before | After |
|------|--------|-------|
| `plot_efa_keller_massart.py` | `dtype=np.float64` | removed (default) |
| `plot_efa_keller_massart.py` | `np.array([[...]])` | `[[...]]` |
| `plot_mcrals_kinetics.py` | `np.array((0.5, 0.05))` | `[0.5, 0.05]` |
| `plot_read_renishaw.py` | `np.where(...)[0]` + indexing | direct boolean-mask selection |
| `hypercomplex.rst` | `np.array([1+2j, 3+4j])` | `[1+2j, 3+4j]` |

All four files had their `import numpy as np` removed (no remaining usages).

## Validations

- EFA example executed twice with seed=42: dataset and EFA results identical
- MCRALS rate constants from list vs np.array: integration results identical
- NDDataset boolean indexing: verified equivalent to np.where pattern
- NDDataset from complex list: verified shape and dtype
- Pre-commit: clean
- EFA test suite: 6/6 passed
- Random seed tests: 3/3 passed

## Bounded audit — profile helpers

A search for manual Gaussian/Lorentzian/Voigt/sigmoid/polynomial expressions across all Gallery examples and User Guides found **zero** category A candidates:

- **4 intentional pedagogy** (category C): manual expressions exist specifically to teach the math or compare with helpers
- **4 semantic mismatches** (category D): replacement would lose information or be semantically incorrect

## References

- Random seed API: #1556
- Fitting tutorial pilot: #1557
- Maintainer audit: `numpy-scipy-docs-examples-audit-2026-08-19.md`