### PR TITLE
FIX: prevent false linearization of descending duplicated coordinates

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Fixed a false linearity detection in ``Coord`` that could silently replace
+  descending coordinates containing duplicated or irregularly spaced values
+  with an artificial uniform grid. Such coordinates are now preserved as
+  provided, while genuinely regular ascending and descending axes keep being
+  detected as linear.
+
 - Hardened polynomial baseline fitting on short or underspecified spectra by
   validating support size explicitly, reporting non-intersecting ranges with
   clear ``ValueError`` messages, and avoiding internal index failures when

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,12 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Fixed a false linearity detection in ``Coord`` that could silently replace
+  descending coordinates containing duplicated or irregularly spaced values
+  with an artificial uniform grid. Such coordinates are now preserved as
+  provided, while genuinely regular ascending and descending axes keep being
+  detected as linear.
+
 - Hardened polynomial baseline fitting on short or underspecified spectra by
   validating support size explicitly, reporting non-intersecting ranges with
   clear ``ValueError`` messages, and avoiding internal index failures when

--- a/src/spectrochempy/core/dataset/coord.py
+++ b/src/spectrochempy/core/dataset/coord.py
@@ -897,17 +897,27 @@ class Coord(NDMath, NDArray):
         makeitlinear = is_number(spacing)
 
         if not makeitlinear and is_iterable(spacing):
-            # may be the variation in % are small enough (0.1%)
-            spacing_max = np.max(spacing)
-            spacing_scale = np.abs(spacing_max)
-            if spacing_scale == 0:
-                variation = 0.0
+            # The spacings are not uniform at the requested precision.
+            # Decide whether they are close enough to uniform to allow
+            # linearization, using magnitude-based comparisons so that
+            # ascending and descending axes are treated symmetrically.
+            mags = np.abs(np.asarray(spacing, dtype=float))
+            signs = np.sign(spacing)
+            if (
+                not np.all(np.isfinite(mags))
+                or np.any(mags == 0)
+                or np.unique(signs[signs != 0]).size > 1
+            ):
+                # A zero spacing (duplicated coordinate value), a non-finite
+                # spacing, or spacings of opposite signs can never describe a
+                # regularly spaced axis: keep the original data untouched.
+                makeitlinear = False
             else:
-                variation = (
-                    (spacing_max - np.min(spacing)) * 100.0 / spacing_scale / 2.0
-                )
-            if variation <= self._linearize_below:
-                makeitlinear = True
+                spacing_max = np.max(mags)
+                spacing_min = np.min(mags)
+                variation = (spacing_max - spacing_min) * 100.0 / spacing_max / 2.0
+                if variation <= self._linearize_below:
+                    makeitlinear = True
 
         if makeitlinear:
             # single spacing with this precision

--- a/tests/test_core/test_dataset/test_coord_linearize.py
+++ b/tests/test_core/test_dataset/test_coord_linearize.py
@@ -1,4 +1,5 @@
-"""Regression tests for Coord.linearize() linearity detection.
+"""
+Regression tests for Coord.linearize() linearity detection.
 
 These tests cover the symmetric handling of ascending and descending axes,
 and ensure that irregular or duplicated coordinates are never silently
@@ -10,7 +11,6 @@ import pytest
 
 from spectrochempy import NDDataset
 from spectrochempy.core.dataset.coord import Coord
-
 
 # ==============================================================================
 # Regular axes: intentional linearization must be preserved
@@ -153,6 +153,7 @@ class TestLinearizeDuplicateValues:
         c = Coord(values)
         np.testing.assert_allclose(c.data, values)
 
+
 # ==============================================================================
 # Non-finite values: no artificial linearization, no silent loss
 # ==============================================================================
@@ -188,9 +189,7 @@ class TestNDDatasetDescendingDuplicateIntegration:
     def test_dataset_keeps_descending_duplicated_coordinates(self):
         # historical bug: this axis was replaced by a uniform grid at
         # dataset-construction time, before any processing could see it
-        values = np.array(
-            [10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 1.0, 0.0]
-        )
+        values = np.array([10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 1.0, 0.0])
         ds = NDDataset(np.arange(len(values), dtype=float))
         ds.set_coordset(Coord(title="x", data=values))
         np.testing.assert_allclose(ds.x._data.squeeze(), values)

--- a/tests/test_core/test_dataset/test_coord_linearize.py
+++ b/tests/test_core/test_dataset/test_coord_linearize.py
@@ -1,0 +1,198 @@
+"""Regression tests for Coord.linearize() linearity detection.
+
+These tests cover the symmetric handling of ascending and descending axes,
+and ensure that irregular or duplicated coordinates are never silently
+rewritten into an artificial uniform grid.
+"""
+
+import numpy as np
+import pytest
+
+from spectrochempy import NDDataset
+from spectrochempy.core.dataset.coord import Coord
+
+
+# ==============================================================================
+# Regular axes: intentional linearization must be preserved
+# ==============================================================================
+
+
+class TestLinearizeRegularAxes:
+    def test_strictly_increasing_regular_is_linear(self):
+        values = np.linspace(0.0, 100.0, 51)
+        c = Coord(values)
+        assert c.linear
+        np.testing.assert_allclose(c.data, values)
+
+    def test_strictly_decreasing_regular_is_linear(self):
+        values = np.linspace(100.0, 0.0, 51)
+        c = Coord(values)
+        assert c.linear
+        np.testing.assert_allclose(c.data, values)
+
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_near_regular_within_tolerance_is_linear(self, reverse):
+        # relative spacing deviation well below the linearization tolerance
+        base = np.linspace(0.0, 10.0, 21)
+        values = base.copy()
+        values[5] += 0.001  # ~0.01% spacing deviation
+        if reverse:
+            values = values[::-1].copy()
+        c = Coord(values)
+        assert c.linear
+
+    def test_ascending_descending_equivalence_for_regular_axes(self):
+        asc = Coord(np.arange(20) * 0.5)
+        desc = Coord((np.arange(20) * 0.5)[::-1].copy())
+        assert asc.linear == desc.linear
+
+    def test_linearization_preserves_units_and_title(self):
+        c = Coord(np.linspace(0, 10, 11), units="cm^-1", title="wavenumber")
+        assert c.units is not None
+        assert c.title == "wavenumber"
+        assert c.linear
+
+
+# ==============================================================================
+# Irregular axes: values must be preserved exactly, never rewritten
+# ==============================================================================
+
+
+class TestLinearizeIrregularAxes:
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.array([0.0, 1.0, 3.0, 6.0, 10.0]),  # accelerating
+            np.array([0.0, 4.0, 7.0, 9.0, 10.0]),  # decelerating
+        ],
+    )
+    def test_irregular_increasing_not_linear(self, values):
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_allclose(c.data, values)
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.array([10.0, 9.0, 7.0, 4.0, 0.0]),
+            np.array([10.0, 6.0, 3.0, 1.0, 0.0]),
+        ],
+    )
+    def test_irregular_decreasing_not_linear(self, values):
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_allclose(c.data, values)
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.array([0.0, 1.0, 3.0, 6.0, 10.0]),
+            np.array([0.0, 4.0, 7.0, 9.0, 10.0]),
+        ],
+    )
+    def test_same_geometry_both_orientations(self, values):
+        asc = Coord(values)
+        desc = Coord(values[::-1].copy())
+        assert asc.linear == desc.linear == False  # noqa: E712
+        np.testing.assert_allclose(desc.data, values[::-1])
+
+    def test_irregular_data_kept_at_full_precision(self):
+        values = np.array([0.0, 0.1, 0.3001, 0.6002, 1.0002])
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_allclose(c._data.squeeze(), values)
+
+
+# ==============================================================================
+# Duplicates: must never be erased by an artificial linspace
+# ==============================================================================
+
+
+class TestLinearizeDuplicateValues:
+    def test_adjacent_duplicate_increasing(self):
+        values = np.array([0.0, 1.0, 1.0, 2.5, 4.0])
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_allclose(c._data.squeeze(), values)
+
+    def test_adjacent_duplicate_decreasing(self):
+        # historical bug: this axis was silently replaced by a uniform grid
+        values = np.array([4.0, 2.5, 1.0, 1.0, 0.0])
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_allclose(c._data.squeeze(), values)
+
+    @pytest.mark.parametrize("position", ["start", "middle", "end"])
+    def test_duplicate_positions_decreasing(self, position):
+        values = np.array([8.0, 6.0, 4.0, 2.0, 0.0])
+        idx = {"start": 0, "middle": 2, "end": 3}[position]
+        values[idx] = values[idx + 1]
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_allclose(c._data.squeeze(), values)
+
+    def test_multiple_duplicates_decreasing(self):
+        values = np.array([9.0, 9.0, 7.0, 5.0, 5.0, 2.0, 0.0, 0.0])
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_allclose(c._data.squeeze(), values)
+
+    def test_duplicate_symmetry_between_orientations(self):
+        asc_values = np.array([0.0, 1.0, 1.0, 3.0, 5.0])
+        desc_values = asc_values[::-1].copy()
+        asc = Coord(asc_values)
+        desc = Coord(desc_values)
+        assert asc.linear == desc.linear == False  # noqa: E712
+        np.testing.assert_allclose(asc._data.squeeze(), asc_values)
+        np.testing.assert_allclose(desc._data.squeeze(), desc_values)
+
+    def test_fully_constant_axis_stays_constant(self):
+        # intentional historical behavior: uniform detection keeps the axis
+        # linear, and the values are unchanged anyway
+        values = np.full(6, 5.0)
+        c = Coord(values)
+        np.testing.assert_allclose(c.data, values)
+
+# ==============================================================================
+# Non-finite values: no artificial linearization, no silent loss
+# ==============================================================================
+
+
+class TestLinearizeNonFiniteValues:
+    @pytest.mark.parametrize(
+        "values",
+        [
+            np.array([0.0, 1.0, np.nan, 3.0]),
+            np.array([1.0, 2.0, 3.0, np.inf]),
+            np.array([-np.inf, 1.0, 2.0, 3.0]),
+        ],
+    )
+    def test_non_finite_values_are_never_linearized(self, values):
+        c = Coord(values)
+        assert not c.linear
+        np.testing.assert_equal(c._data.squeeze(), values)
+
+    def test_non_finite_symmetry_between_orientations(self):
+        asc = Coord(np.array([1.0, 2.0, 3.0, np.inf]))
+        desc = Coord(np.array([3.0, 2.0, 1.0, -np.inf]))
+        assert not asc.linear
+        assert not desc.linear
+
+
+# ==============================================================================
+# Integration: NDDataset construction preserves provided coordinates
+# ==============================================================================
+
+
+class TestNDDatasetDescendingDuplicateIntegration:
+    def test_dataset_keeps_descending_duplicated_coordinates(self):
+        # historical bug: this axis was replaced by a uniform grid at
+        # dataset-construction time, before any processing could see it
+        values = np.array(
+            [10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 1.0, 0.0]
+        )
+        ds = NDDataset(np.arange(len(values), dtype=float))
+        ds.set_coordset(Coord(title="x", data=values))
+        np.testing.assert_allclose(ds.x._data.squeeze(), values)
+        np.testing.assert_allclose(ds.x.data, values)
+        assert not ds.x.linear


### PR DESCRIPTION
## Summary

- fix `Coord.linearize()` linearity detection: use magnitude-based spacing comparison so ascending and descending axes are treated symmetrically
- never force-linearize when a spacing is zero (duplicated coordinate value), non-finite, or of opposite sign to the others; keep the original values untouched in those cases
- preserve intentional linearization of genuinely regular or near-regular axes within the historical tolerance

## Root cause

The old variation computation used the **signed** maximum spacing as both
reference and scale:

```python
spacing_max = np.max(spacing)          # signed
spacing_scale = np.abs(spacing_max)
if spacing_scale == 0:
    variation = 0.0                    # <- forced linearization
else:
    variation = (spacing_max - np.min(spacing)) * 100.0 / spacing_scale / 2.0
```

On a **descending** axis containing a duplicated value, the zero spacing of
the duplicate is the signed maximum, so the scale was zero and the variation
was implicitly treated as 0: the axis was declared linear and its values were
rewritten with `np.linspace(data[0], data[-1], data.size)`, permanently
erasing the duplicate (and any real irregularity). Ascending duplicates kept
a positive signed maximum and were correctly rejected, hence an asymmetric
behavior.

## Fix

The decision now relies only on spacing magnitudes:

```python
mags = np.abs(spacing)
```

- a zero spacing, a non-finite spacing, or opposite-sign spacings can never
  describe a regularly spaced axis -> no linearization;
- otherwise `variation = (max(mags) - min(mags)) * 100 / max(mags) / 2`
  compared against the unchanged historical tolerance.

For ascending axes the numbers are identical to the old formula; for
descending irregular axes this makes the behavior exactly symmetric with the
ascending equivalent. Genuinely regular axes (scalar spacing branch) are
untouched.

## Validation

- new targeted regression tests (`tests/test_core/test_dataset/test_coord_linearize.py`, 26 tests):
  - regular and near-regular axes, ascending and descending (linearization preserved);
  - irregular axes, same geometry in both orientations (values preserved exactly);
  - duplicates at start/middle/end, multiple duplicates, ascending and descending symmetry, constant axis;
  - `NaN` / `+inf` / `-inf`: never linearized, values preserved;
  - integration check: an `NDDataset` built with a descending duplicated axis keeps the provided coordinates.
- `tests/test_core/test_dataset`: 1716 passed
- `tests/test_core`: 2328 passed, 1 pre-existing failure (`test_read_opus.py::TestOpusAssembledTimeResolved::test_default_absorbance`, reproduced on clean `master`)
- `tests/test_analysis/test_baseline`: 85 passed
- `pre-commit run --all-files`: all hooks passed

## Scope

No `Baseline` changes. This fixes the prerequisite defect identified in the
coordinate-order contract audit: descending duplicated coordinates were
corrupted at construction time, before any consumer could validate them.