### PR TITLE
FIX: add temporary PyPI authors workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ requires = ["setuptools>=64", "setuptools-scm>=8", "wheel"]
 
 [project]
 authors = [
-  {name = "Arnaud Travert", email = "contact@spectrochempy.fr"},
-  {name = "Christian Fernandez", email = "christian.fernandez@ensicaen.fr"},
+  {name = "Arnaud Travert & Christian Fernandez", email = "contact@spectrochempy.fr"},
 ]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- apply a temporary `pyproject.toml` metadata workaround so the PyPI project page shows both project authors instead of only the first entry
- keep the workaround isolated from the Baseline API work in a separate PR
- point to the known upstream Warehouse limitation that makes the workaround necessary for now

## Context
This is a temporary workaround for the known PyPI/Warehouse issue:
- https://github.com/pypi/warehouse/issues/12877
- issue title: `Possible to support displaying all authors on PyPI page?`

Current packaging metadata is valid, but Warehouse still displays only the first `authors` entry on the project page. This PR uses a single combined author entry as a provisional workaround until the upstream behavior changes.

## Files changed
- `pyproject.toml`

## Validation
- `pre-commit run --all-files`
- `micromamba run -n scpy-core python - <<'PY' ... tomllib.load(...) ... PY`

## Intentionally deferred
- no runtime code changes
- no documentation rewrite
- no changelog entry for this temporary metadata-only workaround
