### PR TITLE
PERF: reduce polynomial Baseline range assembly overhead

### DIFF
--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -18,9 +18,6 @@ from spectrochempy.application.application import info_
 from spectrochempy.application.application import warning_
 from spectrochempy.processing.baselineprocessing.baselineutils import lls
 from spectrochempy.processing.baselineprocessing.baselineutils import lls_inv
-from spectrochempy.processing.transformation.concatenate import (
-    concatenate,  # noqa: F401
-)
 from spectrochempy.utils.constants import TYPE_FLOAT
 from spectrochempy.utils.constants import TYPE_INTEGER
 from spectrochempy.utils.coordrange import trim_ranges

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -18,7 +18,9 @@ from spectrochempy.application.application import info_
 from spectrochempy.application.application import warning_
 from spectrochempy.processing.baselineprocessing.baselineutils import lls
 from spectrochempy.processing.baselineprocessing.baselineutils import lls_inv
-from spectrochempy.processing.transformation.concatenate import concatenate
+from spectrochempy.processing.transformation.concatenate import (
+    concatenate,  # noqa: F401
+)
 from spectrochempy.utils.constants import TYPE_FLOAT
 from spectrochempy.utils.constants import TYPE_INTEGER
 from spectrochempy.utils.coordrange import trim_ranges
@@ -421,6 +423,30 @@ baseline/trends for different segments of the data.
             f"used_ranges={self._ranges}."
         )
 
+    def _assemble_polynomial_support_dataset(self, X, ranges):
+        dim = X.dims[-1]
+        section_data = []
+        section_coordsets = []
+
+        for pair in ranges:
+            keys = X._make_index((Ellipsis, slice(*pair)))
+            data = X.masked_data[keys]
+            if data.shape[-1] == 0:
+                continue
+            section_data.append(data)
+            section_coordsets.append(X.coordset._slice_dims(X.dims, keys))
+
+        if not section_data:
+            return None
+
+        concatenated = np.ma.concatenate(tuple(section_data), axis=-1)
+
+        out = X.copy(deep=False)
+        out._data = np.asarray(concatenated)
+        out._mask = concatenated.mask
+        out._coordset = X.coordset._concatenate_dim(dim, section_coordsets)
+        return out
+
     @tr.observe("_X", "ranges", "include_limits", "model", "multivariate")
     def _preprocess_as_X_or_ranges_changed(self, change):
         # set X and ranges using the new or current value
@@ -479,29 +505,18 @@ baseline/trends for different segments of the data.
                 "Provide at least one range or keep include_limits=True."
             )
 
-        # Extract the dataset sections corresponding to the provided ranges
-        # BUT warning, this does not work for masked data (as after removal of the
-        # masked part, the  X.x coordinates is not more linear .The coordinate must have
-        # been transformed to normal coordinate before. See AnalysisConfigurable.
-        # _X_validate
-        s = []
-        for pair in ranges:
-            # determine the slices
-            sl = slice(*pair)
-            sect = X[..., sl]
-            if sect is None:
-                continue
-            s.append(sect)
+        # Extract the dataset sections corresponding to the provided ranges.
+        # This preserves the existing location-slicing semantics while avoiding
+        # the construction of intermediate NDDataset sections that would
+        # immediately be re-concatenated for polynomial fitting.
+        self._X_ranges = self._assemble_polynomial_support_dataset(X, ranges)
 
-        if not s:
+        if self._X_ranges is None:
             domain = self._format_domain(domain_min, domain_max)
             raise ValueError(
                 "No baseline support points could be selected from the requested "
                 f"ranges. Coordinate domain={domain}, used_ranges={ranges}."
             )
-
-        # determine _X_ranges (used by fit) by concatenating the sections
-        self._X_ranges = concatenate(s)
 
         # we will also do necessary validation of other parameters:
         if self.multivariate:

--- a/tests/benchmarks/baseline_fit_harness.py
+++ b/tests/benchmarks/baseline_fit_harness.py
@@ -289,13 +289,14 @@ def _measure_instrumented_fit_breakdown(
                 "coord.loc2index",
                 stack,
             )
-            _patch_timed_method(
-                iteration_stats,
-                baseline_module,
-                "concatenate",
-                "baseline.concatenate",
-                stack,
-            )
+            if hasattr(baseline_module, "concatenate"):
+                _patch_timed_method(
+                    iteration_stats,
+                    baseline_module,
+                    "concatenate",
+                    "baseline.concatenate",
+                    stack,
+                )
             _patch_timed_method(
                 iteration_stats,
                 baseline_module,

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -6,6 +6,7 @@ from scipy.sparse import SparseEfficiencyWarning
 
 import spectrochempy as scp
 from spectrochempy.processing.baselineprocessing.baselineprocessing import Baseline
+from spectrochempy.processing.transformation.concatenate import concatenate
 from spectrochempy.utils.testing import assert_dataset_equal
 
 
@@ -63,6 +64,16 @@ def _make_shape_probe_dataset(
     )
     dataset.name = name
     return dataset
+
+
+def _explicit_polynomial_support(dataset, ranges):
+    sections = []
+    for pair in ranges:
+        section = dataset[..., slice(*pair)]
+        if section is None:
+            continue
+        sections.append(section)
+    return concatenate(sections)
 
 
 def test_baseline_fit_1d(synthetic_1d_baseline_dataset):
@@ -539,6 +550,34 @@ def test_baseline_polynomial_accepts_partially_out_of_domain_ranges(descending):
     assert blc.baseline.units == dataset.units
     assert blc.corrected.units == dataset.units
     assert blc.baseline.x.is_descendant == dataset.x.is_descendant
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize(
+    ("n_rows", "descending", "masked"),
+    [
+        (None, False, False),
+        (None, True, False),
+        (3, False, False),
+        (3, True, True),
+    ],
+)
+def test_baseline_polynomial_support_assembly_matches_explicit_concatenation(
+    n_rows, descending, masked
+):
+    dataset = _make_shape_probe_dataset(n_rows=n_rows, descending=descending)
+    if masked:
+        dataset[1400.0:1500.0] = scp.MASKED
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order=3, include_limits=False)
+    blc.ranges = [[1000.0, 1125.0], [1875.0, 2000.0]]
+    blc.fit(dataset)
+
+    expected = _explicit_polynomial_support(blc._X, blc.used_ranges)
+    expected.sort(inplace=True, descend=False)
+
+    assert_dataset_equal(blc._X_ranges, expected)
     assert_dataset_equal(dataset, original)
 
 

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -567,6 +567,7 @@ def test_baseline_polynomial_support_assembly_matches_explicit_concatenation(
 ):
     dataset = _make_shape_probe_dataset(n_rows=n_rows, descending=descending)
     if masked:
+        dataset[1050.0:1100.0] = scp.MASKED
         dataset[1400.0:1500.0] = scp.MASKED
     original = dataset.copy()
 
@@ -578,6 +579,7 @@ def test_baseline_polynomial_support_assembly_matches_explicit_concatenation(
     expected.sort(inplace=True, descend=False)
 
     assert_dataset_equal(blc._X_ranges, expected)
+    assert np.array_equal(np.asarray(blc._X_ranges.mask), np.asarray(expected.mask))
     assert_dataset_equal(dataset, original)
 
 


### PR DESCRIPTION
Summary
- replace the polynomial support assembly path with direct masked-data concatenation plus coordinate reconstruction
- keep the public Baseline contract unchanged while avoiding intermediate section datasets before _X_ranges is built
- add a regression test that compares _X_ranges against the historical explicit slice-plus-concatenate assembly

Validation
- micromamba run -n scpy-core python -m pytest tests/test_analysis/test_baseline/test_baseline.py -k support_assembly_matches_explicit_concatenation -q
- micromamba run -n scpy-core python -m pytest tests/test_analysis/test_baseline/test_baseline.py -q
- pre-commit run --all-files

Before / after median uninstrumented fit()
- poly1d_n1024: 236.83 ms -> 138.27 ms
- poly1d_n4096: 234.78 ms -> 139.33 ms
- poly1d_n16384: 261.36 ms -> 200.17 ms
- poly2d_m1_n4096: 229.56 ms -> 167.01 ms
- poly2d_m8_n4096: 223.85 ms -> 187.93 ms
- poly2d_m32_n4096: 275.96 ms -> 228.32 ms

Notes
- instrumented polynomial runs no longer report baseline.concatenate as a dominant fit component
- no changes were made to traitlets, general sorting, NDDataset.concatenate(), or non-polynomial models