### PR TITLE
PERF: reduce redundant dataset copies in binary arithmetic

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -54,7 +54,9 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
-PERF: Removed a redundant defensive copy of the first operand in binary and
-unary arithmetic result construction, roughly halving the object-reconstruction
-overhead of ``NDDataset`` arithmetic while preserving results, units, masks,
-coordinates, metadata, and operand non-mutation semantics.
+PERF: Skipped the redundant defensive copy of the first operand in out-of-place
+binary and unary arithmetic result construction, removing one root dataset
+reconstruction per operation (root copies from 2 to 1 for dataset/scalar and
+from 4 to 3 for dataset/dataset) while preserving results, units, masks,
+coordinates, metadata, and operand non-mutation semantics. In-place operators
+keep their defensive copy unchanged.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -53,3 +53,8 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+PERF: Removed a redundant defensive copy of the first operand in binary and
+unary arithmetic result construction, roughly halving the object-reconstruction
+overhead of ``NDDataset`` arithmetic while preserving results, units, masks,
+coordinates, metadata, and operand non-mutation semantics.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,7 +15,9 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 Developer
 ~~~~~~~~~
 
-PERF: Removed a redundant defensive copy of the first operand in binary and
-unary arithmetic result construction, roughly halving the object-reconstruction
-overhead of ``NDDataset`` arithmetic while preserving results, units, masks,
-coordinates, metadata, and operand non-mutation semantics.
+PERF: Skipped the redundant defensive copy of the first operand in out-of-place
+binary and unary arithmetic result construction, removing one root dataset
+reconstruction per operation (root copies from 2 to 1 for dataset/scalar and
+from 4 to 3 for dataset/dataset) while preserving results, units, masks,
+coordinates, metadata, and operand non-mutation semantics. In-place operators
+keep their defensive copy unchanged.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -11,3 +11,11 @@ What's New in Revision 0.12.7.dev
 
 These are the changes in SpectroChemPy-0.12.7.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
+
+Developer
+~~~~~~~~~
+
+PERF: Removed a redundant defensive copy of the first operand in binary and
+unary arithmetic result construction, roughly halving the object-reconstruction
+overhead of ``NDDataset`` arithmetic while preserving results, units, masks,
+coordinates, metadata, and operand non-mutation semantics.

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -3573,7 +3573,12 @@ class NDMath:
 
         # Now we can proceed
 
-        obj = cpy.copy(inputs.pop(0))
+        # The first operand is only read by the preparation/execution/mask
+        # helpers below (data, units, mask, coordset); none of them mutate it,
+        # so no defensive copy of it is needed here. Only ``other`` can be
+        # mutated in place (unit conversion through ``ito``), and it keeps its
+        # own defensive copy for that purpose.
+        obj = inputs.pop(0)
         objtype = objtypes.pop(0)
 
         other = None

--- a/src/spectrochempy/core/dataset/arraymixins/ndmath.py
+++ b/src/spectrochempy/core/dataset/arraymixins/ndmath.py
@@ -3554,6 +3554,7 @@ class NDMath:
         inputs: Sequence[ArrayLike],
         isufunc: bool = False,
         reflected: bool = False,
+        inplace: bool = False,
     ) -> tuple[np.ndarray, str | None, np.ndarray, str | None, bool]:
         # Achieve an operation f on the objs
 
@@ -3573,12 +3574,16 @@ class NDMath:
 
         # Now we can proceed
 
-        # The first operand is only read by the preparation/execution/mask
-        # helpers below (data, units, mask, coordset); none of them mutate it,
-        # so no defensive copy of it is needed here. Only ``other`` can be
-        # mutated in place (unit conversion through ``ito``), and it keeps its
-        # own defensive copy for that purpose.
-        obj = inputs.pop(0)
+        # Out-of-place operations only read the first operand in the
+        # preparation/execution/mask helpers below, so its defensive copy can
+        # be skipped. In-place operations dispatch to mutating functions
+        # (e.g. ``operator.iadd``) that modify the first operand's data
+        # buffer directly; there the defensive copy is kept so the observable
+        # behavior is unchanged: caller buffers (including arrays the dataset
+        # was built from) are not mutated before the final assignments, a
+        # non-writable buffer stays usable, and a failure after the numerical
+        # step cannot leave the source partially mutated.
+        obj = cpy.copy(inputs.pop(0)) if inplace else inputs.pop(0)
         objtype = objtypes.pop(0)
 
         other = None
@@ -3734,7 +3739,7 @@ class NDMath:
             fm, objs, reflected = self._check_order(fname, objs)
 
             data, units, mask, returntype, reflected = self._op(
-                fm, objs, reflected=reflected
+                fm, objs, reflected=reflected, inplace=True
             )
             self._data = data
             self._units = units

--- a/tests/test_core/test_dataset/test_math_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_math_semantics_baseline.py
@@ -900,6 +900,56 @@ class TestInplaceOperations:
         assert len(ds.history) == 2
         assert "Inplace binary op" in str(ds.history[1])
 
+    # ---- in-place isolation guards (out-of-place copy elision boundary) ----
+    # In-place operators execute through mutating functions on a defensive
+    # copy of the first operand; these tests pin the observable contracts
+    # that depend on that copy.
+
+    def test_inplace_returns_same_object(self, unmasked_dataset):
+        ds = unmasked_dataset.copy()
+        result = ds.__iadd__(2.0)
+        assert result is ds
+
+    def test_inplace_does_not_mutate_external_buffer(self):
+        arr = np.array([1.0, 2.0, 3.0])
+        ds = NDDataset(arr)
+
+        ds *= 10.0
+
+        assert_array_equal(arr, [1.0, 2.0, 3.0])
+        assert_array_equal(ds.data, [10.0, 20.0, 30.0])
+
+    def test_inplace_with_non_writable_buffer(self):
+        arr = np.array([1.0, 2.0, 3.0])
+        arr.setflags(write=False)
+        ds = NDDataset(arr)
+
+        ds += 1.0
+
+        assert_array_equal(ds.data, [2.0, 3.0, 4.0])
+        assert_array_equal(arr, [1.0, 2.0, 3.0])
+
+    def test_inplace_incompatible_units_raise_without_partial_mutation(self):
+        left = make_semantic_2d_dataset(units="m", title="left metres", name="left_m")
+        right = make_semantic_2d_dataset(
+            title="right seconds",
+            name="right_s",
+            units="s",
+        )
+        before_data = left.data.copy()
+        before_mask = left.mask.copy()
+        before_units = left.units
+
+        with pytest.raises(DimensionalityError):
+            left += right
+
+        # NOTE: the in-place operator appends its history entry before the
+        # computation (pre-existing behavior); data, mask and units must not
+        # be partially mutated by the failed operation.
+        assert_array_equal(left.data, before_data)
+        assert_array_equal(left.mask, before_mask)
+        assert left.units == before_units
+
 
 class TestInplaceOperationsUnmasked:
     """Characterize in-place arithmetic on unmasked dataset."""

--- a/tests/test_core/test_dataset/test_math_semantics_baseline.py
+++ b/tests/test_core/test_dataset/test_math_semantics_baseline.py
@@ -32,6 +32,7 @@ from spectrochempy.core.dataset.coord import Coord
 from spectrochempy.core.dataset.coordset import CoordSet
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.core.units import Unit
+from spectrochempy.utils.constants import MASKED
 from spectrochempy.utils.testing import assert_array_equal
 from tests.test_core.test_dataset._semantic_dataset_helpers import (
     assert_basic_metadata_preserved,
@@ -506,6 +507,90 @@ class TestDatasetDatasetArithmetic:
 
     def test_radd_numerical(self, unmasked_dataset):
         assert_array_equal((2.0 + unmasked_dataset).data, 2.0 + unmasked_dataset.data)
+
+    # ---- result isolation ----
+    # Mutating the arithmetic result through public APIs must never leak back
+    # into the operands (guards the copy-first result construction).
+
+    @staticmethod
+    def _operand_snapshot(ds):
+        return {
+            "data": ds.data.copy(),
+            "mask": ds.mask.copy(),
+            "x_data": ds.x.data.copy(),
+            "x_title": ds.x.title,
+            "meta_project": ds.meta.project,
+            "meta_instrument": ds.meta.instrument,
+            "history": list(ds.history),
+            "units": ds.units,
+            "title": ds.title,
+            "name": ds.name,
+        }
+
+    @classmethod
+    def _assert_operand_snapshot(cls, ds, snapshot):
+        assert_array_equal(ds.data, snapshot["data"])
+        assert_array_equal(ds.mask, snapshot["mask"])
+        assert_array_equal(ds.x.data, snapshot["x_data"])
+        assert ds.x.title == snapshot["x_title"]
+        assert ds.meta.project == snapshot["meta_project"]
+        assert ds.meta.instrument == snapshot["meta_instrument"]
+        assert ds.history == snapshot["history"]
+        assert ds.units == snapshot["units"]
+        assert ds.title == snapshot["title"]
+        assert ds.name == snapshot["name"]
+
+    @pytest.mark.parametrize("other_kind", ["scalar", "dataset"])
+    def test_result_mutation_does_not_affect_operands(
+        self, rich_dataset, compatible_dataset, other_kind
+    ):
+        other = 2.0 if other_kind == "scalar" else compatible_dataset
+        left_before = self._operand_snapshot(rich_dataset)
+        right_before = (
+            self._operand_snapshot(compatible_dataset)
+            if other_kind == "dataset"
+            else None
+        )
+
+        result = rich_dataset + other
+        result[0, 1] = 99.0
+        result[2, 2] = MASKED
+        result.x.data[0] = 1234.0
+        result.x.title = "changed coordinate"
+        result.meta.project = "changed project"
+        result.history = "changed history"
+        result.title = "changed title"
+        result.name = "changed name"
+
+        self._assert_operand_snapshot(rich_dataset, left_before)
+        if other_kind == "dataset":
+            self._assert_operand_snapshot(compatible_dataset, right_before)
+
+    def test_unit_conversion_does_not_mutate_source_operands(self):
+        left = make_semantic_2d_dataset(units="m", title="left metres", name="left_m")
+        right = make_semantic_2d_dataset(
+            data=np.ones((5, 7)) * 100.0,
+            units="cm",
+            title="right centimetres",
+            name="right_cm",
+        )
+        left_before = self._operand_snapshot(left)
+        right_before = self._operand_snapshot(right)
+
+        result = left + right
+
+        assert result.units == Unit("m")
+        assert_array_equal(result.data, left.data + right.data / 100.0)
+        self._assert_operand_snapshot(left, left_before)
+        self._assert_operand_snapshot(right, right_before)
+
+    def test_reflected_add_does_not_mutate_source(self, unmasked_dataset):
+        before = self._operand_snapshot(unmasked_dataset)
+
+        result = 2.0 + unmasked_dataset
+
+        assert_array_equal(result.data, 2.0 + unmasked_dataset.data)
+        self._assert_operand_snapshot(unmasked_dataset, before)
 
     def test_rsub_numerical(self, unmasked_dataset):
         assert_array_equal(


### PR DESCRIPTION
## Summary of changes

Skip the defensive copy of the first operand in `NDMath._op()` (src/spectrochempy/core/dataset/arraymixins/ndmath.py) **for out-of-place operations only**. In-place operators (`+=`, `-=`, `*=`, `/=`, ...) keep their existing defensive copy, via an explicit `inplace=True` flag passed from `_inplace_binary_op()`.

### Why the removed copy was redundant (out-of-place scope)

For out-of-place operations, every helper downstream of the copy point (`_prepare_operation_quantities()`, `_resolve_operation_units()`, `_execute_operation()`, `_apply_explicit_mask()`) only reads the first operand's data, units, mask and coordset; the only in-place mutation on the path is the unit conversion of the second operand (`other.ito(obj.units)`), already protected by its own dedicated copy.

### Why in-place operations keep their copy

In-place operators dispatch to mutating functions (`operator.iadd`, ...) whose first argument is the operand data buffer itself. The defensive copy is preserved there so that the previous observable behavior is unchanged: buffers the dataset was built from are not mutated before the final assignments, non-writable buffers stay usable, and a failure after the numerical step cannot leave the source partially mutated.

### Copy attribution

The dataset/dataset path previously copied the first operand and the second operand inside `_op()`, then built the result template in `_op_result()`. After this PR, out-of-place operations perform one fewer root reconstruction:

| Case | Root NDDataset copies before -> after |
|---|---|
| rich + scalar | 2 -> 1 |
| rich + rich2 | 4 -> 3 |
| scalar + rich reflected | 2 -> 1 |
| m + cm conversion | 4 -> 3 |
| unitless + scalar | 2 -> 1 |
| in-place (`+=`) | 1 -> 1 (unchanged, copy kept) |

Measured medians (temporary uncommitted probe, same methodology before/after, 7 repeats, warm-up, gc outside timed sections; macOS 12.7 x86_64, Python 3.13.14, numpy 2.5.1, start SHA `6f8ecdfc1`; local noisy machine — no CI threshold derived):

| Case | small (8x512) before -> after | medium (64x2048) before -> after |
|---|---:|---:|
| rich + scalar | ~44.8 -> ~24.2 ms | ~62.5 -> ~20.7 ms |
| rich + rich2 | ~68.6 -> ~51.0 ms | ~119.4 -> ~58.6 ms |
| scalar + rich reflected | ~37.2 -> ~17.6 ms | ~56.8 -> ~19.5 ms |
| m + cm conversion | ~78.3 -> ~56.4 ms | ~108.2 -> ~58.4 ms |
| masked + scalar | ~40.5 -> ~13.7 ms | ~76.0 -> ~22.3 ms |
| unitless + scalar | ~2.3 -> ~1.2 ms | ~19.0 -> ~5.3 ms |

In-place timings and counts revert to baseline exactly (verified by probe).

## Scientific contracts preserved

- numerical results, dtype, shape, complex data;
- units propagation and conversion (source operands never persistently converted);
- coordinates, dims order, labels, coordinate non-mutation;
- masks propagation/union and source mask non-mutation;
- meta (including nested), author/description/origin, name, title engine (T1-T5), history append;
- filename policy untouched;
- reflected operations unchanged; **in-place operators keep their previous behavior** (new regression guards below);
- public exceptions unchanged.

New in-place regression tests (fail on the pre-fix head, pass now): external buffer isolation for `ds *= 10` built from a user array, returned-object identity, usability of a non-writable buffer, and no partial data/mask/units mutation when an incompatible-units `+=` raises.

## Intentionally out of scope

- `NDDataset.copy()` itself, `copy(deep=False)` semantics, slicing, concatenation;
- `CoordSet` / `Meta` internals, trait notifications;
- any general result-builder abstraction;
- ufunc/comparison-specific campaigns beyond the shared `_op()` path.

Follows the bounded optimization target recorded in the active audit note `notes/audits/nddataset-copy-cost-and-contract-audit-2026-08-25.md` (maintainer repo), after characterization PR #1585.

## Validation

- full `tests/test_core/test_dataset`: 1744 passed;
- targeted suites (#1585 semantics, math baseline, ndmath mixins, coord/coordset/indexing/combination baselines): pass;
- one known pre-existing local-only OPUS reader failure (pint rendering artifact, green in CI) recorded in the maintainer audit note, unrelated;
- pre-commit run --all-files: passed; ruff and git diff --check: clean.

Changelog: prudent `PERF:` entry under Developer in docs/sources/whatsnew/changelog.rst.
