### PR TITLE
FIX: harden polynomial baseline support validation

### DIFF
--- a/docs/sources/userguide/processing/baseline.py
+++ b/docs/sources/userguide/processing/baseline.py
@@ -153,6 +153,12 @@ X3[:, 891.0:1234.0].mask.all(), blc.baseline[:, 891.0:1234.0].mask.all()
 # using `[3500.0, 4500.]` would
 # lead to exactly the same result. It is also possible to formally pick a single
 # wavenumber `3750.`.
+#
+# The selected support must contain enough distinct coordinate points for the
+# requested fit. In practice, polynomial orders require more support points than
+# the requested degree, while `order="pchip"` requires at least two distinct
+# points. Ranges that do not intersect the coordinate domain now raise a clear
+# `ValueError`.
 
 # %%
 ranges = (

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,10 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Hardened polynomial baseline fitting on short or underspecified spectra by
+  validating support size explicitly, reporting non-intersecting ranges with
+  clear ``ValueError`` messages, and avoiding internal index failures when
+  automatic edge support is enabled.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -18,3 +18,11 @@ New Features
 - Added the ``pseudovoigt`` helper and ``pseudovoigtmodel`` curve-fitting
   model, using the existing ``ampl``, ``pos``, ``width``, ``ratio`` and
   ``normalized`` line-shape conventions.
+
+Bug Fixes
+~~~~~~~~~
+
+- Hardened polynomial baseline fitting on short or underspecified spectra by
+  validating support size explicitly, reporting non-intersecting ranges with
+  clear ``ValueError`` messages, and avoiding internal index failures when
+  automatic edge support is enabled.

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -334,6 +334,93 @@ baseline/trends for different segments of the data.
         # clean the result (reorder and suppress overlaps)
         return trim_ranges(*ranges)
 
+    @staticmethod
+    def _coordinate_domain_bounds(values):
+        values = np.asarray(values)
+        if values.size == 0:
+            raise ValueError(
+                "Baseline polynomial fitting requires a non-empty coordinate domain."
+            )
+        return min(values[0], values[-1]), max(values[0], values[-1])
+
+    @staticmethod
+    def _range_intersects_domain(range_pair, domain_min, domain_max):
+        return not (range_pair[1] < domain_min or range_pair[0] > domain_max)
+
+    @staticmethod
+    def _format_domain(domain_min, domain_max):
+        return f"[{domain_min}, {domain_max}]"
+
+    def _polynomial_edge_ranges(self, values):
+        values = np.asarray(values)
+        if values.size == 0:
+            raise ValueError(
+                "Baseline polynomial fitting requires a non-empty coordinate domain."
+            )
+        required = self._minimum_polynomial_support_points()
+        span = min(values.size, max(3, int(np.ceil(required / 2))))
+        return [[values[0], values[span - 1]], [values[-span], values[-1]]]
+
+    def _minimum_polynomial_support_points(self):
+        if self.order == "pchip":
+            return 2
+        return int(self.order) + 1
+
+    def _validate_requested_polynomial_ranges(self, ranges, domain_min, domain_max):
+        if not ranges:
+            return
+
+        invalid_ranges = [
+            pair
+            for pair in ranges
+            if not self._range_intersects_domain(pair, domain_min, domain_max)
+        ]
+        if not invalid_ranges:
+            return
+
+        domain = self._format_domain(domain_min, domain_max)
+        if len(invalid_ranges) == len(ranges):
+            raise ValueError(
+                "Requested baseline ranges do not intersect the coordinate "
+                f"domain {domain}. Requested ranges={ranges}."
+            )
+
+        raise ValueError(
+            "Some requested baseline ranges do not intersect the coordinate "
+            f"domain {domain}. Non-intersecting ranges={invalid_ranges}."
+        )
+
+    def _validate_polynomial_support(self, x_support, dataset_coord):
+        support_values = np.asarray(x_support)
+        distinct_support = np.unique(support_values).size
+        required = self._minimum_polynomial_support_points()
+        domain_min, domain_max = self._coordinate_domain_bounds(dataset_coord.data)
+        domain = self._format_domain(domain_min, domain_max)
+
+        if distinct_support == 0:
+            raise ValueError(
+                "Baseline polynomial support is empty after range selection. "
+                f"Coordinate domain={domain}, used_ranges={self._ranges}."
+            )
+
+        if distinct_support >= required:
+            return
+
+        distinct_dataset = np.unique(np.asarray(dataset_coord.data)).size
+        if distinct_dataset < required and distinct_support == distinct_dataset:
+            raise ValueError(
+                "Dataset is too short for the requested baseline polynomial fit: "
+                f"order={self.order!r}, distinct_points={distinct_dataset}, "
+                f"required_points>={required}, coordinate domain={domain}."
+            )
+
+        raise ValueError(
+            "Baseline polynomial support is too small for the requested fit: "
+            f"order={self.order!r}, distinct_support_points={distinct_support}, "
+            f"required_points>={required}, coordinate domain={domain}, "
+            f"used_ranges={self._ranges}."
+        )
+
     @tr.observe("_X", "ranges", "include_limits", "model", "multivariate")
     def _preprocess_as_X_or_ranges_changed(self, change):
         # set X and ranges using the new or current value
@@ -355,20 +442,27 @@ baseline/trends for different segments of the data.
             self._X_ranges = X.copy()
             return
 
-        ranges = change.new if change.name == "ranges" else self.ranges.copy()
+        requested_ranges = change.new if change.name == "ranges" else self.ranges.copy()
+        ranges = requested_ranges.copy()
         if X is None:
             # not a lot to do here
             # just return after cleaning ranges
             self._ranges = ranges = trim_ranges(*ranges)
             return
 
+        lastcoord = X.coordset[X.dims[-1]]
+        x = lastcoord.data
+        domain_min, domain_max = self._coordinate_domain_bounds(x)
+        self._validate_requested_polynomial_ranges(
+            requested_ranges, domain_min, domain_max
+        )
+
         if self.include_limits and X is not None:
             # be sure to extend ranges with the extrema of the x-axis
             # (it will not make a difference if this was already done before)
-            lastcoord = X.coordset[X.dims[-1]]  # we have to take into account the
-            # possibility of transposed data, so we can't use directly X.x
-            x = lastcoord.data
-            ranges += [[x[0], x[2]], [x[-3], x[-1]]]
+            # we have to take into account the possibility of transposed data,
+            # so we can't use directly X.x
+            ranges += self._polynomial_edge_ranges(x)
 
         if self.breakpoints:
             # we should also include breakpoints in the ranges
@@ -378,6 +472,12 @@ baseline/trends for different segments of the data.
 
         # trim, order and clean up ranges (save it in self._ranges)
         self._ranges = ranges = trim_ranges(*ranges)
+
+        if not ranges:
+            raise ValueError(
+                "No baseline support ranges were selected for polynomial fitting. "
+                "Provide at least one range or keep include_limits=True."
+            )
 
         # Extract the dataset sections corresponding to the provided ranges
         # BUT warning, this does not work for masked data (as after removal of the
@@ -392,6 +492,13 @@ baseline/trends for different segments of the data.
             if sect is None:
                 continue
             s.append(sect)
+
+        if not s:
+            domain = self._format_domain(domain_min, domain_max)
+            raise ValueError(
+                "No baseline support points could be selected from the requested "
+                f"ranges. Coordinate domain={domain}, used_ranges={ranges}."
+            )
 
         # determine _X_ranges (used by fit) by concatenating the sections
         self._X_ranges = concatenate(s)
@@ -645,6 +752,8 @@ baseline/trends for different segments of the data.
             bplist.append(bp)
         # sort and remove duplicates
         bplist = sorted(set(bplist))
+        if len(bplist) == 1:
+            bplist = [bplist[0], bplist[0]]
 
         # loop on breakpoints pairs
         baseline = np.zeros_like(self._X.data)
@@ -657,6 +766,8 @@ baseline/trends for different segments of the data.
             xb = xbase[istart : iend + 1]
             yb = ybase[..., istart : iend + 1]
             Xpart = self._X[..., ixstart : ixend + 1]
+            if self.model == "polynomial":
+                self._validate_polynomial_support(xb, Xx)
             baseline[..., ixstart : ixend + 1] = self._fit(xb, yb, Xpart)
             istart = iend + 1
             ixstart = ixend + 1

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -237,6 +237,7 @@ def test_baseline_polynomial_with_ranges(synthetic_1d_baseline_dataset):
     ("n_points", "order", "should_fit"),
     [
         (1, "constant", True),
+        (1, 0, True),
         (1, 1, False),
         (2, 1, True),
         (2, 3, False),
@@ -283,6 +284,35 @@ def test_baseline_polynomial_constant_order_accepts_single_point_range():
 
 
 @pytest.mark.parametrize(
+    ("descending", "ranges", "should_fit"),
+    [
+        (False, [[1500.0, 1500.0]], False),
+        (True, [[1500.0, 1500.0]], False),
+        (False, [[1400.0, 1400.0], [1600.0, 1600.0]], True),
+        (True, [[1400.0, 1400.0], [1600.0, 1600.0]], True),
+    ],
+)
+def test_baseline_polynomial_pchip_support_validation(descending, ranges, should_fit):
+    dataset = _make_simple_baseline_dataset(descending=descending)
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order="pchip", include_limits=False)
+    blc.ranges = ranges
+
+    if should_fit:
+        blc.fit(dataset)
+        assert blc.baseline.shape == dataset.shape
+        assert blc.baseline.units == dataset.units
+        assert blc.corrected.units == dataset.units
+        assert blc.baseline.x.is_descendant == dataset.x.is_descendant
+    else:
+        with pytest.raises(ValueError, match="support is too small"):
+            blc.fit(dataset)
+
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize(
     ("ranges", "message"),
     [
         ([[1500.0, 1500.0]], "support is too small"),
@@ -312,6 +342,22 @@ def test_baseline_polynomial_rejects_ranges_outside_domain(descending):
     blc.ranges = [[2500.0, 2600.0]]
 
     with pytest.raises(ValueError, match="do not intersect the coordinate domain"):
+        blc.fit(dataset)
+
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_baseline_polynomial_rejects_mixed_in_and_out_of_domain_ranges(descending):
+    dataset = _make_simple_baseline_dataset(descending=descending)
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order=1, include_limits=False)
+    blc.ranges = [[1100.0, 1200.0], [2500.0, 2600.0]]
+
+    with pytest.raises(
+        ValueError, match="Some requested baseline ranges do not intersect"
+    ):
         blc.fit(dataset)
 
     assert_dataset_equal(dataset, original)

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -9,6 +9,27 @@ from spectrochempy.processing.baselineprocessing.baselineprocessing import Basel
 from spectrochempy.utils.testing import assert_dataset_equal
 
 
+def _make_simple_baseline_dataset(
+    n_points=11, *, descending=False, units="cm^-1", dataset_units="absorbance"
+):
+    x = np.linspace(1000.0, 2000.0, n_points)
+    if descending:
+        x = x[::-1]
+
+    # Exact polynomial support keeps the validation tests focused on API
+    # contracts rather than numeric quality.
+    data = 0.002 * x + 0.5
+
+    dataset = scp.NDDataset(
+        data,
+        coordset=[scp.Coord(x, title="wavenumber", units=units)],
+        units=dataset_units,
+        title="simple baseline dataset",
+    )
+    dataset.name = f"simple_baseline_{n_points}"
+    return dataset
+
+
 def test_baseline_fit_1d(synthetic_1d_baseline_dataset):
     dataset, _, _ = synthetic_1d_baseline_dataset
 
@@ -210,6 +231,106 @@ def test_baseline_polynomial_with_ranges(synthetic_1d_baseline_dataset):
 
     assert blc.baseline.shape == dataset.shape
     assert np.all(np.isfinite(blc.baseline.data))
+
+
+@pytest.mark.parametrize(
+    ("n_points", "order", "should_fit"),
+    [
+        (1, "constant", True),
+        (1, 1, False),
+        (2, 1, True),
+        (2, 3, False),
+        (3, 1, True),
+        (3, 3, False),
+    ],
+)
+def test_baseline_polynomial_short_dataset_validation(n_points, order, should_fit):
+    dataset = _make_simple_baseline_dataset(n_points)
+
+    blc = Baseline(model="polynomial", order=order)
+
+    if should_fit:
+        blc.fit(dataset)
+        assert np.all(np.isfinite(np.asarray(blc.baseline.data)))
+        assert blc.baseline.units == dataset.units
+    else:
+        with pytest.raises(ValueError, match="too short"):
+            blc.fit(dataset)
+
+
+def test_baseline_polynomial_without_ranges_and_without_limits_errors():
+    dataset = _make_simple_baseline_dataset()
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order=1, include_limits=False)
+
+    with pytest.raises(ValueError, match="No baseline support ranges were selected"):
+        blc.fit(dataset)
+
+    assert_dataset_equal(dataset, original)
+
+
+def test_baseline_polynomial_constant_order_accepts_single_point_range():
+    dataset = _make_simple_baseline_dataset()
+
+    blc = Baseline(model="polynomial", order="constant", include_limits=False)
+    blc.ranges = [[1500.0, 1500.0]]
+    blc.fit(dataset)
+
+    assert blc.baseline.shape == dataset.shape
+    assert blc.baseline.units == dataset.units
+    assert blc.corrected.units == dataset.units
+
+
+@pytest.mark.parametrize(
+    ("ranges", "message"),
+    [
+        ([[1500.0, 1500.0]], "support is too small"),
+        ([[1500.0, 1500.1]], "support is too small"),
+        ([[1500.0, 1500.0], [1700.0, 1700.0]], "support is too small"),
+    ],
+)
+def test_baseline_polynomial_rejects_insufficient_support_ranges(ranges, message):
+    dataset = _make_simple_baseline_dataset()
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order=3, include_limits=False)
+    blc.ranges = ranges
+
+    with pytest.raises(ValueError, match=message):
+        blc.fit(dataset)
+
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_baseline_polynomial_rejects_ranges_outside_domain(descending):
+    dataset = _make_simple_baseline_dataset(descending=descending)
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order=1, include_limits=False)
+    blc.ranges = [[2500.0, 2600.0]]
+
+    with pytest.raises(ValueError, match="do not intersect the coordinate domain"):
+        blc.fit(dataset)
+
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_baseline_polynomial_accepts_partially_out_of_domain_ranges(descending):
+    dataset = _make_simple_baseline_dataset(descending=descending)
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order=1, include_limits=False)
+    blc.ranges = [[900.0, 1200.0], [1800.0, 2100.0]]
+    blc.fit(dataset)
+
+    assert blc.baseline.shape == dataset.shape
+    assert blc.baseline.units == dataset.units
+    assert blc.corrected.units == dataset.units
+    assert blc.baseline.x.is_descendant == dataset.x.is_descendant
+    assert_dataset_equal(dataset, original)
 
 
 def test_preprocessing_nddataset_methods(synthetic_1d_baseline_dataset):


### PR DESCRIPTION
## Summary
- validate polynomial baseline support size and range/domain selection explicitly
- avoid short-spectrum index failures by scaling automatic edge support with fit requirements
- add focused regression tests plus userguide and changelog updates for the tightened polynomial contract

## Validation
- pre-commit run --all-files
- micromamba run -n scpy-core python -m pytest tests/test_analysis/test_baseline/test_baseline.py -q