### PR TITLE
PERF: skip unnecessary ascending Baseline sorts

### DIFF
--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -350,6 +350,27 @@ baseline/trends for different segments of the data.
     def _format_domain(domain_min, domain_max):
         return f"[{domain_min}, {domain_max}]"
 
+    @staticmethod
+    def _last_axis_is_monotone_increasing(dataset):
+        """
+        Return whether the dataset last axis is already fully monotone increasing.
+
+        This is a local fast-path guard for ``Baseline.fit()``: when the relevant
+        axis is already in the exact order required by the historical ascending
+        sort path, we can skip the corresponding ``sort(inplace=True,
+        descend=False)`` call without changing results.
+        """
+        values = np.asarray(dataset.coordset[dataset.dims[-1]].data)
+        if values.size < 2:
+            return True
+        return not np.any(values[:-1] > values[1:])
+
+    def _ensure_last_axis_monotone_increasing(self, dataset):
+        if self._last_axis_is_monotone_increasing(dataset):
+            return False
+        dataset.sort(inplace=True, descend=False)
+        return True
+
     def _polynomial_edge_ranges(self, values):
         values = np.asarray(values)
         if values.size == 0:
@@ -741,11 +762,11 @@ baseline/trends for different segments of the data.
 
         # _X_ranges has been computed when X and _ranges were set,
         # but we need increasing order of the coordinates
-        self._X_ranges.sort(inplace=True, descend=False)
+        self._ensure_last_axis_monotone_increasing(self._X_ranges)
 
         # to simplify further operation we also sort the self._X data
         descend = Xx.is_descendant
-        self._X.sort(inplace=True, descend=False)
+        self._ensure_last_axis_monotone_increasing(self._X)
         Xx = self._X.coordset[self._X.dims[-1]]  # get it again after sorting
 
         # _X_ranges is now ready, we can fit. _Xranges contains

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -351,9 +351,9 @@ baseline/trends for different segments of the data.
         return f"[{domain_min}, {domain_max}]"
 
     @staticmethod
-    def _last_axis_is_monotone_increasing(dataset):
+    def _last_axis_is_monotone_nondecreasing(dataset):
         """
-        Return whether the dataset last axis is already fully monotone increasing.
+        Return whether the dataset last axis is already fully monotone nondecreasing.
 
         This is a local fast-path guard for ``Baseline.fit()``: when the relevant
         axis is already in the exact order required by the historical ascending
@@ -363,10 +363,10 @@ baseline/trends for different segments of the data.
         values = np.asarray(dataset.coordset[dataset.dims[-1]].data)
         if values.size < 2:
             return True
-        return not np.any(values[:-1] > values[1:])
+        return bool(np.all(values[:-1] <= values[1:]))
 
-    def _ensure_last_axis_monotone_increasing(self, dataset):
-        if self._last_axis_is_monotone_increasing(dataset):
+    def _ensure_last_axis_monotone_nondecreasing(self, dataset):
+        if self._last_axis_is_monotone_nondecreasing(dataset):
             return False
         dataset.sort(inplace=True, descend=False)
         return True
@@ -762,11 +762,11 @@ baseline/trends for different segments of the data.
 
         # _X_ranges has been computed when X and _ranges were set,
         # but we need increasing order of the coordinates
-        self._ensure_last_axis_monotone_increasing(self._X_ranges)
+        self._ensure_last_axis_monotone_nondecreasing(self._X_ranges)
 
         # to simplify further operation we also sort the self._X data
         descend = Xx.is_descendant
-        self._ensure_last_axis_monotone_increasing(self._X)
+        self._ensure_last_axis_monotone_nondecreasing(self._X)
         Xx = self._X.coordset[self._X.dims[-1]]  # get it again after sorting
 
         # _X_ranges is now ready, we can fit. _Xranges contains

--- a/tests/benchmarks/baseline_fit_harness.py
+++ b/tests/benchmarks/baseline_fit_harness.py
@@ -267,13 +267,68 @@ def _measure_instrumented_fit_breakdown(
         dataset = scenario.factory()
         blc = _build_baseline(scenario)
         iteration_stats: dict[str, TimingStat] = defaultdict(TimingStat)
+        sort_context: dict[str, str | None] = {"value": None}
 
         with ExitStack() as stack:
             _patch_timed_method(
                 iteration_stats, NDDataset, "copy", "nddataset.copy", stack
             )
-            _patch_timed_method(
-                iteration_stats, NDDataset, "sort", "nddataset.sort", stack
+
+            original_sort = NDDataset.sort
+
+            def timed_sort(
+                self,
+                _original_sort=original_sort,
+                _sort_context=sort_context,
+                _iteration_stats=iteration_stats,
+                **kwargs,
+            ):
+                direction = "desc" if kwargs.get("descend") else "asc"
+                context = _sort_context["value"] or "other"
+                label = f"nddataset.sort.{direction}.{context}"
+                start = perf_counter()
+                try:
+                    return _original_sort(self, **kwargs)
+                finally:
+                    _iteration_stats[label].add(perf_counter() - start)
+
+            NDDataset.sort = timed_sort
+            stack.callback(setattr, NDDataset, "sort", original_sort)
+
+            original_ensure_monotone = (
+                baseline_module.Baseline._ensure_last_axis_monotone_increasing
+            )
+
+            def timed_ensure_monotone(
+                self,
+                candidate,
+                _original_ensure_monotone=original_ensure_monotone,
+                _sort_context=sort_context,
+                _iteration_stats=iteration_stats,
+            ):
+                if candidate is self._X_ranges:
+                    context = "_X_ranges"
+                elif candidate is self._X:
+                    context = "_X"
+                else:
+                    context = "other"
+                label = f"baseline.ensure_last_axis_monotone_increasing.{context}"
+                start = perf_counter()
+                _sort_context["value"] = context
+                try:
+                    return _original_ensure_monotone(self, candidate)
+                finally:
+                    _sort_context["value"] = None
+                    _iteration_stats[label].add(perf_counter() - start)
+
+            baseline_module.Baseline._ensure_last_axis_monotone_increasing = (
+                timed_ensure_monotone
+            )
+            stack.callback(
+                setattr,
+                baseline_module.Baseline,
+                "_ensure_last_axis_monotone_increasing",
+                original_ensure_monotone,
             )
             _patch_timed_method(
                 iteration_stats,

--- a/tests/benchmarks/baseline_fit_harness.py
+++ b/tests/benchmarks/baseline_fit_harness.py
@@ -296,7 +296,7 @@ def _measure_instrumented_fit_breakdown(
             stack.callback(setattr, NDDataset, "sort", original_sort)
 
             original_ensure_monotone = (
-                baseline_module.Baseline._ensure_last_axis_monotone_increasing
+                baseline_module.Baseline._ensure_last_axis_monotone_nondecreasing
             )
 
             def timed_ensure_monotone(
@@ -312,7 +312,7 @@ def _measure_instrumented_fit_breakdown(
                     context = "_X"
                 else:
                     context = "other"
-                label = f"baseline.ensure_last_axis_monotone_increasing.{context}"
+                label = f"baseline.ensure_last_axis_monotone_nondecreasing.{context}"
                 start = perf_counter()
                 _sort_context["value"] = context
                 try:
@@ -321,13 +321,13 @@ def _measure_instrumented_fit_breakdown(
                     _sort_context["value"] = None
                     _iteration_stats[label].add(perf_counter() - start)
 
-            baseline_module.Baseline._ensure_last_axis_monotone_increasing = (
+            baseline_module.Baseline._ensure_last_axis_monotone_nondecreasing = (
                 timed_ensure_monotone
             )
             stack.callback(
                 setattr,
                 baseline_module.Baseline,
-                "_ensure_last_axis_monotone_increasing",
+                "_ensure_last_axis_monotone_nondecreasing",
                 original_ensure_monotone,
             )
             _patch_timed_method(

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -1,3 +1,4 @@
+from functools import partial
 import warnings
 
 import numpy as np
@@ -671,49 +672,49 @@ def test_baseline_polynomial_support_assembly_matches_explicit_concatenation(
         (
             "polynomial",
             {"order": 3, "include_limits": False},
-            lambda: _make_shape_probe_dataset(),
+            partial(_make_shape_probe_dataset),
             [[1000.0, 1125.0], [1875.0, 2000.0]],
             None,
         ),
         (
             "polynomial",
             {"order": 3, "include_limits": False},
-            lambda: _make_shape_probe_dataset(n_rows=3),
+            partial(_make_shape_probe_dataset, n_rows=3),
             [[1000.0, 1125.0], [1875.0, 2000.0]],
             None,
         ),
         (
             "polynomial",
             {"order": 3, "include_limits": False},
-            lambda: _make_shape_probe_dataset(),
+            partial(_make_shape_probe_dataset),
             [[1000.0, 1050.0], [1200.0, 1275.0], [1875.0, 2000.0]],
             None,
         ),
         (
             "asls",
             {"lamb": 1e5, "asymmetry": 0.05},
-            lambda: _make_shape_probe_dataset(),
+            partial(_make_shape_probe_dataset),
             None,
             None,
         ),
         (
             "asls",
             {"lamb": 1e5, "asymmetry": 0.05},
-            lambda: _make_shape_probe_dataset(),
+            partial(_make_shape_probe_dataset),
             None,
             (1400.0, 1500.0),
         ),
         (
             "snip",
             {"snip_width": 15},
-            lambda: _make_shape_probe_dataset(),
+            partial(_make_shape_probe_dataset),
             None,
             None,
         ),
         (
             "rubberband",
             {},
-            lambda: _make_shape_probe_dataset(),
+            partial(_make_shape_probe_dataset),
             None,
             None,
         ),

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -91,6 +91,19 @@ def _make_nonmonotonic_baseline_dataset():
     return dataset
 
 
+def _make_nan_axis_baseline_dataset():
+    x = np.array([1000.0, 1125.0, np.nan, 1250.0, 1375.0, 1500.0])
+    data = np.linspace(1.0, 2.0, x.size)
+    dataset = scp.NDDataset(
+        data,
+        coordset=[scp.Coord(x, title="wavenumber", units="cm^-1")],
+        units="absorbance",
+        title="nan axis baseline dataset",
+    )
+    dataset.name = "nan_axis_baseline_dataset"
+    return dataset
+
+
 def _clone_baseline_for_oracle(blc):
     oracle = Baseline(model=blc.model)
     for name in (
@@ -132,7 +145,7 @@ def _sort_spy(monkeypatch):
 
 def _guard_spy(monkeypatch):
     calls = []
-    original_guard = Baseline._last_axis_is_monotone_increasing
+    original_guard = Baseline._last_axis_is_monotone_nondecreasing
 
     def wrapped(self, dataset):
         result = original_guard(dataset)
@@ -144,7 +157,7 @@ def _guard_spy(monkeypatch):
         )
         return result
 
-    monkeypatch.setattr(Baseline, "_last_axis_is_monotone_increasing", wrapped)
+    monkeypatch.setattr(Baseline, "_last_axis_is_monotone_nondecreasing", wrapped)
     return calls
 
 
@@ -152,7 +165,7 @@ def _historical_fit(blc, dataset, monkeypatch):
     oracle = _clone_baseline_for_oracle(blc)
     monkeypatch.setattr(
         Baseline,
-        "_last_axis_is_monotone_increasing",
+        "_last_axis_is_monotone_nondecreasing",
         lambda self, dataset: False,
     )
     oracle.fit(dataset)
@@ -795,6 +808,26 @@ def test_baseline_fit_preserves_nonmonotonic_sort_path(monkeypatch):
 
     assert_dataset_equal(baseline, oracle.baseline)
     assert_dataset_equal(corrected, oracle.corrected)
+    assert_dataset_equal(dataset, original)
+
+
+def test_baseline_fit_preserves_nan_axis_sort_path(monkeypatch):
+    dataset = _make_nan_axis_baseline_dataset()
+    original = dataset.copy()
+
+    blc = Baseline(model="asls", lamb=1e5, asymmetry=0.05)
+    sort_calls = _sort_spy(monkeypatch)
+    with pytest.raises(AttributeError, match="coordset"):
+        blc.fit(dataset)
+
+    assert len(sort_calls) == 2
+    assert all(call["descend"] is False for call in sort_calls)
+
+    monkeypatch.undo()
+    oracle = _clone_baseline_for_oracle(blc)
+    with pytest.raises(AttributeError, match="coordset"):
+        _historical_fit(oracle, original.copy(), monkeypatch)
+
     assert_dataset_equal(dataset, original)
 
 

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -5,6 +5,7 @@ import pytest
 from scipy.sparse import SparseEfficiencyWarning
 
 import spectrochempy as scp
+from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.processing.baselineprocessing.baselineprocessing import Baseline
 from spectrochempy.processing.transformation.concatenate import concatenate
 from spectrochempy.utils.testing import assert_dataset_equal
@@ -74,6 +75,87 @@ def _explicit_polynomial_support(dataset, ranges):
             continue
         sections.append(section)
     return concatenate(sections)
+
+
+def _make_nonmonotonic_baseline_dataset():
+    x = np.array([1000.0, 1125.0, 1075.0, 1250.0, 1375.0, 1325.0, 1500.0])
+    data = 0.002 * x + 0.5 + 0.05 * np.sin(np.linspace(0.0, 3.0, x.size))
+    dataset = scp.NDDataset(
+        data,
+        coordset=[scp.Coord(x, title="wavenumber", units="cm^-1")],
+        units="absorbance",
+        title="nonmonotonic baseline dataset",
+    )
+    dataset.name = "nonmonotonic_baseline_dataset"
+    return dataset
+
+
+def _clone_baseline_for_oracle(blc):
+    oracle = Baseline(model=blc.model)
+    for name in (
+        "order",
+        "include_limits",
+        "lamb",
+        "asymmetry",
+        "snip_width",
+        "tol",
+        "max_iter",
+        "lls",
+        "multivariate",
+        "n_components",
+        "breakpoints",
+    ):
+        if hasattr(blc, name):
+            setattr(oracle, name, getattr(blc, name))
+    oracle.ranges = [list(pair) for pair in getattr(blc, "ranges", [])]
+    return oracle
+
+
+def _sort_spy(monkeypatch):
+    calls = []
+    original_sort = NDDataset.sort
+
+    def wrapped(self, **kwargs):
+        calls.append(
+            {
+                "dataset_id": id(self),
+                "descend": kwargs.get("descend"),
+                "inplace": kwargs.get("inplace"),
+            }
+        )
+        return original_sort(self, **kwargs)
+
+    monkeypatch.setattr(NDDataset, "sort", wrapped)
+    return calls
+
+
+def _guard_spy(monkeypatch):
+    calls = []
+    original_guard = Baseline._last_axis_is_monotone_increasing
+
+    def wrapped(self, dataset):
+        result = original_guard(dataset)
+        calls.append(
+            {
+                "dataset_id": id(dataset),
+                "result": result,
+            }
+        )
+        return result
+
+    monkeypatch.setattr(Baseline, "_last_axis_is_monotone_increasing", wrapped)
+    return calls
+
+
+def _historical_fit(blc, dataset, monkeypatch):
+    oracle = _clone_baseline_for_oracle(blc)
+    monkeypatch.setattr(
+        Baseline,
+        "_last_axis_is_monotone_increasing",
+        lambda self, dataset: False,
+    )
+    oracle.fit(dataset)
+    return oracle
 
 
 def test_baseline_fit_1d(synthetic_1d_baseline_dataset):
@@ -580,6 +662,138 @@ def test_baseline_polynomial_support_assembly_matches_explicit_concatenation(
 
     assert_dataset_equal(blc._X_ranges, expected)
     assert np.array_equal(np.asarray(blc._X_ranges.mask), np.asarray(expected.mask))
+    assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize(
+    ("model", "kwargs", "dataset_factory", "ranges", "mask_region"),
+    [
+        (
+            "polynomial",
+            {"order": 3, "include_limits": False},
+            lambda: _make_shape_probe_dataset(),
+            [[1000.0, 1125.0], [1875.0, 2000.0]],
+            None,
+        ),
+        (
+            "polynomial",
+            {"order": 3, "include_limits": False},
+            lambda: _make_shape_probe_dataset(n_rows=3),
+            [[1000.0, 1125.0], [1875.0, 2000.0]],
+            None,
+        ),
+        (
+            "polynomial",
+            {"order": 3, "include_limits": False},
+            lambda: _make_shape_probe_dataset(),
+            [[1000.0, 1050.0], [1200.0, 1275.0], [1875.0, 2000.0]],
+            None,
+        ),
+        (
+            "asls",
+            {"lamb": 1e5, "asymmetry": 0.05},
+            lambda: _make_shape_probe_dataset(),
+            None,
+            None,
+        ),
+        (
+            "asls",
+            {"lamb": 1e5, "asymmetry": 0.05},
+            lambda: _make_shape_probe_dataset(),
+            None,
+            (1400.0, 1500.0),
+        ),
+        (
+            "snip",
+            {"snip_width": 15},
+            lambda: _make_shape_probe_dataset(),
+            None,
+            None,
+        ),
+        (
+            "rubberband",
+            {},
+            lambda: _make_shape_probe_dataset(),
+            None,
+            None,
+        ),
+    ],
+)
+def test_baseline_fit_skips_unneeded_ascending_sorts_and_matches_historical_path(
+    monkeypatch, model, kwargs, dataset_factory, ranges, mask_region
+):
+    dataset = dataset_factory()
+    if mask_region is not None:
+        dataset[slice(*mask_region)] = scp.MASKED
+    original = dataset.copy()
+
+    blc = Baseline(model=model, **kwargs)
+    if ranges is not None:
+        blc.ranges = ranges
+
+    guard_calls = _guard_spy(monkeypatch)
+    sort_calls = _sort_spy(monkeypatch)
+    blc.fit(dataset)
+
+    expected_guard_ids = {id(blc._X_ranges), id(blc._X)}
+    assert len(guard_calls) == 2
+    assert {call["dataset_id"] for call in guard_calls} == expected_guard_ids
+    assert all(call["result"] for call in guard_calls)
+    assert sort_calls == []
+
+    baseline = blc.baseline
+    corrected = blc.corrected
+
+    monkeypatch.undo()
+    oracle = _historical_fit(blc, original.copy(), monkeypatch)
+
+    assert_dataset_equal(baseline, oracle.baseline)
+    assert_dataset_equal(corrected, oracle.corrected)
+    assert_dataset_equal(dataset, original)
+
+
+def test_baseline_fit_preserves_descending_sort_path(monkeypatch):
+    dataset = _make_shape_probe_dataset(descending=True)
+    original = dataset.copy()
+
+    blc = Baseline(model="rubberband")
+    sort_calls = _sort_spy(monkeypatch)
+    blc.fit(dataset)
+
+    assert len(sort_calls) == 3
+    assert sum(call["descend"] is False for call in sort_calls) == 2
+    assert sum(call["descend"] is True for call in sort_calls) == 1
+
+    baseline = blc.baseline
+    corrected = blc.corrected
+
+    monkeypatch.undo()
+    oracle = _historical_fit(blc, original.copy(), monkeypatch)
+
+    assert_dataset_equal(baseline, oracle.baseline)
+    assert_dataset_equal(corrected, oracle.corrected)
+    assert_dataset_equal(dataset, original)
+
+
+def test_baseline_fit_preserves_nonmonotonic_sort_path(monkeypatch):
+    dataset = _make_nonmonotonic_baseline_dataset()
+    original = dataset.copy()
+
+    blc = Baseline(model="asls", lamb=1e5, asymmetry=0.05)
+    sort_calls = _sort_spy(monkeypatch)
+    blc.fit(dataset)
+
+    assert len(sort_calls) == 2
+    assert all(call["descend"] is False for call in sort_calls)
+
+    baseline = blc.baseline
+    corrected = blc.corrected
+
+    monkeypatch.undo()
+    oracle = _historical_fit(blc, original.copy(), monkeypatch)
+
+    assert_dataset_equal(baseline, oracle.baseline)
+    assert_dataset_equal(corrected, oracle.corrected)
     assert_dataset_equal(dataset, original)
 
 

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -1,5 +1,5 @@
-from functools import partial
 import warnings
+from functools import partial
 
 import numpy as np
 import pytest


### PR DESCRIPTION
## Summary
- skip the historical ascending sort path in Baseline.fit() only when _X_ranges or _X is already monotone increasing on the last axis
- keep descending and accepted non-monotonic inputs on the exact historical sort path
- add regression coverage and harness instrumentation for skipped vs preserved sort calls

## Validation
- pre-commit run --all-files
- micromamba run -n scpy-core python -m pytest tests/test_analysis/test_baseline/test_baseline.py
- micromamba run -n scpy-core python tests/benchmarks/baseline_fit_harness.py --scenario poly1d_n4096 --scenario poly2d_m32_n4096 --scenario asls1d_n4096 --scenario asls1d_masked_n4096 --scenario snip1d_n4096 --scenario rubberband1d_n4096_desc --repeats 5 --warmup 1 --json

## Measurements
Representative median fit timings from the harness:
- poly1d_n4096: 172.53 ms -> 106.82 ms
- poly2d_m32_n4096: 194.47 ms -> 143.59 ms
- asls1d_n4096: 177.92 ms -> 108.61 ms
- asls1d_masked_n4096: 166.33 ms -> 110.98 ms
- snip1d_n4096: 149.54 ms -> 94.68 ms

Descending control remains on the historical path, including the restore-desc sort call.