### PR TITLE
ENH: add pseudo-Voigt lineshape model

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -788,6 +788,8 @@ Lineshape models
     gaussianmodel
     lorentzian
     lorentzianmodel
+    pseudovoigt
+    pseudovoigtmodel
     voigt
     voigtmodel
     asymmetricvoigt

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,9 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Added the ``pseudovoigt`` helper and ``pseudovoigtmodel`` curve-fitting
+  model, using the existing ``ampl``, ``pos``, ``width``, ``ratio`` and
+  ``normalized`` line-shape conventions.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,3 +11,10 @@ What's New in Revision 0.12.6.dev
 
 These are the changes in SpectroChemPy-0.12.6.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+New Features
+~~~~~~~~~~~~
+
+- Added the ``pseudovoigt`` helper and ``pseudovoigtmodel`` curve-fitting
+  model, using the existing ``ampl``, ``pos``, ``width``, ``ratio`` and
+  ``normalized`` line-shape conventions.

--- a/src/spectrochempy/analysis/curvefitting/_models.py
+++ b/src/spectrochempy/analysis/curvefitting/_models.py
@@ -20,6 +20,8 @@ __all__ = [
     "gaussianmodel",
     "lorentzian",
     "lorentzianmodel",
+    "pseudovoigt",
+    "pseudovoigtmodel",
     "voigt",
     "voigtmodel",
     "asymmetricvoigt",
@@ -223,6 +225,48 @@ def lorentzian(x, ampl=1.0, pos=0.0, width=1.0, normalized=True, **kwargs):
         ampl=ampl,
         pos=pos,
         width=width,
+        normalized=normalized,
+        **kwargs,
+    )
+
+
+def pseudovoigt(x, ampl=1.0, pos=0.0, width=1.0, ratio=0.5, normalized=True, **kwargs):
+    """
+    Return a pseudo-Voigt profile.
+
+    The pseudo-Voigt profile is a linear combination of Lorentzian and
+    Gaussian profiles sharing the same centre and FWHM.
+
+    Parameters
+    ----------
+    x : array-like or Coord
+        Abscissa values.
+    ampl : float, optional
+        Amplitude. When *normalized* is ``True`` (default) this scales the
+        area under the curve. When *normalized* is ``False`` this is the peak
+        height.
+    pos : float, optional
+        Position of the peak centre.
+    width : float, optional
+        Full width at half maximum (FWHM).
+    ratio : float, optional
+        Ratio of Gaussian to Lorentzian character (0 = pure Lorentzian,
+        1 = pure Gaussian).
+    normalized : bool, optional
+        If ``True`` (default) the profile is normalized so that its integral
+        is approximately *ampl*. If ``False`` the peak value is exactly
+        *ampl*.
+    **kwargs
+        Additional keyword arguments forwarded to the model evaluator.
+    """
+    return _evaluate_model(
+        pseudovoigtmodel,
+        x,
+        name="pseudovoigt",
+        ampl=ampl,
+        pos=pos,
+        width=width,
+        ratio=ratio,
         normalized=normalized,
         **kwargs,
     )
@@ -461,6 +505,41 @@ class lorentzianmodel:
         normalized = kargs.get("normalized", True)
         w = w * abs(x[1] - x[0]) if normalized else w * np.pi * lb
         return ampl * w
+
+
+# ======================================================================================
+# PseudoVoigtModel
+# ======================================================================================
+class pseudovoigtmodel:
+    """
+    A pseudo-Voigt model.
+
+    The pseudo-Voigt profile is a linear combination of Lorentzian and
+    Gaussian profiles with the same centre and FWHM:
+
+    .. math::
+        f(x) = (1 - ratio) L(x) + ratio G(x)
+
+    The convention follows the existing Voigt parameterization:
+    ``ratio=0`` is pure Lorentzian and ``ratio=1`` is pure Gaussian.
+    """
+
+    type = "1D"
+    args = ["ampl", "pos", "width", "ratio"]
+
+    script = """
+    MODEL: line%(id)d\nshape: pseudovoigtmodel
+    $ ampl: %(ampl).3f, 0.0, None
+    $ width: %(width).3f, 0.0, None
+    $ pos: %(pos).3f, %(poslb).3f, %(poshb).3f
+    $ ratio: 0.5, 0.0, 1.0
+    """
+
+    @make_units_compatibility
+    def f(self, x, ampl, pos, width, ratio, **kargs):
+        gaussian_part = gaussianmodel().f(x, 1.0, pos, width, **kargs)
+        lorentzian_part = lorentzianmodel().f(x, 1.0, pos, width, **kargs)
+        return ampl * ((1.0 - ratio) * lorentzian_part + ratio * gaussian_part)
 
 
 # ======================================================================================

--- a/src/spectrochempy/lazyimport/api_methods.py
+++ b/src/spectrochempy/lazyimport/api_methods.py
@@ -26,6 +26,8 @@ _LAZY_IMPORTS = {
     "gaussianmodel": "spectrochempy.analysis.curvefitting._models",
     "lorentzian": "spectrochempy.analysis.curvefitting._models",
     "lorentzianmodel": "spectrochempy.analysis.curvefitting._models",
+    "pseudovoigt": "spectrochempy.analysis.curvefitting._models",
+    "pseudovoigtmodel": "spectrochempy.analysis.curvefitting._models",
     "voigt": "spectrochempy.analysis.curvefitting._models",
     "voigtmodel": "spectrochempy.analysis.curvefitting._models",
     "asymmetricvoigt": "spectrochempy.analysis.curvefitting._models",

--- a/tests/test_analysis/test_curvefitting/test_models.py
+++ b/tests/test_analysis/test_curvefitting/test_models.py
@@ -33,6 +33,12 @@ _MODELS = [
         "lorentzianmodel", ["ampl", "pos", "width"], 0.6366197723675814, id="lorentzian"
     ),
     pytest.param(
+        "pseudovoigtmodel",
+        ["ampl", "pos", "width", "ratio"],
+        0.7880245271284375,
+        id="pseudovoigt",
+    ),
+    pytest.param(
         "voigtmodel", ["ampl", "pos", "width", "ratio"], 0.8982186579508358, id="voigt"
     ),
     pytest.param(
@@ -58,6 +64,11 @@ _HELPERS = [
     ),
     pytest.param("gaussian", dict(ampl=1.0, pos=0.5, width=0.1), id="gaussian"),
     pytest.param("lorentzian", dict(ampl=1.0, pos=0.5, width=0.1), id="lorentzian"),
+    pytest.param(
+        "pseudovoigt",
+        dict(ampl=1.0, pos=0.5, width=0.1, ratio=0.5),
+        id="pseudovoigt",
+    ),
     pytest.param("voigt", dict(ampl=1.0, pos=0.5, width=0.1, ratio=0.5), id="voigt"),
     pytest.param(
         "asymmetricvoigt",
@@ -292,6 +303,7 @@ class TestNormalizedFalse:
         [
             pytest.param("gaussian", {}, id="gaussian"),
             pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("pseudovoigt", {"ratio": 0.5}, id="pseudovoigt"),
             pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
         ],
     )
@@ -307,6 +319,7 @@ class TestNormalizedFalse:
         [
             pytest.param("gaussian", {}, id="gaussian"),
             pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("pseudovoigt", {"ratio": 0.5}, id="pseudovoigt"),
             pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
         ],
     )
@@ -323,6 +336,7 @@ class TestNormalizedFalse:
         [
             pytest.param("gaussian", {}, id="gaussian"),
             pytest.param("lorentzian", {}, id="lorentzian"),
+            pytest.param("pseudovoigt", {"ratio": 0.5}, id="pseudovoigt"),
             pytest.param("voigt", {"ratio": 0.5}, id="voigt"),
         ],
     )
@@ -345,6 +359,72 @@ class TestNormalizedFalse:
         r1 = scp.gaussian(x, ampl=1.0, pos=0.0, width=1.0, normalized=False)
         r2 = scp.gaussian(x, ampl=2.5, pos=0.0, width=1.0, normalized=False)
         np.testing.assert_allclose(r2, 2.5 * r1, rtol=1e-12)
+
+
+class TestPseudoVoigt:
+    """Pseudo-Voigt contract tests."""
+
+    def test_ratio_zero_matches_lorentzian(self):
+        x = np.linspace(-5, 5, 1001)
+
+        pseudo = scp.pseudovoigt(x, ampl=2.0, pos=0.5, width=1.2, ratio=0.0)
+        lorentzian = scp.lorentzian(x, ampl=2.0, pos=0.5, width=1.2)
+
+        np.testing.assert_allclose(pseudo, lorentzian, rtol=1e-12, atol=1e-14)
+
+    def test_ratio_one_matches_gaussian(self):
+        x = np.linspace(-5, 5, 1001)
+
+        pseudo = scp.pseudovoigt(x, ampl=2.0, pos=0.5, width=1.2, ratio=1.0)
+        gaussian = scp.gaussian(x, ampl=2.0, pos=0.5, width=1.2)
+
+        np.testing.assert_allclose(pseudo, gaussian, rtol=1e-12, atol=1e-14)
+
+    def test_intermediate_ratio_is_linear_mixture(self):
+        x = np.linspace(-5, 5, 1001)
+        kwargs = dict(ampl=2.0, pos=0.5, width=1.2, normalized=True)
+
+        pseudo = scp.pseudovoigt(x, ratio=0.25, **kwargs)
+        expected = 0.75 * scp.lorentzian(x, **kwargs) + 0.25 * scp.gaussian(x, **kwargs)
+
+        np.testing.assert_allclose(pseudo, expected, rtol=1e-12, atol=1e-14)
+
+    def test_normalized_false_keeps_peak_height(self):
+        x = np.linspace(-5, 5, 2001)
+
+        pseudo = scp.pseudovoigt(
+            x, ampl=3.0, pos=0.0, width=1.0, ratio=0.3, normalized=False
+        )
+
+        assert np.isclose(pseudo.max(), 3.0, rtol=1e-12)
+
+    def test_units_follow_existing_lineshape_convention(self):
+        x = scp.Coord.linspace(-5, 5, 1001, units="m")
+
+        pseudo = scp.pseudovoigt(
+            x, ampl=2.0 * ur("g"), pos=0.0 * ur("m"), width=1000.0 * ur("mm")
+        )
+
+        assert isinstance(pseudo, scp.NDDataset)
+        assert pseudo.units == ur("g")
+        assert pseudo.x.units == ur("m")
+        assert np.all(np.isfinite(pseudo.data))
+
+    def test_optimize_accepts_pseudovoigtmodel_shape(self):
+        script = """
+        MODEL: PEAK
+        shape: pseudovoigtmodel
+            $ ampl: 1.0, 0.0, none
+            $ pos: 0.0, -1.0, 1.0
+            $ width: 1.0, 0.0, none
+            $ ratio: 0.5, 0.0, 1.0
+        """
+        opt = scp.Optimize()
+
+        assert opt.validate_script(script) == []
+        opt.script = script
+
+        assert opt.fp is not None
 
 
 class TestBaselineHelper:


### PR DESCRIPTION
## Summary
- add pseudovoigt() and pseudovoigtmodel to the public curve-fitting line-shape API
- define pseudo-Voigt as a linear Gaussian/Lorentzian mixture with shared position and FWHM
- preserve the existing ratio convention: ratio=0 Lorentzian, ratio=1 Gaussian
- expose the new symbols in the API reference and release notes

## Validation
- pytest tests/test_analysis/test_curvefitting/test_models.py
- public import smoke check for scp.pseudovoigt() and scp.pseudovoigtmodel().args
- pre-commit run --all-files