### PR TITLE
FIX: avoid writer identity side effects after failed writes

### DIFF
--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.12
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.12.6
     v0.12.5
     v0.12.4

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,39 +6,8 @@
 
 :orphan:
 
-What's New in Revision 0.12.6
+What's New in Revision 0.12.7.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.6.
+These are the changes in SpectroChemPy-0.12.7.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
-
-New Features
-~~~~~~~~~~~~
-
-- Added the ``pseudovoigt`` helper and ``pseudovoigtmodel`` curve-fitting
-  model, using the existing ``ampl``, ``pos``, ``width``, ``ratio`` and
-  ``normalized`` line-shape conventions.
-
-Bug Fixes
-~~~~~~~~~
-
-- ``Baseline`` fitting is now stricter and more predictable: polynomial
-  support is validated before fitting, invalid or non-intersecting ranges raise
-  clear ``ValueError`` messages, fitted/corrected outputs preserve the input
-  shape, and last-axis coordinates with ``NaN``, infinities, duplicates, or
-  direction changes are rejected before model-specific internals can produce
-  inconsistent results. The Baseline implementation also avoids unnecessary
-  ascending-axis sorts and reduces polynomial range-assembly overhead.
-
-- Fixed a false linearity detection in ``Coord`` that could silently replace
-  descending coordinates containing duplicated or irregularly spaced values
-  with an artificial uniform grid. Such coordinates are now preserved as
-  provided, while genuinely regular ascending and descending axes keep being
-  detected as linear.
-
-- Stateful preprocessing transformers now reset learned state reliably after
-  constructor-parameter changes or failed refits, keep invalid ``set_params()``
-  calls transactional, and reject incompatible transform or inverse-transform
-  datasets before applying learned statistics. The compatibility guard covers
-  feature geometry, coordinate values and units, and data-unit mismatches while
-  still allowing new observations along the fitted reduction axis.

--- a/src/spectrochempy/core/dataset/arraymixins/ndio.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndio.py
@@ -186,7 +186,6 @@ class NDIO(tr.HasTraits):
         # was already saved previously with this name,
         # in this case we do not display a dialog and overwrite the same file
 
-        self.name = filename.stem
         return self.dump(filename, **kwargs)
 
     def save_as(self, filename: str = "", **kwargs: Any) -> pathlib.Path | None:
@@ -263,7 +262,6 @@ class NDIO(tr.HasTraits):
         )
 
         if filename:
-            self.filename = filename
             return self.dump(filename, **kwargs)
         return None
 

--- a/src/spectrochempy/core/writers/exporter.py
+++ b/src/spectrochempy/core/writers/exporter.py
@@ -191,5 +191,4 @@ def write(dataset, filename=None, **kwargs):
 @exportermethod
 def _write_scp(*args, **kwargs):
     dataset, filename = args
-    dataset.filename = str(filename)
     return dataset.dump(filename, **kwargs)

--- a/src/spectrochempy/core/writers/write_csv.py
+++ b/src/spectrochempy/core/writers/write_csv.py
@@ -80,13 +80,14 @@ def _check_dataset_supported(dataset):
 def _write_csv(*args, **kwargs):
     dataset, filename = args
     _check_dataset_supported(dataset)
-    dataset.filename = filename
 
     delimiter = kwargs.get("delimiter", prefs.csv_delimiter)
 
     # check dimensionality of the dataset
     if dataset.squeeze().ndim > 1:
         raise NotImplementedError("Only implemented for 1D NDDatasets")
+
+    dataset.filename = filename
 
     # squeeze if necessary
     if dataset.ndim > 1:

--- a/tests/test_core/test_dataset/test_mixins/test_ndio.py
+++ b/tests/test_core/test_dataset/test_mixins/test_ndio.py
@@ -14,6 +14,7 @@ import pickle
 import zipfile
 from datetime import UTC
 from datetime import datetime
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -167,6 +168,77 @@ def test_ndio_2D(ndataset_2d, tmp_path):
     nd = NDDataset.load(tmp_path / "essai2D")
     assert nd.directory == tmp_path
     f.unlink()
+
+
+def test_save_as_failure_preserves_identity_and_target(tmp_path):
+    ds = NDDataset(np.arange(3.0), name="save_as_source")
+    ds.filename = tmp_path / "initial.scp"
+    target = tmp_path / "broken_save_as.scp"
+    original_filename = ds.filename
+    original_name = ds.name
+
+    with patch.object(
+        type(ds), "dump", side_effect=RuntimeError("forced dump failure")
+    ):
+        with pytest.raises(RuntimeError, match="forced dump failure"):
+            ds.save_as(target, confirm=False)
+
+    assert not target.exists()
+    assert ds.filename == original_filename
+    assert ds.name == original_name
+
+
+def test_save_failure_preserves_identity_and_target(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    ds = NDDataset(np.arange(3.0), name="save_source.raw")
+    ds.filename = tmp_path / "initial.scp"
+    target = tmp_path / "save_source.scp"
+    original_filename = ds.filename
+    original_name = ds.name
+
+    with patch.object(
+        type(ds), "dump", side_effect=RuntimeError("forced dump failure")
+    ):
+        with pytest.raises(RuntimeError, match="forced dump failure"):
+            ds.save(confirm=False)
+
+    assert not target.exists()
+    assert ds.filename == original_filename
+    assert ds.name == original_name
+
+
+def test_native_save_surfaces_success_preserves_identity_semantics(
+    tmp_path, monkeypatch
+):
+    save_as_ds = NDDataset(np.arange(3.0), name="save_as_source")
+    save_as_target = tmp_path / "saved_as.scp"
+
+    save_as_filename = save_as_ds.save_as(save_as_target, confirm=False)
+
+    assert save_as_filename == save_as_target
+    assert save_as_target.exists()
+    assert save_as_ds.filename == save_as_target
+    assert save_as_ds.name == "saved_as"
+
+    monkeypatch.chdir(tmp_path)
+    save_ds = NDDataset(np.arange(3.0), name="save_source.raw")
+
+    save_filename = save_ds.save(confirm=False)
+
+    assert save_filename.name == "save_source.scp"
+    assert save_filename.exists()
+    assert save_ds.filename == save_filename
+    assert save_ds.name == "save_source"
+
+    dump_ds = NDDataset(np.arange(3.0), name="dump_source")
+    dump_target = tmp_path / "dumped.scp"
+
+    dump_filename = dump_ds.dump(dump_target)
+
+    assert dump_filename == dump_target
+    assert dump_target.exists()
+    assert dump_ds.filename == dump_target
+    assert dump_ds.name == "dumped"
 
 
 def test_filename_none_copy_and_deepcopy_preserve_explicit_none():

--- a/tests/test_core/test_writers/test_exporter.py
+++ b/tests/test_core/test_writers/test_exporter.py
@@ -6,7 +6,9 @@
 # ruff: noqa
 
 from pathlib import Path
+from unittest.mock import patch
 
+import numpy as np
 import pytest
 from spectrochempy.utils import testing
 
@@ -52,6 +54,36 @@ def test_write(mock_cwd, ndataset_1d):
     assert filename.stem == nd.name
     assert filename.suffix == ".scp"
     filename.unlink()
+
+
+def test_write_scp_failure_preserves_identity_and_target(tmp_path):
+    nd = NDDataset(np.arange(3.0), name="native_write_source")
+    nd.filename = tmp_path / "initial.scp"
+    target = tmp_path / "broken.scp"
+    original_filename = nd.filename
+    original_name = nd.name
+
+    with patch.object(
+        type(nd), "dump", side_effect=RuntimeError("forced dump failure")
+    ):
+        with pytest.raises(RuntimeError, match="forced dump failure"):
+            nd.write(target, confirm=False)
+
+    assert not target.exists()
+    assert nd.filename == original_filename
+    assert nd.name == original_name
+
+
+def test_write_scp_success_preserves_existing_identity_semantics(tmp_path):
+    nd = NDDataset(np.arange(3.0), name="native_write_source")
+    target = tmp_path / "written.scp"
+
+    filename = nd.write(target, confirm=False)
+
+    assert filename == target
+    assert target.exists()
+    assert nd.filename == target
+    assert nd.name == "written"
 
 
 def test_excel_writer_entry_points_are_not_public(ndataset_1d):

--- a/tests/test_core/test_writers/test_write_csv.py
+++ b/tests/test_core/test_writers/test_write_csv.py
@@ -73,6 +73,48 @@ def test_write_csv_with_coords(mock_cwd, ds_1d_with_coords, ds_2d_with_coords):
     f.unlink()
 
 
+def test_write_csv_rejects_unsupported_2d_without_identity_side_effect(tmp_path):
+    x = scp.Coord(np.linspace(4000, 1000, 5), title="wavenumber", units="cm^-1")
+    y = scp.Coord([1.0, 2.0, 3.0], title="time", units="s")
+    dataset = scp.NDDataset(
+        np.ones((3, 5)),
+        coordset=[y, x],
+        name="csv_2d_rejected",
+    )
+    target = tmp_path / "unsupported_2d.csv"
+    original_filename = dataset.filename
+    original_name = dataset.name
+
+    with pytest.raises(NotImplementedError, match="Only implemented for 1D"):
+        dataset.write_csv(target, confirm=False)
+
+    assert not target.exists()
+    assert dataset.filename == original_filename
+    assert dataset.name == original_name
+
+
+def test_write_csv_rejects_unsupported_2d_keeps_existing_file_and_identity(tmp_path):
+    x = scp.Coord(np.linspace(4000, 1000, 5), title="wavenumber", units="cm^-1")
+    y = scp.Coord([1.0, 2.0, 3.0], title="time", units="s")
+    dataset = scp.NDDataset(
+        np.ones((3, 5)),
+        coordset=[y, x],
+        name="csv_2d_existing",
+    )
+    target = tmp_path / "unsupported_2d.csv"
+    target.write_bytes(b"SENTINEL\n")
+    original_bytes = target.read_bytes()
+    original_filename = dataset.filename
+    original_name = dataset.name
+
+    with pytest.raises(NotImplementedError, match="Only implemented for 1D"):
+        dataset.write_csv(target, confirm=False, overwrite=True)
+
+    assert target.read_bytes() == original_bytes
+    assert dataset.filename == original_filename
+    assert dataset.name == original_name
+
+
 def test_write_csv_masked_values(tmp_path):
     # masked samples must be exported as missing values (NaN), not as their
     # (stale) underlying data (#1135), mirroring the JCAMP-DX writer (#1132)
@@ -179,6 +221,7 @@ def test_write_csv_valid_real_round_trip_still_works(tmp_path, ds_1d_with_coords
 
     assert path.exists()
     assert dataset.filename == path
+    assert dataset.name == "real_csv"
     text = path.read_text()
     assert "wavenumber / cm^-1,absorbance / a.u." in text
 


### PR DESCRIPTION
## Summary
- avoid mutating dataset.filename before unsupported CSV dimensionality checks pass
- let native .scp write/save surfaces commit dataset identity only through dump() after success
- add regression tests for failed write(), save_as(), save(), and CSV rejection identity preservation
- record current successful identity semantics for write(.scp), save_as(), save(), dump(), and supported CSV writes
- include pre-commit-generated post-release latest/index updates for the first PR after 0.12.6

## Validation
- micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_write_csv.py -q
- micromamba run -n scpy-core python -m pytest tests/test_core/test_writers/test_exporter.py -q
- micromamba run -n scpy-core python -m pytest tests/test_core/test_dataset/test_mixins/test_ndio.py -q
- micromamba run -n scpy-core python -m pytest tests/test_core/test_writers -q -x
- micromamba run -n scpy-core python -m pytest tests/test_core/test_projects/test_projects.py -q
- micromamba run -n scpy-core python -m pytest tests/test_core/test_dataset/test_mixins/test_ndio.py tests/test_core/test_writers/test_exporter.py tests/test_core/test_writers/test_write_csv.py -q
- micromamba run -n scpy-core ruff check src/spectrochempy/core/writers/write_csv.py src/spectrochempy/core/writers/exporter.py tests/test_core/test_writers/test_write_csv.py tests/test_core/test_writers/test_exporter.py tests/test_core/test_dataset/test_mixins/test_ndio.py
- pre-commit run --all-files
- git diff --check

Also attempted: micromamba run -n scpy-core python -m pytest tests/test_core -q, interrupted after 250 passed in 197.84s with no failures visible.