### PR TITLE
MAINT: harden estimator contract for future pipeline

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -53,3 +53,8 @@ Deprecations
 Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
+
+- Added the internal estimator-contract helpers required before a future
+  ``Pipeline`` implementation: allowlist-based fitted-state inspection,
+  unfitted cloning, canonical not-fitted behavior for supported transformers,
+  and lifecycle invalidation for accepted analysis terminal candidates.

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.12
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.12.7
     v0.12.6
     v0.12.5

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,10 +6,10 @@
 
 :orphan:
 
-What's New in Revision 0.12.7.dev
+What's New in Revision 0.12.8.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.7.dev.
+These are the changes in SpectroChemPy-0.12.8.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
 Developer

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,27 +6,16 @@
 
 :orphan:
 
-What's New in Revision 0.12.7
+What's New in Revision 0.12.7.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.7.
+These are the changes in SpectroChemPy-0.12.7.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
-
-New Features
-~~~~~~~~~~~~
-
-Added discrete detector-sample fields to ``find_peaks(..., as_result=True)``
-rows. ``PeakFindingResult`` and ``PeakTable`` now expose ``sample_index``,
-``sample_position`` and ``sample_height`` alongside the existing refined
-``position`` and ``height`` values, preserving the local SciPy detector index
-without reconstructing it from interpolated positions.
 
 Developer
 ~~~~~~~~~
 
-PERF: Skipped the redundant defensive copy of the first operand in out-of-place
-binary and unary arithmetic result construction, removing one root dataset
-reconstruction per operation (root copies from 2 to 1 for dataset/scalar and
-from 4 to 3 for dataset/dataset) while preserving results, units, masks,
-coordinates, metadata, and operand non-mutation semantics. In-place operators
-keep their defensive copy unchanged.
+- Added the internal estimator-contract helpers required before a future
+  ``Pipeline`` implementation: allowlist-based fitted-state inspection,
+  unfitted cloning, canonical not-fitted behavior for supported transformers,
+  and lifecycle invalidation for accepted analysis terminal candidates.

--- a/src/spectrochempy/analysis/_base/_analysisbase.py
+++ b/src/spectrochempy/analysis/_base/_analysisbase.py
@@ -8,6 +8,7 @@
 import copy
 import logging
 import warnings
+from contextlib import suppress
 from types import SimpleNamespace
 
 import numpy as np
@@ -18,6 +19,7 @@ from spectrochempy.application.application import app
 from spectrochempy.core.dataset.basearrays.ndarray import NDArray
 from spectrochempy.core.dataset.nddataset import NDDataset
 from spectrochempy.extern.traittypes import Array
+from spectrochempy.utils._estimator import parameter_values_equal
 from spectrochempy.utils.baseconfigurable import BaseConfigurable
 from spectrochempy.utils.constants import NOMASK
 from spectrochempy.utils.decorators import _wrap_ndarray_output_to_nddataset
@@ -100,6 +102,16 @@ class AnalysisConfigurable(BaseConfigurable):
     # ----------------------------------------------------------------------------------
     _fitted = tr.Bool(False, help="False if the model was not yet fitted")
     _outfit = tr.Any(help="the output of the _fit method - generally a tuple")
+    _pipeline_contract_managed = False
+    _learned_attributes = (
+        "_outfit",
+        "_X",
+        "_Y",
+        "_X_preprocessed",
+        "_Y_preprocessed",
+        "_X_source_metadata",
+        "_Y_source_metadata",
+    )
 
     _X_source_metadata = tr.Instance(
         AnalysisSourceMetadata,
@@ -937,31 +949,39 @@ class AnalysisConfigurable(BaseConfigurable):
         fit_reduce : Alias of `fit_transform` (Deprecated).
 
         """
-        self._fitted = False  # reinit this flag
+        if self._pipeline_contract_managed:
+            self._invalidate_fitted_state()
+        else:
+            self._fitted = False  # reinit this flag
 
-        # fire the X and eventually Y validation and preprocessing.
-        # X and Y are expected to be resp. NDDataset and NDDataset or list of NDDataset.
-        self._capture_source_metadata("_X", X, force=True)
-        self._X = X
-        self._capture_source_metadata("_Y", Y, force=True)
-        if Y is not None:
-            self._Y = Y
-
-        # _X_preprocessed has been computed when X was set, as well as _Y_preprocessed.
-        # At this stage they should be simple ndarrays
-        newX = self._X_preprocessed
-        newY = self._Y_preprocessed if Y is not None else None
-
-        # Call to the actual _fit method (overloaded in the subclass)
-        # warning : _fit must take ndarray arguments not NDDataset arguments.
-        # when method must return NDDataset from the calculated data,
-        # we use the decorator _wrap_ndarray_output_to_nddataset, as in the PCA
-        # model for example.
         try:
-            self._outfit = self._fit(newX, newY)
-        except TypeError:
-            # in case Y s not used in _fit
-            self._outfit = self._fit(newX)
+            # fire the X and eventually Y validation and preprocessing.
+            # X and Y are expected to be resp. NDDataset and NDDataset or list of NDDataset.
+            self._capture_source_metadata("_X", X, force=True)
+            self._X = X
+            self._capture_source_metadata("_Y", Y, force=True)
+            if Y is not None:
+                self._Y = Y
+
+            # _X_preprocessed has been computed when X was set, as well as _Y_preprocessed.
+            # At this stage they should be simple ndarrays
+            newX = self._X_preprocessed
+            newY = self._Y_preprocessed if Y is not None else None
+
+            # Call to the actual _fit method (overloaded in the subclass)
+            # warning : _fit must take ndarray arguments not NDDataset arguments.
+            # when method must return NDDataset from the calculated data,
+            # we use the decorator _wrap_ndarray_output_to_nddataset, as in the PCA
+            # model for example.
+            try:
+                self._outfit = self._fit(newX, newY)
+            except TypeError:
+                # in case Y s not used in _fit
+                self._outfit = self._fit(newX)
+        except Exception:
+            if self._pipeline_contract_managed:
+                self._invalidate_fitted_state()
+            raise
 
         # if the process was successful, _fitted is set to True so that other method
         # which needs fit will be possibly used.
@@ -1032,13 +1052,45 @@ class AnalysisConfigurable(BaseConfigurable):
             If a parameter name does not correspond to a configurable trait.
 
         """
-        for key, value in params.items():
-            if not self._has_writable_public_parameter(key):
-                raise SpectroChemPyError(
-                    f"Invalid parameter '{key}' for {self.__class__.__name__}."
-                )
-            setattr(self, key, value)
+        invalid = [
+            key for key in params if not self._has_writable_public_parameter(key)
+        ]
+        if invalid:
+            key = invalid[0]
+            valid_names = ", ".join(sorted(self.get_params(deep=False)))
+            msg = f"Invalid parameter '{key}' for {self.__class__.__name__}."
+            if valid_names:
+                msg += f" Valid parameters: {valid_names}."
+            raise SpectroChemPyError(msg)
+
+        current = self.get_params(deep=False)
+        changed = any(
+            not parameter_values_equal(current[key], value)
+            for key, value in params.items()
+        )
+        applied = []
+        try:
+            for key, value in params.items():
+                setattr(self, key, value)
+                applied.append(key)
+        except Exception:
+            for key in reversed(applied):
+                setattr(self, key, current[key])
+            raise
+        if changed and self._pipeline_contract_managed:
+            self._invalidate_fitted_state()
         return self
+
+    def _invalidate_fitted_state(self):
+        """Mark managed estimators as unfitted and clear known runtime state."""
+        self._fitted = False
+        for name in self._learned_attributes:
+            with suppress(AttributeError, TypeError, NotFittedError):
+                delattr(self, name)
+        self._reset_backend_estimator()
+
+    def _reset_backend_estimator(self):
+        """Reset class-specific numerical backend after invalidation."""
 
     def __repr__(self):
         cls = self.__class__.__name__
@@ -1796,6 +1848,8 @@ class CrossDecompositionAnalysis(DecompositionAnalysis):
 # Base class LinearRegressionAnalysis
 # ======================================================================================
 class LinearRegressionAnalysis(AnalysisConfigurable):
+    _pipeline_contract_managed = True
+
     # ----------------------------------------------------------------------------------
     # Configuration parameters (mostly defined in subclass
     # as they depend on the model estimator)
@@ -1837,7 +1891,10 @@ class LinearRegressionAnalysis(AnalysisConfigurable):
             **kwargs,
         )
 
-        # initialize sklearn LinearRegression
+        self._reset_backend_estimator()
+
+    def _reset_backend_estimator(self):
+        """Initialize the sklearn linear-regression backend from current config."""
         self._linear_regression = linear_model.LinearRegression(
             fit_intercept=self.fit_intercept,
             n_jobs=None,  # not used for the moment (XXX: should we add this?)
@@ -1907,11 +1964,7 @@ class LinearRegressionAnalysis(AnalysisConfigurable):
             Returns the instance itself.
 
         """
-        self._fitted = False  # reiniit this flag
-
-        # store if the original input type is a dataset (or at least a subclass instance
-        # of NDArray)
-        self._is_dataset = isinstance(X, NDArray)
+        self._invalidate_fitted_state()
 
         def _make2D(X):
             # For regression analysis we need X as a NDDataset with two dimensions
@@ -1927,35 +1980,44 @@ class LinearRegressionAnalysis(AnalysisConfigurable):
                 X.set_coordset(x=coordx, a=None)
             return X
 
-        # fire the X and Y validation and preprocessing.
-        if Y is not None:
-            self._capture_source_metadata("_X", X, force=True)
-            self._X = _make2D(X)
-            self._capture_source_metadata("_Y", Y, force=True)
-            self._Y = Y
-        else:
-            # X should contain the X and Y information (X being the coord and Y the data)
-            if X.coordset is None:
-                raise ValueError(
-                    "The passed argument must have a x coordinates,"
-                    "or X input and Y target must be passed separately",
-                )
-            self._capture_source_metadata("_X", X.coord(0), force=True)
-            self._X = _make2D(X.coord(0))
-            self._capture_source_metadata("_Y", X, force=True)
-            self._Y = X
+        try:
+            # store if the original input type is a dataset (or at least a subclass
+            # instance of NDArray)
+            self._is_dataset = isinstance(X, NDArray)
 
-        # _X_preprocessed has been computed when X was set, as well as _Y_preprocessed.
-        # At this stage they should be simple ndarrays
-        newX = self._X_preprocessed
-        newY = self._Y_preprocessed
+            # fire the X and Y validation and preprocessing.
+            if Y is not None:
+                self._capture_source_metadata("_X", X, force=True)
+                self._X = _make2D(X)
+                self._capture_source_metadata("_Y", Y, force=True)
+                self._Y = Y
+            else:
+                # X should contain the X and Y information (X being the coord and Y
+                # the data)
+                if X.coordset is None:
+                    raise ValueError(
+                        "The passed argument must have a x coordinates,"
+                        "or X input and Y target must be passed separately",
+                    )
+                self._capture_source_metadata("_X", X.coord(0), force=True)
+                self._X = _make2D(X.coord(0))
+                self._capture_source_metadata("_Y", X, force=True)
+                self._Y = X
 
-        # call to the actual _fit method (overloaded in the subclass)
-        # warning : _fit must take ndarray arguments not NDDataset arguments.
-        # when method must return NDDataset from the calculated data,
-        # we use the decorator _wrap_ndarray_output_to_nddataset, as below or in the PCA
-        # model for example.
-        self._outfit = self._fit(newX, newY, sample_weight=sample_weight)
+            # _X_preprocessed has been computed when X was set, as well as _Y_preprocessed.
+            # At this stage they should be simple ndarrays
+            newX = self._X_preprocessed
+            newY = self._Y_preprocessed
+
+            # call to the actual _fit method (overloaded in the subclass)
+            # warning : _fit must take ndarray arguments not NDDataset arguments.
+            # when method must return NDDataset from the calculated data,
+            # we use the decorator _wrap_ndarray_output_to_nddataset, as below or in the PCA
+            # model for example.
+            self._outfit = self._fit(newX, newY, sample_weight=sample_weight)
+        except Exception:
+            self._invalidate_fitted_state()
+            raise
 
         # if the process was successful,_fitted is set to True so that other method which
         # needs fit will be possibly used.

--- a/src/spectrochempy/analysis/crossdecomposition/pls.py
+++ b/src/spectrochempy/analysis/crossdecomposition/pls.py
@@ -36,6 +36,23 @@ if sklearn_version < "1.5":
 # ======================================================================================
 @signature_has_configurable_traits
 class PLSRegression(CrossDecompositionAnalysis):
+    _pipeline_contract_managed = True
+    _learned_attributes = CrossDecompositionAnalysis._learned_attributes + (
+        "_x_weights",
+        "_y_weights",
+        "_x_loadings",
+        "_y_loadings",
+        "_x_scores",
+        "_y_scores",
+        "_x_rotations",
+        "_y_rotations",
+        "_coef",
+        "_intercept",
+        "_n_iter",
+        "_n_feature_in",
+        "_n_components",
+    )
+
     # ----------------------------------------------------------------------------------
     # Runtime Parameters,
     # only those specific to PLSRegression, the other being defined in AnalysisConfigurable.
@@ -91,7 +108,10 @@ class PLSRegression(CrossDecompositionAnalysis):
             **kwargs,
         )
 
-        # initialize sklearn PLSRegression
+        self._reset_backend_estimator()
+
+    def _reset_backend_estimator(self):
+        """Initialize the sklearn PLS backend from current configuration."""
         self._plsregression = cross_decomposition.PLSRegression(
             n_components=self.n_components,
             scale=self.scale,
@@ -106,6 +126,7 @@ class PLSRegression(CrossDecompositionAnalysis):
     def _fit(self, X, y):
         # this method is called by the abstract class fit.
         # Input X and Y are np.ndarray
+        self._reset_backend_estimator()
         self._plsregression.fit(X, y)
         self._x_weights = self._plsregression.x_weights_.T
         self._y_weights = self._plsregression.y_weights_.T

--- a/src/spectrochempy/analysis/decomposition/pca.py
+++ b/src/spectrochempy/analysis/decomposition/pca.py
@@ -54,6 +54,20 @@ class PCA(DecompositionAnalysis):
 
     """
 
+    _pipeline_contract_managed = True
+    _learned_attributes = DecompositionAnalysis._learned_attributes + (
+        "_components",
+        "_noise_variance",
+        "_n_observations",
+        "_explained_variance",
+        "_explained_variance_ratio",
+        "_singular_values",
+        "_n_components",
+        "_std",
+        "_min",
+        "_ampl",
+    )
+
     # ----------------------------------------------------------------------------------
     # Runtime Parameters,
     # only those specific to PCA, the other being defined in AnalysisConfigurable.
@@ -184,7 +198,10 @@ for reproducible results across multiple function calls.""",
             **kwargs,
         )
 
-        # initialize sklearn PCA
+        self._reset_backend_estimator()
+
+    def _reset_backend_estimator(self):
+        """Initialize the sklearn PCA backend from current configuration."""
         self._pca = decomposition.PCA(
             n_components=self.n_components,
             whiten=self.whiten,
@@ -244,6 +261,7 @@ for reproducible results across multiple function calls.""",
         # this method is called by the abstract class fit.
         # Input X is a np.ndarray
         # Y is ignored in this model
+        self._reset_backend_estimator()
 
         # call the sklearn _fit function on data (it outputs SVD results)
         # _outfit is a tuple handle the eventual output of _fit for further processing.

--- a/src/spectrochempy/processing/transformation/preprocessing_transformers.py
+++ b/src/spectrochempy/processing/transformation/preprocessing_transformers.py
@@ -53,6 +53,7 @@ import inspect
 
 import numpy as np
 
+from spectrochempy.utils.exceptions import NotFittedError
 from spectrochempy.utils.exceptions import SpectroChemPyError
 
 
@@ -134,10 +135,7 @@ class BasePreprocessor:
 
         """
         if not self._fitted:
-            raise SpectroChemPyError(
-                "This transformer instance is not fitted yet. "
-                "Call 'fit' with appropriate arguments before using this method."
-            )
+            raise NotFittedError(attr="transform")
         return self._transform(dataset)
 
     def fit_transform(self, dataset):
@@ -182,10 +180,7 @@ class BasePreprocessor:
 
         """
         if not self._fitted:
-            raise SpectroChemPyError(
-                "This transformer instance is not fitted yet. "
-                "Call 'fit' with appropriate arguments before using this method."
-            )
+            raise NotFittedError(attr="inverse_transform")
         return self._inverse_transform(dataset)
 
     def get_params(self, deep=True):

--- a/src/spectrochempy/utils/__init__.pyi
+++ b/src/spectrochempy/utils/__init__.pyi
@@ -7,6 +7,7 @@
 # ruff: noqa
 
 __all__ = [
+    "_estimator",
     "_logging",
     "baseconfigurable",
     "colors",
@@ -39,6 +40,7 @@ __all__ = [
     "zip",
 ]
 
+from . import _estimator
 from . import _logging
 from . import baseconfigurable
 from . import colors

--- a/src/spectrochempy/utils/_estimator.py
+++ b/src/spectrochempy/utils/_estimator.py
@@ -129,7 +129,7 @@ def parameter_values_equal(old, new):
             return False
     try:
         equal = old == new
-    except (TypeError, ValueError):
+    except Exception:
         return False
     if isinstance(equal, np.ndarray | np.bool_):
         try:

--- a/src/spectrochempy/utils/_estimator.py
+++ b/src/spectrochempy/utils/_estimator.py
@@ -1,0 +1,178 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Internal estimator-contract helpers for future pipeline support."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from numbers import Number
+
+import numpy as np
+
+from spectrochempy.utils.exceptions import SpectroChemPyError
+
+_PIPELINE_V1_TRANSFORMERS = frozenset(
+    {
+        "spectrochempy.processing.transformation.preprocessing_transformers.CenterTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.AutoscaleTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.ParetoScaleTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.RangeScaleTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.RobustScaleTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.SNVTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.NormalizeTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.MSCTransformer",
+        "spectrochempy.processing.transformation.preprocessing_transformers.LogTransformer",
+        "spectrochempy.analysis.decomposition.pca.PCA",
+    }
+)
+
+_PIPELINE_V1_FINAL_ESTIMATORS = frozenset(
+    {
+        "spectrochempy.analysis.crossdecomposition.pls.PLSRegression",
+        "spectrochempy.analysis.curvefitting.linearregression.LSTSQ",
+        "spectrochempy.analysis.curvefitting.linearregression.NNLS",
+    }
+)
+
+PIPELINE_V1_SUPPORTED_ESTIMATORS = (
+    _PIPELINE_V1_TRANSFORMERS | _PIPELINE_V1_FINAL_ESTIMATORS
+)
+
+
+def _qualified_name(estimator):
+    cls = estimator.__class__
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+def is_pipeline_v1_supported(estimator):
+    """Return whether *estimator* is in the normative v1 pipeline allowlist."""
+    return _qualified_name(estimator) in PIPELINE_V1_SUPPORTED_ESTIMATORS
+
+
+def is_fitted(estimator):
+    """
+    Return the canonical fitted-state predicate for supported estimators.
+
+    The helper is intentionally internal and allowlist-based. It does not infer
+    pipeline support from method names alone.
+    """
+    if not is_pipeline_v1_supported(estimator):
+        raise SpectroChemPyError(
+            f"{estimator.__class__.__name__} is not supported by the "
+            "pipeline v1 estimator contract."
+        )
+    return bool(getattr(estimator, "_fitted", False))
+
+
+def clone_unfitted(estimator):
+    """
+    Reconstruct a supported estimator from its constructor configuration.
+
+    Parameter isolation is deliberately bounded: immutable scalar values are
+    reused; NumPy arrays, masked arrays, SpectroChemPy objects, random-state
+    objects, and built-in containers are copied; arbitrary objects are reused
+    by reference.
+    """
+    if not is_pipeline_v1_supported(estimator):
+        raise SpectroChemPyError(
+            f"{estimator.__class__.__name__} is not supported by the "
+            "pipeline v1 estimator contract."
+        )
+    if not hasattr(estimator, "get_params"):
+        raise SpectroChemPyError(
+            f"{estimator.__class__.__name__} does not expose get_params()."
+        )
+
+    params = estimator.get_params(deep=False)
+    if not isinstance(params, dict):
+        raise SpectroChemPyError(
+            f"{estimator.__class__.__name__}.get_params(deep=False) must "
+            "return a dictionary."
+        )
+    cloned_params = {
+        name: _clone_constructor_parameter(value) for name, value in params.items()
+    }
+    try:
+        cloned = estimator.__class__(**cloned_params)
+    except Exception as exc:
+        raise SpectroChemPyError(
+            f"Cannot clone {estimator.__class__.__name__} from constructor "
+            "parameters."
+        ) from exc
+    if is_fitted(cloned):
+        raise SpectroChemPyError(
+            f"Cloning {estimator.__class__.__name__} produced a fitted instance."
+        )
+    return cloned
+
+
+def parameter_values_equal(old, new):
+    """Return whether two constructor parameter values are effectively equal."""
+    if old is new:
+        return True
+    if old is None or new is None:
+        return False
+    if _is_spectrochempy_object(old) or _is_spectrochempy_object(new):
+        return False
+    if isinstance(old, np.ma.MaskedArray) or isinstance(new, np.ma.MaskedArray):
+        try:
+            return bool(np.ma.allequal(old, new))
+        except (TypeError, ValueError):
+            return False
+    if isinstance(old, np.ndarray) or isinstance(new, np.ndarray):
+        try:
+            return bool(np.array_equal(old, new, equal_nan=True))
+        except (TypeError, ValueError):
+            return False
+    try:
+        equal = old == new
+    except (TypeError, ValueError):
+        return False
+    if isinstance(equal, np.ndarray | np.bool_):
+        try:
+            return bool(np.all(equal))
+        except (TypeError, ValueError):
+            return False
+    return bool(equal)
+
+
+def _clone_constructor_parameter(value):
+    if _is_immutable_scalar(value):
+        return value
+    if isinstance(value, np.ma.MaskedArray):
+        return value.copy()
+    if isinstance(value, np.ndarray):
+        return value.copy()
+    if isinstance(value, np.random.RandomState):
+        cloned = np.random.RandomState()
+        cloned.set_state(value.get_state())
+        return cloned
+    if isinstance(value, np.random.Generator):
+        bit_generator = value.bit_generator.__class__()
+        bit_generator.state = value.bit_generator.state
+        return np.random.Generator(bit_generator)
+    if _is_spectrochempy_object(value):
+        return value.copy()
+    if isinstance(value, tuple):
+        return tuple(_clone_constructor_parameter(item) for item in value)
+    if isinstance(value, list):
+        return [_clone_constructor_parameter(item) for item in value]
+    if isinstance(value, set):
+        return {_clone_constructor_parameter(item) for item in value}
+    if isinstance(value, Mapping):
+        return value.__class__(
+            (key, _clone_constructor_parameter(item)) for key, item in value.items()
+        )
+    return value
+
+
+def _is_immutable_scalar(value):
+    return value is None or isinstance(value, str | bytes | bool | Number)
+
+
+def _is_spectrochempy_object(value):
+    module = getattr(value.__class__, "__module__", "")
+    return module.startswith("spectrochempy.core.dataset")

--- a/src/spectrochempy/utils/_estimator.py
+++ b/src/spectrochempy/utils/_estimator.py
@@ -115,6 +115,8 @@ def parameter_values_equal(old, new):
         return True
     if old is None or new is None:
         return False
+    if _is_immutable_scalar(old) and _is_immutable_scalar(new):
+        return old == new
     if _is_spectrochempy_object(old) or _is_spectrochempy_object(new):
         return False
     if isinstance(old, np.ma.MaskedArray) or isinstance(new, np.ma.MaskedArray):
@@ -127,16 +129,21 @@ def parameter_values_equal(old, new):
             return bool(np.array_equal(old, new, equal_nan=True))
         except (TypeError, ValueError):
             return False
-    try:
-        equal = old == new
-    except Exception:
-        return False
-    if isinstance(equal, np.ndarray | np.bool_):
-        try:
-            return bool(np.all(equal))
-        except (TypeError, ValueError):
-            return False
-    return bool(equal)
+    if isinstance(old, tuple) and isinstance(new, tuple):
+        return len(old) == len(new) and all(
+            parameter_values_equal(left, right)
+            for left, right in zip(old, new, strict=True)
+        )
+    if isinstance(old, list) and isinstance(new, list):
+        return len(old) == len(new) and all(
+            parameter_values_equal(left, right)
+            for left, right in zip(old, new, strict=True)
+        )
+    if isinstance(old, Mapping) and isinstance(new, Mapping):
+        return old.keys() == new.keys() and all(
+            parameter_values_equal(old[key], new[key]) for key in old
+        )
+    return False
 
 
 def _clone_constructor_parameter(value):

--- a/src/spectrochempy/utils/exceptions.py
+++ b/src/spectrochempy/utils/exceptions.py
@@ -91,11 +91,20 @@ class NotFittedError(NotTransformedError):
     """
 
     def __init__(self, attr=None, message=None):
+        if message is not None:
+            super().__init__(message=message)
+            return
         frame = inspect.currentframe().f_back
         caller = frame.f_code.co_name if attr is None else attr
-        model = frame.f_locals["self"].name
+        self_obj = frame.f_locals.get("self")
+        model = getattr(
+            self_obj,
+            "name",
+            self_obj.__class__.__name__ if self_obj is not None else "estimator",
+        )
         message = (
-            f"To use `{caller}` ,  the method `fit` of model `{model}`"
+            f"Model `{model}` is not fitted yet. To use `{caller}` ,  the method `fit`"
+            f" of model `{model}`"
             f" should be executed first"
         )
         super().__init__(message=message)

--- a/tests/test_utils/test_estimator_contract.py
+++ b/tests/test_utils/test_estimator_contract.py
@@ -1,0 +1,297 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Focused tests for the internal estimator contract used by future pipelines."""
+
+import numpy as np
+import pytest
+import traitlets as tr
+
+import spectrochempy as scp
+from spectrochempy.analysis.crossdecomposition.pls import PLSRegression
+from spectrochempy.analysis.curvefitting.linearregression import LSTSQ
+from spectrochempy.analysis.curvefitting.linearregression import NNLS
+from spectrochempy.analysis.decomposition.pca import PCA
+from spectrochempy.analysis.decomposition.svd import SVD
+from spectrochempy.processing.baselineprocessing.baselineprocessing import Baseline
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    AutoscaleTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    CenterTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    LogTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    MSCTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    NormalizeTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    ParetoScaleTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    RangeScaleTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    RobustScaleTransformer,
+)
+from spectrochempy.processing.transformation.preprocessing_transformers import (
+    SNVTransformer,
+)
+from spectrochempy.utils._estimator import clone_unfitted
+from spectrochempy.utils._estimator import is_fitted
+from spectrochempy.utils.exceptions import NotFittedError
+from spectrochempy.utils.exceptions import SpectroChemPyError
+
+
+def _xy():
+    x = scp.Coord.arange(6, title="features")
+    y = scp.Coord.arange(5, title="samples")
+    data = np.arange(30.0).reshape(5, 6) + 1.0
+    X = scp.NDDataset(data, coordset=[y, x], units="absorbance")
+    target = scp.NDDataset(
+        np.column_stack([np.arange(5.0), np.arange(5.0) ** 2 + 1.0]),
+        coordset=[scp.Coord.arange(5), scp.Coord.arange(2)],
+    )
+    return X, target
+
+
+def _preprocessor_cases():
+    ref = np.linspace(1.0, 2.0, 6)
+    return [
+        CenterTransformer(dim="y"),
+        AutoscaleTransformer(dim="y"),
+        ParetoScaleTransformer(dim="y"),
+        RangeScaleTransformer(dim="y"),
+        RobustScaleTransformer(dim="y"),
+        SNVTransformer(),
+        NormalizeTransformer(method="max", dim="y"),
+        MSCTransformer(reference=ref, dim="y"),
+        LogTransformer(method="log1p", eps=1.0e-10),
+    ]
+
+
+def _final_transformer_cases():
+    return [*_preprocessor_cases(), PCA(n_components=2)]
+
+
+def _final_estimator_cases():
+    return [
+        PLSRegression(n_components=2),
+        LSTSQ(),
+        NNLS(),
+    ]
+
+
+def _fit_estimator(estimator, X, Y):
+    if isinstance(estimator, PLSRegression | LSTSQ | NNLS):
+        return estimator.fit(X, Y[:, 0])
+    return estimator.fit(X)
+
+
+def _category_method(estimator):
+    if isinstance(estimator, PLSRegression | LSTSQ | NNLS):
+        return "predict"
+    return "transform"
+
+
+@pytest.mark.parametrize("estimator", _final_transformer_cases() + _final_estimator_cases())
+def test_is_fitted_tracks_allowlisted_estimator_lifecycle(estimator):
+    X, Y = _xy()
+    assert is_fitted(estimator) is False
+
+    result = _fit_estimator(estimator, X, Y)
+
+    assert result is estimator
+    assert is_fitted(estimator) is True
+
+
+@pytest.mark.parametrize("estimator", _final_transformer_cases() + _final_estimator_cases())
+def test_clone_unfitted_reconstructs_configuration_without_learned_state(estimator):
+    X, Y = _xy()
+    _fit_estimator(estimator, X, Y)
+
+    cloned = clone_unfitted(estimator)
+
+    assert cloned is not estimator
+    assert type(cloned) is type(estimator)
+    assert cloned.get_params(deep=False).keys() == estimator.get_params(deep=False).keys()
+    assert is_fitted(cloned) is False
+    if isinstance(estimator, PCA):
+        assert not hasattr(cloned._pca, "components_")
+    elif isinstance(estimator, PLSRegression):
+        assert not hasattr(cloned._plsregression, "x_weights_")
+    elif isinstance(estimator, LSTSQ | NNLS):
+        assert not hasattr(cloned._linear_regression, "coef_")
+    elif hasattr(estimator, "_learned_attributes"):
+        for attr in estimator._learned_attributes:
+            assert not hasattr(cloned, attr)
+
+
+def test_clone_unfitted_copies_mutable_array_parameters():
+    reference = np.linspace(1.0, 2.0, 6)
+    transformer = MSCTransformer(reference=reference, dim="y")
+
+    cloned = clone_unfitted(transformer)
+
+    assert cloned.reference is not transformer.reference
+    assert np.array_equal(cloned.reference, transformer.reference)
+    cloned.reference[0] = 99.0
+    assert transformer.reference[0] != 99.0
+
+
+def test_clone_unfitted_copies_spectrochempy_parameters():
+    X, _ = _xy()
+    reference = X[0].copy()
+    transformer = MSCTransformer(reference=reference, dim="y")
+
+    cloned = clone_unfitted(transformer)
+
+    assert cloned.reference is not transformer.reference
+    assert cloned.reference == transformer.reference
+
+
+def test_clone_unfitted_copies_random_state_without_sharing_state():
+    state = np.random.RandomState(123)
+    pca = PCA(n_components=2, random_state=state)
+
+    cloned = clone_unfitted(pca)
+
+    assert cloned.random_state is not pca.random_state
+    assert cloned.random_state.get_state()[1].tolist() == pca.random_state.get_state()[
+        1
+    ].tolist()
+    cloned.random_state.rand()
+    assert cloned.random_state.get_state()[1].tolist() != pca.random_state.get_state()[
+        1
+    ].tolist()
+
+
+@pytest.mark.parametrize("unsupported", [SVD(), Baseline()])
+def test_clone_and_fitted_helpers_reject_unsupported_candidates(unsupported):
+    with pytest.raises(SpectroChemPyError, match="not supported"):
+        clone_unfitted(unsupported)
+    with pytest.raises(SpectroChemPyError, match="not supported"):
+        is_fitted(unsupported)
+
+
+@pytest.mark.parametrize("estimator", _final_transformer_cases() + _final_estimator_cases())
+def test_allowlisted_methods_raise_canonical_not_fitted_error(estimator):
+    X, Y = _xy()
+    method = _category_method(estimator)
+    args = (X,) if method == "predict" else (X,)
+
+    with pytest.raises(NotFittedError):
+        getattr(estimator, method)(*args)
+
+    _fit_estimator(estimator, X, Y)
+    output = estimator.predict(X) if method == "predict" else estimator.transform(X)
+    assert isinstance(output, scp.NDDataset)
+
+
+@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+def test_analysis_set_params_effective_change_invalidates_fitted_state(estimator):
+    X, Y = _xy()
+    _fit_estimator(estimator, X, Y)
+    assert is_fitted(estimator)
+
+    params = estimator.get_params(deep=False)
+    if "n_components" in params:
+        estimator.set_params(n_components=1)
+    else:
+        estimator.set_params(fit_intercept=not params["fit_intercept"])
+
+    assert is_fitted(estimator) is False
+    with pytest.raises(NotFittedError):
+        getattr(estimator, _category_method(estimator))(X)
+
+
+@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+def test_analysis_set_params_equal_update_preserves_fitted_state(estimator):
+    X, Y = _xy()
+    _fit_estimator(estimator, X, Y)
+
+    estimator.set_params(**estimator.get_params(deep=False))
+
+    assert is_fitted(estimator) is True
+
+
+def test_analysis_set_params_invalid_name_is_transactional():
+    X, Y = _xy()
+    pca = PCA(n_components=2).fit(X)
+
+    with pytest.raises(SpectroChemPyError, match="Invalid parameter"):
+        pca.set_params(n_components=1, invalid_parameter=1)
+
+    assert pca.n_components == 2
+    assert is_fitted(pca) is True
+
+
+def test_analysis_set_params_invalid_value_is_transactional():
+    X, _ = _xy()
+    pca = PCA(n_components=2).fit(X)
+
+    with pytest.raises(tr.TraitError):
+        pca.set_params(n_components=1, svd_solver="bad")
+
+    assert pca.n_components == 2
+    assert pca.svd_solver == "auto"
+    assert is_fitted(pca) is True
+
+
+@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+def test_failed_initial_fit_leaves_allowlisted_analysis_unfitted(estimator):
+    X, Y = _xy()
+
+    if isinstance(estimator, PCA):
+        estimator.n_components = 99
+        with pytest.raises(ValueError):
+            estimator.fit(X)
+    elif isinstance(estimator, PLSRegression):
+        estimator.n_components = 99
+        with pytest.raises(ValueError):
+            estimator.fit(X, Y[:, 0])
+    else:
+        with pytest.raises(ValueError):
+            estimator.fit(scp.NDDataset(np.arange(4.0)))
+
+    assert is_fitted(estimator) is False
+
+
+@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+def test_failed_refit_clears_allowlisted_analysis_state(estimator):
+    X, Y = _xy()
+    _fit_estimator(estimator, X, Y)
+    assert is_fitted(estimator) is True
+
+    if isinstance(estimator, PCA):
+        estimator.n_components = 99
+        with pytest.raises(ValueError):
+            estimator.fit(X)
+    elif isinstance(estimator, PLSRegression):
+        estimator.n_components = 99
+        with pytest.raises(ValueError):
+            estimator.fit(X, Y[:, 0])
+    else:
+        with pytest.raises(ValueError):
+            estimator.fit(scp.NDDataset(np.arange(4.0)))
+
+    assert is_fitted(estimator) is False
+    with pytest.raises(NotFittedError):
+        getattr(estimator, _category_method(estimator))(X)
+
+
+def test_svd_is_characterized_but_excluded_because_transform_is_not_implemented():
+    X, _ = _xy()
+    svd = SVD().fit(X)
+
+    assert svd._fitted is True
+    with pytest.raises(NotImplementedError):
+        svd.transform(X)
+    with pytest.raises(SpectroChemPyError, match="not supported"):
+        clone_unfitted(svd)

--- a/tests/test_utils/test_estimator_contract.py
+++ b/tests/test_utils/test_estimator_contract.py
@@ -5,6 +5,9 @@
 # ======================================================================================
 """Focused tests for the internal estimator contract used by future pipelines."""
 
+from collections.abc import Mapping
+from numbers import Number
+
 import numpy as np
 import pytest
 import traitlets as tr
@@ -43,6 +46,7 @@ from spectrochempy.processing.transformation.preprocessing_transformers import (
 from spectrochempy.processing.transformation.preprocessing_transformers import (
     SNVTransformer,
 )
+from spectrochempy.utils._estimator import _clone_constructor_parameter
 from spectrochempy.utils._estimator import clone_unfitted
 from spectrochempy.utils._estimator import is_fitted
 from spectrochempy.utils.exceptions import NotFittedError
@@ -100,7 +104,64 @@ def _category_method(estimator):
     return "transform"
 
 
-@pytest.mark.parametrize("estimator", _final_transformer_cases() + _final_estimator_cases())
+def _assert_random_state_equal(left, right):
+    left_state = left.get_state()
+    right_state = right.get_state()
+    assert left_state[0] == right_state[0]
+    assert np.array_equal(left_state[1], right_state[1])
+    assert left_state[2:] == right_state[2:]
+
+
+def _assert_cloned_parameter_matches_policy(original, cloned):
+    if original is None or isinstance(original, str | bytes | bool | Number):
+        assert cloned == original
+        return
+    if isinstance(original, np.random.RandomState):
+        assert cloned is not original
+        _assert_random_state_equal(cloned, original)
+        return
+    if isinstance(original, np.ma.MaskedArray):
+        assert cloned is not original
+        assert np.ma.allequal(cloned, original)
+        return
+    if isinstance(original, np.ndarray):
+        assert cloned is not original
+        assert np.array_equal(cloned, original, equal_nan=True)
+        return
+    if isinstance(original, tuple):
+        assert cloned is not original
+        assert type(cloned) is type(original)
+        for original_item, cloned_item in zip(original, cloned, strict=True):
+            _assert_cloned_parameter_matches_policy(original_item, cloned_item)
+        return
+    if isinstance(original, list):
+        assert cloned is not original
+        assert type(cloned) is type(original)
+        for original_item, cloned_item in zip(original, cloned, strict=True):
+            _assert_cloned_parameter_matches_policy(original_item, cloned_item)
+        return
+    if isinstance(original, set):
+        assert cloned is not original
+        assert type(cloned) is type(original)
+        assert cloned == original
+        return
+    if isinstance(original, Mapping):
+        assert cloned is not original
+        assert type(cloned) is type(original)
+        assert cloned.keys() == original.keys()
+        for key, original_item in original.items():
+            _assert_cloned_parameter_matches_policy(original_item, cloned[key])
+        return
+    if original.__class__.__module__.startswith("spectrochempy.core.dataset"):
+        assert cloned is not original
+        assert cloned == original
+        return
+    assert cloned is original
+
+
+@pytest.mark.parametrize(
+    "estimator", _final_transformer_cases() + _final_estimator_cases()
+)
 def test_is_fitted_tracks_allowlisted_estimator_lifecycle(estimator):
     X, Y = _xy()
     assert is_fitted(estimator) is False
@@ -111,7 +172,9 @@ def test_is_fitted_tracks_allowlisted_estimator_lifecycle(estimator):
     assert is_fitted(estimator) is True
 
 
-@pytest.mark.parametrize("estimator", _final_transformer_cases() + _final_estimator_cases())
+@pytest.mark.parametrize(
+    "estimator", _final_transformer_cases() + _final_estimator_cases()
+)
 def test_clone_unfitted_reconstructs_configuration_without_learned_state(estimator):
     X, Y = _xy()
     _fit_estimator(estimator, X, Y)
@@ -120,7 +183,11 @@ def test_clone_unfitted_reconstructs_configuration_without_learned_state(estimat
 
     assert cloned is not estimator
     assert type(cloned) is type(estimator)
-    assert cloned.get_params(deep=False).keys() == estimator.get_params(deep=False).keys()
+    original_params = estimator.get_params(deep=False)
+    cloned_params = cloned.get_params(deep=False)
+    assert cloned_params.keys() == original_params.keys()
+    for name, original_value in original_params.items():
+        _assert_cloned_parameter_matches_policy(original_value, cloned_params[name])
     assert is_fitted(cloned) is False
     if isinstance(estimator, PCA):
         assert not hasattr(cloned._pca, "components_")
@@ -159,17 +226,41 @@ def test_clone_unfitted_copies_spectrochempy_parameters():
 def test_clone_unfitted_copies_random_state_without_sharing_state():
     state = np.random.RandomState(123)
     pca = PCA(n_components=2, random_state=state)
+    state.rand()
 
     cloned = clone_unfitted(pca)
 
     assert cloned.random_state is not pca.random_state
-    assert cloned.random_state.get_state()[1].tolist() == pca.random_state.get_state()[
-        1
-    ].tolist()
+    _assert_random_state_equal(cloned.random_state, pca.random_state)
     cloned.random_state.rand()
-    assert cloned.random_state.get_state()[1].tolist() != pca.random_state.get_state()[
-        1
-    ].tolist()
+    assert cloned.random_state.get_state()[2] != pca.random_state.get_state()[2]
+
+
+def test_clone_unfitted_recursively_copies_container_parameters():
+    reference = {
+        "array": np.arange(3.0),
+        "nested": [np.ma.array([1.0, 2.0], mask=[False, True])],
+    }
+    transformer = MSCTransformer(reference=reference, dim="y")
+
+    cloned = clone_unfitted(transformer)
+
+    _assert_cloned_parameter_matches_policy(transformer.reference, cloned.reference)
+    cloned.reference["array"][0] = 99.0
+    cloned.reference["nested"][0][0] = 42.0
+    assert transformer.reference["array"][0] != 99.0
+    assert transformer.reference["nested"][0][0] != 42.0
+
+
+def test_constructor_parameter_clone_preserves_generator_position():
+    generator = np.random.default_rng(123)
+    generator.random(4)
+
+    cloned = _clone_constructor_parameter(generator)
+
+    assert cloned is not generator
+    assert cloned.bit_generator.state == generator.bit_generator.state
+    assert cloned.random() == generator.random()
 
 
 @pytest.mark.parametrize("unsupported", [SVD(), Baseline()])
@@ -180,7 +271,9 @@ def test_clone_and_fitted_helpers_reject_unsupported_candidates(unsupported):
         is_fitted(unsupported)
 
 
-@pytest.mark.parametrize("estimator", _final_transformer_cases() + _final_estimator_cases())
+@pytest.mark.parametrize(
+    "estimator", _final_transformer_cases() + _final_estimator_cases()
+)
 def test_allowlisted_methods_raise_canonical_not_fitted_error(estimator):
     X, Y = _xy()
     method = _category_method(estimator)
@@ -194,7 +287,21 @@ def test_allowlisted_methods_raise_canonical_not_fitted_error(estimator):
     assert isinstance(output, scp.NDDataset)
 
 
-@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+@pytest.mark.parametrize("estimator", _final_estimator_cases())
+def test_allowlisted_score_raises_canonical_not_fitted_error(estimator):
+    X, Y = _xy()
+
+    with pytest.raises(NotFittedError):
+        estimator.score(X, Y[:, 0])
+
+    _fit_estimator(estimator, X, Y)
+    assert isinstance(estimator.score(X, Y[:, 0]), float)
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()],
+)
 def test_analysis_set_params_effective_change_invalidates_fitted_state(estimator):
     X, Y = _xy()
     _fit_estimator(estimator, X, Y)
@@ -209,9 +316,15 @@ def test_analysis_set_params_effective_change_invalidates_fitted_state(estimator
     assert is_fitted(estimator) is False
     with pytest.raises(NotFittedError):
         getattr(estimator, _category_method(estimator))(X)
+    if isinstance(estimator, PLSRegression | LSTSQ | NNLS):
+        with pytest.raises(NotFittedError):
+            estimator.score(X, Y[:, 0])
 
 
-@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+@pytest.mark.parametrize(
+    "estimator",
+    [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()],
+)
 def test_analysis_set_params_equal_update_preserves_fitted_state(estimator):
     X, Y = _xy()
     _fit_estimator(estimator, X, Y)
@@ -244,7 +357,10 @@ def test_analysis_set_params_invalid_value_is_transactional():
     assert is_fitted(pca) is True
 
 
-@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+@pytest.mark.parametrize(
+    "estimator",
+    [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()],
+)
 def test_failed_initial_fit_leaves_allowlisted_analysis_unfitted(estimator):
     X, Y = _xy()
 
@@ -263,7 +379,10 @@ def test_failed_initial_fit_leaves_allowlisted_analysis_unfitted(estimator):
     assert is_fitted(estimator) is False
 
 
-@pytest.mark.parametrize("estimator", [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()])
+@pytest.mark.parametrize(
+    "estimator",
+    [PCA(n_components=2), PLSRegression(n_components=2), LSTSQ(), NNLS()],
+)
 def test_failed_refit_clears_allowlisted_analysis_state(estimator):
     X, Y = _xy()
     _fit_estimator(estimator, X, Y)
@@ -284,6 +403,9 @@ def test_failed_refit_clears_allowlisted_analysis_state(estimator):
     assert is_fitted(estimator) is False
     with pytest.raises(NotFittedError):
         getattr(estimator, _category_method(estimator))(X)
+    if isinstance(estimator, PLSRegression | LSTSQ | NNLS):
+        with pytest.raises(NotFittedError):
+            estimator.score(X, Y[:, 0])
 
 
 def test_svd_is_characterized_but_excluded_because_transform_is_not_implemented():


### PR DESCRIPTION
## Summary
- add internal allowlist-based estimator helpers for future Pipeline support
- align canonical fitted-state, unfitted cloning, and not-fitted behavior for supported transformers and terminal estimators
- add opt-in lifecycle invalidation for PCA, PLSRegression, LSTSQ, and NNLS, with focused characterization tests

## Validation
- micromamba run -n scpy-core python -m pytest tests/test_utils/test_estimator_contract.py -q
- focused preprocessing / sklearn-compat / PCA / SVD / PLS / estimator-contract suite: 403 passed
- focused Baseline / SVD result / PLS result / Optimize result suite: 247 passed
- pre-commit run --all-files

## Notes
- no Pipeline implementation in this PR
- no public top-level API addition
- SVD, Baseline, PSD, Filter, stateless wrappers, MCRALS, and Optimize remain outside the v1 allowlist