### PR TITLE
FIX: guard stateful preprocessor feature compatibility

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Feature-wise preprocessing transformers now reject incompatible transform
+  or inverse-transform datasets before applying learned statistics, covering
+  feature geometry, coordinate values and units, and data-unit mismatches while
+  still allowing new observations along the fitted reduction axis.
+
 - Preprocessing transformers now invalidate fitted state when constructor
   parameters actually change, clear learned attributes after invalidation or a
   failed refit, and keep ``set_params()`` calls with invalid parameter names

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- Feature-wise preprocessing transformers now reject incompatible transform
+  or inverse-transform datasets before applying learned statistics, covering
+  feature geometry, coordinate values and units, and data-unit mismatches while
+  still allowing new observations along the fitted reduction axis.
+
 - Preprocessing transformers now invalidate fitted state when constructor
   parameters actually change, clear learned attributes after invalidation or a
   failed refit, and keep ``set_params()`` calls with invalid parameter names

--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -317,6 +317,133 @@ class BasePreprocessor:
     def _is_spectrochempy_object(value):
         return hasattr(value, "masked_data") or hasattr(value, "coordset")
 
+    def _record_fit_compatibility(self, dataset, axis, dim_name):
+        r"""Store the dataset signature required to reuse learned statistics."""
+        shape = dataset.masked_data.shape
+        self._fit_signature_ = {
+            "ndim": len(shape),
+            "dims": tuple(str(name) for name in dataset.dims),
+            "axis": axis,
+            "dim_name": str(dim_name),
+            "shape": tuple(shape),
+            "data_units": dataset.units,
+            "coords": self._compatibility_coord_signatures(dataset, axis),
+        }
+
+    def _check_fit_compatibility(self, dataset, axis, action):
+        r"""Validate that *dataset* can reuse statistics learned during fit()."""
+        signature = self._fit_signature_
+        cls = self.__class__.__name__
+        current_shape = dataset.masked_data.shape
+        current_dims = tuple(str(name) for name in dataset.dims)
+
+        if len(current_shape) != signature["ndim"]:
+            self._raise_incompatible(action, "number of dimensions changed", cls)
+
+        if current_dims != signature["dims"]:
+            self._raise_incompatible(action, "dimension order changed", cls)
+
+        if axis != signature["axis"]:
+            self._raise_incompatible(action, "preprocessing axis changed", cls)
+
+        current_dim_name = current_dims[axis]
+        if current_dim_name != signature["dim_name"]:
+            self._raise_incompatible(action, "preprocessing dimension changed", cls)
+
+        if not self._same_units(dataset.units, signature["data_units"]):
+            self._raise_incompatible(action, "data units changed", cls)
+
+        for current_axis, current_size in enumerate(current_shape):
+            if current_axis == axis:
+                continue
+            dim_name = current_dims[current_axis]
+            expected_size = signature["shape"][current_axis]
+            if current_size != expected_size:
+                self._raise_incompatible(
+                    action,
+                    f"non-reduced dimension '{dim_name}' length changed",
+                    cls,
+                )
+
+            expected = signature["coords"][dim_name]
+            current = self._feature_coord_signature(dataset, dim_name)
+            self._check_coord_compatibility(expected, current, dim_name, action, cls)
+
+    @classmethod
+    def _compatibility_coord_signatures(cls, dataset, axis):
+        signatures = {}
+        for current_axis, dim_name in enumerate(dataset.dims):
+            if current_axis == axis:
+                continue
+            name = str(dim_name)
+            signatures[name] = cls._feature_coord_signature(dataset, name)
+        return signatures
+
+    @staticmethod
+    def _feature_coord_signature(dataset, dim_name):
+        coord = dataset.coord(dim_name)
+        if coord is None or getattr(coord, "data", None) is None:
+            return {"present": False, "units": None, "data": None}
+        return {
+            "present": True,
+            "units": coord.units,
+            "data": np.array(coord.data, copy=True),
+        }
+
+    @classmethod
+    def _check_coord_compatibility(cls, expected, current, dim_name, action, owner):
+        if current["present"] != expected["present"]:
+            cls._raise_incompatible(
+                action,
+                f"coordinate presence changed for dimension '{dim_name}'",
+                owner,
+            )
+
+        if not expected["present"]:
+            return
+
+        if (current["units"] is None) != (expected["units"] is None):
+            cls._raise_incompatible(
+                action,
+                f"coordinate units changed for dimension '{dim_name}'",
+                owner,
+            )
+
+        data = np.array(current["data"], copy=True)
+        if current["units"] is not None and current["units"] != expected["units"]:
+            if current["units"].dimensionality != expected["units"].dimensionality:
+                cls._raise_incompatible(
+                    action,
+                    f"coordinate units are incompatible for dimension '{dim_name}'",
+                    owner,
+                )
+            data = (data * current["units"]).to(expected["units"]).magnitude
+
+        if data.shape != expected["data"].shape or not np.allclose(
+            data,
+            expected["data"],
+            rtol=1.0e-12,
+            atol=1.0e-15,
+            equal_nan=True,
+        ):
+            cls._raise_incompatible(
+                action,
+                f"coordinates changed for dimension '{dim_name}'",
+                owner,
+            )
+
+    @staticmethod
+    def _same_units(current, expected):
+        if current is None or expected is None:
+            return current is expected
+        return current == expected
+
+    @staticmethod
+    def _raise_incompatible(action, reason, owner):
+        raise SpectroChemPyError(
+            f"{owner} {action} dataset is incompatible with fit(): {reason}."
+        )
+
     def _fit(self, dataset):
         raise NotImplementedError("Subclasses must implement _fit().")
 
@@ -357,20 +484,26 @@ class CenterTransformer(BasePreprocessor):
 
     """
 
-    _learned_attributes = ("mean_", "_dim_name")
+    _learned_attributes = ("mean_", "_dim_name", "_fit_signature_")
 
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
+        self._dim_name = str(self._dim_name)
+        self._record_fit_compatibility(dataset, axis, self._dim_name)
         self.mean_ = np.ma.mean(dataset.masked_data, axis=axis, keepdims=True)
 
     def _transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "transform")
         self._set_data(new, dataset.masked_data - self.mean_)
         new.history = f"CenterTransformer applied on dimension {self._dim_name}"
         return new
 
     def _inverse_transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "inverse_transform")
         self._set_data(new, dataset.masked_data + self.mean_)
         new.history = f"CenterTransformer inverse applied on dimension {self._dim_name}"
         return new
@@ -408,16 +541,20 @@ class AutoscaleTransformer(BasePreprocessor):
 
     """
 
-    _learned_attributes = ("mean_", "std_", "_dim_name")
+    _learned_attributes = ("mean_", "std_", "_dim_name", "_fit_signature_")
 
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
+        self._dim_name = str(self._dim_name)
+        self._record_fit_compatibility(dataset, axis, self._dim_name)
         data = dataset.masked_data
         self.mean_ = np.ma.mean(data, axis=axis, keepdims=True)
         self.std_ = np.ma.std(data, axis=axis, keepdims=True)
 
     def _transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "transform")
         data = dataset.masked_data
         std_safe = np.where(self.std_ == 0, 1, self.std_)
         self._set_data(new, (data - self.mean_) / std_safe)
@@ -426,6 +563,8 @@ class AutoscaleTransformer(BasePreprocessor):
 
     def _inverse_transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "inverse_transform")
         data = dataset.masked_data
         std_safe = np.where(self.std_ == 0, 1, self.std_)
         self._set_data(new, data * std_safe + self.mean_)
@@ -545,10 +684,7 @@ class NormalizeTransformer(BasePreprocessor):
         "range_",
         "_dim_name",
         "_sample_local_",
-        "_fit_axis_",
-        "_fit_shape_",
-        "_fit_dims_",
-        "_fit_compatible_coords_",
+        "_fit_signature_",
     )
 
     def __init__(self, method="max", dim="x"):
@@ -560,10 +696,6 @@ class NormalizeTransformer(BasePreprocessor):
         self._dim_name = str(self._dim_name)
         data = dataset.masked_data
         self._sample_local_ = self._dim_name == "x"
-        self._fit_axis_ = axis
-        self._fit_shape_ = data.shape
-        self._fit_dims_ = tuple(str(dim_name) for dim_name in dataset.dims)
-        self._fit_compatible_coords_ = self._compatible_coords(dataset, axis)
 
         if self.method not in ("max", "sum", "vector", "minmax"):
             raise SpectroChemPyError(
@@ -574,6 +706,7 @@ class NormalizeTransformer(BasePreprocessor):
         if self._sample_local_:
             return
 
+        self._record_fit_compatibility(dataset, axis, self._dim_name)
         params = self._normalization_parameters(data, axis)
         for name, value in params.items():
             setattr(self, name, value)
@@ -606,19 +739,18 @@ class NormalizeTransformer(BasePreprocessor):
         axis, dim_name = dataset.get_axis(self.dim)
         dim_name = str(dim_name)
 
-        if dim_name != self._dim_name:
-            raise SpectroChemPyError(
-                "NormalizeTransformer transform dimension is incompatible with "
-                "fit(). Refit the transformer after changing dimensions."
-            )
-
         if self._sample_local_:
+            if dim_name != self._dim_name:
+                raise SpectroChemPyError(
+                    "NormalizeTransformer transform dimension is incompatible with "
+                    "fit(). Refit the transformer after changing dimensions."
+                )
             params = self._normalization_parameters(data, axis)
             norm = params.get("norm_")
             dmin = params.get("dmin_")
             drange = params.get("range_")
         else:
-            self._check_dataset_compatibility(dataset, axis, "transform")
+            self._check_fit_compatibility(dataset, axis, "transform")
             norm = getattr(self, "norm_", None)
             dmin = getattr(self, "dmin_", None)
             drange = getattr(self, "range_", None)
@@ -634,59 +766,6 @@ class NormalizeTransformer(BasePreprocessor):
         )
         return new
 
-    @staticmethod
-    def _compatible_coords(dataset, learned_axis):
-        coords = {}
-        for axis, dim_name in enumerate(dataset.dims):
-            if axis == learned_axis:
-                continue
-            coord = dataset.coord(dim_name)
-            if coord is not None:
-                coords[str(dim_name)] = np.array(coord.data, copy=True)
-        return coords
-
-    def _check_dataset_compatibility(self, dataset, axis, action):
-        data_shape = dataset.masked_data.shape
-        dims = tuple(str(dim_name) for dim_name in dataset.dims)
-        if dims != self._fit_dims_:
-            raise SpectroChemPyError(
-                f"NormalizeTransformer {action} dataset is incompatible with "
-                "fit(): dimension order changed."
-            )
-
-        if axis != self._fit_axis_:
-            raise SpectroChemPyError(
-                f"NormalizeTransformer {action} dataset is incompatible with "
-                "fit(): normalization axis changed."
-            )
-
-        if len(data_shape) != len(self._fit_shape_):
-            raise SpectroChemPyError(
-                f"NormalizeTransformer {action} dataset is incompatible with "
-                "fit(): number of dimensions changed."
-            )
-
-        for current_axis, current_size in enumerate(data_shape):
-            if current_axis == axis:
-                continue
-            fit_size = self._fit_shape_[current_axis]
-            if current_size != fit_size:
-                raise SpectroChemPyError(
-                    f"NormalizeTransformer {action} dataset is incompatible "
-                    "with fit(): non-normalized dimensions changed."
-                )
-
-            dim_name = str(dataset.dims[current_axis])
-            expected = self._fit_compatible_coords_.get(dim_name)
-            coord = dataset.coord(dim_name)
-            if expected is not None and coord is not None:
-                current = np.array(coord.data)
-                if not np.array_equal(current, expected):
-                    raise SpectroChemPyError(
-                        f"NormalizeTransformer {action} dataset is incompatible "
-                        "with fit(): non-normalized coordinates changed."
-                    )
-
     def _inverse_transform(self, dataset):
         if self._sample_local_:
             raise SpectroChemPyError(
@@ -697,14 +776,8 @@ class NormalizeTransformer(BasePreprocessor):
 
         new = dataset.copy()
         data = dataset.masked_data
-        axis, dim_name = dataset.get_axis(self.dim)
-        if str(dim_name) != self._dim_name:
-            raise SpectroChemPyError(
-                "NormalizeTransformer inverse_transform dimension is "
-                "incompatible with fit(). Refit the transformer after changing "
-                "dimensions."
-            )
-        self._check_dataset_compatibility(dataset, axis, "inverse_transform")
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "inverse_transform")
 
         if self.method in ("max", "sum", "vector"):
             self._set_data(new, data * self.norm_)
@@ -1005,19 +1078,23 @@ class ParetoScaleTransformer(BasePreprocessor):
 
     """
 
-    _learned_attributes = ("mean_", "std_", "_dim_name")
+    _learned_attributes = ("mean_", "std_", "_dim_name", "_fit_signature_")
 
     def __init__(self, dim="y"):
         super().__init__(dim=dim)
 
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
+        self._dim_name = str(self._dim_name)
+        self._record_fit_compatibility(dataset, axis, self._dim_name)
         data = dataset.masked_data
         self.mean_ = np.ma.mean(data, axis=axis, keepdims=True)
         self.std_ = np.ma.std(data, axis=axis, keepdims=True)
 
     def _transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "transform")
         data = dataset.masked_data
 
         std_safe = np.where(self.std_ == 0, 1, self.std_)
@@ -1027,6 +1104,8 @@ class ParetoScaleTransformer(BasePreprocessor):
 
     def _inverse_transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "inverse_transform")
         data = dataset.masked_data
 
         std_safe = np.where(self.std_ == 0, 1, self.std_)
@@ -1070,13 +1149,15 @@ class RangeScaleTransformer(BasePreprocessor):
 
     """
 
-    _learned_attributes = ("dmin_", "dmax_", "range_", "_dim_name")
+    _learned_attributes = ("dmin_", "dmax_", "range_", "_dim_name", "_fit_signature_")
 
     def __init__(self, dim="y"):
         super().__init__(dim=dim)
 
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
+        self._dim_name = str(self._dim_name)
+        self._record_fit_compatibility(dataset, axis, self._dim_name)
         data = dataset.masked_data
 
         self.dmin_ = np.ma.min(data, axis=axis, keepdims=True)
@@ -1086,6 +1167,8 @@ class RangeScaleTransformer(BasePreprocessor):
 
     def _transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "transform")
         data = dataset.masked_data
 
         self._set_data(new, data / self.range_)
@@ -1094,6 +1177,8 @@ class RangeScaleTransformer(BasePreprocessor):
 
     def _inverse_transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "inverse_transform")
         data = dataset.masked_data
 
         self._set_data(new, data * self.range_)
@@ -1135,13 +1220,15 @@ class RobustScaleTransformer(BasePreprocessor):
 
     """
 
-    _learned_attributes = ("median_", "mad_", "_dim_name")
+    _learned_attributes = ("median_", "mad_", "_dim_name", "_fit_signature_")
 
     def __init__(self, dim="y"):
         super().__init__(dim=dim)
 
     def _fit(self, dataset):
         axis, self._dim_name = dataset.get_axis(self.dim)
+        self._dim_name = str(self._dim_name)
+        self._record_fit_compatibility(dataset, axis, self._dim_name)
         data = dataset.masked_data
 
         self.median_ = np.ma.median(data, axis=axis, keepdims=True)
@@ -1151,6 +1238,8 @@ class RobustScaleTransformer(BasePreprocessor):
 
     def _transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "transform")
         data = dataset.masked_data
 
         self._set_data(new, (data - self.median_) / self.mad_)
@@ -1159,6 +1248,8 @@ class RobustScaleTransformer(BasePreprocessor):
 
     def _inverse_transform(self, dataset):
         new = dataset.copy()
+        axis, _ = dataset.get_axis(self.dim)
+        self._check_fit_compatibility(dataset, axis, "inverse_transform")
         data = dataset.masked_data
 
         self._set_data(new, data * self.mad_ + self.median_)

--- a/tests/test_processing/test_transformation/test_preprocessing.py
+++ b/tests/test_processing/test_transformation/test_preprocessing.py
@@ -86,6 +86,41 @@ def _normalize_oracle(data, method, axis):
     return (data - dmin) / np.where(drange == 0, 1, drange)
 
 
+def _feature_compat_dataset(
+    n_observations=4,
+    x_values=None,
+    x_units="cm",
+    data_units="m",
+    coordset=True,
+):
+    if x_values is None:
+        x_values = np.array([1.0, 2.0, 3.0])
+    x_values = np.asarray(x_values, dtype=float)
+    data = np.arange(n_observations * x_values.size, dtype=float).reshape(
+        n_observations, x_values.size
+    )
+    dataset = NDDataset(data + 1.0)
+    if coordset:
+        dataset.set_coordset(
+            y=Coord(np.arange(n_observations, dtype=float), units="s"),
+            x=Coord(x_values, units=x_units),
+        )
+    if data_units is not None:
+        dataset.units = data_units
+    return dataset
+
+
+def _stateful_preprocessor_factories():
+    return [
+        CenterTransformer,
+        AutoscaleTransformer,
+        ParetoScaleTransformer,
+        RangeScaleTransformer,
+        RobustScaleTransformer,
+        lambda dim="y": NormalizeTransformer(method="max", dim=dim),
+    ]
+
+
 def _snv_oracle(data, axis):
     mean = np.mean(data, axis=axis, keepdims=True)
     std = np.std(data, axis=axis, keepdims=True)
@@ -1437,11 +1472,17 @@ class TestPreprocessorLifecycle:
     @pytest.mark.parametrize(
         ("factory", "learned_attrs"),
         [
-            (CenterTransformer, ("mean_", "_dim_name")),
-            (AutoscaleTransformer, ("mean_", "std_", "_dim_name")),
-            (ParetoScaleTransformer, ("mean_", "std_", "_dim_name")),
-            (RangeScaleTransformer, ("dmin_", "dmax_", "range_", "_dim_name")),
-            (RobustScaleTransformer, ("median_", "mad_", "_dim_name")),
+            (CenterTransformer, ("mean_", "_dim_name", "_fit_signature_")),
+            (AutoscaleTransformer, ("mean_", "std_", "_dim_name", "_fit_signature_")),
+            (ParetoScaleTransformer, ("mean_", "std_", "_dim_name", "_fit_signature_")),
+            (
+                RangeScaleTransformer,
+                ("dmin_", "dmax_", "range_", "_dim_name", "_fit_signature_"),
+            ),
+            (
+                RobustScaleTransformer,
+                ("median_", "mad_", "_dim_name", "_fit_signature_"),
+            ),
         ],
     )
     def test_scaler_fit_failure_invalidates_and_cleans(
@@ -1464,11 +1505,17 @@ class TestPreprocessorLifecycle:
     @pytest.mark.parametrize(
         ("factory", "learned_attrs"),
         [
-            (CenterTransformer, ("mean_", "_dim_name")),
-            (AutoscaleTransformer, ("mean_", "std_", "_dim_name")),
-            (ParetoScaleTransformer, ("mean_", "std_", "_dim_name")),
-            (RangeScaleTransformer, ("dmin_", "dmax_", "range_", "_dim_name")),
-            (RobustScaleTransformer, ("median_", "mad_", "_dim_name")),
+            (CenterTransformer, ("mean_", "_dim_name", "_fit_signature_")),
+            (AutoscaleTransformer, ("mean_", "std_", "_dim_name", "_fit_signature_")),
+            (ParetoScaleTransformer, ("mean_", "std_", "_dim_name", "_fit_signature_")),
+            (
+                RangeScaleTransformer,
+                ("dmin_", "dmax_", "range_", "_dim_name", "_fit_signature_"),
+            ),
+            (
+                RobustScaleTransformer,
+                ("median_", "mad_", "_dim_name", "_fit_signature_"),
+            ),
         ],
     )
     def test_scaler_parameter_change_cleans_declared_state(
@@ -1570,3 +1617,177 @@ class TestPreprocessorLifecycle:
         transformed = scaler.fit_transform(simple_2d)
         expected = procedural(simple_2d, dim="y")
         assert np.allclose(transformed.data, expected.data)
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessors_accept_new_observations(self, factory):
+        train = _feature_compat_dataset(n_observations=4)
+        test = _feature_compat_dataset(n_observations=6)
+        scaler = factory(dim="y").fit(train)
+
+        transformed = scaler.transform(test)
+
+        assert transformed.shape == test.shape
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessors_accept_matching_coordless_data(self, factory):
+        train = _feature_compat_dataset(coordset=False)
+        test = _feature_compat_dataset(n_observations=6, coordset=False)
+        scaler = factory(dim="y").fit(train)
+
+        transformed = scaler.transform(test)
+
+        assert transformed.shape == test.shape
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessors_accept_convertible_feature_units(self, factory):
+        train = _feature_compat_dataset(x_values=[1.0, 2.0, 3.0], x_units="cm")
+        test = _feature_compat_dataset(
+            n_observations=6,
+            x_values=[0.01, 0.02, 0.03],
+            x_units="m",
+        )
+        scaler = factory(dim="y").fit(train)
+
+        transformed = scaler.transform(test)
+
+        assert transformed.shape == test.shape
+
+    @pytest.mark.parametrize(
+        ("factory", "dataset", "message"),
+        [
+            (
+                factory,
+                dataset,
+                message,
+            )
+            for factory in _stateful_preprocessor_factories()
+            for dataset, message in [
+                (
+                    NDDataset(np.ones((4, 3, 1))),
+                    "number of dimensions changed",
+                ),
+                (
+                    _feature_compat_dataset(x_values=[1.0, 2.0, 3.0, 4.0]),
+                    "non-reduced dimension 'x' length changed",
+                ),
+                (
+                    _feature_compat_dataset(x_values=[3.0, 2.0, 1.0]),
+                    "coordinates changed for dimension 'x'",
+                ),
+                (
+                    _feature_compat_dataset(x_values=[1.0, 2.1, 3.0]),
+                    "coordinates changed for dimension 'x'",
+                ),
+                (
+                    _feature_compat_dataset(coordset=False),
+                    "coordinate presence changed for dimension 'x'",
+                ),
+                (
+                    _feature_compat_dataset(x_units=None),
+                    "coordinate units changed for dimension 'x'",
+                ),
+                (
+                    _feature_compat_dataset(x_units="s"),
+                    "coordinate units are incompatible for dimension 'x'",
+                ),
+                (
+                    _feature_compat_dataset(
+                        x_values=[0.01, 0.021, 0.03],
+                        x_units="m",
+                    ),
+                    "coordinates changed for dimension 'x'",
+                ),
+                (
+                    _feature_compat_dataset(data_units="cm"),
+                    "data units changed",
+                ),
+                (
+                    _feature_compat_dataset(data_units=None),
+                    "data units changed",
+                ),
+            ]
+        ],
+    )
+    def test_stateful_preprocessors_reject_incompatible_geometry(
+        self, factory, dataset, message
+    ):
+        scaler = factory(dim="y").fit(_feature_compat_dataset())
+
+        with pytest.raises(SpectroChemPyError, match=message):
+            scaler.transform(dataset)
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessors_reject_dimension_order_change(self, factory):
+        train = _feature_compat_dataset()
+        scaler = factory(dim="y").fit(train)
+
+        with pytest.raises(SpectroChemPyError, match="dimension order changed"):
+            scaler.transform(train.T)
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessors_reject_square_transpose(self, factory):
+        train = _feature_compat_dataset(
+            n_observations=3,
+            x_values=[1.0, 2.0, 3.0],
+        )
+        scaler = factory(dim="y").fit(train)
+
+        with pytest.raises(SpectroChemPyError, match="dimension order changed"):
+            scaler.transform(train.T)
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessors_reject_preprocessing_axis_change(self, factory):
+        train = _feature_compat_dataset()
+        scaler = factory(dim="y").fit(train)
+        scaler.dim = "x"
+
+        with pytest.raises(SpectroChemPyError, match="preprocessing axis changed"):
+            scaler.transform(train)
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessors_reject_inverse_incompatible_geometry(self, factory):
+        train = _feature_compat_dataset()
+        scaler = factory(dim="y").fit(train)
+        transformed = scaler.transform(train)
+        transformed.set_coordset(
+            y=transformed.coord("y"),
+            x=Coord([3.0, 2.0, 1.0], units="cm"),
+        )
+
+        with pytest.raises(SpectroChemPyError, match="coordinates changed"):
+            scaler.inverse_transform(transformed)
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessor_signature_copies_coordinate_values(self, factory):
+        train = _feature_compat_dataset()
+        original = _feature_compat_dataset()
+        scaler = factory(dim="y").fit(train)
+        train.coord("x").data = np.array([3.0, 2.0, 1.0])
+
+        transformed = scaler.transform(original)
+
+        assert transformed.shape == original.shape
+
+    @pytest.mark.parametrize("factory", _stateful_preprocessor_factories())
+    def test_stateful_preprocessor_masks_can_differ(self, factory):
+        train = _feature_compat_dataset()
+        test = _feature_compat_dataset(n_observations=6)
+        test[:, 1] = MASKED
+        scaler = factory(dim="y").fit(train)
+
+        transformed = scaler.transform(test)
+
+        assert np.array_equal(transformed.mask, test.mask)
+
+    def test_sample_local_normalize_does_not_reuse_fit_geometry(self):
+        train = _feature_compat_dataset(x_values=[1.0, 2.0, 3.0])
+        test = _feature_compat_dataset(
+            n_observations=2,
+            x_values=[10.0, 20.0, 30.0, 40.0],
+        )
+        scaler = NormalizeTransformer(method="max", dim="x").fit(train)
+
+        transformed = scaler.transform(test)
+
+        assert transformed.shape == test.shape
+        assert not hasattr(scaler, "_fit_signature_")


### PR DESCRIPTION
## Summary
- add a common fitted-dataset compatibility signature for reusable preprocessing statistics
- guard transform and inverse_transform for CenterTransformer, AutoscaleTransformer, ParetoScaleTransformer, RangeScaleTransformer, RobustScaleTransformer, and stateful NormalizeTransformer(dim != "x")
- compare non-reduced geometry, coordinate presence, coordinate values with compatible-unit conversion, coordinate units, and data units before applying learned statistics
- keep sample-local NormalizeTransformer(dim="x") free from train/test geometry coupling

## Tests
- pre-commit run --all-files
- micromamba run -n scpy-core python -m pytest tests/test_processing/test_transformation/test_preprocessing.py

## Deferred
- MSC geometry/reference compatibility remains out of scope for this PR.