### PR TITLE
DOC: make remaining synthetic documentation deterministic

### DIFF
--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -68,7 +68,7 @@ baseline = scp.polynomial(
 )
 peak_1 = scp.gaussian(x, ampl=0.95, pos=3624.0, width=42.39, normalized=False)
 peak_2 = scp.gaussian(x, ampl=0.32, pos=3542.0, width=51.81, normalized=False)
-noise = scp.normal(loc=0.0, scale=0.007, size=x.size)
+noise = scp.normal(loc=0.0, scale=0.007, size=x.size, seed=42)
 
 nd_oh = baseline + peak_1 + peak_2 + noise
 nd_oh.title = "Synthetic OH region"

--- a/docs/sources/userguide/processing/smoothing.py
+++ b/docs/sources/userguide/processing/smoothing.py
@@ -62,7 +62,7 @@ _ = X.plot()
 # %%
 # select a region by slicing (note the original shape is (1, 1024)
 Xn = X[:, :400.0]
-Xn += 200 * scp.random(Xn.shape)  # add some noise
+Xn += 200 * scp.random(Xn.shape, seed=42)  # add some noise
 Xn.name = "initial"
 _ = Xn.plot()
 

--- a/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
@@ -19,7 +19,7 @@ import spectrochempy as scp
 # -------------------------
 dataset = scp.read("ramandata/labspec/SMC1-Initial_RT.txt")
 region = dataset[:, :400.0]
-region += 200 * scp.random(region.shape)
+region += 200 * scp.random(region.shape, seed=42)
 region.name = "noisy spectrum"
 
 prefs = scp.preferences


### PR DESCRIPTION
## Objective

Seed the three last non-reproducible noise generators in documentation so every Sphinx-Gallery build produces identical figures. All category A changes.

## Changes

| File | Before | After |
|------|--------|-------|
| `peak_analysis_workflow.py` | `scp.normal(loc=0.0, scale=0.007, size=x.size)` | `+ seed=42` |
| `smoothing.py` | `scp.random(Xn.shape)` | `+ seed=42` |
| `plot_smoothing_window_size.py` | `scp.random(region.shape)` | `+ seed=42` |

All three use `seed=42` for consistency with the existing Gallery examples.

## Why this matters

- **peak_analysis_workflow.py**: noise directly influences detected peaks, their selection, and the fit results. Non-deterministic noise means the tutorial figures and fitting output vary between builds.
- **smoothing.py** and **plot_smoothing_window_size.py**: the smoothing comparison figures change between builds, making it harder to discuss specific visual features in the documentation.

## Validations

- All three examples executed twice with seed=42: results identical
- Pre-commit: clean
- Random seed tests: 2/2 passed

## Campaign closure

This PR completes the SpectroChemPy-first documentation campaign:

- **PR #1555**: Savitzky-Golay Gallery example (zero NumPy/SciPy)
- **PR #1556**: `scp.random(seed=...)` API
- **PR #1557**: Fitting tutorial deterministic noise
- **PR #1558**: Gallery cleanup (EFA deterministic + B simplifications)
- **This PR**: Last three non-deterministic examples seeded

The bounded audit of manual formulas found zero additional category A candidates. All remaining NumPy/SciPy usages are justified (category C) or rejected (category D).