### PR TITLE
DOC: keep gallery show footer as visible code cell

### DIFF
--- a/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
+++ b/plugins/spectrochempy-iris/examples/analysis/a_decomposition/plot_iris_intro.py
@@ -138,6 +138,7 @@ _ = iris3.plotmerit(5)
 
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
+++ b/plugins/spectrochempy-nmr/examples/core/c_importer/plot_read_nmr_from_bruker.py
@@ -39,6 +39,7 @@ _ = ndd.plot()
 # supported public scope.
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_em.py
@@ -68,6 +68,7 @@ _ = new2.real.plot(
 _ = ax.legend()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
+++ b/plugins/spectrochempy-nmr/examples/processing/apodization/plot_proc_sp.py
@@ -96,6 +96,7 @@ _ = new5.real.plot(
 _ = ax.legend()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_cp_nmr.py
@@ -264,6 +264,7 @@ ax.set_xlim(0, 16000)
 # Deconvolution of these two peaks is therefore probably necessary for a better analysis.
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr.py
@@ -199,6 +199,7 @@ som = f1.inverse_transform()
 _ = f1.plot_merit(offset=2)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_processing_nmr_relax.py
@@ -119,6 +119,7 @@ _ = som.plot(clear=False, color="tab:orange", lw=1.8, label="fitted curve")
 _ = ax.legend()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-nmr/examples/processing/nmr/plot_read_nmr_topspin.py
+++ b/plugins/spectrochempy-nmr/examples/processing/nmr/plot_read_nmr_topspin.py
@@ -102,6 +102,7 @@ ax = topspin.imag.plot(color="black")
 _ = spectrum.imag.plot(ax=ax, clear=False, color="red")
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/plugins/spectrochempy-perkinelmer/examples/core/c_importer/plot_read_perkinelmer.py
+++ b/plugins/spectrochempy-perkinelmer/examples/core/c_importer/plot_read_perkinelmer.py
@@ -49,6 +49,7 @@ print(f"Accumulations:   {dataset.meta.accumulations}")
 _ = dataset.plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa.py
@@ -93,6 +93,7 @@ LT = pca.loadings
 _ = LT.plot(title="PCA components", legend=LT.k.labels)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_efa_keller_massart.py
@@ -94,6 +94,7 @@ C = efa.transform()
 _ = C.T.plot(title="EFA concentration")
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_fast_ica.py
@@ -83,6 +83,7 @@ _ = X_hat_b.plot(title=r"$\hat{X} =$ ica.inverse_transform()")
 
 _ = ica.plot_merit(nb_traces=15)
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_chrom1.py
@@ -98,6 +98,7 @@ _ = mcr.St.plot()
 _ = mcr.plot_merit(nb_traces=5)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_mcrals_kinetics.py
@@ -116,6 +116,7 @@ _ = mcr_2.St.plot()
 _ = mcr_2.plot_merit(nb_traces=10, offset=5)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_nmf.py
@@ -77,6 +77,7 @@ ax = St.plot(title="Components", colormap=None, legend=St.k.labels)
 _ = ax.set_yticks([])
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_iris.py
@@ -91,6 +91,7 @@ ax = pca.plot_score(components=(1, 2, 3), color_mapping="labels")
 _ = ax.view_init(10, 75)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_pca_spec.py
@@ -125,6 +125,7 @@ scores.y.labels = labels  # Note this does not replace previous labels,
 _ = pca.plot_score(scores=scores, show_labels=True, labels_column=2)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
+++ b/src/spectrochempy/examples/analysis/a_decomposition/plot_simplisma.py
@@ -60,6 +60,7 @@ _ = simpl.components.plot(title="Pure profiles")
 _ = simpl.plot_merit(offset=0, nb_traces=5)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls.py
@@ -83,6 +83,7 @@ if ds_list is not None:
     _ = ax.legend(loc="lower right")
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_fit.py
@@ -104,6 +104,7 @@ som = f1.inverse_transform()
 _ = f1.plot_merit(ndOH, som, offset=15)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
+++ b/src/spectrochempy/examples/analysis/c_curvefitting/plot_lstsq_single_equation.py
@@ -104,6 +104,7 @@ distance_fitted3 = lstsq.predict()
 _ = distance_fitted3.plot_pen(clear=False, color="g", label="Fitted line", legend=True)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_finding.py
@@ -95,6 +95,7 @@ evolution.units = "cm^-1"
 _ = evolution.plot(ls=":", marker="o", ms=3)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
+++ b/src/spectrochempy/examples/analysis/d_peak_analysis/plot_peak_integration.py
@@ -65,6 +65,7 @@ relative_difference.units = "percent"
 _ = relative_difference.plot(scatter=True, ms=5)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_a_create_dataset.py
@@ -110,6 +110,7 @@ _ = scp.abs(new).plot(method="contour")
 _ = scp.plot_contour(new)
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_b_coordinates.py
@@ -138,6 +138,7 @@ row10.x.select(2)
 _ = row10.plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_c_units.py
@@ -115,6 +115,7 @@ ds.x.ito("cm^-1")
 _ = ds.plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
+++ b/src/spectrochempy/examples/core/a_nddataset/plot_d_slicing.py
@@ -60,6 +60,7 @@ selected = dataset[60.0]
 selected.y
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_generic_read.py
@@ -83,6 +83,7 @@ else:
     _ = dataset_list[-4].plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_omnic.py
@@ -31,6 +31,7 @@ dataset.y.title = "acquisition time"
 _ = dataset.plot_stack()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_IR_from_opus.py
@@ -26,6 +26,7 @@ Z
 _ = Z.plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_raman_from_labspec.py
@@ -36,6 +36,7 @@ B = scp.read_labspec("ramandata/labspec/subdir")
 _ = B.plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_renishaw.py
@@ -62,6 +62,7 @@ _ = dataset[..., 1529.0].plot_image(equal_aspect=True)
 
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
+++ b/src/spectrochempy/examples/core/c_importer/plot_read_spc.py
@@ -35,6 +35,7 @@ for nd in ex3:
 ex3
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_multiple.py
@@ -63,6 +63,7 @@ _ = scp.plot_multiple(
 )
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plot_types.py
@@ -52,6 +52,7 @@ _ = dataset.plot_image(
 )
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_plotting.py
@@ -60,6 +60,7 @@ _ = scp.plot_multiple(
 _ = scp.plot_multiple(method="scatter", datasets=datasets, labels=labels, legend="best")
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/core/d_plotting/plot_styles.py
+++ b/src/spectrochempy/examples/core/d_plotting/plot_styles.py
@@ -44,6 +44,7 @@ _ = dataset.plot()
 scp.preferences.style = original_style
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
+++ b/src/spectrochempy/examples/processing/baseline/plot_baseline_correction.py
@@ -181,6 +181,7 @@ _ = ndp[-1].plot(clear=False, color="green", ls="--")
 _ = corrected.plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/denoising/plot_denoising.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_denoising.py
@@ -59,6 +59,7 @@ _ = nd4.plot(title="denoised data")
 # effect on cosmic ray spikes.  Consider using ``despike`` methods for those.
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/denoising/plot_despike.py
+++ b/src/spectrochempy/examples/processing/denoising/plot_despike.py
@@ -60,6 +60,7 @@ _ = X4.plot(clear=False, ls="-", c="r")
 
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/filtering/plot_savgol_derivatives.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_savgol_derivatives.py
@@ -125,6 +125,7 @@ ax.set_ylabel(f"derivative / ({ds_d1.units})")
 _ = ax.legend(loc="best")
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
+++ b/src/spectrochempy/examples/processing/filtering/plot_smoothing_window_size.py
@@ -48,6 +48,7 @@ sg = scp.Filter(method="savgol", size=7, order=2)(region)
 _ = scp.plot_compare(region, sg, title="Savitzky-Golay smoothing (size=7, order=2)")
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
+++ b/src/spectrochempy/examples/processing/raman/plot_processing_raman.py
@@ -171,6 +171,7 @@ G = scp.denoise(D, ratio=98)
 _ = G[::10].plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_masking_transpose_units.py
@@ -51,6 +51,7 @@ dataset.y.ito("hours")
 _ = dataset.plot()
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_preprocessing.py
@@ -56,6 +56,7 @@ msc = region.msc()
 _ = msc.plot(title="MSC corrected")
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
@@ -104,6 +104,7 @@ print(
 )
 
 # %%
+
 # Uncomment the following line to display all figures when running the script
 # directly with Python.
 #

--- a/tests/test_docs/test_gallery_examples_static.py
+++ b/tests/test_docs/test_gallery_examples_static.py
@@ -21,6 +21,7 @@ THUMBNAIL_PREFIXES = (
 )
 CANONICAL_FOOTER = (
     "# %%\n"
+    "\n"
     "# Uncomment the following line to display all figures when running the script\n"
     "# directly with Python.\n"
     "#\n"


### PR DESCRIPTION
Inserts a blank line immediately after the `# %%` separator in the canonical gallery show footer across all core and plugin examples, and updates the static gallery test accordingly.

Sphinx-Gallery classifies a cell as narrative text only when the comments directly follow the separator. With the blank line, the block becomes a genuine Python code cell: the comments (including the final commented `scp.show()`) are rendered as visible code and stay inert during the doc build. Verified against `sphinx_gallery.py_source_parser.split_code_and_text_blocks`.

Supersedes #1567.