### PR TITLE
ENH: expose detector sample fields in peak finding results

### DIFF
--- a/docs/sources/userguide/analysis/peak_analysis_workflow.py
+++ b/docs/sources/userguide/analysis/peak_analysis_workflow.py
@@ -109,7 +109,11 @@ table
 # `PeakTable` gives us a dependency-light view of the detected peaks.  The raw
 # peak dataset and the raw SciPy-style property dictionary are still available on
 # `result`, but the table is often a better starting point for inspection,
-# export, and later workflow steps.
+# export, and later workflow steps.  Each row keeps both the refined
+# `position`/`height` and the exact discrete sample reported by the detector:
+# `sample_index` is local to the 1D signal passed to `find_peaks`, while
+# `sample_position` and `sample_height` are the coordinate and signal value at
+# that sample.
 
 # %%
 rows = table.to_dict()

--- a/docs/sources/userguide/analysis/peak_finding.py
+++ b/docs/sources/userguide/analysis/peak_finding.py
@@ -364,7 +364,11 @@ _ = ax.legend(fontsize=6)
 # If a tabular representation is needed for reporting or export, use
 # `as_result=True`. This keeps the default tuple return unchanged, but returns a
 # lightweight result object with a `table` view, dictionary rows and CSV export
-# helpers.
+# helpers. In result rows, `index` is only the row identifier. `sample_index` is
+# the local detector index in the 1D signal that was analyzed, with
+# `sample_position` and `sample_height` giving the exact coordinate and signal
+# value at that point. `position` and `height` remain the refined values and may
+# differ after interpolation.
 
 # %%
 result = s.find_peaks(height=(0.15, 0.22), prominence=0, as_result=True)

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,12 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+Added discrete detector-sample fields to ``find_peaks(..., as_result=True)``
+rows. ``PeakFindingResult`` and ``PeakTable`` now expose ``sample_index``,
+``sample_position`` and ``sample_height`` alongside the existing refined
+``position`` and ``height`` values, preserving the local SciPy detector index
+without reconstructing it from interpolated positions.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,15 @@ What's New in Revision 0.12.7.dev
 These are the changes in SpectroChemPy-0.12.7.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+New Features
+~~~~~~~~~~~~
+
+Added discrete detector-sample fields to ``find_peaks(..., as_result=True)``
+rows. ``PeakFindingResult`` and ``PeakTable`` now expose ``sample_index``,
+``sample_position`` and ``sample_height`` alongside the existing refined
+``position`` and ``height`` values, preserving the local SciPy detector index
+without reconstructing it from interpolated positions.
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/peakfinding/peakfinding.py
+++ b/src/spectrochempy/analysis/peakfinding/peakfinding.py
@@ -74,7 +74,16 @@ def _column_value(value, *, unit=None, as_float=False):
     return value
 
 
-_BASE_PEAK_COLUMNS = ("index", "position", "height")
+_BASE_PEAK_COLUMNS = (
+    "index",
+    "position",
+    "height",
+)
+_SAMPLE_PEAK_COLUMNS = (
+    "sample_index",
+    "sample_position",
+    "sample_height",
+)
 _PROPERTY_COLUMN_NAMES = {
     "peak_heights": "peak_height",
     "prominences": "prominence",
@@ -90,7 +99,24 @@ _PROPERTY_COLUMN_NAMES = {
 }
 
 
-def _peak_rows(peaks, properties, *, raw_property_names=False):
+def _copy_values(values):
+    """Return a detached copy when the object supports copying."""
+    if values is None:
+        return None
+    if hasattr(values, "copy"):
+        return values.copy()
+    return list(values)
+
+
+def _peak_rows(
+    peaks,
+    properties,
+    *,
+    sample_index=None,
+    sample_position=None,
+    sample_height=None,
+    raw_property_names=False,
+):
     """Build row dictionaries from peak positions, heights, and properties."""
     if peaks is None:
         return []
@@ -116,6 +142,12 @@ def _peak_rows(peaks, properties, *, raw_property_names=False):
             "position": _sequence_item(positions, index),
             "height": _sequence_item(heights, index),
         }
+        if sample_index is not None:
+            row["sample_index"] = _sequence_item(sample_index, index)
+        if sample_position is not None:
+            row["sample_position"] = _sequence_item(sample_position, index)
+        if sample_height is not None:
+            row["sample_height"] = _sequence_item(sample_height, index)
         for key, values in per_peak_properties.items():
             column = key if raw_property_names else _PROPERTY_COLUMN_NAMES.get(key, key)
             row[column] = _sequence_item(values, index)
@@ -142,6 +174,13 @@ def _fieldnames(rows, *, columns=_BASE_PEAK_COLUMNS):
     return fieldnames
 
 
+def _has_sample_fields(sample_index, sample_position, sample_height):
+    """Return True when all discrete sample fields are available."""
+    return all(
+        value is not None for value in (sample_index, sample_position, sample_height)
+    )
+
+
 class PeakTable:
     """
     Dependency-light tabular view of detected peaks.
@@ -160,11 +199,30 @@ class PeakTable:
     dictionary remains available on :class:`PeakFindingResult`.
     """
 
-    __slots__ = ("peaks", "properties", "_rows")
+    __slots__ = (
+        "peaks",
+        "properties",
+        "sample_index",
+        "sample_position",
+        "sample_height",
+        "_rows",
+    )
 
-    def __init__(self, peaks, properties=None, rows=None):
+    def __init__(
+        self,
+        peaks,
+        properties=None,
+        rows=None,
+        *,
+        sample_index=None,
+        sample_position=None,
+        sample_height=None,
+    ):
         self.peaks = peaks
         self.properties = dict(properties or {})
+        self.sample_index = _copy_values(sample_index)
+        self.sample_position = _copy_values(sample_position)
+        self.sample_height = _copy_values(sample_height)
         self._rows = None if rows is None else [dict(row) for row in rows]
 
     def __len__(self):
@@ -181,19 +239,32 @@ class PeakTable:
     @property
     def columns(self):
         """Return stable base columns plus currently available optional columns."""
-        return tuple(_fieldnames(self.to_dict()))
+        columns = list(_BASE_PEAK_COLUMNS)
+        if _has_sample_fields(
+            self.sample_index,
+            self.sample_position,
+            self.sample_height,
+        ):
+            columns.extend(_SAMPLE_PEAK_COLUMNS)
+        return tuple(_fieldnames(self.to_dict(), columns=columns))
 
     def to_dict(self):
         """
         Return peak information as a list of dictionaries.
 
-        Each dictionary contains ``index``, ``position``, ``height`` and any
-        available per-peak properties. Values keep their native units when they
-        are unit-bearing quantities.
+        Each dictionary contains ``index``, ``position``, ``height``, available
+        discrete sample fields and any available per-peak properties. Values
+        keep their native units when they are unit-bearing quantities.
         """
         if self._rows is not None:
             return [dict(row) for row in self._rows]
-        return _peak_rows(self.peaks, self.properties)
+        return _peak_rows(
+            self.peaks,
+            self.properties,
+            sample_index=self.sample_index,
+            sample_position=self.sample_position,
+            sample_height=self.sample_height,
+        )
 
     def head(self, n):
         """
@@ -283,7 +354,7 @@ class PeakTable:
         """
         path = Path(path)
         rows = self.to_dict()
-        fieldnames = _fieldnames(rows)
+        fieldnames = self.columns
 
         with path.open("w", newline="", encoding="utf-8") as fid:
             writer = csv.DictWriter(fid, fieldnames=fieldnames, delimiter=delimiter)
@@ -313,11 +384,28 @@ class PeakFindingResult:
     table helpers and does not require pandas.
     """
 
-    __slots__ = ("peaks", "properties")
+    __slots__ = (
+        "peaks",
+        "properties",
+        "sample_index",
+        "sample_position",
+        "sample_height",
+    )
 
-    def __init__(self, peaks, properties=None):
+    def __init__(
+        self,
+        peaks,
+        properties=None,
+        *,
+        sample_index=None,
+        sample_position=None,
+        sample_height=None,
+    ):
         self.peaks = peaks
         self.properties = dict(properties or {})
+        self.sample_index = _copy_values(sample_index)
+        self.sample_position = _copy_values(sample_position)
+        self.sample_height = _copy_values(sample_height)
 
     def __len__(self):
         return 0 if self.peaks is None else len(self.peaks)
@@ -333,17 +421,31 @@ class PeakFindingResult:
     @property
     def table(self):
         """Return a dependency-light tabular view of the detected peaks."""
-        return PeakTable(self.peaks, self.properties)
+        return PeakTable(
+            self.peaks,
+            self.properties,
+            sample_index=self.sample_index,
+            sample_position=self.sample_position,
+            sample_height=self.sample_height,
+        )
 
     def to_dict(self):
         """
         Return peak information as a list of dictionaries.
 
-        Each dictionary contains ``index``, ``position``, ``height``, and any
+        Each dictionary contains ``index`` (the row identifier), refined
+        ``position`` and ``height``, available discrete sample fields, plus any
         per-peak properties whose length matches the number of detected peaks.
         Values keep their native units when they are unit-bearing quantities.
         """
-        return _peak_rows(self.peaks, self.properties, raw_property_names=True)
+        return _peak_rows(
+            self.peaks,
+            self.properties,
+            sample_index=self.sample_index,
+            sample_position=self.sample_position,
+            sample_height=self.sample_height,
+            raw_property_names=True,
+        )
 
     def to_csv(self, path, *, delimiter=","):
         """
@@ -526,12 +628,21 @@ def find_peaks(
         ``as_result=False``.
     result : PeakFindingResult
         Structured peak finding result. Returned when ``as_result=True``.
+        Result rows include ``sample_index``, ``sample_position`` and
+        ``sample_height`` for the discrete detector sample in addition to the
+        refined ``position`` and ``height``.
 
     Notes
     -----
     - Peak positions are refined using quadratic interpolation when window_length > 1
     - The function handles units automatically when use_coord=True
     - For noisy data, consider preprocessing with smoothing functions
+    - In :class:`PeakFindingResult`, ``index`` is the row identifier,
+      ``sample_index`` is the local index returned by the detector for the
+      1D signal actually analyzed, ``sample_position`` and ``sample_height``
+      are the coordinate and signal value at that sample, and ``position`` and
+      ``height`` are the existing refined values. No global index into a parent
+      dataset is reported for sliced inputs.
 
     Examples
     --------
@@ -654,6 +765,14 @@ def find_peaks(
     properties = properties if properties else {}
 
     out = X[peaks]
+    sample_index = peaks.astype(int, copy=True)
+    if use_coord:
+        sample_position = _copy_values(lastcoord.values[sample_index])
+    else:
+        sample_position = sample_index.copy()
+    sample_height = _copy_values(X.data[sample_index])
+    if X.units is not None:
+        sample_height = sample_height * X.units
 
     if not use_coord:
         out.coordset = None  # remove the coordinates
@@ -731,6 +850,12 @@ def find_peaks(
     out.history = f"find_peaks(): {len(peaks)} peak(s) found"
 
     if as_result:
-        return PeakFindingResult(out, properties)
+        return PeakFindingResult(
+            out,
+            properties,
+            sample_index=sample_index,
+            sample_position=sample_position,
+            sample_height=sample_height,
+        )
 
     return out, properties

--- a/tests/test_analysis/test_peakfinding/test_peakfinding.py
+++ b/tests/test_analysis/test_peakfinding/test_peakfinding.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import pytest
+import scipy.signal
 
 from spectrochempy.analysis.peakfinding.peakfinding import PeakFindingResult
 from spectrochempy.analysis.peakfinding.peakfinding import PeakTable
@@ -188,13 +189,24 @@ def test_as_result_keeps_peak_data_and_allows_unpacking(simple_peaks_dataset):
 def test_peak_finding_result_to_dict(simple_peaks_dataset):
     """Structured result exposes dependency-light row dictionaries."""
     result = find_peaks(simple_peaks_dataset, height=0.5, width=0.1, as_result=True)
+    expected_indices, _ = scipy.signal.find_peaks(simple_peaks_dataset.data, height=0.5)
 
     rows = result.to_dict()
 
     assert len(rows) == 3
     assert rows[0]["index"] == 0
+    assert result.sample_index.tolist() == expected_indices.tolist()
+    assert rows[0]["sample_index"] == int(expected_indices[0])
     assert rows[0]["position"].units == ur("cm^-1")
     assert rows[0]["height"].units == ur.absorbance
+    assert rows[0]["sample_position"].units == ur("cm^-1")
+    assert rows[0]["sample_height"].units == ur.absorbance
+    assert rows[0]["sample_position"].m == pytest.approx(
+        simple_peaks_dataset.x.values[expected_indices[0]].m
+    )
+    assert rows[0]["sample_height"].m == pytest.approx(
+        simple_peaks_dataset.data[expected_indices[0]]
+    )
     assert "peak_heights" in rows[0]
     assert "widths" in rows[0]
 
@@ -212,13 +224,157 @@ def test_peak_table_exposes_singular_column_names(simple_peaks_dataset):
     assert list(table) == rows
     assert "peak_height" in table.columns
     assert "width" in table.columns
+    assert "sample_index" in table.columns
+    assert "sample_position" in table.columns
+    assert "sample_height" in table.columns
     assert "peak_heights" not in table.columns
     assert "widths" not in table.columns
     assert rows[0]["position"].units == ur("cm^-1")
     assert rows[0]["height"].units == ur.absorbance
+    assert rows[0]["sample_position"].units == ur("cm^-1")
+    assert rows[0]["sample_height"].units == ur.absorbance
     assert rows[0]["peak_height"].units == ur.absorbance
     assert rows[0]["width"].units == ur("cm^-1")
     assert "peak_heights" in result.properties
+
+
+def test_peak_finding_result_discrete_fields_track_scipy_indices():
+    """sample_index preserves the raw detector indices, not nearest positions."""
+    x = np.linspace(0.0, 6.0, 7)
+    y = np.array([0.0, 0.0, 2.0, 1.8, 0.0, 1.0, 0.0])
+    dataset = NDDataset(
+        y,
+        coordset=[Coord(x, title="x", units="cm^-1")],
+        units="absorbance",
+    )
+    expected_indices, _ = scipy.signal.find_peaks(y, height=0.5)
+
+    result = find_peaks(dataset, height=0.5, as_result=True)
+    rows = result.to_dict()
+
+    assert result.sample_index.tolist() == expected_indices.tolist()
+    assert [row["sample_index"] for row in rows] == expected_indices.tolist()
+    assert [row["sample_position"].m for row in rows] == pytest.approx(
+        x[expected_indices]
+    )
+    assert [row["sample_height"].m for row in rows] == pytest.approx(
+        y[expected_indices]
+    )
+    assert rows[0]["position"].m != pytest.approx(rows[0]["sample_position"].m)
+    assert rows[0]["height"].m != pytest.approx(rows[0]["sample_height"].m)
+
+
+def test_peak_finding_result_sample_fields_with_descending_axis():
+    """Discrete sample fields follow signal order on descending coordinates."""
+    x = np.linspace(10.0, 0.0, 11)
+    y = np.zeros_like(x)
+    y[[2, 8]] = [1.0, 2.0]
+    dataset = NDDataset(
+        y,
+        coordset=[Coord(x, title="x", units="cm^-1")],
+        units="absorbance",
+    )
+    expected_indices, _ = scipy.signal.find_peaks(y, height=0.5)
+
+    result = find_peaks(dataset, height=0.5, as_result=True)
+
+    assert result.sample_index.tolist() == expected_indices.tolist()
+    assert [value.m for value in result.sample_position] == pytest.approx(
+        x[expected_indices]
+    )
+    assert [value.m for value in result.sample_height] == pytest.approx(
+        y[expected_indices]
+    )
+
+
+def test_peak_finding_result_sample_fields_with_irregular_axis():
+    """sample_position uses the actual coordinate at the detector index."""
+    x = np.array([0.0, 0.3, 1.0, 2.1, 3.8, 6.0, 8.5])
+    y = np.array([0.0, 1.0, 0.0, 0.2, 2.0, 0.1, 0.0])
+    dataset = NDDataset(
+        y,
+        coordset=[Coord(x, title="x", units="cm^-1")],
+        units="absorbance",
+    )
+    expected_indices, _ = scipy.signal.find_peaks(y, height=0.5)
+
+    with pytest.warns(UserWarning):
+        result = find_peaks(dataset, height=0.5, as_result=True)
+
+    assert result.sample_index.tolist() == expected_indices.tolist()
+    assert [value.m for value in result.sample_position] == pytest.approx(
+        x[expected_indices]
+    )
+    assert [value.m for value in result.sample_height] == pytest.approx(
+        y[expected_indices]
+    )
+
+
+def test_peak_finding_result_sample_fields_without_coordinate_use():
+    """With use_coord=False, sample_position is the local point index."""
+    x = np.linspace(0.0, 10.0, 11)
+    y = np.zeros_like(x)
+    y[[3, 7]] = [1.0, 2.0]
+    dataset = NDDataset(y, coordset=[Coord(x, title="x")])
+    expected_indices, _ = scipy.signal.find_peaks(y, height=0.5)
+
+    result = find_peaks(dataset, height=0.5, use_coord=False, as_result=True)
+
+    assert result.sample_index.tolist() == expected_indices.tolist()
+    assert result.sample_position.tolist() == expected_indices.tolist()
+    assert result.sample_height.tolist() == y[expected_indices].tolist()
+
+
+def test_peak_finding_result_sample_index_is_local_to_roi():
+    """sample_index is local to the 1D dataset passed to find_peaks."""
+    x = np.linspace(0.0, 10.0, 11)
+    y = np.zeros_like(x)
+    y[6] = 1.0
+    dataset = NDDataset(
+        y,
+        coordset=[Coord(x, title="x", units="cm^-1")],
+        units="absorbance",
+    )
+    roi = dataset[3:9]
+    expected_indices, _ = scipy.signal.find_peaks(roi.data, height=0.5)
+
+    result = find_peaks(roi, height=0.5, as_result=True)
+    row = result.to_dict()[0]
+
+    assert result.sample_index.tolist() == expected_indices.tolist()
+    assert row["sample_index"] == 3
+    assert row["sample_position"].m == pytest.approx(6.0)
+    assert row["sample_height"].m == pytest.approx(1.0)
+
+
+def test_peak_finding_result_sample_fields_align_with_plateau_properties():
+    """Plateau properties remain aligned with the same rows as sample fields."""
+    y = np.zeros(12)
+    y[2:5] = 1.0
+    y[8:10] = 2.0
+    expected_indices, expected_properties = scipy.signal.find_peaks(y, plateau_size=2)
+    dataset = NDDataset(y)
+
+    result = find_peaks(
+        dataset,
+        plateau_size=2,
+        use_coord=False,
+        window_length=0,
+        as_result=True,
+    )
+    rows = result.to_dict()
+
+    assert result.sample_index.tolist() == expected_indices.tolist()
+    assert [row["sample_index"] for row in rows] == expected_indices.tolist()
+    assert [row["sample_height"] for row in rows] == pytest.approx(y[expected_indices])
+    assert (
+        result.properties["left_edges"].tolist()
+        == expected_properties["left_edges"].tolist()
+    )
+    assert (
+        result.properties["right_edges"].tolist()
+        == expected_properties["right_edges"].tolist()
+    )
 
 
 def test_peak_table_sort_head_and_column_helpers(simple_peaks_dataset):
@@ -252,6 +408,25 @@ def test_peak_table_helper_unknown_column(simple_peaks_dataset):
         result.table.column("missing")
 
 
+def test_manual_peak_table_without_sample_fields_does_not_advertise_them(
+    simple_peaks_dataset,
+):
+    """Manual public construction keeps columns aligned with row contents."""
+    peaks, properties = find_peaks(simple_peaks_dataset, height=0.5, width=0.1)
+
+    table = PeakTable(peaks, properties)
+    result_table = PeakFindingResult(peaks, properties).table
+
+    assert "sample_index" not in table.columns
+    assert "sample_position" not in table.columns
+    assert "sample_height" not in table.columns
+    assert table.to_dict()[0].keys() == result_table.to_dict()[0].keys()
+    with pytest.raises(KeyError, match="Unknown peak-table column"):
+        table.column("sample_index")
+    with pytest.raises(KeyError, match="Unknown peak-table column"):
+        result_table.column("sample_index")
+
+
 def test_peak_finding_result_to_dict_single_peak(simple_peaks_dataset):
     """Single-peak coordinate values can be scalar quantities."""
     result = find_peaks(
@@ -275,6 +450,9 @@ def test_peak_finding_result_to_csv(simple_peaks_dataset, tmp_path):
     assert written == path
     text = path.read_text(encoding="utf-8")
     assert text.startswith("index,position,height")
+    assert "sample_index" in text
+    assert "sample_position" in text
+    assert "sample_height" in text
     assert "peak_heights" in text
     assert "widths" in text
 
@@ -289,6 +467,9 @@ def test_peak_table_to_csv(simple_peaks_dataset, tmp_path):
     assert written == path
     text = path.read_text(encoding="utf-8")
     assert text.startswith("index,position,height")
+    assert "sample_index" in text
+    assert "sample_position" in text
+    assert "sample_height" in text
     assert "peak_height" in text
     assert "width" in text
     assert "peak_heights" not in text


### PR DESCRIPTION
## Summary

Adds discrete detector-sample fields to `find_peaks(..., as_result=True)` while preserving the existing refined peak outputs.

`PeakFindingResult` and `PeakTable` rows now include:

- `sample_index`: local index returned by the underlying detector for the 1D signal actually analyzed
- `sample_position`: coordinate at `sample_index`
- `sample_height`: signal value at `sample_index`

Existing `index`, `position`, `height`, raw properties, tuple unpacking, sorting, and interpolation behavior are preserved.

Follow-up review correction:

- `PeakTable.columns` and CSV headers now advertise `sample_*` fields only when those fields are actually present
- Manual public construction with `PeakTable(peaks, properties)` or `PeakFindingResult(peaks, properties).table` keeps the historical column set and raises `KeyError` for `column("sample_index")`

## Out of scope

- No detector threshold/default changes
- No interpolation changes
- No peak reordering
- No global/parent dataset index reconstruction for sliced inputs

## Validation

- `micromamba run -n scpy-core python -m pytest -q tests/test_analysis/test_peakfinding/test_peakfinding.py`
  - `38 passed`
- `pre-commit run --all-files`
  - passed after one automatic formatting pass
- `micromamba run -n scpy-core python -m pytest -q`
  - `5640 passed, 18 skipped, 2 xpassed, 2 failed`
  - Failures appear unrelated to this change:
    - `tests/test_core/test_readers/test_read_opus.py::TestOpusAssembledTimeResolved::test_default_absorbance`: expected `cm^-1`, got `cm⁻¹`
    - `tests/test_extern/test_brukeropus.py::test_opus_file_detection`: local OPUS testdata cache reports 6 files instead of expected 5