### PR TITLE
DOC: deduplicate plugin gallery examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,6 @@
 # ruff: noqa: T201,S603
 """SpectroChemPy documentation build configuration file."""
 
-import ast
 import inspect
 import json
 import os
@@ -277,7 +276,8 @@ def _load_zenodo_contributors():
 with open(os.path.join(SRC, "credits", "credits.rst.tmpl"), encoding="utf-8") as f:
     t = jinja2.Template(f.read())
 with open(os.path.join(SRC, "credits", "credits.rst"), "w", encoding="utf-8") as f:
-    f.write(t.render(contributors=_load_zenodo_contributors()))
+    rendered_credits = t.render(contributors=_load_zenodo_contributors()).rstrip()
+    f.write(f"{rendered_credits}\n")
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -414,8 +414,6 @@ html_context = {
 
 # Sphinx-gallery ---------------------------------------------------------------
 # Generate the plots for the gallery
-from sphinx_gallery.sorting import FileNameSortKey
-
 example_source_dir = SOURCES / "examples"
 example_generated_dir = "gettingstarted/examples/gallery"
 gallery_sections = ("core", "processing", "analysis", "plugins")
@@ -527,15 +525,6 @@ def _gallery_ref_for_example(path: str) -> str:
     return f"sphx_glr_{ref_path.replace('/', '_')}"
 
 
-def _gallery_thumbnail_for_example(path: str) -> str:
-    source_path = Path(path)
-    section = source_path.parts[0]
-    generated_path = Path(example_generated_dir, f"auto_examples_{section}")
-    example_dir = generated_path.joinpath(*source_path.parts[1:-1])
-    thumbnail = f"sphx_glr_{source_path.stem}_thumb.png"
-    return example_dir.joinpath("images", "thumb", thumbnail).as_posix()
-
-
 def _section_cell(section: str, section_ref: str) -> str:
     if section_ref:
         return f":ref:`{section} <{section_ref}>`"
@@ -594,9 +583,9 @@ def _plugin_gallery_readme(entries: list[dict[str, str]]) -> str:
         "Plugin-dependent functionality",
         "###############################",
         "",
-        "This section contains examples that require optional SpectroChemPy plugins.",
-        "Official plugin examples also appear in their respective scientific sections,",
-        "so you can browse either by topic or by plugin.",
+        "This section indexes examples that require optional SpectroChemPy plugins.",
+        "Each entry links to the canonical gallery page in its scientific section,",
+        "where the example script is generated and executed once.",
         "",
         _plugin_examples_table(entries),
         "",
@@ -613,67 +602,6 @@ def _write_plugin_gallery_readmes(
         _plugin_gallery_readme(entries),
         encoding="utf-8",
     )
-
-    plugins = {}
-    for entry in entries:
-        plugins.setdefault(entry["plugin"], entry["plugin_title"])
-
-    for name, title in sorted(plugins.items()):
-        title = str(title)
-        underline = "-" * len(title)
-        plugin_section_dir = plugin_dir / name
-        plugin_section_dir.mkdir(parents=True, exist_ok=True)
-        (plugin_section_dir / "readme.rst").write_text(
-            f"{title}\n{underline}\n",
-            encoding="utf-8",
-        )
-
-
-def _stage_plugin_gallery_examples(
-    staged_examples: Path, entries: list[dict[str, str]]
-) -> None:
-    plugin_dir = staged_examples / "plugins"
-    for entry in entries:
-        source = entry["manifest"].parent / entry["path"]
-        if not source.exists():
-            continue
-
-        source_path = Path(entry["path"])
-        stem = "__".join([entry["plugin"], *source_path.with_suffix("").parts])
-        stem = re.sub(r"[^0-9A-Za-z_]+", "_", stem)
-        destination = plugin_dir / entry["plugin"] / f"plot_{stem}.py"
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        content = source.read_text(encoding="utf-8")
-        thumbnail_path = _gallery_thumbnail_for_example(entry["path"])
-        destination.write_text(
-            _with_plugin_gallery_thumbnail(content, thumbnail_path),
-            encoding="utf-8",
-        )
-
-
-def _with_plugin_gallery_thumbnail(content: str, thumbnail_path: str) -> str:
-    directive = f"# sphinx_gallery_thumbnail_path = {thumbnail_path!r}"
-    lines = content.splitlines()
-
-    try:
-        module = ast.parse(content)
-    except SyntaxError:
-        return f"{directive}\n{content}"
-
-    if (
-        module.body
-        and isinstance(module.body[0], ast.Expr)
-        and isinstance(module.body[0].value, ast.Constant)
-        and isinstance(module.body[0].value.value, str)
-        and module.body[0].end_lineno is not None
-    ):
-        insert_at = module.body[0].end_lineno
-        return "\n".join([*lines[:insert_at], directive, *lines[insert_at:]]) + "\n"
-
-    if lines and lines[0].startswith("# %%"):
-        return "\n".join([lines[0], directive, *lines[1:]]) + "\n"
-
-    return f"{directive}\n{content}"
 
 
 def _stage_gallery_examples() -> Path:
@@ -701,10 +629,11 @@ def _get_default_image_scraper():
 
 if not single_doc_or_dir:
     # generate example only if were are in full doc mode
+    from sphinx_gallery.sorting import FileNameSortKey
+
     plugin_gallery_entries = _load_plugin_gallery_entries()
     example_source_dir = _stage_gallery_examples()
     _write_plugin_gallery_readmes(example_source_dir, plugin_gallery_entries)
-    _stage_plugin_gallery_examples(example_source_dir, plugin_gallery_entries)
 
     sphinx_gallery_conf = {
         "plot_gallery": not noexec,

--- a/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
+++ b/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
@@ -65,4 +65,8 @@ f = iris_analysis.result.f
 
 _ = f[-7].plot_contour(colorbar=True)
 
+# %%
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-iris/examples/plot_iris.py
+++ b/plugins/spectrochempy-iris/examples/plot_iris.py
@@ -11,6 +11,8 @@
 In this example, we perform the 2D IRIS analysis of CO adsorption on a sulfide catalyst.
 """
 
+# sphinx_gallery_thumbnail_number = 11
+
 # %%
 import spectrochempy as scp
 from spectrochempy_iris import IRIS
@@ -165,13 +167,12 @@ _ = iris3.plotlcurve(title="L curve, automated search")
 # The data corresponding to the largest curvature of the L-curve
 # are at index 5 of the output data.
 
-# sphinx_gallery_thumbnail_number = 11
 
 _ = iris3.f[5].plot_contour()
 _ = iris3.plotmerit(5)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
+++ b/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
@@ -20,12 +20,7 @@ Install with: ``pip install spectrochempy[nmr]``.
 # %%
 import spectrochempy as scp
 
-# %%
-# ``datadir.path`` contains the path to a default data directory.
-
-datadir = scp.preferences.datadir
-
-path = datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d"
+path = "nmrdata/bruker/tests/nmr/topspin_1d"
 
 # %%
 # load the data in a new dataset
@@ -44,7 +39,7 @@ _ = ndd.plot()
 # supported public scope.
 
 # %%
-# This ends the example! The following line can be uncommented if no plot shows
-# when running the .py script with python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-nmr/examples/gallery.toml
+++ b/plugins/spectrochempy-nmr/examples/gallery.toml
@@ -4,15 +4,18 @@ title = "NMR plugin"
 
 [[examples]]
 path = "core/c_importer/plot_read_nmr_from_bruker.py"
-section = "Import/export"
+section = "Import / Export"
+section_ref = "examples-importer-index"
 
 [[examples]]
 path = "processing/apodization/plot_proc_em.py"
 section = "Processing / apodization"
+section_ref = "examples-processing-apodization-index"
 
 [[examples]]
 path = "processing/apodization/plot_proc_sp.py"
 section = "Processing / apodization"
+section_ref = "examples-processing-apodization-index"
 
 [[examples]]
 path = "processing/nmr/plot_read_nmr_topspin.py"

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
@@ -1,4 +1,3 @@
-# %%
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -16,13 +15,15 @@ Install with: ``pip install spectrochempy[nmr]``.
 
 """
 
+# sphinx_gallery_thumbnail_number = -1
+
 # %%
 import spectrochempy as scp
 
 Hz = scp.ur.Hz
 us = scp.ur.us
 
-path = scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d"
+path = "nmrdata/bruker/tests/nmr/topspin_1d"
 dataset1D = scp.nmr.read(path, expno=1, remove_digital_filter=True)
 
 # %%
@@ -67,9 +68,7 @@ _ = new2.real.plot(
 _ = ax.legend()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()
-
-# %%
-# sphinx_gallery_thumbnail_number = -1

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
@@ -1,4 +1,3 @@
-# %%
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -16,11 +15,12 @@ Install with: ``pip install spectrochempy[nmr]``.
 
 """
 
+# sphinx_gallery_thumbnail_number = -1
+
 # %%
 import spectrochempy as scp
 
-DATADIR = scp.preferences.datadir
-path = DATADIR / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d"
+path = "nmrdata/bruker/tests/nmr/topspin_1d"
 
 # %%
 dataset1D = scp.nmr.read(path, expno=1, remove_digital_filter=True)
@@ -96,7 +96,7 @@ _ = new5.real.plot(
 _ = ax.legend()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()
-# sphinx_gallery_thumbnail_number = -1

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
@@ -34,15 +34,10 @@ import spectrochempy as scp
 # %%
 # Import NMR spectra
 # ------------------
-# Define the folder where are the spectra
-datadir = scp.preferences.datadir
-nmrdir = datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "CP"
-
-# %%
 # Set the ``glob`` pattern in order to load a series of spectra of given type
 # in the given directory (here we read fid, but we could also read "1r" files
 # when available)
-dataset = scp.nmr.read(nmrdir, glob="**/fid")
+dataset = scp.nmr.read("nmrdata/bruker/tests/nmr/CP", glob="**/fid")
 
 # %%
 # 15 fids have been read and merged into a single dataset
@@ -269,7 +264,7 @@ ax.set_xlim(0, 16000)
 # Deconvolution of these two peaks is therefore probably necessary for a better analysis.
 
 # %%
-# This ends the example ! The following line can be removed or commented
-# when the example is run as a notebook (``.ipynb``).
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -31,10 +31,7 @@ import spectrochempy as scp
 # %%
 # Import a 1D NMR FID
 # -------------------
-datadir = scp.preferences.datadir
-nmrdir = datadir / "nmrdata"
-
-fid = scp.nmr.read(nmrdir / "bruker" / "tests" / "nmr" / "topspin_1d" / "1" / "fid")
+fid = scp.nmr.read("nmrdata/bruker/tests/nmr/topspin_1d/1/fid")
 
 # %%
 # Compare two explicit apodization choices
@@ -202,7 +199,7 @@ som = f1.inverse_transform()
 _ = f1.plot_merit(offset=2)
 
 # %%
-# This ends the example ! The following line can be removed or commented
-# when the example is run as a notebook (``.ipynb``).
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_2d.py
@@ -51,8 +51,11 @@ import spectrochempy as scp
 # The raw SER file contains time-domain data together with the acquisition
 # metadata needed to decode the hypercomplex encoding in F1.
 
-nmrdir = scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr"
-ser = scp.nmr.read(nmrdir / "topspin_2d", expno=1, remove_digital_filter=True)
+ser = scp.nmr.read(
+    "nmrdata/bruker/tests/nmr/topspin_2d",
+    expno=1,
+    remove_digital_filter=True,
+)
 
 # %%
 # Print dataset summary — both dimensions are in time domain
@@ -65,7 +68,7 @@ _ = ser.plot_map()
 # %%
 # For comparison, load the TopSpin-processed reference spectrum.
 # This is similar to the dataset used in ``plot_processing_nmr.py``.
-reference = scp.nmr.read(nmrdir / "topspin_2d" / "1" / "pdata" / "1" / "2rr")
+reference = scp.nmr.read("nmrdata/bruker/tests/nmr/topspin_2d/1/pdata/1/2rr")
 
 # %%
 # Plot the processed TopSpin reference

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
@@ -39,11 +39,7 @@ U = scp.ur
 # %%
 # Import a pseudo-2D delay series
 # -------------------------------
-# Define the folder containing the Bruker experiment.
-datadir = scp.preferences.datadir
-nmrdir = datadir / "nmrdata" / "bruker" / "tests" / "nmr"
-
-dataset = scp.nmr.read(nmrdir / "relax" / "100" / "ser", use_list="vdlist")
+dataset = scp.nmr.read("nmrdata/bruker/tests/nmr/relax/100/ser", use_list="vdlist")
 
 # %%
 # Analysing the data
@@ -123,7 +119,7 @@ _ = som.plot(clear=False, color="tab:orange", lw=1.8, label="fitted curve")
 _ = ax.legend()
 
 # %%
-# This ends the example ! The following line can be removed or commented
-# when the example is run as a notebook (``.ipynb``).
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_read_nmr_topspin.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_read_nmr_topspin.py
@@ -30,7 +30,7 @@ import spectrochempy as scp
 # remain available for compatibility.
 
 fid = scp.nmr.read(
-    scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d",
+    "nmrdata/bruker/tests/nmr/topspin_1d",
     expno=1,
     remove_digital_filter=True,
 )
@@ -45,7 +45,7 @@ _ = fid.plot()
 # %%
 # Read the processed TopSpin reference spectrum.
 topspin = scp.nmr.read(
-    scp.preferences.datadir / "nmrdata" / "bruker" / "tests" / "nmr" / "topspin_1d",
+    "nmrdata/bruker/tests/nmr/topspin_1d",
     expno=1,
     procno=1,
 )
@@ -102,8 +102,7 @@ ax = topspin.imag.plot(color="black")
 _ = spectrum.imag.plot(ax=ax, clear=False, color="red")
 
 # %%
-# If the plugin is not installed, the function or method raises a
-# :class:`~spectrochempy.plugins.deps.MissingPluginError` with installation
-# instructions.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-perkinelmer/examples/core/c_importer/plot_read_perkinelmer.py
+++ b/plugins/spectrochempy-perkinelmer/examples/core/c_importer/plot_read_perkinelmer.py
@@ -1,4 +1,3 @@
-# %%
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -7,7 +6,7 @@
 # ruff: noqa
 """
 Reading a PerkinElmer SP file (plugin)
-=========================================
+======================================
 
 This example shows how to read a PerkinElmer ``.sp`` binary IR file using the
 optional ``spectrochempy-perkinelmer`` plugin.
@@ -17,6 +16,9 @@ optional ``spectrochempy-perkinelmer`` plugin.
    **Requires the official ``spectrochempy-perkinelmer`` plugin.**
    Install with: ``pip install spectrochempy[perkinelmer]``.
 """
+
+
+# sphinx_gallery_thumbnail_number = 1
 
 # %%
 import spectrochempy as scp
@@ -28,10 +30,7 @@ import spectrochempy as scp
 # ``scp.perkinelmer``. A single-spectrum ``.sp`` file is loaded as an
 # ``NDDataset`` with wavelength coordinates and available metadata.
 
-datadir = scp.preferences.datadir
-filename = datadir / "irdata" / "perkinelmer" / "spectra.sp"
-
-dataset = scp.perkinelmer.read(filename)
+dataset = scp.perkinelmer.read("irdata/perkinelmer/spectra.sp")
 
 # %%
 # Display the dataset summary:
@@ -51,11 +50,7 @@ print(f"Accumulations:   {dataset.meta.accumulations}")
 _ = dataset.plot()
 
 # %%
-# Use the plotted spectrum as the gallery thumbnail.
-# sphinx_gallery_thumbnail_number = 1
-
-# %%
-# This ends the example ! The following line can be removed or commented
-# when the example is run as a notebook (``.ipynb``).
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/plugins/spectrochempy-perkinelmer/examples/gallery.toml
+++ b/plugins/spectrochempy-perkinelmer/examples/gallery.toml
@@ -3,5 +3,6 @@ name = "spectrochempy-perkinelmer"
 title = "PerkinElmer plugin"
 
 [[examples]]
-path = "plot_read_perkinelmer.py"
-section = "Import/export"
+path = "core/c_importer/plot_read_perkinelmer.py"
+section = "Import / Export"
+section_ref = "examples-importer-index"

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -12,19 +12,15 @@ In this example, we perform the Evolving Factor Analysis
 
 """
 
-# %%
 # sphinx_gallery_thumbnail_number = 2
 
 # %%
-import os
-
 import spectrochempy as scp
 
 # %%
 # Load and preprocess the dataset
 # --------------------------------
-datadir = scp.preferences.datadir
-dataset = scp.read_omnic(os.path.join(datadir, "irdata", "nh4y-activation.spg"))
+dataset = scp.read_omnic("irdata/nh4y-activation.spg")
 
 # %%
 # Change the time origin
@@ -97,7 +93,7 @@ LT = pca.loadings
 _ = LT.plot(title="PCA components", legend=LT.k.labels)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -14,10 +14,11 @@ In this example, we perform the Evolving Factor Analysis of a TEST dataset
 
 """
 
+# sphinx_gallery_thumbnail_number = 5
+
 # %%
 import spectrochempy as scp
 
-# sphinx_gallery_thumbnail_number = 5
 
 # %%
 # Generate a test dataset
@@ -93,7 +94,7 @@ C = efa.transform()
 _ = C.T.plot(title="EFA concentration")
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
@@ -10,6 +10,8 @@ FastICA example
 
 """
 
+# sphinx_gallery_thumbnail_number = 3
+
 # %%
 # Import the spectrochempy API package
 import spectrochempy as scp
@@ -58,7 +60,6 @@ St = ica.St  # or model.mixing.T
 # %%
 # Plot them
 
-# sphinx_gallery_thumbnail_number = 3
 
 _ = A.T.plot(title="Mixing System", colormap=None)
 _ = St.plot(title="Sources spectral profiles", colormap=None)
@@ -82,7 +83,7 @@ _ = X_hat_b.plot(title=r"$\hat{X} =$ ica.inverse_transform()")
 
 _ = ica.plot_merit(nb_traces=15)
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
@@ -98,7 +98,7 @@ _ = mcr.St.plot()
 _ = mcr.plot_merit(nb_traces=5)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -19,6 +19,8 @@ For convenience, this dataset is also available in the SpectroChemPy test-data
 directory as ``matlabdata/METING9.MAT``.
 """
 
+# sphinx_gallery_thumbnail_number = 6
+
 import spectrochempy as scp
 
 # %%
@@ -103,7 +105,6 @@ _ = mcr_2.fit(X, Ckin)
 # Now, let's compare the concentration profile of the hard-soft modeling with
 # the previous one:
 
-# sphinx_gallery_thumbnail_number = 6
 
 _ = mcr_2.C.T.plot()
 _ = mcr_1.C_constrained.T.plot(clear=False, ls="--")
@@ -115,7 +116,7 @@ _ = mcr_2.St.plot()
 _ = mcr_2.plot_merit(nb_traces=10, offset=5)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
@@ -77,7 +77,7 @@ ax = St.plot(title="Components", colormap=None, legend=St.k.labels)
 _ = ax.set_yticks([])
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -91,7 +91,7 @@ ax = pca.plot_score(components=(1, 2, 3), color_mapping="labels")
 _ = ax.view_init(10, 75)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
@@ -125,7 +125,7 @@ scores.y.labels = labels  # Note this does not replace previous labels,
 _ = pca.plot_score(scores=scores, show_labels=True, labels_column=2)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
@@ -60,7 +60,7 @@ _ = simpl.components.plot(title="Pure profiles")
 _ = simpl.plot_merit(offset=0, nb_traces=5)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -83,7 +83,7 @@ if ds_list is not None:
     _ = ax.legend(loc="lower right")
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
-scp.show()
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
+# scp.show()

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -1,4 +1,3 @@
-# %%
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -13,17 +12,16 @@ In this example, we find the least  square solution of a simple linear
 equation.
 
 """
+
 # sphinx_gallery_thumbnail_number = 2
 
 # %%
-import os
-
 import spectrochempy as scp
 
 # %%
 # Load and prepare an IR spectrum
 # --------------------------------
-nd = scp.read_omnic(os.path.join("irdata", "nh4y-activation.spg"))
+nd = scp.read_omnic("irdata/nh4y-activation.spg")
 
 # %%
 # Select the OH region and mask a noisy interval:
@@ -106,7 +104,7 @@ som = f1.inverse_transform()
 _ = f1.plot_merit(ndOH, som, offset=15)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
@@ -12,6 +12,7 @@ In this example, we find the least  square solution of a simple linear
 equation.
 
 """
+
 # sphinx_gallery_thumbnail_number = 2
 
 # %%
@@ -103,7 +104,7 @@ distance_fitted3 = lstsq.predict()
 _ = distance_fitted3.plot_pen(clear=False, color="g", label="Fitted line", legend=True)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
@@ -95,7 +95,7 @@ evolution.units = "cm^-1"
 _ = evolution.plot(ls=":", marker="o", ms=3)
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
@@ -65,7 +65,7 @@ relative_difference.units = "percent"
 _ = relative_difference.plot(scatter=True, ms=5)
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
@@ -1,4 +1,3 @@
-# %%
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -12,11 +11,12 @@ In this example, we create a 3D NDDataset from scratch,
 and then we plot one section (a 2D plane)
 """
 
+# sphinx_gallery_thumbnail_number = 2
+
 # %%
 # Creation
 # --------
 # Now we will create a 3D NDDataset from scratch
-import numpy as np
 
 # %%
 # As usual, we start by loading the spectrochempy library
@@ -45,12 +45,14 @@ coord2 = scp.Coord.linspace(4000.0, 1000.0, 100, units="cm^-1", title="wavenumbe
 a = coord0["normal"]
 a
 
-
 # %%
 # Data and nd-Dataset
 # ~~~~~~~~~~~~~~~~~~~
 # ``scp.fromfunction`` builds an NDDataset directly from a Python function.
 # The function receives the coordinate arrays and returns the intensity values.
+import numpy as np
+
+
 def synth_func(temperature, time, wavenumber):
     return np.sin(2.0 * np.pi * wavenumber / 4000.0) * np.exp(-time / 60) * temperature
 
@@ -91,7 +93,6 @@ _ = new.plot(colorbar=True)
 # related to the value of the absorbance. As the dataset contains both negative and positive values, the default
 # colormap is diverging (``RdBu``).
 #
-# sphinx_gallery_thumbnail_number = 2
 _ = new.plot(method="image", colorbar=True)
 
 # %%
@@ -109,7 +110,7 @@ _ = scp.abs(new).plot(method="contour")
 _ = scp.plot_contour(new)
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
@@ -138,7 +138,7 @@ row10.x.select(2)
 _ = row10.plot()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
@@ -115,7 +115,7 @@ ds.x.ito("cm^-1")
 _ = ds.plot()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
@@ -60,7 +60,7 @@ selected = dataset[60.0]
 selected.y
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
@@ -14,20 +14,16 @@ either from local or remote files.
 
 # %%
 # First we need to import the spectrochempy API package
-import os
 from pathlib import Path
 
 import spectrochempy as scp
-
-TEST_FILE = Path(os.environ.get("TEST_FILE", "irdata/nh4y-activation.spg"))
-TEST_FOLDER = Path(os.environ.get("TEST_FOLDER", "irdata"))
 
 # %%
 # Import dataset from local files
 # -------------------------------
 # Read a IR data recorded in Omnic format (``.spg`` extension).
 # We just pass the file name as parameter.
-dataset = scp.read(TEST_FILE)
+dataset = scp.read("irdata/nh4y-activation.spg")
 dataset
 
 # %%
@@ -36,14 +32,8 @@ if dataset is not None:
 
 # %%
 # When using ``read``, we can pass filename as a ``str`` or a ``pathlib.Path`` object.
-filename = TEST_FILE
+filename = Path("irdata/nh4y-activation.spg")
 dataset = scp.read(filename)
-
-# %%
-# Note that is the file is not found in the current working directory, SpectroChemPy
-# will try to find it in the ``datadir`` directory defined in ``preferences`` :
-datadir = scp.preferences.datadir
-datadir
 
 # %%
 # If the supplied argument is a directory, then the whole directory is read at once.
@@ -52,7 +42,7 @@ datadir
 # or else a WARNING appears. To avoid the warning and get individual spectra, you can
 # set ``merge`` to ``False`` . This test-data directory may also contain historical
 # trusted native ``.scp`` archives, which require explicit legacy opt-in.
-dataset_list = scp.read(TEST_FOLDER, merge=False, allow_unsafe_legacy=True)
+dataset_list = scp.read("irdata", merge=False, allow_unsafe_legacy=True)
 print(dataset_list)
 
 # %%
@@ -93,7 +83,7 @@ else:
     _ = dataset_list[-4].plot()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
@@ -18,8 +18,7 @@ import spectrochempy as scp
 # %%
 # Load and display the dataset
 # -----------------------------
-datadir = scp.preferences.datadir
-dataset = scp.read_omnic(datadir / "irdata" / "nh4y-activation.spg")
+dataset = scp.read_omnic("irdata/nh4y-activation.spg")
 _ = dataset.plot_stack(style="paper")
 
 # %%
@@ -32,7 +31,7 @@ dataset.y.title = "acquisition time"
 _ = dataset.plot_stack()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
@@ -26,7 +26,7 @@ Z
 _ = Z.plot()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
 #
 # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
@@ -13,9 +13,7 @@ import spectrochempy as scp
 # %%
 # Read and plot a single file
 # ----------------------------
-datadir = scp.preferences.datadir
-ramandir = datadir / "ramandata/labspec"
-A = scp.read_labspec("Activation.txt", directory=ramandir)
+A = scp.read_labspec("ramandata/labspec/Activation.txt")
 A
 
 # %%
@@ -34,11 +32,11 @@ _ = A.plot_map()
 # %%
 # Read and merge multiple files
 # ------------------------------
-B = scp.read_labspec(ramandir / "subdir")
+B = scp.read_labspec("ramandata/labspec/subdir")
 _ = B.plot()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -62,7 +62,7 @@ _ = dataset[..., 1529.0].plot_image(equal_aspect=True)
 
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
@@ -34,9 +34,8 @@ for nd in ex3:
     _ = nd.plot_bar(width=0.1, clear=False)
 ex3
 
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
-# scp.show()
-
 # %%
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
+# scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
@@ -15,16 +15,12 @@ options are available to customize that overlay.
 
 # %%
 # Import spectrochempy as usual
-import os
-from pathlib import Path
-
 import spectrochempy as scp
 
 # %%
 # Load and inspect the data
 # --------------------------
-TEST_FILE = Path(os.environ.get("TEST_FILE", "ramandata/labspec/serie190214-1.txt"))
-B1 = scp.read(TEST_FILE)
+B1 = scp.read("ramandata/labspec/serie190214-1.txt")
 
 # %%
 # Basic plot with categorical colors (``cmap=None``):
@@ -67,7 +63,7 @@ _ = scp.plot_multiple(
 )
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
@@ -12,16 +12,12 @@ This example compares a few explicit plotting methods available for the same
 infrared dataset.
 """
 
-import os
-from pathlib import Path
-
 import spectrochempy as scp
 
 # %%
 # Load and prepare the dataset
 # -----------------------------
-TEST_FILE = Path(os.environ.get("TEST_FILE", "irdata/nh4y-activation.spg"))
-dataset = scp.read(TEST_FILE)
+dataset = scp.read("irdata/nh4y-activation.spg")
 dataset = dataset[:, 4000.0:650.0]
 dataset.y -= dataset.y[0]
 dataset.y.ito("hour")
@@ -56,7 +52,7 @@ _ = dataset.plot_image(
 )
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
@@ -15,22 +15,13 @@ This short gallery example shows three common ideas:
 - ``plot_multiple()`` overlaying several 1D datasets on one shared axes.
 """
 
-# %%
-
-import os
-from pathlib import Path
-
 import numpy as np
 import spectrochempy as scp
 
 # %%
 # Locate and load a dataset
 # --------------------------
-datadir = scp.preferences.datadir
-TEST_FILE = Path(
-    os.environ.get("TEST_FILE", datadir / "irdata" / "nh4y-activation.spg")
-)
-dataset = scp.read(TEST_FILE)
+dataset = scp.read("irdata/nh4y-activation.spg")
 
 # %%
 # Default plot and style
@@ -69,7 +60,7 @@ _ = scp.plot_multiple(
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_styles.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_styles.py
@@ -44,7 +44,7 @@ _ = dataset.plot()
 scp.preferences.style = original_style
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/plugins/readme.rst
+++ b/src/spectrochempy/examples/plugins/readme.rst
@@ -4,21 +4,22 @@
 Plugin-dependent functionality
 ###############################
 
-This section contains examples that require optional SpectroChemPy plugins,
+This section indexes examples that require optional SpectroChemPy plugins,
 including both official plugins (``spectrochempy-iris``, ``spectrochempy-nmr``)
 and third-party plugins.
 
 When the SpectroChemPy documentation is built, this page is completed from
 ``examples/gallery.toml`` manifests provided by bundled plugins or listed in
-``SCP_PLUGIN_GALLERY_MANIFESTS``.
+``SCP_PLUGIN_GALLERY_MANIFESTS``. Each entry points to the canonical generated
+page in the relevant scientific gallery section.
 
 .. note::
 
-   Official plugin examples also appear in their respective thematic sections
+   Official plugin examples are generated in their respective thematic sections
    (:ref:`Decomposition <examples-analysis-decomposition-index>`,
    :ref:`Simulation <examples-analysis-simulation-index>`,
-   :ref:`NMR processing <examples-processing-nmr-index>`, etc.), so you can
-   browse by scientific topic or filter by required plugin.
+   :ref:`NMR processing <examples-processing-nmr-index>`, etc.), so this page
+   can filter by required plugin without duplicating scripts.
 
    Third-party plugins can add their own examples by providing an
    ``examples/gallery.toml`` manifest.

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -22,8 +22,7 @@ import spectrochempy as scp
 # %%
 # Load and prepare the dataset
 # ----------------------------
-datadir = scp.preferences.datadir
-nd = scp.read_omnic(datadir / "irdata" / "nh4y-activation.spg")
+nd = scp.read_omnic("irdata/nh4y-activation.spg")
 
 # %%
 # Keep only the spectral region of interest
@@ -182,7 +181,7 @@ _ = ndp[-1].plot(clear=False, color="green", ls="--")
 _ = corrected.plot()
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/processing/denoising/plot_denoising.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_denoising.py
@@ -1,4 +1,3 @@
-# %%
 # ======================================================================================
 # Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
 # CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
@@ -12,6 +11,8 @@ Denoising a 2D Raman spectrum
 In this example, we use the ``denoise`` method to remove the noise from a 2D Raman
 spectrum.
 """
+
+# sphinx_gallery_thumbnail_number = -1
 
 # %%
 # Import spectrochempy
@@ -49,7 +50,6 @@ _ = nd2.plot(title="denoised data")
 # ------------------------------
 nd3 = nd1.denoise(ratio=95)
 _ = nd3.plot(title="denoised data")
-# sphinx_gallery_thumbnail_number = 5
 
 nd4 = nd1.denoise(ratio=90)
 _ = nd4.plot(title="denoised data")
@@ -59,6 +59,7 @@ _ = nd4.plot(title="denoised data")
 # effect on cosmic ray spikes.  Consider using ``despike`` methods for those.
 
 # %%
-# This ends the basic example of denoising a 2D Raman spectrum.
-# scp.show()  # uncomment to show plot if running from a script
-# sphinx_gallery_thumbnail_number = -1
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
+# scp.show()

--- a/src/spectrochempy/examples/processing/denoising/plot_despike.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_despike.py
@@ -12,6 +12,8 @@ In this example, we use the ``despike`` method to remove the noise from a Raman
 spectrum.
 """
 
+# sphinx_gallery_thumbnail_number = -1
+
 import spectrochempy as scp
 
 # %%
@@ -58,9 +60,7 @@ _ = X4.plot(clear=False, ls="-", c="r")
 
 
 # %%
-# This ends the example ! The following line can be uncommented if no plot shows when
-# running the .py script with python
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()
-
-# sphinx_gallery_thumbnail_number = -1

--- a/src/spectrochempy/examples/processing/filtering/plot_savgol_derivatives.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_savgol_derivatives.py
@@ -125,7 +125,7 @@ ax.set_ylabel(f"derivative / ({ds_d1.units})")
 _ = ax.legend(loc="best")
 
 # %%
-# This ends the example. Uncomment the next line to display the figures
-# when running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
@@ -48,7 +48,7 @@ sg = scp.Filter(method="savgol", size=7, order=2)(region)
 _ = scp.plot_compare(region, sg, title="Savitzky-Golay smoothing (size=7, order=2)")
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
+++ b/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
@@ -17,13 +17,8 @@ import spectrochempy as scp
 # %%
 # Importing a 1D spectra
 # ----------------------
-# Define the folder where are the spectra
-datadir = scp.preferences.datadir
-ramandir = datadir / "ramandata/labspec"
-
-# %%
 # Read a single spectrum
-A = scp.read_labspec("SMC1-Initial_RT.txt", directory=ramandir)
+A = scp.read_labspec("ramandata/labspec/SMC1-Initial_RT.txt")
 
 # %%
 # Plot the spectrum
@@ -138,7 +133,7 @@ plot_result(Bs, corr, baseline)
 # --------------------------------------------------
 # First, we read the series of spectra
 
-C = scp.read_labspec("Activation.txt", directory=ramandir)
+C = scp.read_labspec("ramandata/labspec/Activation.txt")
 # C = C[20:]  # discard the first 20 spectra
 _ = C.plot()
 
@@ -176,7 +171,7 @@ G = scp.denoise(D, ratio=98)
 _ = G[::10].plot()
 
 # %%
-# This ends the example ! The following line can be removed or commented
-# when the example is run as a notebook (``.ipynb``).
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
@@ -51,7 +51,7 @@ dataset.y.ito("hours")
 _ = dataset.plot()
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
@@ -56,7 +56,7 @@ msc = region.msc()
 _ = msc.plot(title="MSC corrected")
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
@@ -104,7 +104,7 @@ print(
 )
 
 # %%
-# This ends the example. Uncomment the next line to display the figures when
-# running the script directly with Python.
-
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+#
 # scp.show()

--- a/tests/test_docs/test_gallery_examples_static.py
+++ b/tests/test_docs/test_gallery_examples_static.py
@@ -1,0 +1,145 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Static checks for gallery example formatting."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_ROOTS = (
+    REPO_ROOT / "src" / "spectrochempy" / "examples",
+    *sorted((REPO_ROOT / "plugins").glob("spectrochempy-*/examples")),
+)
+THUMBNAIL_PREFIXES = (
+    "# sphinx_gallery_thumbnail_number",
+    "# sphinx_gallery_thumbnail_path",
+)
+CANONICAL_FOOTER = (
+    "# %%\n"
+    "# Uncomment the following line to display all figures when running the script\n"
+    "# directly with Python.\n"
+    "#\n"
+    "# scp.show()\n"
+)
+DATADIR_TEST_VARIABLES = {"TEST_FILE", "TEST_FOLDER", "TEST_NMR_FOLDER"}
+
+
+def _example_files() -> list[Path]:
+    return sorted(
+        path
+        for root in EXAMPLE_ROOTS
+        for path in root.rglob("*.py")
+        if path.name.startswith("plot_") and ".ipynb_checkpoints" not in path.parts
+    )
+
+
+def _module_docstring_end(lines: list[str], source: str) -> int | None:
+    module = ast.parse(source)
+    if (
+        module.body
+        and isinstance(module.body[0], ast.Expr)
+        and isinstance(module.body[0].value, ast.Constant)
+        and isinstance(module.body[0].value.value, str)
+    ):
+        return module.body[0].end_lineno
+
+    for lineno, line in enumerate(lines, start=1):
+        if line.strip().startswith('"""') or line.strip().startswith("'''"):
+            quote = line.strip()[:3]
+            if line.strip().count(quote) >= 2 and len(line.strip()) > 3:
+                return lineno
+            for end_lineno in range(lineno + 1, len(lines) + 1):
+                if quote in lines[end_lineno - 1]:
+                    return end_lineno
+    return None
+
+
+def test_thumbnail_directives_follow_module_docstring():
+    misplaced = []
+    for path in _example_files():
+        source = path.read_text(encoding="utf-8")
+        lines = source.splitlines()
+        directive_indexes = [
+            index
+            for index, line in enumerate(lines)
+            if line.strip().startswith(THUMBNAIL_PREFIXES)
+        ]
+        if not directive_indexes:
+            continue
+
+        docstring_end = _module_docstring_end(lines, source)
+        first_cell = next(
+            (index for index, line in enumerate(lines) if line.startswith("# %%")),
+            None,
+        )
+        first_directive = directive_indexes[0]
+        expected = docstring_end
+        while (
+            expected is not None
+            and expected < len(lines)
+            and not lines[expected].strip()
+        ):
+            expected += 1
+
+        if (
+            len(directive_indexes) != 1
+            or expected is None
+            or first_directive != expected
+            or (first_cell is not None and first_cell < first_directive)
+        ):
+            misplaced.append(path.relative_to(REPO_ROOT).as_posix())
+
+    assert misplaced == []
+
+
+def test_gallery_examples_use_canonical_show_footer():
+    offenders = []
+    for path in _example_files():
+        source = path.read_text(encoding="utf-8")
+        if "scp.show()" not in source:
+            continue
+        if not source.endswith(CANONICAL_FOOTER):
+            offenders.append(path.relative_to(REPO_ROOT).as_posix())
+        assert "This ends the example" not in source
+        assert "# scp.show()  #" not in source
+        assert "\nscp.show()\n" not in source
+
+    assert offenders == []
+
+
+def test_gallery_examples_use_datadir_relative_paths():
+    offenders = []
+    for path in _example_files():
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            uses_scp_datadir = (
+                isinstance(node, ast.Attribute)
+                and node.attr == "datadir"
+                and isinstance(node.value, ast.Attribute)
+                and node.value.attr == "preferences"
+                and isinstance(node.value.value, ast.Name)
+                and node.value.value.id == "scp"
+            )
+            uses_os_path_join = (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "join"
+                and isinstance(node.func.value, ast.Attribute)
+                and node.func.value.attr == "path"
+                and isinstance(node.func.value.value, ast.Name)
+                and node.func.value.value.id == "os"
+            )
+            uses_test_variable = (
+                isinstance(node, ast.Name) and node.id in DATADIR_TEST_VARIABLES
+            )
+            if uses_scp_datadir or uses_os_path_join or uses_test_variable:
+                offenders.append(path.relative_to(REPO_ROOT).as_posix())
+
+    assert sorted(set(offenders)) == []

--- a/tests/test_docs/test_gallery_staging.py
+++ b/tests/test_docs/test_gallery_staging.py
@@ -1,0 +1,126 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Tests for Sphinx-Gallery example staging."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONF_PATH = REPO_ROOT / "docs" / "conf.py"
+
+
+def _load_docs_conf(monkeypatch):
+    monkeypatch.setenv("SPHINX_PATTERN", "index")
+    module_name = "_spectrochempy_docs_conf_for_tests"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, CONF_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_external_plugin_manifest(root: Path) -> Path:
+    examples = root / "examples"
+    source = examples / "core" / "c_importer" / "plot_external_reader.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        textwrap.dedent(
+            '''
+            """
+            External reader example
+            =======================
+            """
+
+            # sphinx_gallery_thumbnail_number = 1
+
+            # %%
+            import spectrochempy as scp
+
+            dataset = scp.read("irdata/nh4y-activation.spg")
+            '''
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    (source.parent / "readme.rst").write_text(
+        ".. _examples-importer-index:\n\nImport / Export\n---------------\n",
+        encoding="utf-8",
+    )
+    manifest = examples / "gallery.toml"
+    manifest.write_text(
+        textwrap.dedent(
+            """
+            [plugin]
+            name = "spectrochempy-external"
+            title = "External plugin"
+
+            [[examples]]
+            path = "core/c_importer/plot_external_reader.py"
+            section = "Import / Export"
+            section_ref = "examples-importer-index"
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_plugin_manifest_examples_are_staged_once(monkeypatch, tmp_path):
+    conf = _load_docs_conf(monkeypatch)
+    manifest = _write_external_plugin_manifest(tmp_path / "external-plugin")
+
+    project = tmp_path / "project"
+    (project / "plugins").mkdir(parents=True)
+    monkeypatch.setattr(conf, "PROJECT", project)
+    monkeypatch.setattr(conf, "BUILDIR", tmp_path / "build")
+    monkeypatch.setattr(conf, "example_source_dir", tmp_path / "empty-examples")
+    monkeypatch.setattr(
+        conf, "gallery_sections", ("core", "processing", "analysis", "plugins")
+    )
+    monkeypatch.setenv("SCP_PLUGIN_GALLERY_MANIFESTS", str(manifest))
+
+    entries = conf._load_plugin_gallery_entries()
+    staged = conf._stage_gallery_examples()
+    conf._write_plugin_gallery_readmes(staged, entries)
+
+    canonical = staged / "core" / "c_importer" / "plot_external_reader.py"
+    plugin_copy = staged / "plugins" / "spectrochempy-external"
+
+    assert canonical.exists()
+    assert not plugin_copy.exists()
+    assert not list((staged / "plugins").glob("**/plot_*.py"))
+    assert not list((staged / "plugins").glob("**/*.ipynb"))
+
+
+def test_plugin_index_references_canonical_gallery_page(monkeypatch, tmp_path):
+    conf = _load_docs_conf(monkeypatch)
+    manifest = _write_external_plugin_manifest(tmp_path / "external-plugin")
+
+    project = tmp_path / "project"
+    (project / "plugins").mkdir(parents=True)
+    monkeypatch.setattr(conf, "PROJECT", project)
+    monkeypatch.setenv("SCP_PLUGIN_GALLERY_MANIFESTS", str(manifest))
+
+    entries = conf._load_plugin_gallery_entries()
+    readme = conf._plugin_gallery_readme(entries)
+
+    assert (
+        ":ref:`sphx_glr_gettingstarted_examples_gallery_auto_examples_core_c_importer_plot_external_reader.py`"
+        in readme
+    )
+    assert "``spectrochempy-external``" in readme
+    assert ":ref:`Import / Export <examples-importer-index>`" in readme
+
+
+def test_generated_credits_file_keeps_final_newline(monkeypatch):
+    _load_docs_conf(monkeypatch)
+
+    credits = REPO_ROOT / "docs" / "sources" / "credits" / "credits.rst"
+    assert credits.read_bytes().endswith(b"\n")


### PR DESCRIPTION
## Summary

- stop staging duplicate plugin example scripts under the plugin-only gallery
- keep plugin manifest examples generated once in their canonical scientific sections
- make the plugin-dependent gallery page an index of links to canonical examples
- move the PerkinElmer example into the Import / Export gallery section
- simplify gallery data paths to datadir-relative strings where readers resolve them directly
- normalize Sphinx-Gallery thumbnail directives and final `scp.show()` footers
- stabilize generated `docs/sources/credits/credits.rst` so docs/conf.py always writes a final newline
- keep lightweight gallery staging tests independent from `sphinx_gallery` unless a full gallery build is requested
- add static and staging tests for these invariants

## Validation

- `micromamba run -n scpy-core pre-commit run --all-files`
- `micromamba run -n scpy-core python -m pytest tests/test_docs/test_gallery_staging.py tests/test_docs/test_gallery_examples_static.py plugins/spectrochempy-nmr/tests/test_examples_gallery.py::test_nmr_gallery_manifest_focuses_on_public_1d_examples` — 7 passed
- targeted reader-resolution checks for OMNIC/generic, Labspec, NMR TopSpin/relax/CP, and the PerkinElmer local plugin reader
- targeted examples with `MPLBACKEND=Agg`: core OMNIC, NMR apodization, PerkinElmer import
- `python docs/make.py html --no-exec --no-api --no-sync` was attempted; without plugin paths it stops because PerkinElmer is optional, and with official plugin `src` paths on `PYTHONPATH` it reaches IRIS then stops because the local env lacks `osqp`

## Generated Gallery Inspection

- `build/~gallery_examples/plugins` contains only `__init__.py` and `readme.rst`
- PerkinElmer is staged under `core/c_importer` with the other import examples
- NMR plugin examples are staged under `core/c_importer`, `processing/apodization`, and `processing/nmr`
- IRIS is staged under `analysis/a_decomposition`
