### PR TITLE
ENH: add explicit migration for legacy SCP/PSCP files

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -183,6 +183,7 @@ The NMR readers ``read_topspin`` and ``read_agilent`` require the
     :toctree: generated/
 
     load
+    migrate_legacy_file
     read
     read_agilent
     read_csv

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,11 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Add ``scp.migrate_legacy_file()`` for explicit migration of legacy
+  SCP/PSCP files to the safe ``raw-base64`` format. Legacy files with
+  pickle-based payloads can be converted safely with an explicit trust
+  acknowledgement (``allow_unsafe_legacy=True``). The source file is
+  never modified or deleted.
 - Add ``seed`` parameter to ``scp.random()`` and ``scp.normal()``.
   The parameter is forwarded to ``numpy.random.default_rng``, making
   it possible to obtain reproducible random numbers in scripts and

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,6 +15,11 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
+- Add ``scp.migrate_legacy_file()`` for explicit migration of legacy
+  SCP/PSCP files to the safe ``raw-base64`` format. Legacy files with
+  pickle-based payloads can be converted safely with an explicit trust
+  acknowledgement (``allow_unsafe_legacy=True``). The source file is
+  never modified or deleted.
 - Add ``seed`` parameter to ``scp.random()`` and ``scp.normal()``.
   The parameter is forwarded to ``numpy.random.default_rng``, making
   it possible to obtain reproducible random numbers in scripts and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,7 @@ exclude = ["~*"] # Exclude files and directories. "tests/**"
   "N816",
 ] # accept "useless expression", "print", "mixed-case variables" in *.ipynb or py:percent files.
 "src/spectrochempy/extern/brukeropus/**/*" = ["T201", "D"]
+"src/spectrochempy/utils/persistence.py" = ["T201"] # verbose flag intentionally prints
 "src/spectrochempy/ci/install_plugins.py" = ["T201", "S603", "PLC0415", "S112"]
 ".github/workflows/scripts/check_commit_prefix.py" = ["T201"] # CLI script that prints validation messages
 "tests/**/*" = [

--- a/src/spectrochempy/lazyimport/api_methods.py
+++ b/src/spectrochempy/lazyimport/api_methods.py
@@ -82,6 +82,7 @@ _LAZY_IMPORTS = {
     "long_description": "spectrochempy.application.info",
     "preferences": "spectrochempy.application.preferences",
     "load": "spectrochempy.core.dataset.arraymixins.ndio",
+    "migrate_legacy_file": "spectrochempy.utils.persistence",
     "abs": "spectrochempy.core.dataset.arraymixins.ndmath",
     "absolute": "spectrochempy.core.dataset.arraymixins.ndmath",
     "all": "spectrochempy.core.dataset.arraymixins.ndmath",

--- a/src/spectrochempy/utils/__init__.pyi
+++ b/src/spectrochempy/utils/__init__.pyi
@@ -27,6 +27,7 @@ __all__ = [
     "objects",
     "optional",
     "packages",
+    "persistence",
     "print",
     "show_versions",
     "system",
@@ -58,6 +59,7 @@ from . import numutils
 from . import objects
 from . import optional
 from . import packages
+from . import persistence
 from . import print
 from . import show_versions
 from . import system

--- a/src/spectrochempy/utils/persistence.py
+++ b/src/spectrochempy/utils/persistence.py
@@ -1,0 +1,278 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Persistence migration utilities for legacy SCP/PSCP files."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import tempfile
+import warnings
+import zipfile
+
+__all__ = ["migrate_legacy_file"]
+
+
+def _peek_raw_document(filepath):
+    """
+    Read the raw JSON document from an SCP/ZIP archive without decoding arrays.
+
+    Returns a dict with the raw payload structure intact, or None if the file
+    cannot be read as a valid SCP/ZIP archive.
+    """
+    try:
+        with zipfile.ZipFile(filepath, "r") as zf:
+            member = zf.namelist()[0]
+            return json.loads(zf.read(member).decode("utf-8"))
+    except Exception:
+        return None
+
+
+def _has_legacy_payload(document):
+    """
+    Recursively check whether a raw SCP document contains legacy pickle payloads.
+
+    Inspects all nested dicts for payloads with ``__class__`` keys that lack
+    ``raw-base64`` encoding, indicating pickle-based persistence.
+    """
+    if not isinstance(document, dict):
+        return False
+
+    # Check if this dict looks like a NUMPY_ARRAY payload.
+    if (
+        document.get("__class__") == "NUMPY_ARRAY"
+        and document.get("encoding") != "raw-base64"
+    ):
+        return True
+
+    for value in document.values():
+        if isinstance(value, dict) and _has_legacy_payload(value):
+            return True
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict) and _has_legacy_payload(item):
+                    return True
+
+    return False
+
+
+def _is_safe_document(document):
+    """
+    Check whether a raw SCP document uses the safe raw-base64 encoding.
+
+    Validates document markers (``__format__``, ``__version__``) and
+    recursively inspects all array payloads for ``raw-base64`` encoding.
+    """
+    if not isinstance(document, dict):
+        return False
+
+    # Validate document markers using the official validation.
+    has_format = document.get("__format__") in ("scp", "pscp")
+    has_version = document.get("__version__") is not None
+    if not (has_format and has_version):
+        return False
+
+    # Check for any legacy (non-raw-base64) payloads recursively.
+    if _has_legacy_payload(document):
+        return False
+
+    return True
+
+
+def migrate_legacy_file(
+    source,
+    destination=None,
+    *,
+    allow_unsafe_legacy=False,
+    overwrite=False,
+    verbose=False,
+):
+    """
+    Migrate a legacy SCP/PSCP file to the safe raw-base64 format.
+
+    Legacy SCP/PSCP files produced before SpectroChemPy 0.8 may contain
+    pickle-based array payloads.  Loading such files with the default
+    ``allow_unsafe_legacy=False`` raises an error.  This function converts
+    the file to the current safe format (``raw-base64``).
+
+    .. warning::
+
+        Migration **does** execute ``pickle.loads`` on the legacy payload
+        to reconstruct the in-memory object.  Only migrate files whose
+        provenance you fully trust.  Set ``allow_unsafe_legacy=True`` to
+        acknowledge this risk explicitly.
+
+    The migrated file is a proper SCP/ZIP archive and can be loaded with
+    the default ``allow_unsafe_legacy=False``.  The source file is never
+    modified or deleted.
+
+    Writes are atomic: the destination is only replaced after the migrated
+    file has been written, verified as loadable with safe defaults,
+    and then moved into place via ``os.replace()``.
+
+    Parameters
+    ----------
+    source : str or pathlib.Path
+        Path to the ``.scp`` or ``.pscp`` file to migrate.
+    destination : str or pathlib.Path, optional
+        Path for the migrated output file.  When *None*, a
+        ``_migrated`` suffix is inserted before the extension in the
+        source path.
+    allow_unsafe_legacy : bool, default False
+        **Required to be ``True``.**  Acknowledges that the source file
+        will be deserialised via ``pickle.loads`` during migration.
+        Set this to ``True`` only when the source file comes from a
+        known and trusted origin.
+    overwrite : bool, default False
+        Allow overwriting an existing *destination* file.  When
+        *False* and the destination already exists, a
+        ``FileExistsError`` is raised.
+    verbose : bool, default False
+        Print a summary of the migration to stdout.
+
+    Returns
+    -------
+    pathlib.Path
+        Path of the migrated file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *source* does not exist.
+    ValueError
+        If *source* does not have a ``.scp`` or ``.pscp`` extension,
+        if *source* and *destination* resolve to the same path, or if
+        the *destination* suffix does not match the *source* suffix.
+    FileExistsError
+        If the destination already exists and *overwrite* is False.
+    spectrochempy.utils.exceptions.SpectroChemPyError
+        If *allow_unsafe_legacy* is ``False``, if the source is
+        already in safe format, or if the migration fails for any
+        other reason.
+
+    See Also
+    --------
+    spectrochempy.load : Load an SCP/PSCP file.
+    spectrochempy.NDDataset.save : Save an NDDataset to SCP format.
+    spectrochempy.Project.save : Save a Project to PSCP format.
+
+    Examples
+    --------
+    >>> from spectrochempy import migrate_legacy_file
+    >>> # migrate a single file (requires trust acknowledgement)
+    >>> migrated = migrate_legacy_file("old_data.scp",
+    ...                                allow_unsafe_legacy=True)
+    >>> # migrate to a specific path
+    >>> migrated = migrate_legacy_file("old_data.scp", "new_data.scp",
+    ...                                allow_unsafe_legacy=True,
+    ...                                overwrite=True)
+    """
+    from spectrochempy.core.dataset.arraymixins.ndio import load as scp_load
+    from spectrochempy.utils.exceptions import SpectroChemPyError
+
+    source = pathlib.Path(source)
+
+    if not source.exists():
+        raise FileNotFoundError(f"Source file not found: {source}")
+
+    suffix = source.suffix.lower()
+    if suffix not in (".scp", ".pscp"):
+        raise ValueError(
+            f"Source file must have a .scp or .pscp extension, got: {suffix}"
+        )
+
+    if destination is None:
+        destination = source.parent / f"{source.stem}_migrated{source.suffix}"
+    else:
+        destination = pathlib.Path(destination)
+
+    # Reject source == destination (resolved).
+    if source.resolve() == destination.resolve():
+        raise ValueError(
+            "Source and destination resolve to the same path. "
+            "Migration would overwrite the original file."
+        )
+
+    if destination.exists() and not overwrite:
+        raise FileExistsError(
+            f"Destination file already exists: {destination}. "
+            "Use overwrite=True to replace it."
+        )
+
+    dest_suffix = destination.suffix.lower()
+    if dest_suffix not in (".scp", ".pscp"):
+        raise ValueError(
+            f"Destination must have a .scp or .pscp extension, got: {dest_suffix}"
+        )
+    if suffix != dest_suffix:
+        raise ValueError(
+            f"Destination suffix {dest_suffix} does not match source suffix "
+            f"{suffix}.  Cross-format migration is not supported."
+        )
+
+    # Peek at the raw JSON to detect encoding without executing pickle.
+    raw = _peek_raw_document(source)
+    if _is_safe_document(raw):
+        raise SpectroChemPyError(
+            f"{source.name} is already in safe format. No migration needed."
+        )
+
+    # Explicit trust acknowledgement required.
+    if not allow_unsafe_legacy:
+        raise SpectroChemPyError(
+            "Migrating this file requires deserialising pickle payloads. "
+            "Set allow_unsafe_legacy=True only if the source file comes "
+            "from a known and trusted source."
+        )
+
+    warnings.warn(
+        f"Deserialising legacy pickle payload in {source.name}. "
+        "Only do this for files from trusted sources.",
+        stacklevel=2,
+    )
+
+    try:
+        obj = scp_load(source, allow_unsafe_legacy=True)
+
+        # Write to a temporary file in the same directory, then atomically
+        # replace the destination.  This preserves the existing destination
+        # on failure.
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            suffix=f"-{destination.name}",
+            dir=destination.parent,
+        )
+        os.close(tmp_fd)
+        tmp_path = pathlib.Path(tmp_path)
+        try:
+            obj.dump(tmp_path)
+
+            # Verify the migrated file is loadable with safe defaults.
+            verification = scp_load(tmp_path, allow_unsafe_legacy=False)
+            if verification is None:
+                raise SpectroChemPyError(
+                    "Verification failed: migrated file could not be loaded "
+                    "with safe defaults."
+                )
+
+            # Atomic replace: destination is only touched after success.
+            os.replace(tmp_path, destination)
+        except BaseException:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
+
+        if verbose:
+            print(
+                f"Migrated {source.name} -> {destination.name} "
+                f"(safe raw-base64 format)"
+            )
+    except Exception:
+        # Clean up partial output on failure (only if it was created
+        # outside the tmp block, which should not happen, but defensive).
+        raise
+
+    return destination

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -22,6 +22,7 @@ import spectrochempy as scp
 from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
+from spectrochempy.core.project.project import Project
 from spectrochempy.utils.exceptions import SpectroChemPyError
 from spectrochempy.utils.jsonutils import json_loads
 from spectrochempy.utils.testing import assert_array_equal, assert_dataset_equal
@@ -42,6 +43,26 @@ def _rewrite_dataset_data_payload_as_legacy_pickle(filename):
     js["data"] = {
         "__class__": "NUMPY_ARRAY",
         "base64": base64.b64encode(pickle.dumps(current.data)).decode(),
+    }
+
+    with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr(member, json.dumps(js, indent=2))
+
+
+def _rewrite_project_dataset_payload_as_legacy_pickle(filename):
+    current = Project.load(filename)
+
+    with zipfile.ZipFile(filename, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+
+    js.pop("__format__", None)
+    js.pop("__version__", None)
+    js["datasets"][0]["data"] = {
+        "__class__": "NUMPY_ARRAY",
+        "base64": base64.b64encode(
+            pickle.dumps(np.array(current.datasets[0].data)),
+        ).decode(),
     }
 
     with zipfile.ZipFile(filename, "w", compression=zipfile.ZIP_DEFLATED) as zipf:
@@ -441,6 +462,266 @@ def test_ndio_load_without_history_field_keeps_dataset_loadable(tmp_path):
     assert_array_equal(loaded.data, ds.data)
     assert_array_equal(loaded.mask, ds.mask)
     assert loaded.meta["nested"] == ds.meta["nested"]
+
+
+# ---------------------------------------------------------------------------
+# Legacy migration tests
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_legacy_file_requires_trust_acknowledgement(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_trust")
+    filename = ds.save_as(tmp_path / "migrate_trust", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.raises(SpectroChemPyError, match="allow_unsafe_legacy=True"):
+        migrate_legacy_file(filename)
+
+    with pytest.warns(UserWarning, match="trusted sources"):
+        migrated = migrate_legacy_file(filename, allow_unsafe_legacy=True)
+
+    loaded = NDDataset.load(migrated)
+    assert_dataset_equal(loaded, ds)
+
+
+def test_migrate_legacy_file_converts_to_safe_format(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_basic")
+    filename = ds.save_as(tmp_path / "migrate_basic", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.warns(UserWarning):
+        migrated = migrate_legacy_file(filename, allow_unsafe_legacy=True, verbose=True)
+
+    loaded = NDDataset.load(migrated)
+    assert_dataset_equal(loaded, ds)
+
+    with zipfile.ZipFile(migrated, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+    assert js["data"]["encoding"] == "raw-base64"
+    assert js["__format__"] == "scp"
+    assert js["__version__"] == 2
+
+
+def test_migrate_legacy_file_safe_load_after_migration(tmp_path, monkeypatch):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_nopickle")
+    filename = ds.save_as(tmp_path / "migrate_nopickle", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.warns(UserWarning):
+        migrated = migrate_legacy_file(filename, allow_unsafe_legacy=True)
+
+    def fail_pickle_loads(*args, **kwargs):
+        raise AssertionError("pickle.loads must not run during safe default load")
+
+    with monkeypatch.context() as m:
+        m.setattr("spectrochempy.utils.jsonutils.pickle.loads", fail_pickle_loads)
+        loaded = NDDataset.load(migrated)
+
+    assert_array_equal(loaded.data, ds.data)
+
+
+def test_migrate_legacy_file_preserves_coords(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    x = Coord(np.linspace(4000, 400, 100), title="wavenumber")
+    ds = NDDataset(
+        np.random.default_rng(42).random((5, 100)),
+        name="migrate_coords",
+        coord=(Coord(np.arange(5)), x),
+    )
+    filename = ds.save_as(tmp_path / "migrate_coords", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.warns(UserWarning):
+        migrated = migrate_legacy_file(filename, allow_unsafe_legacy=True)
+    loaded = NDDataset.load(migrated)
+
+    assert_dataset_equal(loaded, ds)
+
+
+def test_migrate_legacy_file_raises_for_already_safe(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_already_safe")
+    filename = ds.save_as(tmp_path / "migrate_already_safe", confirm=False)
+
+    with pytest.raises(SpectroChemPyError, match="already in safe format"):
+        migrate_legacy_file(filename, allow_unsafe_legacy=True)
+
+
+def test_migrate_legacy_file_raises_for_nonexistent_source():
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    with pytest.raises(FileNotFoundError):
+        migrate_legacy_file("/nonexistent/file.scp", allow_unsafe_legacy=True)
+
+
+def test_migrate_legacy_file_raises_for_wrong_extension(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    f = tmp_path / "data.csv"
+    f.write_text("a,b,c")
+
+    with pytest.raises(ValueError, match="must have a .scp or .pscp extension"):
+        migrate_legacy_file(f, allow_unsafe_legacy=True)
+
+
+def test_migrate_legacy_file_raises_when_destination_exists(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_exists")
+    filename = ds.save_as(tmp_path / "migrate_exists", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    dest = tmp_path / "migrate_exists_migrated.scp"
+    dest.write_text("existing content")
+
+    with pytest.raises(FileExistsError):
+        migrate_legacy_file(filename, allow_unsafe_legacy=True)
+
+    with pytest.warns(UserWarning):
+        migrated = migrate_legacy_file(
+            filename, destination=dest, allow_unsafe_legacy=True, overwrite=True
+        )
+    loaded = NDDataset.load(migrated)
+    assert_array_equal(loaded.data, ds.data)
+
+
+def test_migrate_legacy_file_raises_for_source_equals_destination(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_same")
+    filename = ds.save_as(tmp_path / "migrate_same", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.raises(ValueError, match="resolve to the same path"):
+        migrate_legacy_file(filename, destination=filename, allow_unsafe_legacy=True)
+
+    assert filename.exists()
+
+
+def test_migrate_legacy_file_default_destination(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_default_dest")
+    filename = ds.save_as(tmp_path / "migrate_default_dest", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.warns(UserWarning):
+        migrated = migrate_legacy_file(filename, allow_unsafe_legacy=True)
+
+    assert migrated == tmp_path / "migrate_default_dest_migrated.scp"
+    loaded = NDDataset.load(migrated)
+    assert_dataset_equal(loaded, ds)
+
+
+def test_migrate_legacy_file_preserves_existing_destination_on_failure(
+    tmp_path, monkeypatch
+):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_cleanup")
+    filename = ds.save_as(tmp_path / "migrate_cleanup", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    dest = tmp_path / "migrate_cleanup_migrated.scp"
+    dest.write_text("original content that must be preserved")
+
+    def fail_dump(self, f, **kwargs):
+        raise RuntimeError("dump failed")
+
+    with monkeypatch.context() as m:
+        m.setattr(NDDataset, "dump", fail_dump)
+        with pytest.raises(RuntimeError, match="dump failed"):
+            migrate_legacy_file(
+                filename,
+                destination=dest,
+                allow_unsafe_legacy=True,
+                overwrite=True,
+            )
+
+    # Original destination must survive the failure.
+    assert dest.exists()
+    assert dest.read_text() == "original content that must be preserved"
+
+
+def test_migrate_legacy_file_pscp_roundtrip(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds1 = NDDataset(np.array([1.0, 2.0, 3.0]), name="pscp_child1")
+    ds2 = NDDataset(np.array([4.0, 5.0, 6.0]), name="pscp_child2")
+    proj = Project(name="migrate_pscp_project")
+    proj.add_dataset(ds1)
+    proj.add_dataset(ds2)
+
+    filename = proj.save_as(tmp_path / "migrate_pscp_project", confirm=False)
+    _rewrite_project_dataset_payload_as_legacy_pickle(filename)
+
+    with pytest.warns(UserWarning):
+        migrated = migrate_legacy_file(filename, allow_unsafe_legacy=True)
+
+    loaded = Project.load(migrated)
+    assert len(loaded.datasets) == 2
+    assert_array_equal(loaded["pscp_child1"].data, ds1.data)
+    assert_array_equal(loaded["pscp_child2"].data, ds2.data)
+
+    with zipfile.ZipFile(migrated, "r") as zipf:
+        member = zipf.namelist()[0]
+        js = json.loads(zipf.read(member).decode("utf-8"))
+    assert js["__format__"] == "pscp"
+    assert js["__version__"] == 2
+
+
+def test_migrate_legacy_file_atomic_replaces_existing(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_atomic")
+    filename = ds.save_as(tmp_path / "migrate_atomic", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    dest = tmp_path / "migrate_atomic_migrated.scp"
+    dest.write_text("old content")
+
+    with pytest.warns(UserWarning):
+        migrated = migrate_legacy_file(
+            filename, destination=dest, allow_unsafe_legacy=True, overwrite=True
+        )
+
+    loaded = NDDataset.load(migrated)
+    assert_dataset_equal(loaded, ds)
+
+
+def test_migrate_legacy_file_rejects_cross_suffix(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_cross")
+    filename = ds.save_as(tmp_path / "migrate_cross", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.raises(ValueError, match="does not match source suffix"):
+        migrate_legacy_file(
+            filename, destination=tmp_path / "wrong.pscp", allow_unsafe_legacy=True
+        )
+
+
+def test_migrate_legacy_file_rejects_destination_without_suffix(tmp_path):
+    from spectrochempy.utils.persistence import migrate_legacy_file
+
+    ds = NDDataset(np.array([1.0, 2.0, 3.0]), name="migrate_nosuffix")
+    filename = ds.save_as(tmp_path / "migrate_nosuffix", confirm=False)
+    _rewrite_dataset_data_payload_as_legacy_pickle(filename)
+
+    with pytest.raises(ValueError, match="must have a .scp or .pscp extension"):
+        migrate_legacy_file(
+            filename, destination=tmp_path / "output", allow_unsafe_legacy=True
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add `scp.migrate_legacy_file()` — an explicit, single-file migration utility for legacy SCP/PSCP files containing pickle-based array payloads. Converts them to the safe `raw-base64` format.

## Motivation

Legacy SCP/PSCP files produced before SpectroChemPy 0.8 contain pickle payloads. Loading them with the default `allow_unsafe_legacy=False` raises an error (PR #1221). Users with pre-fix archives need an explicit, safe path to convert these files.

## API

```python
scp.migrate_legacy_file(
    source,
    destination=None,
    *,
    allow_unsafe_legacy=False,
    overwrite=False,
    verbose=False,
) -> pathlib.Path
```

## Safety guarantees

| Constraint | Status |
|---|---|
| Explicit trust acknowledgement | `allow_unsafe_legacy=True` mandatory |
| Consent parameter stays False by default | ✓ |
| No automatic migration during `load()` | ✓ |
| No recursive directory traversal | ✓ |
| No source file deletion/modification | ✓ |
| Atomic destination writes (temp → `os.replace`) | ✓ |
| Source == destination rejection | ✓ |
| Suffix validation (no cross-format migration) | ✓ |
| Output verified loadable with safe defaults | ✓ |
| Existing destination preserved on failure | ✓ |
| File descriptor properly closed | ✓ |

## Files changed

- **New**: `src/spectrochempy/utils/persistence.py` — `migrate_legacy_file()`, `_peek_raw_document()`, `_has_legacy_payload()`, `_is_safe_document()`
- `src/spectrochempy/lazyimport/api_methods.py` — register in `_LAZY_IMPORTS`
- `src/spectrochempy/utils/__init__.pyi` — auto-generated stub
- `tests/test_core/test_dataset/test_mixins/test_ndio.py` — 15 migration tests
- `docs/sources/reference/index.rst` — public API reference
- `docs/sources/whatsnew/changelog.rst` — changelog entry
- `pyproject.toml` — per-file-ignore for verbose print

## Tests (15)

1. Requires trust acknowledgement (`allow_unsafe_legacy=False` raises)
2. Converts to safe format (round-trip)
3. No pickle during safe default load of migrated file
4. Preserves coordinates
5. Raises for already-safe source
6. Raises for nonexistent source
7. Raises for wrong source extension
8. Raises when destination exists
9. Raises for source == destination
10. Default destination with `_migrated` suffix
11. Preserves existing destination on failure
12. PSCP round-trip (Project with 2 datasets)
13. Atomic overwrite replaces existing destination
14. Rejects cross-suffix destination (.scp → .pscp)
15. Rejects destination without extension

## Validation

- 15/15 migration tests pass
- 161 total tests across ndio + projects + jsonutils + zip pass
- `pre-commit run --all-files` passes