### PR TITLE
DOC: keep gallery show footer in code cell

### DIFF
--- a/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
+++ b/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
@@ -141,4 +141,4 @@ _ = iris3.plotmerit(5)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
+++ b/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
@@ -42,4 +42,4 @@ _ = ndd.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
@@ -71,4 +71,4 @@ _ = ax.legend()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
@@ -99,4 +99,4 @@ _ = ax.legend()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
@@ -267,4 +267,4 @@ ax.set_xlim(0, 16000)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -202,4 +202,4 @@ _ = f1.plot_merit(offset=2)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
@@ -122,4 +122,4 @@ _ = ax.legend()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_read_nmr_topspin.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_read_nmr_topspin.py
@@ -105,4 +105,4 @@ _ = spectrum.imag.plot(ax=ax, clear=False, color="red")
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/plugins/spectrochempy-perkinelmer/examples/core/c_importer/plot_read_perkinelmer.py
+++ b/plugins/spectrochempy-perkinelmer/examples/core/c_importer/plot_read_perkinelmer.py
@@ -52,4 +52,4 @@ _ = dataset.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -96,4 +96,4 @@ _ = LT.plot(title="PCA components", legend=LT.k.labels)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -97,4 +97,4 @@ _ = C.T.plot(title="EFA concentration")
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
@@ -86,4 +86,4 @@ _ = ica.plot_merit(nb_traces=15)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
@@ -101,4 +101,4 @@ _ = mcr.plot_merit(nb_traces=5)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -119,4 +119,4 @@ _ = mcr_2.plot_merit(nb_traces=10, offset=5)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
@@ -80,4 +80,4 @@ _ = ax.set_yticks([])
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -94,4 +94,4 @@ _ = ax.view_init(10, 75)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
@@ -128,4 +128,4 @@ _ = pca.plot_score(scores=scores, show_labels=True, labels_column=2)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
@@ -63,4 +63,4 @@ _ = simpl.plot_merit(offset=0, nb_traces=5)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -86,4 +86,4 @@ if ds_list is not None:
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -107,4 +107,4 @@ _ = f1.plot_merit(ndOH, som, offset=15)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
@@ -107,4 +107,4 @@ _ = distance_fitted3.plot_pen(clear=False, color="g", label="Fitted line", legen
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
@@ -98,4 +98,4 @@ _ = evolution.plot(ls=":", marker="o", ms=3)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
@@ -68,4 +68,4 @@ _ = relative_difference.plot(scatter=True, ms=5)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
@@ -113,4 +113,4 @@ _ = scp.plot_contour(new)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
@@ -141,4 +141,4 @@ _ = row10.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
@@ -118,4 +118,4 @@ _ = ds.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
@@ -63,4 +63,4 @@ selected.y
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
@@ -86,4 +86,4 @@ else:
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
@@ -34,4 +34,4 @@ _ = dataset.plot_stack()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
@@ -29,4 +29,4 @@ _ = Z.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
@@ -39,4 +39,4 @@ _ = B.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -65,4 +65,4 @@ _ = dataset[..., 1529.0].plot_image(equal_aspect=True)
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
@@ -38,4 +38,4 @@ ex3
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
@@ -66,4 +66,4 @@ _ = scp.plot_multiple(
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
@@ -55,4 +55,4 @@ _ = dataset.plot_image(
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
@@ -63,4 +63,4 @@ _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/core/d_plotting/plot_styles.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_styles.py
@@ -47,4 +47,4 @@ scp.preferences.style = original_style
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -184,4 +184,4 @@ _ = corrected.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/denoising/plot_denoising.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_denoising.py
@@ -62,4 +62,4 @@ _ = nd4.plot(title="denoised data")
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/denoising/plot_despike.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_despike.py
@@ -63,4 +63,4 @@ _ = X4.plot(clear=False, ls="-", c="r")
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/filtering/plot_savgol_derivatives.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_savgol_derivatives.py
@@ -128,4 +128,4 @@ _ = ax.legend(loc="best")
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
@@ -51,4 +51,4 @@ _ = scp.plot_compare(region, sg, title="Savitzky-Golay smoothing (size=7, order=
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
+++ b/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
@@ -174,4 +174,4 @@ _ = G[::10].plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
@@ -54,4 +54,4 @@ _ = dataset.plot()
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
@@ -59,4 +59,4 @@ _ = msc.plot(title="MSC corrected")
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
@@ -107,4 +107,4 @@ print(
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #
-# scp.show()
+# # scp.show()

--- a/tests/test_docs/test_gallery_examples_static.py
+++ b/tests/test_docs/test_gallery_examples_static.py
@@ -24,7 +24,7 @@ CANONICAL_FOOTER = (
     "# Uncomment the following line to display all figures when running the script\n"
     "# directly with Python.\n"
     "#\n"
-    "# scp.show()\n"
+    "# # scp.show()\n"
 )
 DATADIR_TEST_VARIABLES = {"TEST_FILE", "TEST_FOLDER", "TEST_NMR_FOLDER"}
 


### PR DESCRIPTION
Keeps the canonical `# %%` cell separator before the show footer in all gallery examples, but writes the commented line as `# # scp.show()`.

Sphinx-Gallery consumes the leading comment marker of a narrative block; the doubled `#` therefore renders as a visible `# scp.show()` comment in the generated gallery pages, while the script itself remains unchanged for direct execution.