### PR TITLE
FIX: enforce finite strictly monotonic coordinates in Baseline.fit

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,13 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- ``Baseline.fit()`` now explicitly rejects datasets whose last-axis
+  coordinates contain non-finite values (``NaN`` or infinities), duplicated
+  values, or direction changes, raising a clear ``ValueError`` instead of
+  silently reordering results or failing with model-dependent internal
+  errors. Strictly monotonic but irregularly spaced axes remain accepted, in
+  both increasing and decreasing orders.
+
 - Fixed a false linearity detection in ``Coord`` that could silently replace
   descending coordinates containing duplicated or irregularly spaced values
   with an artificial uniform grid. Such coordinates are now preserved as

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,13 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- ``Baseline.fit()`` now explicitly rejects datasets whose last-axis
+  coordinates contain non-finite values (``NaN`` or infinities), duplicated
+  values, or direction changes, raising a clear ``ValueError`` instead of
+  silently reordering results or failing with model-dependent internal
+  errors. Strictly monotonic but irregularly spaced axes remain accepted, in
+  both increasing and decreasing orders.
+
 - Fixed a false linearity detection in ``Coord`` that could silently replace
   descending coordinates containing duplicated or irregularly spaced values
   with an artificial uniform grid. Such coordinates are now preserved as

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -391,9 +391,10 @@ baseline/trends for different segments of the data.
         try:
             coord = X.coordset[X.dims[-1]]
             values = np.asarray(coord.data)
-        except Exception:
-            # datasets without usable coordinates are left to the existing
-            # machinery, which reports its own historical error
+        except (AttributeError, TypeError):
+            # inputs without usable coordinates (plain arrays or datasets
+            # without a coordset) are left to the existing machinery, which
+            # reports its own historical error; anything else must propagate
             return
         if values.dtype.kind not in "fiu" or values.size < 2:
             return
@@ -787,7 +788,11 @@ baseline/trends for different segments of the data.
             increasing or strictly decreasing.
 
         """
-        # Reject invalid last-axis coordinates first, before any copy, range
+        # Reset the fitted state first: a rejected fit must not leave the
+        # instance exposing results from a previous successful fit.
+        self._fitted = False
+
+        # Reject invalid last-axis coordinates before any copy, range
         # construction, mask removal, sort or numerical work.
         self._validate_last_axis_coordinates(X)
 

--- a/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
+++ b/src/spectrochempy/processing/baselineprocessing/baselineprocessing.py
@@ -103,6 +103,12 @@ class Baseline(AnalysisConfigurable):
     By default, `ranges` is set to the feature limits (i.e., ``ranges=[features[0],
     features[-1]]``) and the baseline is fitted on the full range of the dataset.
 
+    The last axis of the input dataset must have finite coordinates that are
+    strictly increasing or strictly decreasing. Irregularly spaced coordinates
+    are accepted as long as they are strictly monotonic. Duplicated coordinate
+    values, direction changes, and non-finite values (``NaN`` or infinities)
+    are rejected with a ``ValueError`` when ``fit`` is called.
+
     Parameters
     ----------
     log_level : any of [``"INFO"``, ``"DEBUG"``, ``"WARNING"``, ``"ERROR"``], optional, default: ``"WARNING"``
@@ -370,6 +376,39 @@ baseline/trends for different segments of the data.
             return False
         dataset.sort(inplace=True, descend=False)
         return True
+
+    @staticmethod
+    def _validate_last_axis_coordinates(X):
+        """
+        Reject invalid last-axis coordinates before any fitting work.
+
+        The last axis coordinates must be finite and strictly increasing or
+        strictly decreasing (full-axis check, not inferred from the axis
+        endpoints). Duplicated coordinate values and direction changes are
+        rejected, as well as ``NaN`` or infinite values. Irregularly spaced
+        but strictly monotonic coordinates are accepted.
+        """
+        try:
+            coord = X.coordset[X.dims[-1]]
+            values = np.asarray(coord.data)
+        except Exception:
+            # datasets without usable coordinates are left to the existing
+            # machinery, which reports its own historical error
+            return
+        if values.dtype.kind not in "fiu" or values.size < 2:
+            return
+        if not np.all(np.isfinite(values)):
+            raise ValueError(
+                "Baseline fitting requires finite last-axis coordinates: "
+                "NaN or infinite coordinate values are not accepted."
+            )
+        diffs = np.diff(values)
+        if not (np.all(diffs > 0) or np.all(diffs < 0)):
+            raise ValueError(
+                "Baseline fitting requires last-axis coordinates to be "
+                "strictly increasing or strictly decreasing: duplicated "
+                "coordinate values and direction changes are not accepted."
+            )
 
     def _polynomial_edge_ranges(self, values):
         values = np.asarray(values)
@@ -732,14 +771,26 @@ baseline/trends for different segments of the data.
         Parameters
         ----------
         X : `NDDataset` or :term:`array-like` of shape (:term:`n_observations`, :term:`n_features`)
-            Training data.
+            Training data. The last-axis coordinates must be finite and
+            strictly increasing or strictly decreasing (duplicated values,
+            direction changes and non-finite values are rejected).
 
         Returns
         -------
         self
             The fitted instance itself.
 
+        Raises
+        ------
+        ValueError
+            If the last-axis coordinates are not finite, or not strictly
+            increasing or strictly decreasing.
+
         """
+        # Reject invalid last-axis coordinates first, before any copy, range
+        # construction, mask removal, sort or numerical work.
+        self._validate_last_axis_coordinates(X)
+
         self._fitted = False  # reinit this flag
 
         # Set X

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -9,6 +9,7 @@ import spectrochempy as scp
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.processing.baselineprocessing.baselineprocessing import Baseline
 from spectrochempy.processing.transformation.concatenate import concatenate
+from spectrochempy.utils.exceptions import NotFittedError
 from spectrochempy.utils.testing import assert_dataset_equal
 
 
@@ -927,6 +928,29 @@ def test_baseline_validation_runs_before_numerical_kernel(model, kwargs):
     finally:
         mp.undo()
     assert kernel_spy_called == []
+
+
+@pytest.mark.parametrize("model,kwargs", _BASELINE_CONTRACT_MODELS)
+def test_baseline_rejected_refit_resets_fitted_state(model, kwargs):
+    # a successful fit followed by an invalid refit must not leave the
+    # instance exposing the previous results as if they were still valid
+    good_dataset = _make_shape_probe_dataset()
+    bad_dataset = _make_contract_probe_dataset([1000.0, 1125.0, 1125.0, 1375.0, 1500.0])
+
+    blc = _contract_baseline(model, kwargs)
+    blc.fit(good_dataset)
+    assert blc._fitted is True
+
+    with pytest.raises(ValueError, match="strictly"):
+        blc.fit(bad_dataset)
+
+    assert blc._fitted is False
+    with pytest.raises(NotFittedError):
+        _ = blc.baseline
+    with pytest.raises(NotFittedError):
+        _ = blc.corrected
+    with pytest.raises(NotFittedError):
+        blc.transform()
 
 
 def test_baseline_rejects_duplicates_before_breakpoint_and_pchip_paths():

--- a/tests/test_analysis/test_baseline/test_baseline.py
+++ b/tests/test_analysis/test_baseline/test_baseline.py
@@ -78,32 +78,6 @@ def _explicit_polynomial_support(dataset, ranges):
     return concatenate(sections)
 
 
-def _make_nonmonotonic_baseline_dataset():
-    x = np.array([1000.0, 1125.0, 1075.0, 1250.0, 1375.0, 1325.0, 1500.0])
-    data = 0.002 * x + 0.5 + 0.05 * np.sin(np.linspace(0.0, 3.0, x.size))
-    dataset = scp.NDDataset(
-        data,
-        coordset=[scp.Coord(x, title="wavenumber", units="cm^-1")],
-        units="absorbance",
-        title="nonmonotonic baseline dataset",
-    )
-    dataset.name = "nonmonotonic_baseline_dataset"
-    return dataset
-
-
-def _make_nan_axis_baseline_dataset():
-    x = np.array([1000.0, 1125.0, np.nan, 1250.0, 1375.0, 1500.0])
-    data = np.linspace(1.0, 2.0, x.size)
-    dataset = scp.NDDataset(
-        data,
-        coordset=[scp.Coord(x, title="wavenumber", units="cm^-1")],
-        units="absorbance",
-        title="nan axis baseline dataset",
-    )
-    dataset.name = "nan_axis_baseline_dataset"
-    return dataset
-
-
 def _clone_baseline_for_oracle(blc):
     oracle = Baseline(model=blc.model)
     for name in (
@@ -217,7 +191,7 @@ def test_baseline_corrected_preserves_shape_for_strict_1d_inputs(
     dataset = _make_shape_probe_dataset(descending=descending)
     original = dataset.copy()
 
-    blc = Baseline(model=model, **kwargs)
+    blc = _contract_baseline(model, kwargs)
     blc.fit(dataset)
 
     baseline = blc.baseline
@@ -254,7 +228,7 @@ def test_baseline_corrected_preserves_shape_for_2d_inputs(model, kwargs, n_rows)
     dataset = _make_shape_probe_dataset(n_rows=n_rows)
     original = dataset.copy()
 
-    blc = Baseline(model=model, **kwargs)
+    blc = _contract_baseline(model, kwargs)
     blc.fit(dataset)
 
     baseline = blc.baseline
@@ -741,7 +715,7 @@ def test_baseline_fit_skips_unneeded_ascending_sorts_and_matches_historical_path
         dataset[slice(*mask_region)] = scp.MASKED
     original = dataset.copy()
 
-    blc = Baseline(model=model, **kwargs)
+    blc = _contract_baseline(model, kwargs)
     if ranges is not None:
         blc.ranges = ranges
 
@@ -789,45 +763,196 @@ def test_baseline_fit_preserves_descending_sort_path(monkeypatch):
     assert_dataset_equal(dataset, original)
 
 
-def test_baseline_fit_preserves_nonmonotonic_sort_path(monkeypatch):
-    dataset = _make_nonmonotonic_baseline_dataset()
+# ==============================================================================
+# Last-axis coordinate contract: finite and strictly monotonic
+# ==============================================================================
+
+_BASELINE_CONTRACT_MODELS = [
+    ("polynomial", {}),
+    ("polynomial-pchip", {"model": "polynomial", "order": "pchip"}),
+    ("asls", {"lamb": 1e5, "asymmetry": 0.05}),
+    ("snip", {"snip_width": 15}),
+    ("rubberband", {}),
+]
+
+
+# (name, coordinate values, expected message fragment)
+def _contract_baseline(model, kwargs):
+    """Build a Baseline instance from a contract-test model entry."""
+    merged = {"model": model.split("-")[0], **kwargs}
+    return Baseline(**merged)
+
+
+_INVALID_COORDINATE_CASES = [
+    ("ascending_duplicate", [1000.0, 1125.0, 1125.0, 1375.0, 1500.0], "strictly"),
+    ("descending_duplicate", [1500.0, 1375.0, 1250.0, 1250.0, 1000.0], "strictly"),
+    (
+        "multiple_duplicates",
+        [1000.0, 1000.0, 1125.0, 1250.0, 1250.0, 1500.0],
+        "strictly",
+    ),
+    ("constant_axis", [1250.0] * 5, "strictly"),
+    (
+        "nonmonotonic_ascending_endpoints",
+        [1000.0, 1125.0, 1075.0, 1250.0, 1375.0, 1325.0, 1500.0],
+        "strictly",
+    ),
+    (
+        "nonmonotonic_descending_endpoints",
+        [1500.0, 1375.0, 1425.0, 1250.0, 1125.0, 1175.0, 1000.0],
+        "strictly",
+    ),
+    ("nan_at_start", [np.nan, 1125.0, 1250.0, 1375.0, 1500.0], "finite"),
+    ("nan_in_middle", [1000.0, 1125.0, np.nan, 1375.0, 1500.0], "finite"),
+    ("nan_at_end", [1000.0, 1125.0, 1250.0, 1375.0, np.nan], "finite"),
+    ("plus_inf", [1000.0, 1125.0, 1250.0, 1375.0, np.inf], "finite"),
+    ("minus_inf", [-np.inf, 1125.0, 1250.0, 1375.0, 1500.0], "finite"),
+    ("multiple_nonfinite", [-np.inf, 1125.0, np.nan, 1375.0, np.inf], "finite"),
+]
+
+
+def _make_contract_probe_dataset(x_values, n_rows=None, mask_region=None):
+    x = np.asarray(x_values, dtype=float)
+    base = 0.002 * x + 0.5 + 0.05 * np.sin(np.linspace(0.0, 3.0, x.size))
+    if n_rows is None:
+        data = base
+        coordset = [scp.Coord(x, title="wavenumber", units="cm^-1")]
+    else:
+        data = np.vstack([base + 0.01 * i for i in range(n_rows)])
+        coordset = [
+            scp.Coord(np.arange(n_rows, dtype=float), title="row"),
+            scp.Coord(x, title="wavenumber", units="cm^-1"),
+        ]
+    dataset = scp.NDDataset(
+        data,
+        coordset=coordset,
+        units="absorbance",
+        title="coordinate contract probe dataset",
+    )
+    if mask_region is not None:
+        dataset[..., slice(*mask_region)] = scp.MASKED
+    return dataset
+
+
+@pytest.mark.parametrize("model,kwargs", _BASELINE_CONTRACT_MODELS)
+@pytest.mark.parametrize(
+    "case_name,x_values,message_fragment", _INVALID_COORDINATE_CASES
+)
+def test_baseline_rejects_invalid_last_axis_coordinates(
+    model, kwargs, case_name, x_values, message_fragment
+):
+    dataset = _make_contract_probe_dataset(x_values)
     original = dataset.copy()
 
-    blc = Baseline(model="asls", lamb=1e5, asymmetry=0.05)
-    sort_calls = _sort_spy(monkeypatch)
-    blc.fit(dataset)
+    blc = _contract_baseline(model, kwargs)
+    with pytest.raises(ValueError, match=message_fragment):
+        blc.fit(dataset)
 
-    assert len(sort_calls) == 2
-    assert all(call["descend"] is False for call in sort_calls)
+    # no silent mutation, whatever the model
+    assert_dataset_equal(dataset, original)
 
-    baseline = blc.baseline
-    corrected = blc.corrected
+    # the fitted flag must not have been set by the failed fit
+    assert not blc._fitted
 
-    monkeypatch.undo()
-    oracle = _historical_fit(blc, original.copy(), monkeypatch)
 
-    assert_dataset_equal(baseline, oracle.baseline)
-    assert_dataset_equal(corrected, oracle.corrected)
+@pytest.mark.parametrize("model,kwargs", _BASELINE_CONTRACT_MODELS)
+def test_baseline_rejects_invalid_coordinates_for_masked_2d_inputs(model, kwargs):
+    dataset = _make_contract_probe_dataset(
+        [1000.0, 1125.0, 1125.0, 1375.0, 1500.0],
+        n_rows=2,
+        mask_region=(1100.0, 1400.0),
+    )
+    original = dataset.copy()
+    blc = _contract_baseline(model, kwargs)
+    with pytest.raises(ValueError, match="strictly"):
+        blc.fit(dataset)
     assert_dataset_equal(dataset, original)
 
 
-def test_baseline_fit_preserves_nan_axis_sort_path(monkeypatch):
-    dataset = _make_nan_axis_baseline_dataset()
-    original = dataset.copy()
+@pytest.mark.parametrize("model,kwargs", _BASELINE_CONTRACT_MODELS)
+def test_baseline_accepts_irregular_strictly_monotonic_coordinates(model, kwargs):
+    for descending in (False, True):
+        values = np.array([1000.0, 1090.0, 1234.5, 1300.0, 1520.0, 1611.0, 2000.0])
+        if descending:
+            values = values[::-1].copy()
+        dataset = _make_contract_probe_dataset(values)
+        original = dataset.copy()
 
-    blc = Baseline(model="asls", lamb=1e5, asymmetry=0.05)
-    sort_calls = _sort_spy(monkeypatch)
-    with pytest.raises(AttributeError, match="coordset"):
+        blc = _contract_baseline(model, kwargs)
         blc.fit(dataset)
 
-    assert len(sort_calls) == 2
-    assert all(call["descend"] is False for call in sort_calls)
+        baseline = blc.baseline
+        corrected = blc.corrected
 
-    monkeypatch.undo()
-    oracle = _clone_baseline_for_oracle(blc)
-    with pytest.raises(AttributeError, match="coordset"):
-        _historical_fit(oracle, original.copy(), monkeypatch)
+        assert baseline.shape == dataset.shape
+        assert corrected.shape == dataset.shape
+        np.testing.assert_allclose(
+            np.asarray(baseline.x.data), np.asarray(dataset.x.data), atol=1e-3
+        )
+        assert_dataset_equal(dataset, original)
 
+
+@pytest.mark.parametrize("model,kwargs", _BASELINE_CONTRACT_MODELS)
+def test_baseline_accepts_regular_axes_both_orientations_2d(model, kwargs):
+    for descending in (False, True):
+        dataset = _make_shape_probe_dataset(descending=descending, n_rows=2)
+        original = dataset.copy()
+        blc = _contract_baseline(model, kwargs)
+        blc.fit(dataset)
+        baseline = blc.baseline
+        corrected = blc.corrected
+        assert baseline.shape == dataset.shape
+        assert corrected.shape == dataset.shape
+        assert_dataset_equal(dataset, original)
+
+
+@pytest.mark.parametrize("model,kwargs", _BASELINE_CONTRACT_MODELS)
+def test_baseline_validation_runs_before_numerical_kernel(model, kwargs):
+    # even a kernel that would crash later on invalid input fails fast with
+    # the public contract error instead
+    dataset = _make_contract_probe_dataset([1000.0, 1100.0, np.nan, 1300.0])
+    kernel_spy_called = []
+    original_fit_method = Baseline._fit
+
+    def spy_fit(self, *args, **kwargs):
+        kernel_spy_called.append(True)
+        return original_fit_method(self, *args, **kwargs)
+
+    mp = pytest.MonkeyPatch()
+    try:
+        mp.setattr(Baseline, "_fit", spy_fit)
+        blc = _contract_baseline(model, kwargs)
+        with pytest.raises(ValueError, match="finite"):
+            blc.fit(dataset)
+    finally:
+        mp.undo()
+    assert kernel_spy_called == []
+
+
+def test_baseline_rejects_duplicates_before_breakpoint_and_pchip_paths():
+    # historical internal failures (breakpoint TypeError, pchip strictness
+    # error) become unreachable thanks to the early validation
+    values = [1000.0, 1125.0, 1125.0, 1375.0, 1500.0]
+    dataset = _make_contract_probe_dataset(values)
+    blc = Baseline(
+        model="polynomial", order="pchip", breakpoints=[1125.0], include_limits=True
+    )
+    with pytest.raises(ValueError, match="strictly"):
+        blc.fit(dataset)
+
+
+def test_baseline_accepts_valid_breakpoints_and_multiple_ranges():
+    dataset = _make_shape_probe_dataset()
+    original = dataset.copy()
+
+    blc = Baseline(model="polynomial", order=2, breakpoints=[1450.0])
+    blc.ranges = [[1000.0, 1200.0], [1700.0, 2000.0]]
+    blc.fit(dataset)
+
+    baseline = blc.baseline
+    corrected = blc.corrected
+    assert baseline.shape == dataset.shape
+    assert corrected.shape == dataset.shape
     assert_dataset_equal(dataset, original)
 
 


### PR DESCRIPTION
## Summary

- `Baseline.fit()` now validates the last-axis coordinates **before any
  work**: no copy, no range assembly, no mask removal, no sort, no numerical
  kernel.
- Contract: the last-axis coordinates must be **finite** and **strictly
  increasing or strictly decreasing** (full-axis adjacent-differences check;
  never inferred from endpoints). Irregular spacing remains accepted in both
  directions.

## Rejected inputs (uniform public `ValueError`)

- duplicated coordinate values (adjacent or not), constant axes, direction
  changes, non-monotonic axes whose endpoints look ascending or descending;
- `NaN`, `+inf`, `-inf`, and any mix of non-finite values.

This replaces the previously accidental behaviors: silent reordering of
public outputs (polynomial/pchip/snip/rubberband on non-monotonic input),
late `AttributeError` / `QhullError` / `LinAlgError` /
`CoordinatesMismatchError`, misleading support-size errors on NaN axes,
and the breakpoint `TypeError` with non-scalar spacing. All models now
produce the same error category for the same invalid input.

## Implementation

- new private helper `_validate_last_axis_coordinates(X)`: reads the last
  axis values without copying or mutating anything, checks finiteness then
  strict monotonicity via `np.diff`; datasets without usable coordinates
  keep their historical handling; two stable public messages distinguish
  non-finite from duplicated/non-monotonic axes;
- deliberately kept separate from the `#1577` fast-path guard, which only
  decides whether an internal ascending sort can be skipped; after this
  validation, valid ascending axes take the fast path and valid descending
  axes keep the historical sort-and-restore path unchanged.

Prerequisite: #1578 (descending duplicated axes are no longer rewritten into
a uniform grid before reaching `fit()`). Functional audit and recorded
decision: maintained in the project governance notes.

## Validation

- `tests/test_analysis/test_baseline`: **165 passed**, including:
  - parametrized rejection of 12 invalid-coordinate cases x 5 model
    configurations (polynomial, polynomial+pchip, asls, snip, rubberband),
    checking the error category, source non-mutation, and that `_fitted`
    stays false;
  - masked 2D rejection case;
  - acceptance of irregular strictly monotonic axes in both orientations,
    regular 1D/2D axes both orientations, valid breakpoints plus multiple
    ranges;
  - a spy test proving validation runs before the numerical kernel;
  - pchip + duplicates + breakpoints now fail early with the contract error;
- `tests/test_core/test_dataset/test_coord_linearize.py`: 26 passed;
- `pre-commit run --all-files` (after `pre-commit clean`): all hooks passed.

## Scope exclusions

No performance work, no `Coord`/`NDDataset` changes beyond #1578, no
traitlets changes, no `transform()`/`.corrected` refactor, no AsLS solver
change, no caches, no CI timing thresholds.