### PR TITLE
FIX: reset preprocessor state on lifecycle changes

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Preprocessing transformers now invalidate fitted state when constructor
+  parameters actually change, clear learned attributes after invalidation or a
+  failed refit, and keep ``set_params()`` calls with invalid parameter names
+  from partially modifying the transformer.
+
 - ``Baseline.fit()`` now explicitly rejects datasets whose last-axis
   coordinates contain non-finite values (``NaN`` or infinities), duplicated
   values, or direction changes, raising a clear ``ValueError`` instead of

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Preprocessing transformers now invalidate fitted state when constructor
+  parameters actually change, clear learned attributes after invalidation or a
+  failed refit, and keep ``set_params()`` calls with invalid parameter names
+  from partially modifying the transformer.
+
 - ``Baseline.fit()`` now explicitly rejects datasets whose last-axis
   coordinates contain non-finite values (``NaN`` or infinities), duplicated
   values, or direction changes, raising a clear ``ValueError`` instead of

--- a/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
+++ b/src/spectrochempy/examples/processing/transformations/plot_transformers_sklearn.py
@@ -95,9 +95,13 @@ except ImportError:
 # -----------------
 # ``inverse_transform()`` restores the original absorbance units.  This
 # is useful when interpreting model predictions (e.g., converting
-# PCA scores back to original space).
+# PCA scores back to original space).  Since changing parameters invalidates
+# fitted transformer state, set the intended parameters and fit before
+# inverting.
 
-X_train_restored = scaler.set_params(dim="y").inverse_transform(X_train_scaled)
+scaler.set_params(dim="y")
+scaler.fit(X_train)
+X_train_restored = scaler.inverse_transform(X_train_scaled)
 print(
     "Restored data matches original?",
     np.allclose(X_train_restored.data, X_train.data),

--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -82,6 +82,8 @@ class BasePreprocessor:
 
     """
 
+    _learned_attributes = ()
+
     def __init__(self, dim="y"):
         self.dim = dim
         self._fitted = False
@@ -101,8 +103,14 @@ class BasePreprocessor:
             The fitted instance.
 
         """
-        self._fit(dataset)
-        self._fitted = True
+        self._invalidate_fitted_state()
+        try:
+            self._fit(dataset)
+        except Exception:
+            self._invalidate_fitted_state()
+            raise
+        else:
+            self._fitted = True
         return self
 
     def transform(self, dataset):
@@ -242,14 +250,24 @@ class BasePreprocessor:
         AutoscaleTransformer(dim='x')
 
         """
-        valid = self.get_params().keys()
+        valid = self.get_params()
+        invalid = [key for key in params if key not in valid]
+        if invalid:
+            key = invalid[0]
+            valid_names = ", ".join(sorted(valid))
+            raise SpectroChemPyError(
+                f"Invalid parameter '{key}' for {self.__class__.__name__}. "
+                f"Valid parameters: {valid_names}."
+            )
+
+        changed = any(
+            not self._parameter_values_equal(valid[key], value)
+            for key, value in params.items()
+        )
         for key, value in params.items():
-            if key not in valid:
-                raise SpectroChemPyError(
-                    f"Invalid parameter '{key}' for {self.__class__.__name__}. "
-                    f"Valid parameters: {', '.join(sorted(valid))}."
-                )
             setattr(self, key, value)
+        if changed:
+            self._invalidate_fitted_state()
         return self
 
     def __repr__(self):
@@ -263,6 +281,44 @@ class BasePreprocessor:
     def _set_data(self, new, data):
         r"""Assign transformed data, coercing MaskedArray → plain ndarray."""
         new._data = np.asarray(data)
+
+    def _invalidate_fitted_state(self):
+        r"""Mark the transformer as unfitted and clear declared learned state."""
+        self._fitted = False
+        for name in self._learned_attributes:
+            if hasattr(self, name):
+                delattr(self, name)
+
+    @classmethod
+    def _parameter_values_equal(cls, old, new):
+        r"""Return whether two constructor parameter values are effectively equal."""
+        if old is new:
+            return True
+        if old is None or new is None:
+            return False
+        if cls._is_spectrochempy_object(old) or cls._is_spectrochempy_object(new):
+            return False
+        if isinstance(old, np.ma.MaskedArray) or isinstance(new, np.ma.MaskedArray):
+            try:
+                return bool(np.ma.allequal(old, new))
+            except (TypeError, ValueError):
+                return False
+        if isinstance(old, np.ndarray) or isinstance(new, np.ndarray):
+            try:
+                return bool(np.array_equal(old, new, equal_nan=True))
+            except (TypeError, ValueError):
+                return False
+        try:
+            result = old == new
+        except (TypeError, ValueError):
+            return False
+        if isinstance(result, (bool, np.bool_)):
+            return bool(result)
+        return False
+
+    @staticmethod
+    def _is_spectrochempy_object(value):
+        return hasattr(value, "masked_data") or hasattr(value, "coordset")
 
     def _fit(self, dataset):
         raise NotImplementedError("Subclasses must implement _fit().")
@@ -303,6 +359,8 @@ class CenterTransformer(BasePreprocessor):
     center : Procedural mean-centering function.
 
     """
+
+    _learned_attributes = ("mean_", "_dim_name")
 
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
@@ -353,6 +411,8 @@ class AutoscaleTransformer(BasePreprocessor):
 
     """
 
+    _learned_attributes = ("mean_", "std_", "_dim_name")
+
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
         data = dataset.masked_data
@@ -402,6 +462,8 @@ class SNVTransformer(AutoscaleTransformer):
     AutoscaleTransformer : General autoscaling transformer.
 
     """
+
+    _learned_attributes = ("_dim_name",)
 
     def __init__(self):
         super().__init__(dim="x")
@@ -478,6 +540,19 @@ class NormalizeTransformer(BasePreprocessor):
     normalize : Procedural normalization function.
 
     """
+
+    _learned_attributes = (
+        "norm_",
+        "dmin_",
+        "dmax_",
+        "range_",
+        "_dim_name",
+        "_sample_local_",
+        "_fit_axis_",
+        "_fit_shape_",
+        "_fit_dims_",
+        "_fit_compatible_coords_",
+    )
 
     def __init__(self, method="max", dim="x"):
         super().__init__(dim=dim)
@@ -696,6 +771,17 @@ class MSCTransformer(BasePreprocessor):
     msc : Procedural MSC function.
 
     """
+
+    _learned_attributes = (
+        "reference_",
+        "a_",
+        "b_",
+        "_dim_name",
+        "_spectral_axis_",
+        "_spectral_dim_name_",
+        "_spectral_size_",
+        "_spectral_coord_",
+    )
 
     def __init__(self, reference=None, dim="y"):
         super().__init__(dim=dim)
@@ -922,6 +1008,8 @@ class ParetoScaleTransformer(BasePreprocessor):
 
     """
 
+    _learned_attributes = ("mean_", "std_", "_dim_name")
+
     def __init__(self, dim="y"):
         super().__init__(dim=dim)
 
@@ -984,6 +1072,8 @@ class RangeScaleTransformer(BasePreprocessor):
     range_scale : Procedural range scaling function.
 
     """
+
+    _learned_attributes = ("dmin_", "dmax_", "range_", "_dim_name")
 
     def __init__(self, dim="y"):
         super().__init__(dim=dim)
@@ -1048,6 +1138,8 @@ class RobustScaleTransformer(BasePreprocessor):
 
     """
 
+    _learned_attributes = ("median_", "mad_", "_dim_name")
+
     def __init__(self, dim="y"):
         super().__init__(dim=dim)
 
@@ -1111,14 +1203,19 @@ class LogTransformer(BasePreprocessor):
 
     """
 
+    _learned_attributes = ()
+
     def __init__(self, method="log1p", eps=1e-10):
         super().__init__(dim=None)
         self.method = method
         self.eps = eps
 
     def _fit(self, dataset):
-        # Stateless — nothing to learn
-        pass
+        if self.method not in ("log1p", "log"):
+            raise SpectroChemPyError(
+                f"Unknown LogTransformer method '{self.method}'. "
+                f"Choose from 'log1p' or 'log'."
+            )
 
     def _transform(self, dataset):
         new = dataset.copy()

--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -309,12 +309,9 @@ class BasePreprocessor:
             except (TypeError, ValueError):
                 return False
         try:
-            result = old == new
+            return bool(old == new)
         except (TypeError, ValueError):
             return False
-        if isinstance(result, (bool, np.bool_)):
-            return bool(result)
-        return False
 
     @staticmethod
     def _is_spectrochempy_object(value):

--- a/tests/test_processing/test_transformation/test_preprocessing.py
+++ b/tests/test_processing/test_transformation/test_preprocessing.py
@@ -1337,6 +1337,62 @@ class TestSklearnCompatibility:
         with pytest.raises(SpectroChemPyError, match="Invalid parameter"):
             scaler.set_params(invalid_param=42)
 
+    def test_set_params_invalid_name_is_transactional(self):
+        scaler = NormalizeTransformer(method="max", dim="y")
+        with pytest.raises(SpectroChemPyError, match="Invalid parameter"):
+            scaler.set_params(dim="x", invalid_parameter=1)
+        assert scaler.dim == "y"
+        assert scaler.method == "max"
+
+    def test_set_params_applies_multiple_valid_parameters(self):
+        scaler = NormalizeTransformer(method="max", dim="x")
+        result = scaler.set_params(method="sum", dim="y")
+        assert result is scaler
+        assert scaler.method == "sum"
+        assert scaler.dim == "y"
+
+    def test_set_params_unchanged_value_preserves_fit(self, simple_2d):
+        scaler = AutoscaleTransformer(dim="y").fit(simple_2d)
+        mean = scaler.mean_.copy()
+        std = scaler.std_.copy()
+        scaler.set_params(dim="y")
+        assert scaler._fitted
+        assert np.array_equal(scaler.mean_, mean)
+        assert np.array_equal(scaler.std_, std)
+
+    def test_set_params_changed_value_invalidates_and_clears_state(self, simple_2d):
+        scaler = AutoscaleTransformer(dim="y").fit(simple_2d)
+        scaler.set_params(dim="x")
+        assert scaler.dim == "x"
+        assert not scaler._fitted
+        assert not hasattr(scaler, "mean_")
+        assert not hasattr(scaler, "std_")
+        with pytest.raises(SpectroChemPyError, match="not fitted yet"):
+            scaler.transform(simple_2d)
+        with pytest.raises(SpectroChemPyError, match="not fitted yet"):
+            scaler.inverse_transform(simple_2d)
+
+    def test_msc_reference_array_comparison_is_not_ambiguous(self, msc_2d):
+        ref = msc_2d.data[0].copy()
+        scaler = MSCTransformer(reference=ref, dim="y").fit(msc_2d)
+        scaler.set_params(reference=ref.copy())
+        assert scaler._fitted
+        assert hasattr(scaler, "reference_")
+
+        scaler.set_params(reference=ref + 1.0)
+        assert not scaler._fitted
+        assert not hasattr(scaler, "reference_")
+
+    def test_msc_reference_dataset_comparison_uses_identity(self, msc_2d):
+        ref = NDDataset(msc_2d.data[0], coordset=[msc_2d.coord("x")])
+        scaler = MSCTransformer(reference=ref, dim="y").fit(msc_2d)
+        scaler.set_params(reference=ref)
+        assert scaler._fitted
+
+        scaler.set_params(reference=ref.copy())
+        assert not scaler._fitted
+        assert not hasattr(scaler, "reference_")
+
     def test_repr_autoscale(self):
         scaler = AutoscaleTransformer(dim="y")
         assert repr(scaler) == "AutoscaleTransformer(dim='y')"
@@ -1375,3 +1431,142 @@ class TestSklearnCompatibility:
         transformer = LogTransformer(method="log", eps=1e-5)
         cloned = clone(transformer)
         assert cloned.get_params() == transformer.get_params()
+
+
+class TestPreprocessorLifecycle:
+    @pytest.mark.parametrize(
+        ("factory", "learned_attrs"),
+        [
+            (CenterTransformer, ("mean_", "_dim_name")),
+            (AutoscaleTransformer, ("mean_", "std_", "_dim_name")),
+            (ParetoScaleTransformer, ("mean_", "std_", "_dim_name")),
+            (RangeScaleTransformer, ("dmin_", "dmax_", "range_", "_dim_name")),
+            (RobustScaleTransformer, ("median_", "mad_", "_dim_name")),
+        ],
+    )
+    def test_scaler_fit_failure_invalidates_and_cleans(
+        self, simple_2d, factory, learned_attrs
+    ):
+        scaler = factory(dim="y").fit(simple_2d)
+        for attr in learned_attrs:
+            assert hasattr(scaler, attr)
+
+        scaler.dim = "missing"
+        with pytest.raises(ValueError, match="Dimension"):
+            scaler.fit(simple_2d)
+
+        assert not scaler._fitted
+        for attr in learned_attrs:
+            assert not hasattr(scaler, attr)
+        with pytest.raises(SpectroChemPyError, match="not fitted yet"):
+            scaler.transform(simple_2d)
+
+    @pytest.mark.parametrize(
+        ("factory", "learned_attrs"),
+        [
+            (CenterTransformer, ("mean_", "_dim_name")),
+            (AutoscaleTransformer, ("mean_", "std_", "_dim_name")),
+            (ParetoScaleTransformer, ("mean_", "std_", "_dim_name")),
+            (RangeScaleTransformer, ("dmin_", "dmax_", "range_", "_dim_name")),
+            (RobustScaleTransformer, ("median_", "mad_", "_dim_name")),
+        ],
+    )
+    def test_scaler_parameter_change_cleans_declared_state(
+        self, simple_2d, factory, learned_attrs
+    ):
+        scaler = factory(dim="y").fit(simple_2d)
+        scaler.set_params(dim="x")
+        assert not scaler._fitted
+        for attr in learned_attrs:
+            assert not hasattr(scaler, attr)
+
+    def test_normalize_fit_failure_removes_partial_state(self, simple_2d):
+        scaler = NormalizeTransformer(method="unknown", dim="y")
+        with pytest.raises(SpectroChemPyError, match="Unknown normalization method"):
+            scaler.fit(simple_2d)
+        assert not scaler._fitted
+        for attr in scaler._learned_attributes:
+            assert not hasattr(scaler, attr)
+
+    def test_normalize_refit_failure_invalidates_previous_state(self, simple_2d):
+        scaler = NormalizeTransformer(method="max", dim="y").fit(simple_2d)
+        assert hasattr(scaler, "norm_")
+        scaler.method = "unknown"
+        with pytest.raises(SpectroChemPyError, match="Unknown normalization method"):
+            scaler.fit(simple_2d)
+        assert not scaler._fitted
+        for attr in scaler._learned_attributes:
+            assert not hasattr(scaler, attr)
+
+    def test_msc_fit_failure_removes_partial_state(self, msc_2d):
+        scaler = MSCTransformer(reference=np.ones(3), dim="y")
+        with pytest.raises(SpectroChemPyError, match="reference size"):
+            scaler.fit(msc_2d)
+        assert not scaler._fitted
+        for attr in scaler._learned_attributes:
+            assert not hasattr(scaler, attr)
+
+    def test_msc_refit_failure_invalidates_previous_state(self, msc_2d):
+        scaler = MSCTransformer(dim="y").fit(msc_2d)
+        assert hasattr(scaler, "reference_")
+        scaler.reference = np.ones(3)
+        with pytest.raises(SpectroChemPyError, match="reference size"):
+            scaler.fit(msc_2d)
+        assert not scaler._fitted
+        for attr in scaler._learned_attributes:
+            assert not hasattr(scaler, attr)
+
+    def test_fit_transform_failure_does_not_use_old_state(self, simple_2d):
+        scaler = AutoscaleTransformer(dim="y").fit(simple_2d)
+        scaler.dim = "missing"
+        with pytest.raises(ValueError, match="Dimension"):
+            scaler.fit_transform(simple_2d)
+        assert not scaler._fitted
+        assert not hasattr(scaler, "mean_")
+        assert not hasattr(scaler, "std_")
+
+    def test_logtransformer_parameter_change_requires_refit(self, simple_2d):
+        transformer = LogTransformer(method="log1p").fit(simple_2d)
+        transformer.set_params(eps=1.0e-5)
+        assert not transformer._fitted
+        with pytest.raises(SpectroChemPyError, match="not fitted yet"):
+            transformer.transform(simple_2d)
+        transformer.fit(simple_2d)
+        assert transformer._fitted
+
+    def test_logtransformer_fit_validates_method(self, simple_2d):
+        transformer = LogTransformer(method="unknown")
+        with pytest.raises(SpectroChemPyError, match="Unknown LogTransformer method"):
+            transformer.fit(simple_2d)
+        assert not transformer._fitted
+        with pytest.raises(SpectroChemPyError, match="Unknown LogTransformer method"):
+            transformer.fit_transform(simple_2d)
+        assert not transformer._fitted
+
+    def test_snv_refit_failure_invalidates_validation_state(self, simple_2d):
+        scaler = SNVTransformer().fit(simple_2d)
+        assert hasattr(scaler, "_dim_name")
+        with pytest.raises(ValueError, match="Dimension"):
+            scaler.fit(NDDataset(np.array(1.0)))
+        assert not scaler._fitted
+        assert not hasattr(scaler, "_dim_name")
+        with pytest.raises(SpectroChemPyError, match="not fitted yet"):
+            scaler.transform(simple_2d)
+
+    @pytest.mark.parametrize(
+        ("factory", "procedural"),
+        [
+            (CenterTransformer, center),
+            (AutoscaleTransformer, autoscale),
+            (ParetoScaleTransformer, pareto_scale),
+            (RangeScaleTransformer, range_scale),
+            (RobustScaleTransformer, robust_scale),
+        ],
+    )
+    def test_successful_scaler_transformations_are_unchanged(
+        self, simple_2d, factory, procedural
+    ):
+        scaler = factory(dim="y")
+        transformed = scaler.fit_transform(simple_2d)
+        expected = procedural(simple_2d, dim="y")
+        assert np.allclose(transformed.data, expected.data)


### PR DESCRIPTION
## Summary
- make BasePreprocessor.set_params() validate all parameter names before assignment
- invalidate fitted preprocessors only when constructor parameters effectively change
- clear declared learned state on invalidation and after failed fit/refit
- validate LogTransformer.method during fit and add lifecycle regression coverage

## Parameter comparison contract
- identity is equal for all parameter values
- scalars, strings, None, and arrays use bounded value equality where appropriate
- SpectroChemPy objects use identity equality only to avoid deep dataset comparisons
- array-like MSC references compare by array value without ambiguous boolean results

## Deferred
- no feature-wise train/test geometry, coordinate, or unit compatibility hardening in this PR
- no scientific transformation math changes
- no 0.12.6 release work

## Validation
- micromamba run -n scpy-core python -m pytest tests/test_processing/test_transformation/test_preprocessing.py -q: 187 passed
- micromamba run -n scpy-core python -m pytest tests/test_processing/test_transformation -q: 215 passed
- micromamba run -n scpy-core python -m ruff check src/spectrochempy/processing/transformation/preprocessing_transformers.py tests/test_processing/test_transformation/test_preprocessing.py: passed
- micromamba run -n scpy-core pre-commit run update_version_and_release_notes --all-files: passed after regenerating latest.rst
- git diff --check: passed
- micromamba run -n scpy-core pre-commit run --all-files: passed