### PR TITLE
FIX: restore FTIR FFT frequency coordinates

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -34,6 +34,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
+- Fix FFT frequency-coordinate generation.  FTIR interferogram FFT results now
+  use a positive descending wavenumber axis from the Nyquist wavenumber toward
+  zero, so the documented ``400–4000 cm^-1`` window again contains the
+  calculated spectra.  Generic FFT coordinates now follow the
+  ``fftshift(fftfreq)`` order used by the transformed data, while NMR plugin
+  FFT post-processing remains unchanged.
+
 - Fix ``MSCTransformer.inverse_transform()`` so it no longer reuses
   fit-dataset diagnostic coefficients positionally for independently
   transformed datasets.  ``MSCTransformer`` now documents ``a_`` and ``b_`` as

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -35,9 +35,9 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 - Fix FFT frequency-coordinate generation.  FTIR interferogram FFT results now
-  use a positive descending wavenumber axis from the Nyquist wavenumber toward
-  zero, so the documented ``400–4000 cm^-1`` window again contains the
-  calculated spectra.  Generic FFT coordinates now follow the
+  use a positive descending wavenumber axis from the highest retained
+  ``rfft`` bin toward zero, so the documented ``400–4000 cm^-1`` window again
+  contains the calculated spectra.  Generic FFT coordinates now follow the
   ``fftshift(fftfreq)`` order used by the transformed data, while NMR plugin
   FFT post-processing remains unchanged.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -28,9 +28,9 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 - Fix FFT frequency-coordinate generation.  FTIR interferogram FFT results now
-  use a positive descending wavenumber axis from the Nyquist wavenumber toward
-  zero, so the documented ``400–4000 cm^-1`` window again contains the
-  calculated spectra.  Generic FFT coordinates now follow the
+  use a positive descending wavenumber axis from the highest retained
+  ``rfft`` bin toward zero, so the documented ``400–4000 cm^-1`` window again
+  contains the calculated spectra.  Generic FFT coordinates now follow the
   ``fftshift(fftfreq)`` order used by the transformed data, while NMR plugin
   FFT post-processing remains unchanged.
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -27,6 +27,13 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
+- Fix FFT frequency-coordinate generation.  FTIR interferogram FFT results now
+  use a positive descending wavenumber axis from the Nyquist wavenumber toward
+  zero, so the documented ``400–4000 cm^-1`` window again contains the
+  calculated spectra.  Generic FFT coordinates now follow the
+  ``fftshift(fftfreq)`` order used by the transformed data, while NMR plugin
+  FFT post-processing remains unchanged.
+
 - Fix ``MSCTransformer.inverse_transform()`` so it no longer reuses
   fit-dataset diagnostic coefficients positionally for independently
   transformed datasets.  ``MSCTransformer`` now documents ``a_`` and ``b_`` as

--- a/src/spectrochempy/processing/fft/fft.py
+++ b/src/spectrochempy/processing/fft/fft.py
@@ -323,14 +323,17 @@ def fft(dataset, size=None, sizeff=None, inv=False, **kwargs):
             dw = x.spacing
             if isinstance(dw, list):
                 pass  # print()
-            sw = 1 / 2 / dw
-            sf = -sw / 2
+            nyquist = 1 / 2 / dw
 
-            sizem = max(coord_size - 1, 1)
-            deltaf = -sw / sizem
-            first = sf - deltaf * sizem / 2.0
+            if is_ir:
+                sizem = max(coord_size - 1, 1)
+                deltaf = -nyquist / sizem
+                first = nyquist
+                newcoord = Coord.arange(coord_size) * deltaf + first
+            else:
+                shifted_frequencies = np.fft.fftshift(np.fft.fftfreq(coord_size))
+                newcoord = Coord(shifted_frequencies / dw)
 
-            newcoord = Coord.arange(coord_size) * deltaf + first
             newcoord.show_datapoints = False
             newcoord.name = x.name
             new.title = "intensity"

--- a/src/spectrochempy/processing/fft/fft.py
+++ b/src/spectrochempy/processing/fft/fft.py
@@ -323,13 +323,9 @@ def fft(dataset, size=None, sizeff=None, inv=False, **kwargs):
             dw = x.spacing
             if isinstance(dw, list):
                 pass  # print()
-            nyquist = 1 / 2 / dw
-
             if is_ir:
-                sizem = max(coord_size - 1, 1)
-                deltaf = -nyquist / sizem
-                first = nyquist
-                newcoord = Coord.arange(coord_size) * deltaf + first
+                kept_frequencies = np.fft.rfftfreq(size)[:coord_size][::-1]
+                newcoord = Coord(kept_frequencies / abs(dw))
             else:
                 shifted_frequencies = np.fft.fftshift(np.fft.fftfreq(coord_size))
                 newcoord = Coord(shifted_frequencies / dw)

--- a/tests/test_processing/test_fft/test_ftir_fft.py
+++ b/tests/test_processing/test_fft/test_ftir_fft.py
@@ -8,8 +8,6 @@
 import numpy as np
 
 import spectrochempy as scp
-from spectrochempy import Coord
-from spectrochempy import NDDataset
 from spectrochempy.core.units import ur
 
 
@@ -48,7 +46,7 @@ def _assert_ftir_coordinate_matches_rfft_bins(source, transformed):
     x = np.asarray(transformed.x.data, dtype=float)
     spacing = abs(source.x.spacing)
     expected = np.fft.rfftfreq(source.size)[: transformed.x.size][::-1] / spacing
-    expected = Coord(expected).to("cm^-1").data
+    expected = scp.Coord(expected).to("cm^-1").data
 
     assert np.array_equal(x, expected)
     assert x[0] == expected[0]
@@ -116,9 +114,9 @@ def test_generic_complex_fft_coordinate_matches_shifted_frequency_order():
     frequency = bin_index / (size * spacing)
     time = np.arange(size) * spacing
     data = np.exp(2j * np.pi * frequency * time)
-    dataset = NDDataset(
+    dataset = scp.NDDataset(
         data,
-        coordset=[Coord(time, units="s")],
+        coordset=[scp.Coord(time, units="s")],
         meta={"td": [size], "isfreq": [False]},
     )
 
@@ -141,9 +139,9 @@ def test_generic_real_fft_coordinate_matches_shifted_frequency_order():
     frequency = bin_index / (size * spacing)
     time = np.arange(size) * spacing
     data = np.cos(2 * np.pi * frequency * time)
-    dataset = NDDataset(
+    dataset = scp.NDDataset(
         data,
-        coordset=[Coord(time, units="s")],
+        coordset=[scp.Coord(time, units="s")],
         meta={"td": [size], "isfreq": [False]},
     )
 

--- a/tests/test_processing/test_fft/test_ftir_fft.py
+++ b/tests/test_processing/test_fft/test_ftir_fft.py
@@ -44,6 +44,19 @@ def _assert_ftir_coordinate(dataset):
     assert ((x >= 400.0) & (x <= 4000.0)).sum() > 1000
 
 
+def _assert_ftir_coordinate_matches_rfft_bins(source, transformed):
+    x = np.asarray(transformed.x.data, dtype=float)
+    spacing = abs(source.x.spacing)
+    expected = np.fft.rfftfreq(source.size)[: transformed.x.size][::-1] / spacing
+    expected = Coord(expected).to("cm^-1").data
+
+    assert np.array_equal(x, expected)
+    assert x[0] == expected[0]
+    assert np.isclose(x[0], 7898.731)
+    assert np.isclose(x[0] - x[1], expected[0] - expected[1])
+    assert np.isclose(x[0] - x[1], 1.899)
+
+
 def _compare_to_omnic(dataset):
     omnic = scp.read_spa("irdata/interferogram/spectre.SPA")
     x = np.asarray(dataset.x.data, dtype=float)
@@ -77,6 +90,7 @@ def test_ftir_interferogram_fft_coordinate_matches_spectrum_window():
     assert work.shape == (1, 8320)
     assert transformed.shape == (1, 4160)
     _assert_ftir_coordinate(transformed)
+    _assert_ftir_coordinate_matches_rfft_bins(work, transformed)
     _compare_to_omnic(transformed)
     assert np.array_equal(ir.data, source_data)
     assert np.array_equal(ir.x.data, source_coord)
@@ -89,6 +103,7 @@ def test_ftir_interferogram_hamming_fft_coordinate_matches_spectrum_window():
     assert work.shape == (1, 8320)
     assert transformed.shape == (1, 4160)
     _assert_ftir_coordinate(transformed)
+    _assert_ftir_coordinate_matches_rfft_bins(work, transformed)
     _compare_to_omnic(transformed)
     assert np.array_equal(ir.data, source_data)
     assert np.array_equal(ir.x.data, source_coord)

--- a/tests/test_processing/test_fft/test_ftir_fft.py
+++ b/tests/test_processing/test_fft/test_ftir_fft.py
@@ -1,0 +1,142 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Regression tests for FFT coordinate generation."""
+
+import numpy as np
+
+import spectrochempy as scp
+from spectrochempy import Coord
+from spectrochempy import NDDataset
+from spectrochempy.core.units import ur
+
+
+def _ftir_chain(use_hamming=False):
+    ir = scp.read_spa("irdata/interferogram/interfero.SPA")
+    source_data = ir.data.copy()
+    source_coord = ir.x.data.copy()
+
+    if use_hamming:
+        work = ir.dc().hamming()
+        work.zf(inplace=True, size=2 * ir.size)
+    else:
+        work = ir.dc()
+        work = work.zf(size=2 * work.size)
+
+    transformed = work.fft()
+    return ir, work, transformed, source_data, source_coord
+
+
+def _assert_ftir_coordinate(dataset):
+    x = np.asarray(dataset.x.data, dtype=float)
+
+    assert dataset.x.units == ur("cm^-1")
+    assert dataset.x.title in {"wavenumber", "wavenumbers"}
+    assert dataset.shape[-1] == dataset.x.size
+    assert np.isfinite(x).all()
+    assert np.isfinite(dataset.data).all()
+    assert np.all(np.diff(x) < 0)
+    assert x[0] > 4000.0
+    assert abs(x[-1]) < 1.0e-12
+    assert x.min() >= -1.0e-12
+    assert ((x >= 400.0) & (x <= 4000.0)).sum() > 1000
+
+
+def _compare_to_omnic(dataset):
+    omnic = scp.read_spa("irdata/interferogram/spectre.SPA")
+    x = np.asarray(dataset.x.data, dtype=float)
+    y = np.asarray(dataset.data[0], dtype=float)
+    xo = np.asarray(omnic.x.data, dtype=float)
+    yo = np.asarray(omnic.data[0], dtype=float)
+
+    lo = max(x.min(), xo.min(), 400.0)
+    hi = min(x.max(), xo.max(), 4000.0)
+    assert lo < hi
+
+    grid = np.linspace(lo, hi, 2000)
+    yi = np.interp(grid, x[np.argsort(x)], y[np.argsort(x)])
+    yoi = np.interp(grid, xo[np.argsort(xo)], yo[np.argsort(xo)])
+    offset = np.median(yi - yoi)
+    residual = yi - offset - yoi
+    correlation = np.corrcoef(yi - yi.mean(), yoi - yoi.mean())[0, 1]
+
+    calc_band = grid[np.argmax(yi)]
+    omnic_band = grid[np.argmax(yoi)]
+
+    assert correlation > 0.999
+    assert np.sqrt(np.mean(residual**2)) < 0.03
+    assert abs(calc_band - omnic_band) < 10.0
+
+
+def test_ftir_interferogram_fft_coordinate_matches_spectrum_window():
+    ir, work, transformed, source_data, source_coord = _ftir_chain()
+
+    assert ir.shape == (1, 4160)
+    assert work.shape == (1, 8320)
+    assert transformed.shape == (1, 4160)
+    _assert_ftir_coordinate(transformed)
+    _compare_to_omnic(transformed)
+    assert np.array_equal(ir.data, source_data)
+    assert np.array_equal(ir.x.data, source_coord)
+
+
+def test_ftir_interferogram_hamming_fft_coordinate_matches_spectrum_window():
+    ir, work, transformed, source_data, source_coord = _ftir_chain(use_hamming=True)
+
+    assert ir.shape == (1, 4160)
+    assert work.shape == (1, 8320)
+    assert transformed.shape == (1, 4160)
+    _assert_ftir_coordinate(transformed)
+    _compare_to_omnic(transformed)
+    assert np.array_equal(ir.data, source_data)
+    assert np.array_equal(ir.x.data, source_coord)
+
+
+def test_generic_complex_fft_coordinate_matches_shifted_frequency_order():
+    size = 1024
+    spacing = 0.001
+    bin_index = 64
+    frequency = bin_index / (size * spacing)
+    time = np.arange(size) * spacing
+    data = np.exp(2j * np.pi * frequency * time)
+    dataset = NDDataset(
+        data,
+        coordset=[Coord(time, units="s")],
+        meta={"td": [size], "isfreq": [False]},
+    )
+
+    transformed = dataset.fft()
+    x = np.asarray(transformed.x.data, dtype=float)
+    peak_frequency = x[np.argmax(np.abs(transformed.data))]
+
+    assert transformed.x.units == ur.Hz
+    assert transformed.shape[-1] == transformed.x.size
+    assert np.isclose(x[0], -1.0 / (2.0 * spacing))
+    assert np.isclose(x[-1], 1.0 / (2.0 * spacing) - 1.0 / (size * spacing))
+    assert np.all(np.diff(x) > 0)
+    assert abs(peak_frequency - frequency) < 1.0 / (size * spacing)
+
+
+def test_generic_real_fft_coordinate_matches_shifted_frequency_order():
+    size = 1024
+    spacing = 0.001
+    bin_index = 64
+    frequency = bin_index / (size * spacing)
+    time = np.arange(size) * spacing
+    data = np.cos(2 * np.pi * frequency * time)
+    dataset = NDDataset(
+        data,
+        coordset=[Coord(time, units="s")],
+        meta={"td": [size], "isfreq": [False]},
+    )
+
+    transformed = dataset.fft()
+    x = np.asarray(transformed.x.data, dtype=float)
+    peak_frequencies = x[np.argsort(np.abs(transformed.data))[-2:]]
+
+    assert transformed.x.units == ur.Hz
+    assert transformed.shape[-1] == transformed.x.size
+    assert np.all(np.diff(x) > 0)
+    assert np.allclose(np.sort(peak_frequencies), [-frequency, frequency])

--- a/tests/test_processing/test_fft/test_nmr.py
+++ b/tests/test_processing/test_fft/test_nmr.py
@@ -91,6 +91,11 @@ def test_nmr_fft_1D(NMR_dataset_1D):
     assert new.shape == (2**15,)
     assert new.data.dtype == np.complex128
     assert np.any(new.data.imag != 0)  # result should be complex
+    assert str(new.x.units) == "ppm"
+    assert new.x.title == r"$\delta\ ^{1}H$"
+    assert np.all(np.diff(new.x.data) < 0)
+    assert_array_almost_equal(new.x.data[0], 253.092, decimal=3)
+    assert_array_almost_equal(new.x.data[-1], -246.838, decimal=3)
 
     # IFFT preserves energy (Parseval's theorem)
     energy_time = np.sum(np.abs(dataset1D.data) ** 2)


### PR DESCRIPTION
## Summary
- Restore FTIR interferogram FFT coordinates to a positive descending wavenumber axis from the highest retained `rfft` bin toward zero.
- Align generic core FFT coordinates with `np.fft.fftshift(np.fft.fftfreq(...))`, matching `_fft()` data order.
- Keep NMR plugin FFT post-processing unchanged and add a targeted NMR coordinate regression assertion.
- Add real SPA FTIR tests for `dc -> zf -> fft`, Hamming apodization, full retained-bin coordinate oracle, OMNIC comparison, coordinate shape/units/order, window coverage, data finiteness, and source immutability.

## Cause
The plugin-refactor coordinate formula changed the core frequency-axis origin from the old `sfo1 - sf - deltaf * sizem / 2.0` form to `sf - deltaf * sizem / 2.0`. For FTIR, this produced `0 -> -sw`. `_interferogram_fft()` keeps `rfft` bins `0..N/2-1`, excludes the Nyquist bin, then reverses them, so the coordinate must be built from those retained bins exactly.

## Numerical Characterization
- Before: `irt` / `irth` coordinates were `0.0 -> -7900.632 cm^-1`; the `400-4000 cm^-1` window contained 0 points.
- After: `irt` / `irth` coordinates are `7898.731 -> 0.0 cm^-1`; the `400-4000 cm^-1` window contains 1896 points.
- Retained-bin oracle checks the full FTIR axis against `np.fft.rfftfreq(size)[:coord_size][::-1] / abs(dw)`, including first point `7898.731 cm^-1` and spectral step `1.899 cm^-1`.
- OMNIC comparison over `400.164-3999.706 cm^-1`:
  - no Hamming: correlation `0.999935`, RMS residual `0.00989`, main band `2643.8 / 2642.0 cm^-1`
  - Hamming: correlation `0.999977`, RMS residual `0.00598`, main band `2643.8 / 2642.0 cm^-1`

## Validation
- `git diff --check`
- `micromamba run -n scpy-core python -m pytest tests/test_processing/test_fft/test_ftir_fft.py`
- `micromamba run -n scpy-core python -m pytest tests/test_processing/test_fft/test_ftir_fft.py tests/test_processing/test_fft/test_nmr.py::test_nmr_fft_1D tests/test_processing/test_fft`
- `micromamba run -n scpy-core pre-commit run --all-files`
- `micromamba run -n scpy-core python /tmp/run_interferogram_example.py`

The interferogram example generated six figures; the final spectra and OMNIC comparison plots were visually inspected.
