### PR TITLE
FIX: preserve input shape in Baseline.corrected

### DIFF
--- a/docs/sources/userguide/processing/baseline.py
+++ b/docs/sources/userguide/processing/baseline.py
@@ -93,7 +93,9 @@ _ = blc.plot()
 
 # %% [markdown]
 # One can also use the property `corrected` instead of the method `transform()`,
-# both giving equivalent results.
+# both giving equivalent results. In both cases, `baseline` and `corrected`
+# preserve the logical shape of the input dataset: a strictly 1D input remains
+# 1D, while an explicitly 2D input remains 2D.
 
 # %%
 X1 = blc.corrected

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -34,6 +34,10 @@ Bug Fixes
   clear ``ValueError`` messages, and avoiding internal index failures when
   automatic edge support is enabled.
 
+- Fixed model-dependent shape inconsistencies in ``Baseline.corrected`` so that
+  baseline and corrected datasets preserve the input dataset shape and
+  dimensions.
+
 .. section
 
 Dependency Updates

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -26,3 +26,7 @@ Bug Fixes
   validating support size explicitly, reporting non-intersecting ranges with
   clear ``ValueError`` messages, and avoiding internal index failures when
   automatic edge support is enabled.
+
+- Fixed model-dependent shape inconsistencies in ``Baseline.corrected`` so that
+  baseline and corrected datasets preserve the input dataset shape and
+  dimensions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ requires = ["setuptools>=64", "setuptools-scm>=8", "wheel"]
 
 [project]
 authors = [
-  {name = "Arnaud Travert & Christian Fernandez", email = "contact@spectrochempy.fr"},
+  {name = "Arnaud Travert", email = "contact@spectrochempy.fr"},
+  {name = "Christian Fernandez", email = "christian.fernandez@ensicaen.fr"},
 ]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ requires = ["setuptools>=64", "setuptools-scm>=8", "wheel"]
 
 [project]
 authors = [
-  {name = "Arnaud Travert", email = "contact@spectrochempy.fr"},
-  {name = "Christian Fernandez", email = "christian.fernandez@ensicaen.fr"},
+  {name = "Arnaud Travert & Christian Fernandez", email = "contact@spectrochempy.fr"},
 ]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -712,7 +712,7 @@ baseline/trends for different segments of the data.
         # Set X
         # -----
         X = X.copy()
-        self._X_input = X.copy()
+        self._X_input_was_1d = X.ndim == 1
 
         if (
             self.model == "asls"
@@ -806,14 +806,16 @@ baseline/trends for different segments of the data.
         NDDataset
             Dataset with baseline correction applied
         """
-        source = getattr(self, "_X_input", None)
-        if source is None:
-            source = (
-                self.Xmasked
-                if self.model == "asls" and hasattr(self, "Xmasked")
-                else self.X
-            )
-        return source - self.baseline
+        if self.model == "asls" and hasattr(self, "Xmasked"):
+            return self.Xmasked - self.baseline
+
+        corrected = self.X - self.baseline
+        if getattr(self, "_X_input_was_1d", False):
+            restored = self.baseline.copy()
+            restored._data = np.ma.getdata(corrected.data)[0]
+            return restored
+
+        return corrected
 
     @property
     def corrected(self):

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -712,6 +712,7 @@ baseline/trends for different segments of the data.
         # Set X
         # -----
         X = X.copy()
+        self._X_input = X.copy()
 
         if (
             self.model == "asls"
@@ -805,11 +806,14 @@ baseline/trends for different segments of the data.
         NDDataset
             Dataset with baseline correction applied
         """
-        if self.model == "asls" and hasattr(self, "Xmasked"):
-            corrected = self.Xmasked - self.baseline
-        else:
-            corrected = self.X - self.baseline
-        return corrected
+        source = getattr(self, "_X_input", None)
+        if source is None:
+            source = (
+                self.Xmasked
+                if self.model == "asls" and hasattr(self, "Xmasked")
+                else self.X
+            )
+        return source - self.baseline
 
     @property
     def corrected(self):

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -30,6 +30,41 @@ def _make_simple_baseline_dataset(
     return dataset
 
 
+def _make_shape_probe_dataset(
+    n_points=64,
+    *,
+    n_rows=None,
+    descending=False,
+    units="cm^-1",
+    dataset_units="absorbance",
+):
+    x = np.linspace(1000.0, 2000.0, n_points)
+    if descending:
+        x = x[::-1]
+
+    base = 0.002 * x + 0.5 + 0.1 * np.sin(np.linspace(0.0, 4.0, n_points))
+    if n_rows is None:
+        data = base
+        coordset = [scp.Coord(x, title="wavenumber", units=units)]
+        name = f"shape_probe_1d_{n_points}"
+    else:
+        data = np.vstack([base + 0.01 * i for i in range(n_rows)])
+        coordset = [
+            scp.Coord(np.arange(n_rows, dtype=float), title="row", units=None),
+            scp.Coord(x, title="wavenumber", units=units),
+        ]
+        name = f"shape_probe_{n_rows}x{n_points}"
+
+    dataset = scp.NDDataset(
+        data,
+        coordset=coordset,
+        units=dataset_units,
+        title="baseline shape probe dataset",
+    )
+    dataset.name = name
+    return dataset
+
+
 def test_baseline_fit_1d(synthetic_1d_baseline_dataset):
     dataset, _, _ = synthetic_1d_baseline_dataset
 
@@ -57,6 +92,116 @@ def test_baseline_fit_2d(synthetic_2d_baseline_dataset):
     assert baseline.shape == dataset.shape
     assert np.all(np.isfinite(baseline.data))
     assert np.all(np.isfinite(corrected.data))
+
+
+@pytest.mark.parametrize(
+    ("model", "kwargs"),
+    [
+        ("polynomial", {"order": 3}),
+        ("asls", {"lamb": 1e5, "asymmetry": 0.05}),
+        ("snip", {"snip_width": 15}),
+        ("rubberband", {}),
+    ],
+)
+@pytest.mark.parametrize("descending", [False, True])
+def test_baseline_corrected_preserves_shape_for_strict_1d_inputs(
+    model, kwargs, descending
+):
+    dataset = _make_shape_probe_dataset(descending=descending)
+    original = dataset.copy()
+
+    blc = Baseline(model=model, **kwargs)
+    blc.fit(dataset)
+
+    baseline = blc.baseline
+    corrected = blc.corrected
+
+    assert baseline.shape == dataset.shape
+    assert corrected.shape == dataset.shape
+    assert baseline.dims == dataset.dims
+    assert corrected.dims == dataset.dims
+    assert baseline.units == dataset.units
+    assert corrected.units == dataset.units
+    np.testing.assert_allclose(baseline.x.data, dataset.x.data)
+    np.testing.assert_allclose(corrected.x.data, dataset.x.data)
+    assert baseline.x.is_descendant == dataset.x.is_descendant
+    assert corrected.x.is_descendant == dataset.x.is_descendant
+    np.testing.assert_allclose(
+        np.asarray(corrected.data),
+        np.asarray(dataset.data) - np.asarray(baseline.data),
+    )
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize(
+    ("model", "kwargs"),
+    [
+        ("polynomial", {"order": 3}),
+        ("asls", {"lamb": 1e5, "asymmetry": 0.05}),
+        ("snip", {"snip_width": 15}),
+        ("rubberband", {}),
+    ],
+)
+@pytest.mark.parametrize("n_rows", [1, 3])
+def test_baseline_corrected_preserves_shape_for_2d_inputs(model, kwargs, n_rows):
+    dataset = _make_shape_probe_dataset(n_rows=n_rows)
+    original = dataset.copy()
+
+    blc = Baseline(model=model, **kwargs)
+    blc.fit(dataset)
+
+    baseline = blc.baseline
+    corrected = blc.corrected
+
+    assert baseline.shape == dataset.shape
+    assert corrected.shape == dataset.shape
+    assert baseline.dims == dataset.dims
+    assert corrected.dims == dataset.dims
+    assert baseline.units == dataset.units
+    assert corrected.units == dataset.units
+    np.testing.assert_allclose(baseline.x.data, dataset.x.data)
+    np.testing.assert_allclose(corrected.x.data, dataset.x.data)
+    np.testing.assert_allclose(baseline.y.data, dataset.y.data)
+    np.testing.assert_allclose(corrected.y.data, dataset.y.data)
+    np.testing.assert_allclose(
+        np.asarray(corrected.data),
+        np.asarray(dataset.data) - np.asarray(baseline.data),
+    )
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize(
+    ("func", "kwargs"),
+    [
+        (scp.basc, {}),
+        (scp.asls, {"lamb": 1e5, "asymmetry": 0.05}),
+        (lambda dataset: dataset.get_baseline(model="polynomial", order=3), {}),
+    ],
+)
+@pytest.mark.parametrize(
+    ("n_rows", "descending"),
+    [
+        (None, False),
+        (None, True),
+        (1, False),
+    ],
+)
+def test_baseline_public_helpers_preserve_public_shape(
+    func, kwargs, n_rows, descending
+):
+    dataset = _make_shape_probe_dataset(n_rows=n_rows, descending=descending)
+    original = dataset.copy()
+
+    output = func(dataset, **kwargs) if kwargs else func(dataset)
+
+    assert output.shape == dataset.shape
+    assert output.dims == dataset.dims
+    assert output.units == dataset.units
+    np.testing.assert_allclose(output.x.data, dataset.x.data)
+    assert output.x.is_descendant == dataset.x.is_descendant
+    if n_rows is not None:
+        np.testing.assert_allclose(output.y.data, dataset.y.data)
+    assert_dataset_equal(dataset, original)
 
 
 def test_baseline_polynomial_recovers_known_1d_baseline(

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -204,6 +204,24 @@ def test_baseline_public_helpers_preserve_public_shape(
     assert_dataset_equal(dataset, original)
 
 
+def test_baseline_corrected_preserves_mask_and_shape_for_strict_1d_snip():
+    dataset = _make_shape_probe_dataset()
+    dataset[1400.0:1500.0] = scp.MASKED
+    original = dataset.copy()
+    expected_mask = np.asarray(dataset.mask).copy()
+
+    blc = Baseline(model="snip", snip_width=15)
+    blc.fit(dataset)
+    corrected = blc.corrected
+
+    assert corrected.shape == dataset.shape
+    assert corrected.dims == dataset.dims
+    assert np.asarray(corrected.mask).shape == expected_mask.shape
+    assert np.array_equal(np.asarray(corrected.mask), expected_mask)
+    assert np.array_equal(np.asarray(dataset.mask), np.asarray(original.mask))
+    assert_dataset_equal(dataset, original)
+
+
 def test_baseline_polynomial_recovers_known_1d_baseline(
     synthetic_1d_baseline_dataset,
 ):


### PR DESCRIPTION
## Summary
- preserve the logical input shape of `Baseline.corrected` across the supported baseline models
- characterize the current shape behavior for strict 1D, explicit `(1, N)`, and ordinary 2D inputs, including the relevant one-shot public helpers
- add a focused masked 1D regression test to confirm that the corrected-shape fix does not change the current mask behavior

## Reference baseline
- public base SHA: `89c532f109db3a55b8203e34f54f8bf877c9a53d`
- previous campaign step: `#1572`

## Cause
For strict 1D inputs, `Baseline.fit()` promotes the internal working dataset to `(1, N)` in `self._X`. `transform()` then subtracted `self.baseline` from that promoted internal view, so `Baseline.corrected` inherited the extra observation dimension for at least the `polynomial`, `snip`, and `rubberband` paths. The `asls` path already avoided the issue because it subtracts from the original masked 1D input.

## Contract retained in this PR
- strict 1D input `(N,)` -> `baseline.shape == corrected.shape == (N,)`
- explicit one-row 2D input `(1, N)` -> `baseline.shape == corrected.shape == (1, N)`
- ordinary 2D input `(M, N)` -> `baseline.shape == corrected.shape == (M, N)`
- preserve dims, coordinates, units, ordinary mask behavior, and non-mutation of the source dataset

## Files changed
- `src/spectrochempy/processing/baselineprocessing/baselineprocessing.py`
- `tests/test_analysis/test_baseline/test_baseline.py`
- `docs/sources/userguide/processing/baseline.py`
- `docs/sources/whatsnew/changelog.rst`
- `docs/sources/whatsnew/latest.rst`

## Test coverage added
- models: `polynomial`, `asls`, `snip`, `rubberband`
- input shapes: `(N,)`, `(1, N)`, `(M, N)`
- strict 1D ascending and descending axes
- helper checks for `dataset.get_baseline(...)`, `scp.basc(...)`, and `scp.asls(...)`
- focused masked 1D regression coverage on the strict-1D `snip` path

## Validation
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_baseline/test_baseline.py -k "corrected_preserves_shape or public_helpers_preserve_public_shape or preserves_mask_and_shape_for_strict_1d_snip" -q`
- `micromamba run -n scpy-core python -m pytest tests/test_analysis/test_baseline/test_baseline.py -q`
- `pre-commit run --all-files`

## Results
- targeted shape and mask regression tests: passing
- `tests/test_analysis/test_baseline/test_baseline.py -q`: `71 passed`
- `pre-commit run --all-files`: passing

## Intentionally deferred
- no change to the polynomial support/range validation contract delivered by `#1572`
- no performance work on copying, traitlets, or dataset reconstruction
- no array-first or fast-path API work
- no refactor of general `NDDataset` arithmetic