### PR TITLE
FIX: correct sample-local preprocessing transformers

### DIFF
--- a/docs/sources/userguide/processing/transformations.py
+++ b/docs/sources/userguide/processing/transformations.py
@@ -217,9 +217,9 @@ _ = nd.plot(title="MSC corrected")
 # %% [markdown]
 # ## Using transformers for machine-learning workflows
 #
-# For train/test splits or cross-validation, the procedural API above
-# recalculates statistics on every call.  To reuse statistics learned from
-# a training set, use the transformer classes instead:
+# For train/test splits or cross-validation, transformer classes make
+# preprocessing state explicit.  Feature-wise scalers reuse statistics learned
+# from a training set:
 #
 # ```python
 # scaler = scp.AutoscaleTransformer(dim="y")
@@ -227,11 +227,16 @@ _ = nd.plot(title="MSC corrected")
 # X_test_scaled  = scaler.transform(X_test)   # uses train mean/std
 # ```
 #
+# Sample-local operations such as `SNVTransformer` and
+# `NormalizeTransformer(dim="x")` still compute each observation's statistics
+# during `transform()`, because those statistics belong to the spectrum being
+# transformed rather than to the training set.
+#
 # All nine operations have a matching transformer (e.g.
 # `CenterTransformer`, `NormalizeTransformer`, `MSCTransformer`, …).
 # They implement the familiar `fit()` / `transform()` / `fit_transform()` /
-# `inverse_transform()` lifecycle and expose `get_params()` / `set_params()`
-# for scikit-learn-compatible cloning.
+# `inverse_transform()` lifecycle where meaningful and expose `get_params()` /
+# `set_params()` for scikit-learn-compatible cloning.
 
 # %% [markdown]
 # All operations support `inplace=True` and can be called as either top-level

--- a/docs/sources/userguide/processing/transformations.py
+++ b/docs/sources/userguide/processing/transformations.py
@@ -230,7 +230,9 @@ _ = nd.plot(title="MSC corrected")
 # Sample-local operations such as `SNVTransformer` and
 # `NormalizeTransformer(dim="x")` still compute each observation's statistics
 # during `transform()`, because those statistics belong to the spectrum being
-# transformed rather than to the training set.
+# transformed rather than to the training set.  Their inverse transform is not
+# supported unless a future API carries the required per-observation state on
+# the transformed result.
 #
 # All nine operations have a matching transformer (e.g.
 # `CenterTransformer`, `NormalizeTransformer`, `MSCTransformer`, …).

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -39,7 +39,9 @@ Bug Fixes
   dataset being transformed instead of reusing training spectra positionally.
   Their ``inverse_transform()`` now raises an explicit error for these
   sample-local modes because the required per-observation factors are not
-  learned reusable state.
+  learned reusable state. This is an intentional behavior break from the
+  previous unsafe inverse, which could only work by reusing training or
+  last-transform state positionally.
 
 - Fix ``dim`` keyword argument in Savitzky-Golay, smoothing and Whittaker
   filters (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -34,6 +34,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
+- Fix sample-local preprocessing transformers so ``SNVTransformer`` and
+  ``NormalizeTransformer(dim="x")`` compute per-spectrum statistics on the
+  dataset being transformed instead of reusing training spectra positionally.
+  Their ``inverse_transform()`` now raises an explicit error for these
+  sample-local modes because the required per-observation factors are not
+  learned reusable state.
+
 - Fix ``dim`` keyword argument in Savitzky-Golay, smoothing and Whittaker
   filters (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).
   ``savgol()``, ``smooth()``, ``whittaker()`` and

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -32,7 +32,9 @@ Bug Fixes
   dataset being transformed instead of reusing training spectra positionally.
   Their ``inverse_transform()`` now raises an explicit error for these
   sample-local modes because the required per-observation factors are not
-  learned reusable state.
+  learned reusable state. This is an intentional behavior break from the
+  previous unsafe inverse, which could only work by reusing training or
+  last-transform state positionally.
 
 - Fix ``dim`` keyword argument in Savitzky-Golay, smoothing and Whittaker
   filters (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,13 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
+- Fix sample-local preprocessing transformers so ``SNVTransformer`` and
+  ``NormalizeTransformer(dim="x")`` compute per-spectrum statistics on the
+  dataset being transformed instead of reusing training spectra positionally.
+  Their ``inverse_transform()`` now raises an explicit error for these
+  sample-local modes because the required per-observation factors are not
+  learned reusable state.
+
 - Fix ``dim`` keyword argument in Savitzky-Golay, smoothing and Whittaker
   filters (`#1091 <https://github.com/spectrochempy/spectrochempy/issues/1091>`_).
   ``savgol()``, ``smooth()``, ``whittaker()`` and

--- a/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
@@ -13,7 +13,8 @@ SpectroChemPy preprocessing operations can be used as transformer objects
 with an explicit ``fit()`` / ``transform()`` lifecycle.  Feature-wise
 scalers learn statistics from a training set and reuse them on new data.
 Sample-local operations such as SNV and spectral normalization compute
-each observation's statistics during ``transform()``.
+each observation's statistics during ``transform()`` and do not support a
+safe inverse without result-attached per-observation state.
 
 The transformers also expose ``get_params()`` / ``set_params()`` so they
 work with ``sklearn.base.clone()`` when scikit-learn is installed.

--- a/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
@@ -9,11 +9,11 @@
 Preprocessing transformers and scikit-learn compatibility
 =========================================================
 
-SpectroChemPy preprocessing operations can be used as **stateful
-transformers** that learn statistics from a training set and reuse them
-on new data.  This is essential for machine-learning workflows where
-train and test sets must be processed with the *same* scaling
-parameters.
+SpectroChemPy preprocessing operations can be used as transformer objects
+with an explicit ``fit()`` / ``transform()`` lifecycle.  Feature-wise
+scalers learn statistics from a training set and reuse them on new data.
+Sample-local operations such as SNV and spectral normalization compute
+each observation's statistics during ``transform()``.
 
 The transformers also expose ``get_params()`` / ``set_params()`` so they
 work with ``sklearn.base.clone()`` when scikit-learn is installed.
@@ -63,7 +63,7 @@ print("Std shape:  ", scaler.std_.shape)
 # %%
 # Parameter inspection with ``get_params`` / ``set_params``
 # ---------------------------------------------------------
-# All transformers follow scikit-learn conventions.
+# Transformers follow scikit-learn parameter conventions.
 
 print("Original params:", scaler.get_params())
 

--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -380,12 +380,13 @@ class SNVTransformer(AutoscaleTransformer):
     r"""
     Standard Normal Variate (SNV) transformer.
 
-    Equivalent to :class:`AutoscaleTransformer` with ``dim='x'``.
     Each observation (spectrum) is mean-centered and scaled to unit
-    variance individually.
+    variance individually.  ``fit()`` validates the preprocessing axis,
+    while ``transform()`` computes the per-spectrum statistics on the
+    dataset being transformed.
 
-    This is a thin wrapper that hard-codes ``dim='x'`` and provides a
-    more descriptive name for the common NIR preprocessing step.
+    This transformer hard-codes ``dim='x'`` and provides a descriptive
+    name for the common NIR preprocessing step.
 
     Examples
     --------
@@ -403,23 +404,37 @@ class SNVTransformer(AutoscaleTransformer):
     def __init__(self):
         super().__init__(dim="x")
 
+    def _fit(self, dataset):
+        _, self._dim_name = dataset.get_axis(self.dim)
+
     def _transform(self, dataset):
-        new = super()._transform(dataset)
+        new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        data = dataset.masked_data
+        mean = np.ma.mean(data, axis=axis, keepdims=True)
+        std = np.ma.std(data, axis=axis, keepdims=True)
+        std_safe = np.where(std == 0, 1, std)
+        self._set_data(new, (data - mean) / std_safe)
         new.history = "SNVTransformer applied"
         return new
 
     def _inverse_transform(self, dataset):
-        new = super()._inverse_transform(dataset)
-        new.history = "SNVTransformer inverse applied"
-        return new
+        raise SpectroChemPyError(
+            "SNVTransformer inverse_transform is not supported because SNV "
+            "computes sample-local statistics during transform()."
+        )
 
 
 class NormalizeTransformer(BasePreprocessor):
     r"""
     Normalization transformer.
 
-    Learns the normalization factor along a dimension during ``fit()``
-    and applies it during ``transform()``.
+    Learns the normalization factor along a reusable feature dimension
+    during ``fit()`` and applies it during ``transform()``.  For the
+    standard spectral case ``dim='x'`` on 2-D datasets, normalization is
+    sample-local: ``fit()`` validates the mode and ``transform()`` computes
+    each observation's normalization factor on the dataset being
+    transformed.
 
     Parameters
     ----------
@@ -464,39 +479,62 @@ class NormalizeTransformer(BasePreprocessor):
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
         data = dataset.masked_data
+        self._sample_local_ = data.ndim == 2 and axis == 1
 
-        if self.method == "max":
-            self.norm_ = np.ma.max(np.ma.abs(data), axis=axis, keepdims=True)
-            self.norm_ = np.where(self.norm_ == 0, 1, self.norm_)
-
-        elif self.method == "sum":
-            self.norm_ = np.ma.sum(np.ma.abs(data), axis=axis, keepdims=True)
-            self.norm_ = np.where(self.norm_ == 0, 1, self.norm_)
-
-        elif self.method == "vector":
-            self.norm_ = np.sqrt(np.ma.sum(data**2, axis=axis, keepdims=True))
-            self.norm_ = np.where(self.norm_ == 0, 1, self.norm_)
-
-        elif self.method == "minmax":
-            self.dmin_ = np.ma.min(data, axis=axis, keepdims=True)
-            self.dmax_ = np.ma.max(data, axis=axis, keepdims=True)
-            self.range_ = self.dmax_ - self.dmin_
-            self.range_ = np.where(self.range_ == 0, 1, self.range_)
-
-        else:
+        if self.method not in ("max", "sum", "vector", "minmax"):
             raise SpectroChemPyError(
                 f"Unknown normalization method '{self.method}'. "
                 f"Choose from 'max', 'sum', 'vector', 'minmax'."
             )
 
+        if self._sample_local_:
+            return
+
+        params = self._normalization_parameters(data, axis)
+        for name, value in params.items():
+            setattr(self, name, value)
+
+    def _normalization_parameters(self, data, axis):
+        if self.method == "max":
+            norm = np.ma.max(np.ma.abs(data), axis=axis, keepdims=True)
+            return {"norm_": np.where(norm == 0, 1, norm)}
+
+        if self.method == "sum":
+            norm = np.ma.sum(np.ma.abs(data), axis=axis, keepdims=True)
+            return {"norm_": np.where(norm == 0, 1, norm)}
+
+        if self.method == "vector":
+            norm = np.sqrt(np.ma.sum(data**2, axis=axis, keepdims=True))
+            return {"norm_": np.where(norm == 0, 1, norm)}
+
+        dmin = np.ma.min(data, axis=axis, keepdims=True)
+        dmax = np.ma.max(data, axis=axis, keepdims=True)
+        drange = dmax - dmin
+        return {
+            "dmin_": dmin,
+            "dmax_": dmax,
+            "range_": np.where(drange == 0, 1, drange),
+        }
+
     def _transform(self, dataset):
         new = dataset.copy()
         data = dataset.masked_data
+        axis, _ = dataset.get_axis(self.dim)
+
+        if self._sample_local_:
+            params = self._normalization_parameters(data, axis)
+            norm = params.get("norm_")
+            dmin = params.get("dmin_")
+            drange = params.get("range_")
+        else:
+            norm = getattr(self, "norm_", None)
+            dmin = getattr(self, "dmin_", None)
+            drange = getattr(self, "range_", None)
 
         if self.method in ("max", "sum", "vector"):
-            self._set_data(new, data / self.norm_)
+            self._set_data(new, data / norm)
         elif self.method == "minmax":
-            self._set_data(new, (data - self.dmin_) / self.range_)
+            self._set_data(new, (data - dmin) / drange)
 
         new.history = (
             f"NormalizeTransformer ({self.method}) applied on dimension "
@@ -505,6 +543,13 @@ class NormalizeTransformer(BasePreprocessor):
         return new
 
     def _inverse_transform(self, dataset):
+        if self._sample_local_:
+            raise SpectroChemPyError(
+                "NormalizeTransformer inverse_transform is not supported for "
+                "sample-local normalization because normalization factors are "
+                "computed during transform()."
+            )
+
         new = dataset.copy()
         data = dataset.masked_data
 

--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -490,6 +490,7 @@ class NormalizeTransformer(BasePreprocessor):
         self._sample_local_ = self._dim_name == "x"
         self._fit_axis_ = axis
         self._fit_shape_ = data.shape
+        self._fit_dims_ = tuple(str(dim_name) for dim_name in dataset.dims)
         self._fit_compatible_coords_ = self._compatible_coords(dataset, axis)
 
         if self.method not in ("max", "sum", "vector", "minmax"):
@@ -545,7 +546,7 @@ class NormalizeTransformer(BasePreprocessor):
             dmin = params.get("dmin_")
             drange = params.get("range_")
         else:
-            self._check_transform_compatibility(dataset, axis)
+            self._check_dataset_compatibility(dataset, axis, "transform")
             norm = getattr(self, "norm_", None)
             dmin = getattr(self, "dmin_", None)
             drange = getattr(self, "range_", None)
@@ -572,11 +573,24 @@ class NormalizeTransformer(BasePreprocessor):
                 coords[str(dim_name)] = np.array(coord.data, copy=True)
         return coords
 
-    def _check_transform_compatibility(self, dataset, axis):
+    def _check_dataset_compatibility(self, dataset, axis, action):
         data_shape = dataset.masked_data.shape
+        dims = tuple(str(dim_name) for dim_name in dataset.dims)
+        if dims != self._fit_dims_:
+            raise SpectroChemPyError(
+                f"NormalizeTransformer {action} dataset is incompatible with "
+                "fit(): dimension order changed."
+            )
+
+        if axis != self._fit_axis_:
+            raise SpectroChemPyError(
+                f"NormalizeTransformer {action} dataset is incompatible with "
+                "fit(): normalization axis changed."
+            )
+
         if len(data_shape) != len(self._fit_shape_):
             raise SpectroChemPyError(
-                "NormalizeTransformer transform dataset is incompatible with "
+                f"NormalizeTransformer {action} dataset is incompatible with "
                 "fit(): number of dimensions changed."
             )
 
@@ -586,7 +600,7 @@ class NormalizeTransformer(BasePreprocessor):
             fit_size = self._fit_shape_[current_axis]
             if current_size != fit_size:
                 raise SpectroChemPyError(
-                    "NormalizeTransformer transform dataset is incompatible "
+                    f"NormalizeTransformer {action} dataset is incompatible "
                     "with fit(): non-normalized dimensions changed."
                 )
 
@@ -597,7 +611,7 @@ class NormalizeTransformer(BasePreprocessor):
                 current = np.array(coord.data)
                 if not np.array_equal(current, expected):
                     raise SpectroChemPyError(
-                        "NormalizeTransformer transform dataset is incompatible "
+                        f"NormalizeTransformer {action} dataset is incompatible "
                         "with fit(): non-normalized coordinates changed."
                     )
 
@@ -611,6 +625,14 @@ class NormalizeTransformer(BasePreprocessor):
 
         new = dataset.copy()
         data = dataset.masked_data
+        axis, dim_name = dataset.get_axis(self.dim)
+        if str(dim_name) != self._dim_name:
+            raise SpectroChemPyError(
+                "NormalizeTransformer inverse_transform dimension is "
+                "incompatible with fit(). Refit the transformer after changing "
+                "dimensions."
+            )
+        self._check_dataset_compatibility(dataset, axis, "inverse_transform")
 
         if self.method in ("max", "sum", "vector"):
             self._set_data(new, data * self.norm_)

--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -17,8 +17,10 @@ scikit-learn conventions (scikit-learn itself is **not** a dependency).
 They complement the procedural functions in
 :mod:`spectrochempy.processing.transformation.preprocessing` and are
 intended for machine-learning workflows (train/test splits,
-cross-validation, pipelines) where statistics must be learned once and
-reused across multiple datasets.
+cross-validation, pipelines) where feature-wise statistics must be
+learned once and reused across multiple datasets.  Sample-local
+operations such as SNV and normalization along ``x`` compute their
+statistics from the dataset passed to ``transform()``.
 
 """
 
@@ -406,10 +408,16 @@ class SNVTransformer(AutoscaleTransformer):
 
     def _fit(self, dataset):
         _, self._dim_name = dataset.get_axis(self.dim)
+        self._dim_name = str(self._dim_name)
 
     def _transform(self, dataset):
         new = dataset.copy()
-        axis, _ = dataset.get_axis(self.dim)
+        axis, dim_name = dataset.get_axis(self.dim)
+        if str(dim_name) != self._dim_name:
+            raise SpectroChemPyError(
+                "SNVTransformer transform dimension is incompatible with fit(). "
+                "Refit the transformer after changing dimensions."
+            )
         data = dataset.masked_data
         mean = np.ma.mean(data, axis=axis, keepdims=True)
         std = np.ma.std(data, axis=axis, keepdims=True)
@@ -431,10 +439,9 @@ class NormalizeTransformer(BasePreprocessor):
 
     Learns the normalization factor along a reusable feature dimension
     during ``fit()`` and applies it during ``transform()``.  For the
-    standard spectral case ``dim='x'`` on 2-D datasets, normalization is
-    sample-local: ``fit()`` validates the mode and ``transform()`` computes
-    each observation's normalization factor on the dataset being
-    transformed.
+    spectral dimension ``dim='x'``, normalization is sample-local:
+    ``fit()`` validates the mode and ``transform()`` computes each
+    observation's normalization factor on the dataset being transformed.
 
     Parameters
     ----------
@@ -478,8 +485,12 @@ class NormalizeTransformer(BasePreprocessor):
 
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
+        self._dim_name = str(self._dim_name)
         data = dataset.masked_data
-        self._sample_local_ = data.ndim == 2 and axis == 1
+        self._sample_local_ = self._dim_name == "x"
+        self._fit_axis_ = axis
+        self._fit_shape_ = data.shape
+        self._fit_compatible_coords_ = self._compatible_coords(dataset, axis)
 
         if self.method not in ("max", "sum", "vector", "minmax"):
             raise SpectroChemPyError(
@@ -519,7 +530,14 @@ class NormalizeTransformer(BasePreprocessor):
     def _transform(self, dataset):
         new = dataset.copy()
         data = dataset.masked_data
-        axis, _ = dataset.get_axis(self.dim)
+        axis, dim_name = dataset.get_axis(self.dim)
+        dim_name = str(dim_name)
+
+        if dim_name != self._dim_name:
+            raise SpectroChemPyError(
+                "NormalizeTransformer transform dimension is incompatible with "
+                "fit(). Refit the transformer after changing dimensions."
+            )
 
         if self._sample_local_:
             params = self._normalization_parameters(data, axis)
@@ -527,6 +545,7 @@ class NormalizeTransformer(BasePreprocessor):
             dmin = params.get("dmin_")
             drange = params.get("range_")
         else:
+            self._check_transform_compatibility(dataset, axis)
             norm = getattr(self, "norm_", None)
             dmin = getattr(self, "dmin_", None)
             drange = getattr(self, "range_", None)
@@ -541,6 +560,46 @@ class NormalizeTransformer(BasePreprocessor):
             f"{self._dim_name}"
         )
         return new
+
+    @staticmethod
+    def _compatible_coords(dataset, learned_axis):
+        coords = {}
+        for axis, dim_name in enumerate(dataset.dims):
+            if axis == learned_axis:
+                continue
+            coord = dataset.coord(dim_name)
+            if coord is not None:
+                coords[str(dim_name)] = np.array(coord.data, copy=True)
+        return coords
+
+    def _check_transform_compatibility(self, dataset, axis):
+        data_shape = dataset.masked_data.shape
+        if len(data_shape) != len(self._fit_shape_):
+            raise SpectroChemPyError(
+                "NormalizeTransformer transform dataset is incompatible with "
+                "fit(): number of dimensions changed."
+            )
+
+        for current_axis, current_size in enumerate(data_shape):
+            if current_axis == axis:
+                continue
+            fit_size = self._fit_shape_[current_axis]
+            if current_size != fit_size:
+                raise SpectroChemPyError(
+                    "NormalizeTransformer transform dataset is incompatible "
+                    "with fit(): non-normalized dimensions changed."
+                )
+
+            dim_name = str(dataset.dims[current_axis])
+            expected = self._fit_compatible_coords_.get(dim_name)
+            coord = dataset.coord(dim_name)
+            if expected is not None and coord is not None:
+                current = np.array(coord.data)
+                if not np.array_equal(current, expected):
+                    raise SpectroChemPyError(
+                        "NormalizeTransformer transform dataset is incompatible "
+                        "with fit(): non-normalized coordinates changed."
+                    )
 
     def _inverse_transform(self, dataset):
         if self._sample_local_:

--- a/tests/test_processing/test_transformation/test_preprocessing.py
+++ b/tests/test_processing/test_transformation/test_preprocessing.py
@@ -505,12 +505,11 @@ class TestSNVTransformer:
         with pytest.raises(SpectroChemPyError, match="not fitted yet"):
             scaler.transform(simple_2d)
 
-    def test_inverse_transform_restores_data(self, simple_2d):
+    def test_inverse_transform_raises(self, simple_2d):
         scaler = SNVTransformer()
         scaled = scaler.fit_transform(simple_2d)
-        restored = scaler.inverse_transform(scaled)
-        assert np.allclose(restored.data, simple_2d.data)
-        assert "SNVTransformer inverse applied" in restored.history[-1]
+        with pytest.raises(SpectroChemPyError, match="not supported"):
+            scaler.inverse_transform(scaled)
 
     def test_dim_is_x(self, simple_2d):
         scaler = SNVTransformer()
@@ -523,12 +522,27 @@ class TestSNVTransformer:
         scaler = SNVTransformer()
         scaler.fit(train)
         test_snv = scaler.transform(test)
-        # Stats computed per spectrum (dim=x)
-        train_mean = np.mean(train.data, axis=1, keepdims=True)
-        train_std = np.std(train.data, axis=1, keepdims=True)
-        train_std_safe = np.where(train_std == 0, 1, train_std)
-        expected = (test.data - train_mean) / train_std_safe
-        assert np.allclose(test_snv.data, expected)
+        expected = snv(test)
+        assert np.allclose(test_snv.data, expected.data)
+
+    def test_transform_handles_different_number_of_observations(self, simple_2d):
+        train = simple_2d[:1]
+        test = simple_2d[1:]
+        scaler = SNVTransformer()
+        scaler.fit(train)
+        test_snv = scaler.transform(test)
+        expected = snv(test)
+        assert np.allclose(test_snv.data, expected.data)
+
+    def test_transform_is_observation_local_after_fit(self, simple_2d):
+        train = simple_2d[:3]
+        test = simple_2d[1:].copy()
+        test._data = test.data * np.array([[2.0], [3.0], [4.0]])
+        scaler = SNVTransformer()
+        scaler.fit(train)
+        test_snv = scaler.transform(test)
+        expected = snv(test)
+        assert np.allclose(test_snv.data, expected.data)
 
 
 class TestNormalizeTransformer:
@@ -561,8 +575,8 @@ class TestNormalizeTransformer:
         for method in ("max", "sum", "vector", "minmax"):
             scaler = NormalizeTransformer(method=method, dim="x")
             scaled = scaler.fit_transform(simple_2d)
-            restored = scaler.inverse_transform(scaled)
-            assert np.allclose(restored.data, simple_2d.data)
+            with pytest.raises(SpectroChemPyError, match="not supported"):
+                scaler.inverse_transform(scaled)
 
     def test_unknown_method(self, simple_2d):
         with pytest.raises(SpectroChemPyError, match="Unknown normalization method"):
@@ -574,7 +588,45 @@ class TestNormalizeTransformer:
         scaler = NormalizeTransformer(method="max", dim="x")
         scaler.fit(train)
         test_norm = scaler.transform(test)
-        train_norm = np.max(np.abs(train.data), axis=1, keepdims=True)
+        expected = normalize(test, method="max", dim="x")
+        assert np.allclose(test_norm.data, expected.data)
+
+    @pytest.mark.parametrize("method", ["max", "sum", "vector", "minmax"])
+    def test_sample_local_transform_handles_different_observations(
+        self, simple_2d, method
+    ):
+        train = simple_2d[:1]
+        test = simple_2d[1:]
+        scaler = NormalizeTransformer(method=method, dim="x")
+        scaler.fit(train)
+        test_norm = scaler.transform(test)
+        expected = normalize(test, method=method, dim="x")
+        assert np.allclose(test_norm.data, expected.data)
+
+    def test_sample_local_transform_is_observation_local_after_fit(self, simple_2d):
+        train = simple_2d[:3]
+        test = simple_2d[1:].copy()
+        test._data = test.data * np.array([[2.0], [3.0], [4.0]])
+        scaler = NormalizeTransformer(method="max", dim="x")
+        scaler.fit(train)
+        test_norm = scaler.transform(test)
+        expected = normalize(test, method="max", dim="x")
+        assert np.allclose(test_norm.data, expected.data)
+
+    def test_feature_wise_inverse_transform_restores_data(self, simple_2d):
+        for method in ("max", "sum", "vector", "minmax"):
+            scaler = NormalizeTransformer(method=method, dim="y")
+            scaled = scaler.fit_transform(simple_2d)
+            restored = scaler.inverse_transform(scaled)
+            assert np.allclose(restored.data, simple_2d.data)
+
+    def test_feature_wise_train_test_reuse(self, simple_2d):
+        train = simple_2d[:2]
+        test = simple_2d[2:]
+        scaler = NormalizeTransformer(method="max", dim="y")
+        scaler.fit(train)
+        test_norm = scaler.transform(test)
+        train_norm = np.max(np.abs(train.data), axis=0, keepdims=True)
         expected = test.data / train_norm
         assert np.allclose(test_norm.data, expected)
 

--- a/tests/test_processing/test_transformation/test_preprocessing.py
+++ b/tests/test_processing/test_transformation/test_preprocessing.py
@@ -54,6 +54,28 @@ def simple_2d():
     return NDDataset(data, coordset=[y, x])
 
 
+def _normalize_oracle(data, method, axis):
+    if method == "max":
+        norm = np.max(np.abs(data), axis=axis, keepdims=True)
+        return data / np.where(norm == 0, 1, norm)
+    if method == "sum":
+        norm = np.sum(np.abs(data), axis=axis, keepdims=True)
+        return data / np.where(norm == 0, 1, norm)
+    if method == "vector":
+        norm = np.sqrt(np.sum(data**2, axis=axis, keepdims=True))
+        return data / np.where(norm == 0, 1, norm)
+
+    dmin = np.min(data, axis=axis, keepdims=True)
+    drange = np.max(data, axis=axis, keepdims=True) - dmin
+    return (data - dmin) / np.where(drange == 0, 1, drange)
+
+
+def _snv_oracle(data, axis):
+    mean = np.mean(data, axis=axis, keepdims=True)
+    std = np.std(data, axis=axis, keepdims=True)
+    return (data - mean) / np.where(std == 0, 1, std)
+
+
 # ---------------------------------------------------------------------------
 # normalize
 # ---------------------------------------------------------------------------
@@ -541,8 +563,74 @@ class TestSNVTransformer:
         scaler = SNVTransformer()
         scaler.fit(train)
         test_snv = scaler.transform(test)
-        expected = snv(test)
-        assert np.allclose(test_snv.data, expected.data)
+        expected = _snv_oracle(test.data, axis=1)
+        assert np.allclose(test_snv.data, expected)
+
+    def test_transform_is_observation_permutation_local(self, simple_2d):
+        train = simple_2d[:2]
+        test = NDDataset(
+            np.array(
+                [
+                    [2.0, 5.0, 9.0, 3.0, 8.0, 13.0],
+                    [7.0, 1.0, 4.0, 6.0, 11.0, 10.0],
+                    [3.0, 12.0, 2.0, 14.0, 5.0, 9.0],
+                ]
+            ),
+            coordset=[Coord([20.0, 10.0, 30.0], title="time"), simple_2d.coord("x")],
+        )
+        scaler = SNVTransformer().fit(train)
+        test_snv = scaler.transform(test)
+        expected = _snv_oracle(test.data, axis=1)
+        assert np.allclose(test_snv.data, expected)
+        assert np.array_equal(test_snv.coord("y").data, test.coord("y").data)
+
+    def test_transform_1d_is_sample_local(self):
+        train = NDDataset(np.array([1.0, 2.0, 4.0]))
+        test = NDDataset(np.array([2.0, 5.0, 10.0, 20.0]))
+        scaler = SNVTransformer().fit(train)
+        test_snv = scaler.transform(test)
+        expected = _snv_oracle(test.data, axis=0)
+        assert np.allclose(test_snv.data, expected)
+
+    def test_transform_3d_x_is_sample_local(self):
+        train = NDDataset(np.arange(12.0).reshape(1, 3, 4))
+        test = NDDataset(np.arange(24.0).reshape(2, 3, 4) + 1.0)
+        scaler = SNVTransformer().fit(train)
+        test_snv = scaler.transform(test)
+        expected = _snv_oracle(test.data, axis=2)
+        assert np.allclose(test_snv.data, expected)
+
+    def test_transposed_x_dimension_is_sample_local(self, simple_2d):
+        train = simple_2d.T[:, :2]
+        test = simple_2d.T[:, 2:]
+        scaler = SNVTransformer().fit(train)
+        test_snv = scaler.transform(test)
+        expected = _snv_oracle(test.data, axis=0)
+        assert np.allclose(test_snv.data, expected)
+
+    def test_transform_preserves_metadata_and_inputs(self, simple_2d):
+        train = simple_2d[:2].copy()
+        test = simple_2d[2:].copy()
+        test._mask = np.zeros_like(test.data, dtype=bool)
+        test._mask[0, 2] = True
+        test.units = "absorbance"
+        test.title = "test spectra"
+        test.meta.foo = "bar"
+        train_data = train.data.copy()
+        test_data = test.data.copy()
+        test_mask = test.mask.copy()
+
+        scaler = SNVTransformer().fit(train)
+        test_snv = scaler.transform(test)
+
+        assert np.array_equal(train.data, train_data)
+        assert np.array_equal(test.data, test_data)
+        assert np.array_equal(test.mask, test_mask)
+        assert np.array_equal(test_snv.mask, test_mask)
+        assert test_snv.units == test.units
+        assert test_snv.title == test.title
+        assert test_snv.meta.foo == "bar"
+        assert test_snv.coordset == test.coordset
 
 
 class TestNormalizeTransformer:
@@ -610,8 +698,93 @@ class TestNormalizeTransformer:
         scaler = NormalizeTransformer(method="max", dim="x")
         scaler.fit(train)
         test_norm = scaler.transform(test)
-        expected = normalize(test, method="max", dim="x")
-        assert np.allclose(test_norm.data, expected.data)
+        expected = _normalize_oracle(test.data, method="max", axis=1)
+        assert np.allclose(test_norm.data, expected)
+
+    def test_sample_local_transform_is_observation_permutation_local(self, simple_2d):
+        train = simple_2d[:2]
+        test = NDDataset(
+            np.array(
+                [
+                    [2.0, 5.0, 9.0, 3.0, 8.0, 13.0],
+                    [7.0, 1.0, 4.0, 6.0, 11.0, 10.0],
+                    [3.0, 12.0, 2.0, 14.0, 5.0, 9.0],
+                ]
+            ),
+            coordset=[Coord([20.0, 10.0, 30.0], title="time"), simple_2d.coord("x")],
+        )
+        scaler = NormalizeTransformer(method="max", dim="x").fit(train)
+        test_norm = scaler.transform(test)
+        expected = _normalize_oracle(test.data, method="max", axis=1)
+        assert np.allclose(test_norm.data, expected)
+        assert np.array_equal(test_norm.coord("y").data, test.coord("y").data)
+
+    @pytest.mark.parametrize("method", ["max", "sum", "vector", "minmax"])
+    def test_sample_local_transform_1d_uses_test_spectrum(self, method):
+        train = NDDataset(np.array([1.0, 2.0, 4.0]))
+        test = NDDataset(np.array([2.0, 5.0, 10.0, 20.0]))
+        scaler = NormalizeTransformer(method=method, dim="x").fit(train)
+        test_norm = scaler.transform(test)
+        expected = _normalize_oracle(test.data, method=method, axis=0)
+        assert np.allclose(test_norm.data, expected)
+
+    @pytest.mark.parametrize("method", ["max", "sum", "vector", "minmax"])
+    def test_sample_local_transform_3d_x_uses_test_spectra(self, method):
+        train = NDDataset(np.arange(12.0).reshape(1, 3, 4))
+        test = NDDataset(np.arange(24.0).reshape(2, 3, 4) + 1.0)
+        scaler = NormalizeTransformer(method=method, dim="x").fit(train)
+        test_norm = scaler.transform(test)
+        expected = _normalize_oracle(test.data, method=method, axis=2)
+        assert np.allclose(test_norm.data, expected)
+
+    def test_transposed_x_dimension_is_sample_local(self, simple_2d):
+        train = simple_2d.T[:, :2]
+        test = simple_2d.T[:, 2:]
+        scaler = NormalizeTransformer(method="max", dim="x").fit(train)
+        test_norm = scaler.transform(test)
+        expected = _normalize_oracle(test.data, method="max", axis=0)
+        assert np.allclose(test_norm.data, expected)
+
+    def test_transposed_y_dimension_remains_feature_wise(self, simple_2d):
+        train = simple_2d.T[:, :2]
+        test = simple_2d.T[:, 2:]
+        scaler = NormalizeTransformer(method="max", dim="y").fit(train)
+        test_norm = scaler.transform(test)
+        train_norm = np.max(np.abs(train.data), axis=1, keepdims=True)
+        expected = test.data / np.where(train_norm == 0, 1, train_norm)
+        assert np.allclose(test_norm.data, expected)
+
+    def test_sample_local_transform_preserves_metadata_and_inputs(self, simple_2d):
+        train = simple_2d[:2].copy()
+        test = simple_2d[2:].copy()
+        test._mask = np.zeros_like(test.data, dtype=bool)
+        test._mask[0, 2] = True
+        test.units = "absorbance"
+        test.title = "test spectra"
+        test.meta.foo = "bar"
+        train_data = train.data.copy()
+        test_data = test.data.copy()
+        test_mask = test.mask.copy()
+
+        scaler = NormalizeTransformer(method="max", dim="x").fit(train)
+        test_norm = scaler.transform(test)
+
+        assert np.array_equal(train.data, train_data)
+        assert np.array_equal(test.data, test_data)
+        assert np.array_equal(test.mask, test_mask)
+        assert np.array_equal(test_norm.mask, test_mask)
+        assert test_norm.units == test.units
+        assert test_norm.title == test.title
+        assert test_norm.meta.foo == "bar"
+        assert test_norm.coordset == test.coordset
+
+    def test_feature_wise_transform_rejects_reordered_coordinates(self, simple_2d):
+        train = simple_2d[:2]
+        test = simple_2d[2:].copy()
+        test.set_coordset(y=test.coord("y"), x=Coord(test.coord("x").data[::-1]))
+        scaler = NormalizeTransformer(method="max", dim="y").fit(train)
+        with pytest.raises(SpectroChemPyError, match="coordinates changed"):
+            scaler.transform(test)
 
     def test_feature_wise_inverse_transform_restores_data(self, simple_2d):
         for method in ("max", "sum", "vector", "minmax"):

--- a/tests/test_processing/test_transformation/test_preprocessing.py
+++ b/tests/test_processing/test_transformation/test_preprocessing.py
@@ -786,6 +786,45 @@ class TestNormalizeTransformer:
         with pytest.raises(SpectroChemPyError, match="coordinates changed"):
             scaler.transform(test)
 
+    def test_feature_wise_transform_rejects_square_transposed_dataset(self):
+        coord = Coord(np.array([1.0, 2.0, 3.0]), title="shared")
+        train = NDDataset(
+            np.array(
+                [
+                    [1.0, 2.0, 5.0],
+                    [3.0, 7.0, 11.0],
+                    [13.0, 17.0, 19.0],
+                ]
+            ),
+            coordset=[coord, coord],
+        )
+        scaler = NormalizeTransformer(method="max", dim="y").fit(train)
+        with pytest.raises(SpectroChemPyError, match="dimension order changed"):
+            scaler.transform(train.T)
+
+    def test_feature_wise_inverse_rejects_square_transposed_dataset(self):
+        coord = Coord(np.array([1.0, 2.0, 3.0]), title="shared")
+        train = NDDataset(
+            np.array(
+                [
+                    [1.0, 2.0, 5.0],
+                    [3.0, 7.0, 11.0],
+                    [13.0, 17.0, 19.0],
+                ]
+            ),
+            coordset=[coord, coord],
+        )
+        scaler = NormalizeTransformer(method="max", dim="y").fit(train)
+        scaled = scaler.transform(train)
+        with pytest.raises(SpectroChemPyError, match="dimension order changed"):
+            scaler.inverse_transform(scaled.T)
+
+    def test_feature_wise_transform_rejects_3d_permuted_non_normalized_axes(self):
+        train = NDDataset(np.arange(27.0).reshape(3, 3, 3) + 1.0)
+        scaler = NormalizeTransformer(method="max", dim="y").fit(train)
+        with pytest.raises(SpectroChemPyError, match="dimension order changed"):
+            scaler.transform(train.transpose(2, 1, 0))
+
     def test_feature_wise_inverse_transform_restores_data(self, simple_2d):
         for method in ("max", "sum", "vector", "minmax"):
             scaler = NormalizeTransformer(method=method, dim="y")


### PR DESCRIPTION
## Summary
- make SNVTransformer and NormalizeTransformer(dim="x") compute sample-local statistics on the dataset passed to transform(), by resolved dimension role rather than NumPy axis position
- cover 1-D spectra, 2-D transposed data, 3-D data, observation permutation, and independent NumPy oracles
- preserve feature-wise NormalizeTransformer(dim!="x") train/test reuse while rejecting incompatible stateful geometry, coordinate changes, dimension-order changes, and inverse_transform() misuse
- raise explicit errors for sample-local inverse_transform(); the old inverse could restore fit_transform() on the same dataset but was unsafe for data transformed later without result-attached per-observation state

## Validation
- micromamba run -n scpy-core python -m pytest tests/test_processing/test_transformation/test_preprocessing.py -q
- micromamba run -n scpy-core python -m ruff check src/spectrochempy/processing/transformation/preprocessing_transformers.py tests/test_processing/test_transformation/test_preprocessing.py
- micromamba run -n scpy-core pre-commit run --all-files
- git diff --check

Maintainer notes pushed separately to spectrochempy_maintainer master: 6f70d9a.