### PR TITLE
ENH: add minimal estimator Pipeline

### DIFF
--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -349,6 +349,15 @@ Chemometric preprocessing
     RobustScaleTransformer
     LogTransformer
 
+Pipeline composition
+====================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    Pipeline
+
 
 Indexing
 ========

--- a/docs/sources/userguide/analysis/index.rst
+++ b/docs/sources/userguide/analysis/index.rst
@@ -20,6 +20,7 @@ in the gallery (:ref:`examples-index`).
    peak_analysis_workflow
    peak_integration
    fitting
+   pipeline
    pca
    pls
    mcr_als

--- a/docs/sources/userguide/analysis/pipeline.py
+++ b/docs/sources/userguide/analysis/pipeline.py
@@ -1,0 +1,112 @@
+"""
+Pipeline.
+
+Pipeline
+========
+
+``Pipeline`` composes a small, reproducible sequence of SpectroChemPy
+preprocessing transformers and a final transformer or supervised estimator.
+It is useful when the same fitted preprocessing must be applied consistently
+to calibration and test spectra.
+
+The steps passed to ``Pipeline`` are templates. Calling ``fit()`` clones those
+templates, fits the clones, and leaves the original step objects unchanged.
+Template steps remain available through ``steps`` and ``named_steps``. Fitted
+runtime clones are available after fitting through ``fitted_steps_`` and
+``fitted_named_steps_``.
+"""
+
+import numpy as np
+
+import spectrochempy as scp
+
+rng = np.random.default_rng(42)
+wavenumbers = scp.Coord.linspace(1000.0, 1100.0, 24, title="wavenumber", units="cm^-1")
+samples = scp.Coord.arange(12, title="sample")
+dataset = scp.NDDataset(
+    rng.normal(size=(12, 24)),
+    coordset=[samples, wavenumbers],
+    dims=["y", "x"],
+    units="absorbance",
+    title="calibration spectra",
+)
+target = scp.NDDataset(
+    np.linspace(0.1, 1.2, 12),
+    coordset=[samples.copy()],
+    dims=["y"],
+    units="mol/L",
+    title="concentration",
+)
+
+# %%
+# Transformer-final pipelines
+# ---------------------------
+#
+# A transformer-final pipeline ends with a preprocessing transformer or with
+# ``PCA``. ``fit_transform(X)`` is equivalent to ``fit(X).transform(X)``.
+
+pipeline = scp.Pipeline(
+    [
+        ("center", scp.CenterTransformer(dim="y")),
+        ("pca", scp.PCA(n_components=3)),
+    ]
+)
+scores = pipeline.fit_transform(dataset)
+scores
+
+# %%
+# Estimator-final pipelines
+# -------------------------
+#
+# A supervised estimator-final pipeline passes ``y`` only to the final
+# estimator. Intermediate preprocessing steps receive only the transformed
+# ``NDDataset``.
+
+pipeline = scp.Pipeline(
+    [
+        ("scale", scp.AutoscaleTransformer(dim="y")),
+        ("pls", scp.PLSRegression(n_components=3)),
+    ]
+)
+pipeline.fit(dataset, target)
+predicted = pipeline.predict(dataset)
+predicted
+
+# %%
+# Template and fitted steps
+# -------------------------
+#
+# ``steps``, ``named_steps`` and ``get_params()`` describe the templates.
+# Learned runtime state lives on fitted clones.
+
+print(pipeline.named_steps["scale"] is pipeline.fitted_named_steps_["scale"])
+
+# %%
+# Nested parameters
+# -----------------
+#
+# Template parameters are visible and editable with ``step__parameter`` names.
+# Effective nested changes replace only the modified template step with an
+# unfitted clone and preserve untouched template instances. Explicit
+# replacement with another compatible instance is always effective, even when
+# the new instance has the same constructor parameters.
+
+pipeline.get_params(deep=True)["pls__n_components"]
+pipeline.set_params(pls__n_components=2)
+
+# %%
+# Supported v1 classes
+# --------------------
+#
+# Intermediate positions accept ``CenterTransformer``, ``AutoscaleTransformer``,
+# ``ParetoScaleTransformer``, ``RangeScaleTransformer``,
+# ``RobustScaleTransformer``, ``SNVTransformer``, ``NormalizeTransformer``,
+# ``MSCTransformer`` and ``LogTransformer``.
+#
+# Final positions accept those transformers, ``PCA``, ``PLSRegression``,
+# ``LSTSQ`` and ``NNLS``.
+#
+# Version 1 intentionally excludes ``Baseline``, ``SVD``, ``PSD``, ``Filter``,
+# functional processing wrappers, ``MCRALS``, ``Optimize``, optional steps,
+# branching, caching, persistence guarantees and arbitrary fit-parameter
+# routing.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,9 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- Added ``Pipeline`` for linear, reproducible composition of allowlisted
+  SpectroChemPy preprocessing transformers with a final transformer or
+  supervised estimator.
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,13 @@ What's New in Revision 0.12.8.dev
 These are the changes in SpectroChemPy-0.12.8.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+New Features
+~~~~~~~~~~~~
+
+- Added ``Pipeline`` for linear, reproducible composition of allowlisted
+  SpectroChemPy preprocessing transformers with a final transformer or
+  supervised estimator.
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/analysis/__init__.pyi
+++ b/src/spectrochempy/analysis/__init__.pyi
@@ -15,6 +15,7 @@ __all__ = [
     "integration",
     "kinetic",
     "peakfinding",
+    "pipeline",
 ]
 
 from . import _base
@@ -25,3 +26,4 @@ from . import decomposition
 from . import integration
 from . import kinetic
 from . import peakfinding
+from . import pipeline

--- a/src/spectrochempy/analysis/pipeline.py
+++ b/src/spectrochempy/analysis/pipeline.py
@@ -1,0 +1,421 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Minimal linear Pipeline for SpectroChemPy estimators."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from spectrochempy.core.dataset.nddataset import NDDataset
+from spectrochempy.utils._estimator import clone_unfitted
+from spectrochempy.utils._estimator import parameter_values_equal
+from spectrochempy.utils._estimator import pipeline_v1_step_kind
+from spectrochempy.utils.exceptions import NotFittedError
+from spectrochempy.utils.exceptions import SpectroChemPyError
+
+__all__ = ["Pipeline"]
+__configurables__ = ["Pipeline"]
+
+_RESERVED_STEP_NAMES = frozenset(
+    {
+        "steps",
+        "named_steps",
+        "fitted_steps_",
+        "fitted_named_steps_",
+        "fit",
+        "fit_transform",
+        "transform",
+        "predict",
+        "score",
+        "get_params",
+        "set_params",
+    }
+)
+
+
+class Pipeline:
+    """
+    Linear composition of allowlisted SpectroChemPy preprocessing and estimators.
+
+    The supplied steps are templates. Calling :meth:`fit` clones those
+    templates, fits the clones, and exposes fitted runtime state through
+    :attr:`fitted_steps_` and :attr:`fitted_named_steps_`.
+    """
+
+    def __init__(self, steps):
+        self._steps = self._validate_steps(steps)
+        self._fitted = False
+        self._fitted_steps = None
+
+    @property
+    def steps(self):
+        """Return ordered template ``(name, step)`` pairs."""
+        return self._steps
+
+    @property
+    def named_steps(self):
+        """Return a read-only mapping of template step names to steps."""
+        return MappingProxyType(dict(self._steps))
+
+    @property
+    def fitted_steps_(self):
+        """Return ordered fitted ``(name, step)`` pairs."""
+        if not self._fitted or self._fitted_steps is None:
+            raise NotFittedError(attr="fitted_steps_")
+        return self._fitted_steps
+
+    @property
+    def fitted_named_steps_(self):
+        """Return a read-only mapping of fitted step names to fitted steps."""
+        if not self._fitted or self._fitted_steps is None:
+            raise NotFittedError(attr="fitted_named_steps_")
+        return MappingProxyType(dict(self._fitted_steps))
+
+    def fit(self, X, y=None):
+        """
+        Fit the pipeline on *X* and optional supervised target *y*.
+
+        Intermediate preprocessing transformers receive only the current
+        dataset. A supervised final estimator receives the transformed dataset
+        and *y*.
+        """
+        self._clear_fitted_state()
+        final_name, final_step = self._steps[-1]
+        final_kind = self._step_kind(final_step, final=True)
+        if y is not None and final_kind == "transformer":
+            raise SpectroChemPyError(
+                "Pipeline.fit received y, but final step "
+                f"'{final_name}' is a transformer and does not accept y."
+            )
+        if y is None and final_kind == "estimator":
+            raise SpectroChemPyError(
+                "Pipeline.fit requires y because final step "
+                f"'{final_name}' is a supervised estimator."
+            )
+
+        fitted_steps = []
+        current = X
+        try:
+            for position, (name, template) in enumerate(self._steps):
+                step = self._clone_step(template, name, position)
+                is_final = position == len(self._steps) - 1
+                if is_final:
+                    if final_kind == "estimator":
+                        self._fit_step(step, current, y, name, position)
+                    else:
+                        self._fit_step(step, current, None, name, position)
+                    fitted_steps.append((name, step))
+                    break
+
+                self._fit_step(step, current, None, name, position)
+                current = self._transform_step(step, current, name, position)
+                fitted_steps.append((name, step))
+        except Exception:
+            self._clear_fitted_state()
+            raise
+
+        self._fitted_steps = tuple(fitted_steps)
+        self._fitted = True
+        return self
+
+    def fit_transform(self, X, y=None):
+        """Fit the pipeline and transform *X* with the fitted pipeline."""
+        final_name, final_step = self._steps[-1]
+        if self._step_kind(final_step, final=True) != "transformer":
+            raise SpectroChemPyError(
+                "Pipeline.fit_transform is not available because final step "
+                f"'{final_name}' is a supervised estimator."
+            )
+        return self.fit(X, y).transform(X)
+
+    def transform(self, X):
+        """Transform *X* with a transformer-final fitted pipeline."""
+        self._require_fitted("transform")
+        final_name, final_step = self._steps[-1]
+        if self._step_kind(final_step, final=True) != "transformer":
+            raise SpectroChemPyError(
+                "Pipeline.transform is not available because final step "
+                f"'{final_name}' is a supervised estimator."
+            )
+        current = X
+        for position, (name, step) in enumerate(self.fitted_steps_):
+            current = self._transform_step(step, current, name, position)
+        return current
+
+    def predict(self, X):
+        """Predict from *X* with an estimator-final fitted pipeline."""
+        self._require_fitted("predict")
+        final_name, final_step = self._steps[-1]
+        if self._step_kind(final_step, final=True) != "estimator":
+            raise SpectroChemPyError(
+                "Pipeline.predict is not available because final step "
+                f"'{final_name}' is a transformer."
+            )
+        current = self._transform_intermediates(X, operation="predict")
+        fitted_final = self.fitted_steps_[-1][1]
+        try:
+            return fitted_final.predict(current)
+        except Exception as exc:
+            raise self._step_error(
+                "predict", final_name, len(self._steps) - 1, fitted_final, exc
+            ) from exc
+
+    def score(self, X, y=None):
+        """Score predictions from *X* against *y* with a fitted final estimator."""
+        self._require_fitted("score")
+        final_name, final_step = self._steps[-1]
+        if self._step_kind(final_step, final=True) != "estimator":
+            raise SpectroChemPyError(
+                "Pipeline.score is not available because final step "
+                f"'{final_name}' is a transformer."
+            )
+        fitted_final = self.fitted_steps_[-1][1]
+        if not hasattr(fitted_final, "score"):
+            raise SpectroChemPyError(
+                f"Final step '{final_name}' does not provide score()."
+            )
+        if y is None:
+            raise SpectroChemPyError(
+                f"Pipeline.score requires y for final step '{final_name}'."
+            )
+        current = self._transform_intermediates(X, operation="score")
+        try:
+            return fitted_final.score(current, y)
+        except Exception as exc:
+            raise self._step_error(
+                "score", final_name, len(self._steps) - 1, fitted_final, exc
+            ) from exc
+
+    def get_params(self, deep=True):
+        """
+        Return template configuration parameters.
+
+        With ``deep=True``, each template is exposed under its step name and
+        its constructor parameters under ``step__parameter`` keys.
+        """
+        params = {"steps": self.steps}
+        if not deep:
+            return params
+        for name, step in self._steps:
+            params[name] = step
+            if hasattr(step, "get_params"):
+                for key, value in step.get_params(deep=False).items():
+                    params[f"{name}__{key}"] = value
+        return params
+
+    def set_params(self, **params):
+        """Transactionally update template steps or nested template parameters."""
+        if not params:
+            return self
+
+        candidate_steps = (
+            self._validate_steps(params["steps"]) if "steps" in params else self._steps
+        )
+        candidate_by_name = dict(candidate_steps)
+        step_replacements = {}
+        nested_updates = {}
+
+        valid_top_level = {"steps", *(name for name, _ in self._steps)}
+        for key, value in params.items():
+            if key == "steps":
+                continue
+            if "__" in key:
+                step_name, parameter = key.split("__", 1)
+                if not step_name or not parameter:
+                    raise SpectroChemPyError(
+                        f"Invalid nested parameter '{key}' for Pipeline."
+                    )
+                if step_name not in candidate_by_name:
+                    valid = ", ".join(sorted(candidate_by_name))
+                    raise SpectroChemPyError(
+                        f"Invalid step name '{step_name}' for Pipeline. "
+                        f"Valid step names: {valid}."
+                    )
+                nested_updates.setdefault(step_name, {})[parameter] = value
+            elif key in candidate_by_name:
+                step_replacements[key] = value
+            else:
+                valid = ", ".join(sorted(valid_top_level))
+                raise SpectroChemPyError(
+                    f"Invalid parameter '{key}' for Pipeline. Valid parameters: {valid}."
+                )
+
+        if step_replacements:
+            replaced = []
+            for name, step in candidate_steps:
+                replaced.append((name, step_replacements.get(name, step)))
+            candidate_steps = self._validate_steps(replaced)
+
+        candidate_steps = self._apply_nested_updates(candidate_steps, nested_updates)
+        changed = not self._steps_identical(self._steps, candidate_steps)
+        if changed:
+            self._steps = candidate_steps
+            self._clear_fitted_state()
+        return self
+
+    def _apply_nested_updates(self, candidate_steps, nested_updates):
+        if not nested_updates:
+            return candidate_steps
+        updated = []
+        for name, step in candidate_steps:
+            updates = nested_updates.get(name)
+            if updates:
+                original_step = step
+                try:
+                    step = clone_unfitted(step)
+                    step.set_params(**updates)
+                except Exception as exc:
+                    raise SpectroChemPyError(
+                        f"Invalid nested parameter update for Pipeline step '{name}'."
+                    ) from exc
+                if self._step_equal(original_step, step):
+                    step = original_step
+            updated.append((name, step))
+        return self._validate_steps(updated)
+
+    def _clear_fitted_state(self):
+        self._fitted = False
+        self._fitted_steps = None
+
+    def _require_fitted(self, attr):
+        if not self._fitted or self._fitted_steps is None:
+            raise NotFittedError(attr=attr)
+
+    def _transform_intermediates(self, X, *, operation):
+        current = X
+        for position, (name, step) in enumerate(self.fitted_steps_[:-1]):
+            current = self._transform_step(step, current, name, position, operation)
+        return current
+
+    def _clone_step(self, template, name, position):
+        try:
+            return clone_unfitted(template)
+        except Exception as exc:
+            raise self._step_error("clone", name, position, template, exc) from exc
+
+    def _fit_step(self, step, X, y, name, position):
+        try:
+            if y is None:
+                step.fit(X)
+            else:
+                step.fit(X, y)
+        except Exception as exc:
+            raise self._step_error("fit", name, position, step, exc) from exc
+
+    def _transform_step(self, step, X, name, position, operation="transform"):
+        try:
+            result = step.transform(X)
+        except Exception as exc:
+            raise self._step_error(operation, name, position, step, exc) from exc
+        if not isinstance(result, NDDataset):
+            raise SpectroChemPyError(
+                f"Pipeline {operation} step '{name}' at position {position} "
+                f"returned {result.__class__.__name__}, expected NDDataset."
+            )
+        return result
+
+    @staticmethod
+    def _step_error(operation, name, position, step, exc):
+        return SpectroChemPyError(
+            f"Pipeline {operation} failed at step '{name}' "
+            f"(position {position}, class {step.__class__.__name__}): {exc}"
+        )
+
+    @classmethod
+    def _validate_steps(cls, steps):
+        if not isinstance(steps, list | tuple):
+            raise SpectroChemPyError("Pipeline steps must be an ordered list or tuple.")
+        if not steps:
+            raise SpectroChemPyError("Pipeline requires at least one step.")
+
+        validated = []
+        seen = set()
+        for position, item in enumerate(steps):
+            if not isinstance(item, tuple) or len(item) != 2:
+                raise SpectroChemPyError(
+                    "Pipeline steps must be ordered (name, step) pairs."
+                )
+            name, step = item
+            cls._validate_step_name(name, seen)
+            cls._validate_step_object(step, name, position, position == len(steps) - 1)
+            validated.append((name, step))
+            seen.add(name)
+        return tuple(validated)
+
+    @classmethod
+    def _validate_step_name(cls, name, seen):
+        if not isinstance(name, str):
+            raise SpectroChemPyError("Pipeline step names must be strings.")
+        if not name:
+            raise SpectroChemPyError("Pipeline step names must be non-empty strings.")
+        if "__" in name:
+            raise SpectroChemPyError(
+                f"Pipeline step name '{name}' cannot contain '__'."
+            )
+        if name in seen:
+            raise SpectroChemPyError(f"Pipeline step name '{name}' is duplicated.")
+        if name in _RESERVED_STEP_NAMES:
+            raise SpectroChemPyError(
+                f"Pipeline step name '{name}' is reserved by Pipeline."
+            )
+
+    @classmethod
+    def _validate_step_object(cls, step, name, position, final):
+        if step is None:
+            raise SpectroChemPyError(
+                f"Pipeline step '{name}' at position {position} cannot be None."
+            )
+        if isinstance(step, str):
+            raise SpectroChemPyError(
+                f"Pipeline step '{name}' at position {position} cannot be a string."
+            )
+
+        kind = cls._step_kind(step, final=final)
+        if not final and kind != "intermediate":
+            raise SpectroChemPyError(
+                f"Pipeline step '{name}' at position {position} with class "
+                f"{step.__class__.__name__} is not an allowlisted intermediate "
+                "transformer."
+            )
+        if final and kind == "unsupported":
+            raise SpectroChemPyError(
+                f"Pipeline final step '{name}' at position {position} with class "
+                f"{step.__class__.__name__} is not in the v1 allowlist."
+            )
+
+    @staticmethod
+    def _step_kind(step, *, final):
+        return pipeline_v1_step_kind(step, final=final)
+
+    @staticmethod
+    def _steps_identical(left, right):
+        if len(left) != len(right):
+            return False
+        for (left_name, left_step), (right_name, right_step) in zip(
+            left, right, strict=True
+        ):
+            if left_name != right_name or left_step is not right_step:
+                return False
+        return True
+
+    @staticmethod
+    def _step_equal(left_step, right_step):
+        if left_step is right_step:
+            return True
+        if type(left_step) is not type(right_step):
+            return False
+        left_params = left_step.get_params(deep=False)
+        right_params = right_step.get_params(deep=False)
+        if left_params.keys() != right_params.keys():
+            return False
+        for key, left_value in left_params.items():
+            if not parameter_values_equal(left_value, right_params[key]):
+                return False
+        return True
+
+    def __repr__(self):
+        inner = ", ".join(f"({name!r}, {step!r})" for name, step in self._steps)
+        return f"Pipeline([{inner}])"

--- a/src/spectrochempy/lazyimport/api_methods.py
+++ b/src/spectrochempy/lazyimport/api_methods.py
@@ -54,6 +54,7 @@ _LAZY_IMPORTS = {
     "find_peaks": "spectrochempy.analysis.peakfinding.peakfinding",
     "PeakFindingResult": "spectrochempy.analysis.peakfinding.peakfinding",
     "PeakTable": "spectrochempy.analysis.peakfinding.peakfinding",
+    "Pipeline": "spectrochempy.analysis.pipeline",
     "DEBUG": "spectrochempy.application.application",
     "INFO": "spectrochempy.application.application",
     "WARNING": "spectrochempy.application.application",

--- a/src/spectrochempy/utils/_estimator.py
+++ b/src/spectrochempy/utils/_estimator.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from spectrochempy.utils.exceptions import SpectroChemPyError
 
-_PIPELINE_V1_TRANSFORMERS = frozenset(
+_PIPELINE_V1_INTERMEDIATE_TRANSFORMERS = frozenset(
     {
         "spectrochempy.processing.transformation.preprocessing_transformers.CenterTransformer",
         "spectrochempy.processing.transformation.preprocessing_transformers.AutoscaleTransformer",
@@ -25,8 +25,11 @@ _PIPELINE_V1_TRANSFORMERS = frozenset(
         "spectrochempy.processing.transformation.preprocessing_transformers.NormalizeTransformer",
         "spectrochempy.processing.transformation.preprocessing_transformers.MSCTransformer",
         "spectrochempy.processing.transformation.preprocessing_transformers.LogTransformer",
-        "spectrochempy.analysis.decomposition.pca.PCA",
     }
+)
+
+_PIPELINE_V1_FINAL_TRANSFORMERS = _PIPELINE_V1_INTERMEDIATE_TRANSFORMERS | frozenset(
+    {"spectrochempy.analysis.decomposition.pca.PCA"}
 )
 
 _PIPELINE_V1_FINAL_ESTIMATORS = frozenset(
@@ -38,7 +41,7 @@ _PIPELINE_V1_FINAL_ESTIMATORS = frozenset(
 )
 
 PIPELINE_V1_SUPPORTED_ESTIMATORS = (
-    _PIPELINE_V1_TRANSFORMERS | _PIPELINE_V1_FINAL_ESTIMATORS
+    _PIPELINE_V1_FINAL_TRANSFORMERS | _PIPELINE_V1_FINAL_ESTIMATORS
 )
 
 
@@ -50,6 +53,18 @@ def _qualified_name(estimator):
 def is_pipeline_v1_supported(estimator):
     """Return whether *estimator* is in the normative v1 pipeline allowlist."""
     return _qualified_name(estimator) in PIPELINE_V1_SUPPORTED_ESTIMATORS
+
+
+def pipeline_v1_step_kind(estimator, *, final):
+    """Return the normative v1 Pipeline category for *estimator*."""
+    qualified = _qualified_name(estimator)
+    if qualified in _PIPELINE_V1_INTERMEDIATE_TRANSFORMERS:
+        return "transformer" if final else "intermediate"
+    if final and qualified in _PIPELINE_V1_FINAL_TRANSFORMERS:
+        return "transformer"
+    if final and qualified in _PIPELINE_V1_FINAL_ESTIMATORS:
+        return "estimator"
+    return "unsupported"
 
 
 def is_fitted(estimator):

--- a/tests/test_analysis/test_pipeline.py
+++ b/tests/test_analysis/test_pipeline.py
@@ -1,0 +1,713 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+"""Tests for the public SpectroChemPy Pipeline v1 contract."""
+
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+import spectrochempy.analysis.pipeline as pipeline_module
+from spectrochempy.analysis.pipeline import Pipeline
+from spectrochempy.processing.baselineprocessing.baselineprocessing import Baseline
+from spectrochempy.utils.exceptions import NotFittedError
+from spectrochempy.utils.exceptions import SpectroChemPyError
+
+
+def _xy():
+    x = scp.Coord.linspace(1000.0, 1010.0, 6, title="wavenumber", units="cm^-1")
+    y = scp.Coord.arange(5, title="sample")
+    X = scp.NDDataset(
+        np.arange(30.0).reshape(5, 6) + 1.0,
+        coordset=[y, x],
+        dims=["y", "x"],
+        units="absorbance",
+        title="spectra",
+        name="calibration",
+    )
+    X.meta.operator = "Alice"
+    X.history = "created calibration data"
+    target = scp.NDDataset(
+        np.linspace(1.0, 5.0, 5),
+        coordset=[y.copy()],
+        dims=["y"],
+        units="mol/L",
+        title="concentration",
+        name="target",
+    )
+    return X, target
+
+
+def _test_x():
+    X, _ = _xy()
+    new = X.copy()
+    new.data = X.data + 3.0
+    new.name = "test"
+    return new
+
+
+def _assert_unfitted(pipeline):
+    assert pipeline._fitted is False
+    with pytest.raises(NotFittedError):
+        _ = pipeline.fitted_steps_
+    with pytest.raises(NotFittedError):
+        _ = pipeline.fitted_named_steps_
+
+
+def test_constructs_valid_one_step_transformer_pipeline():
+    pipeline = Pipeline([("center", scp.CenterTransformer(dim="y"))])
+
+    assert scp.Pipeline is Pipeline
+    assert pipeline.steps[0][0] == "center"
+    assert isinstance(pipeline.named_steps, MappingProxyType)
+    assert pipeline.named_steps["center"] is pipeline.steps[0][1]
+
+
+def test_constructs_valid_multi_step_transformer_pipeline():
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+
+    assert [name for name, _ in pipeline.steps] == ["center", "pca"]
+
+
+def test_constructs_valid_predictor_terminal_pipeline():
+    pipeline = Pipeline(
+        [
+            ("scale", scp.AutoscaleTransformer(dim="y")),
+            ("pls", scp.PLSRegression(n_components=2)),
+        ]
+    )
+
+    assert [name for name, _ in pipeline.steps] == ["scale", "pls"]
+
+
+@pytest.mark.parametrize(
+    "steps, match",
+    [
+        ([], "at least one"),
+        (
+            [("a", scp.CenterTransformer()), ("a", scp.AutoscaleTransformer())],
+            "duplicated",
+        ),
+        ([("", scp.CenterTransformer())], "non-empty"),
+        ([(1, scp.CenterTransformer())], "strings"),
+        ([("a__b", scp.CenterTransformer())], "cannot contain"),
+        ([("steps", scp.CenterTransformer())], "reserved"),
+        ([("none", None)], "cannot be None"),
+        ([("pass", "passthrough")], "cannot be a string"),
+    ],
+)
+def test_constructor_rejects_invalid_step_structure(steps, match):
+    with pytest.raises(SpectroChemPyError, match=match):
+        Pipeline(steps)
+
+
+@pytest.mark.parametrize(
+    "steps, match",
+    [
+        ([("baseline", Baseline())], "not in the v1 allowlist"),
+        ([("svd", scp.SVD())], "not in the v1 allowlist"),
+        (
+            [
+                ("pca", scp.PCA(n_components=2)),
+                ("center", scp.CenterTransformer()),
+            ],
+            "not an allowlisted intermediate transformer",
+        ),
+        (
+            [
+                ("pls", scp.PLSRegression(n_components=2)),
+                ("center", scp.CenterTransformer()),
+            ],
+            "not an allowlisted intermediate transformer",
+        ),
+    ],
+)
+def test_constructor_rejects_unsupported_classes_and_positions(steps, match):
+    with pytest.raises(SpectroChemPyError, match=match):
+        Pipeline(steps)
+
+
+def test_fit_clones_steps_and_leaves_templates_unfitted():
+    X, _ = _xy()
+    center = scp.CenterTransformer(dim="y")
+    pca = scp.PCA(n_components=2)
+    pipeline = Pipeline([("center", center), ("pca", pca)])
+
+    fitted = pipeline.fit(X)
+
+    assert fitted is pipeline
+    assert center._fitted is False
+    assert pca._fitted is False
+    assert pipeline.fitted_steps_[0][1] is not center
+    assert pipeline.fitted_steps_[1][1] is not pca
+    assert pipeline.fitted_named_steps_["center"] is pipeline.fitted_steps_[0][1]
+    assert isinstance(pipeline.fitted_named_steps_, MappingProxyType)
+    with pytest.raises(TypeError):
+        pipeline.fitted_named_steps_["center"] = center
+    assert not hasattr(center, "mean_")
+    assert hasattr(pipeline.fitted_named_steps_["center"], "mean_")
+
+
+def test_each_fit_creates_fresh_fitted_instances():
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+
+    pipeline.fit(X)
+    first = pipeline.fitted_steps_
+    pipeline.fit(X)
+    second = pipeline.fitted_steps_
+
+    assert first[0][1] is not second[0][1]
+    assert first[1][1] is not second[1][1]
+
+
+def test_mutable_constructor_parameters_are_isolated_from_fitted_steps():
+    X, _ = _xy()
+    reference = np.linspace(1.0, 2.0, 6)
+    pipeline = Pipeline([("msc", scp.MSCTransformer(reference=reference, dim="y"))])
+
+    pipeline.fit(X)
+    fitted_reference = pipeline.fitted_named_steps_["msc"].reference
+
+    assert fitted_reference is not pipeline.named_steps["msc"].reference
+    fitted_reference[0] = 99.0
+    assert pipeline.named_steps["msc"].reference[0] != 99.0
+
+
+def test_transformer_only_fit_and_transform():
+    X, _ = _xy()
+    pipeline = Pipeline([("center", scp.CenterTransformer(dim="y"))])
+
+    pipeline.fit(X)
+    transformed = pipeline.transform(_test_x())
+
+    assert isinstance(transformed, scp.NDDataset)
+    assert transformed.dims == X.dims
+    assert transformed.units == X.units
+    assert transformed.coordset["x"] == X.coordset["x"]
+
+
+def test_preprocessing_followed_by_pca_fit_transform_equivalence():
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+    expected_pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+
+    result = pipeline.fit_transform(X)
+    expected = expected_pipeline.fit(X).transform(X)
+
+    assert isinstance(result, scp.NDDataset)
+    assert result.shape == (5, 2)
+    assert np.allclose(result.data, expected.data)
+
+
+def test_preprocessing_followed_by_pls_predict_and_score():
+    X, y = _xy()
+    pipeline = Pipeline(
+        [
+            ("scale", scp.AutoscaleTransformer(dim="y")),
+            ("pls", scp.PLSRegression(n_components=2)),
+        ]
+    )
+
+    pipeline.fit(X, y)
+    predicted = pipeline.predict(_test_x())
+    score = pipeline.score(_test_x(), y)
+
+    assert isinstance(predicted, scp.NDDataset)
+    assert isinstance(score, float)
+
+
+def test_estimator_final_fit_transform_is_unavailable_without_fitting():
+    X, y = _xy()
+    pipeline = Pipeline([("pls", scp.PLSRegression(n_components=2))])
+
+    with pytest.raises(SpectroChemPyError, match="fit_transform is not available"):
+        pipeline.fit_transform(X, y)
+
+    _assert_unfitted(pipeline)
+
+
+@pytest.mark.parametrize("final", [scp.LSTSQ(), scp.NNLS()])
+def test_preprocessing_followed_by_linear_regression_terminal(final):
+    X, y = _xy()
+    pipeline = Pipeline([("center", scp.CenterTransformer(dim="y")), ("linear", final)])
+
+    pipeline.fit(X, y)
+
+    assert isinstance(pipeline.predict(_test_x()), scp.NDDataset)
+    assert isinstance(pipeline.score(_test_x(), y), float)
+
+
+def test_y_is_routed_only_to_supervised_final_estimators():
+    X, y = _xy()
+    transformer_pipeline = Pipeline([("center", scp.CenterTransformer(dim="y"))])
+    estimator_pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pls", scp.PLSRegression(n_components=2)),
+        ]
+    )
+
+    with pytest.raises(SpectroChemPyError, match="does not accept y"):
+        transformer_pipeline.fit(X, y)
+    with pytest.raises(SpectroChemPyError, match="requires y"):
+        estimator_pipeline.fit(X)
+
+    estimator_pipeline.fit(X, y)
+    assert estimator_pipeline.fitted_named_steps_["center"]._fitted
+    assert estimator_pipeline.fitted_named_steps_["pls"]._fitted
+
+
+def test_incompatible_y_preserves_original_error_cause():
+    X, _ = _xy()
+    pipeline = Pipeline([("pls", scp.PLSRegression(n_components=2))])
+
+    with pytest.raises(SpectroChemPyError, match="step 'pls'") as excinfo:
+        pipeline.fit(X, scp.NDDataset(np.arange(4.0)))
+
+    assert excinfo.value.__cause__ is not None
+    _assert_unfitted(pipeline)
+
+
+def test_intermediate_fit_failure_leaves_no_partial_state():
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("msc", scp.MSCTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+
+    with pytest.raises(SpectroChemPyError, match="step 'msc'"):
+        pipeline.fit(scp.NDDataset(np.arange(6.0)))
+
+    _assert_unfitted(pipeline)
+
+
+def test_intermediate_transform_failure_leaves_no_partial_state(monkeypatch):
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+    original_clone = pipeline_module.clone_unfitted
+
+    class BrokenTransform:
+        _fitted = False
+
+        def fit(self, X):
+            self._fitted = True
+            return self
+
+        def transform(self, X):
+            raise ValueError("broken transform")
+
+    def clone_with_broken_transform(step):
+        if isinstance(step, scp.CenterTransformer):
+            return BrokenTransform()
+        return original_clone(step)
+
+    monkeypatch.setattr(pipeline_module, "clone_unfitted", clone_with_broken_transform)
+
+    with pytest.raises(SpectroChemPyError, match="Pipeline transform failed"):
+        pipeline.fit(X)
+
+    _assert_unfitted(pipeline)
+
+
+def test_intermediate_transform_must_return_nddataset(monkeypatch):
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+    original_clone = pipeline_module.clone_unfitted
+
+    class ArrayTransform:
+        _fitted = False
+
+        def fit(self, X):
+            self._fitted = True
+            return self
+
+        def transform(self, X):
+            return X.data
+
+    def clone_with_array_transform(step):
+        if isinstance(step, scp.CenterTransformer):
+            return ArrayTransform()
+        return original_clone(step)
+
+    monkeypatch.setattr(pipeline_module, "clone_unfitted", clone_with_array_transform)
+
+    with pytest.raises(SpectroChemPyError, match="expected NDDataset"):
+        pipeline.fit(X)
+
+    _assert_unfitted(pipeline)
+
+
+def test_clone_failure_reports_step_context(monkeypatch):
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+    original_clone = pipeline_module.clone_unfitted
+
+    def clone_with_broken_pca(step):
+        if isinstance(step, scp.PCA):
+            raise ValueError("broken clone")
+        return original_clone(step)
+
+    monkeypatch.setattr(pipeline_module, "clone_unfitted", clone_with_broken_pca)
+
+    with pytest.raises(
+        SpectroChemPyError,
+        match="Pipeline clone failed at step 'pca' \\(position 1, class PCA\\)",
+    ) as excinfo:
+        pipeline.fit(X)
+
+    assert excinfo.value.__cause__ is not None
+    _assert_unfitted(pipeline)
+
+
+def test_final_fit_failure_leaves_no_partial_state():
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=99)),
+        ]
+    )
+
+    with pytest.raises(SpectroChemPyError, match="step 'pca'"):
+        pipeline.fit(X)
+
+    _assert_unfitted(pipeline)
+
+
+def test_failed_refit_clears_previous_fitted_state():
+    X, _ = _xy()
+    pipeline = Pipeline([("pca", scp.PCA(n_components=2))]).fit(X)
+
+    assert pipeline._fitted
+    pipeline.set_params(pca__n_components=99)
+    with pytest.raises(SpectroChemPyError, match="step 'pca'"):
+        pipeline.fit(X)
+
+    _assert_unfitted(pipeline)
+
+
+def test_public_operations_require_fit():
+    X, y = _xy()
+    transformer_pipeline = Pipeline([("center", scp.CenterTransformer(dim="y"))])
+    estimator_pipeline = Pipeline([("pls", scp.PLSRegression(n_components=2))])
+
+    with pytest.raises(NotFittedError):
+        transformer_pipeline.transform(X)
+    with pytest.raises(NotFittedError):
+        estimator_pipeline.predict(X)
+    with pytest.raises(NotFittedError):
+        estimator_pipeline.score(X, y)
+    with pytest.raises(NotFittedError):
+        _ = transformer_pipeline.fitted_steps_
+    with pytest.raises(NotFittedError):
+        _ = transformer_pipeline.fitted_named_steps_
+
+
+def test_incompatible_category_methods_fail_after_fit():
+    X, y = _xy()
+    transformer_pipeline = Pipeline([("pca", scp.PCA(n_components=2))]).fit(X)
+    estimator_pipeline = Pipeline([("pls", scp.PLSRegression(n_components=2))]).fit(
+        X, y
+    )
+
+    assert callable(transformer_pipeline.transform)
+    assert callable(transformer_pipeline.predict)
+    assert callable(estimator_pipeline.predict)
+    assert callable(estimator_pipeline.transform)
+    with pytest.raises(SpectroChemPyError, match="predict is not available"):
+        transformer_pipeline.predict(X)
+    with pytest.raises(SpectroChemPyError, match="score is not available"):
+        transformer_pipeline.score(X, y)
+    with pytest.raises(SpectroChemPyError, match="transform is not available"):
+        estimator_pipeline.transform(X)
+    with pytest.raises(SpectroChemPyError, match="score requires y"):
+        estimator_pipeline.score(X)
+
+
+def test_repeated_predict_does_not_refit_steps(monkeypatch):
+    X, y = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pls", scp.PLSRegression(n_components=2)),
+        ]
+    ).fit(X, y)
+    fitted_center = pipeline.fitted_named_steps_["center"]
+
+    def fail_fit(X):
+        raise AssertionError("fit should not be called")
+
+    monkeypatch.setattr(fitted_center, "fit", fail_fit)
+
+    pipeline.predict(_test_x())
+    pipeline.predict(_test_x())
+
+
+def test_get_params_exposes_template_configuration_only():
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+    shallow = pipeline.get_params(deep=False)
+    deep = pipeline.get_params(deep=True)
+
+    assert shallow == {"steps": pipeline.steps}
+    assert deep["center"] is pipeline.named_steps["center"]
+    assert deep["pca"] is pipeline.named_steps["pca"]
+    assert deep["center__dim"] == "y"
+    assert deep["pca__n_components"] == 2
+
+    X, _ = _xy()
+    pipeline.fit(X)
+    assert deep["center"] is pipeline.named_steps["center"]
+    assert "fitted_steps_" not in pipeline.get_params(deep=True)
+
+
+def test_set_params_nested_effective_and_equal_updates():
+    X, _ = _xy()
+    center = scp.CenterTransformer(dim="y")
+    pca = scp.PCA(n_components=2)
+    pipeline = Pipeline(
+        [
+            ("center", center),
+            ("pca", pca),
+        ]
+    ).fit(X)
+    fitted_steps = pipeline.fitted_steps_
+
+    pipeline.set_params(pca__n_components=2)
+    assert pipeline.fitted_steps_ is fitted_steps
+    assert pipeline.named_steps["center"] is center
+    assert pipeline.named_steps["pca"] is pca
+
+    pipeline.set_params(pca__n_components=1)
+    assert pipeline.named_steps["center"] is center
+    assert pipeline.named_steps["pca"] is not pca
+    assert pipeline.named_steps["pca"].n_components == 1
+    _assert_unfitted(pipeline)
+
+
+def test_set_params_nested_update_preserves_unmodified_step_instances():
+    center = scp.CenterTransformer(dim="y")
+    pca = scp.PCA(n_components=2)
+    pipeline = Pipeline([("center", center), ("pca", pca)])
+
+    pipeline.set_params(pca__n_components=1)
+
+    assert pipeline.named_steps["center"] is center
+    assert pipeline.named_steps["pca"] is not pca
+
+
+def test_set_params_whole_step_replacement_and_steps_replacement():
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    )
+    new_pca = scp.PCA(n_components=1)
+
+    pipeline.set_params(pca=new_pca)
+    assert pipeline.named_steps["pca"] is new_pca
+
+    pipeline.set_params(steps=[("scale", scp.AutoscaleTransformer(dim="y"))])
+    assert [name for name, _ in pipeline.steps] == ["scale"]
+
+
+def test_set_params_identical_step_replacement_is_noop():
+    X, _ = _xy()
+    pca = scp.PCA(n_components=2)
+    pipeline = Pipeline([("pca", pca)]).fit(X)
+    original_steps = pipeline.steps
+    original_fitted_steps = pipeline.fitted_steps_
+
+    pipeline.set_params(pca=pca)
+
+    assert pipeline.steps is original_steps
+    assert pipeline.fitted_steps_ is original_fitted_steps
+
+
+def test_set_params_equivalent_new_step_replacement_is_effective():
+    X, _ = _xy()
+    old_pca = scp.PCA(n_components=2)
+    new_pca = scp.PCA(n_components=2)
+    pipeline = Pipeline([("pca", old_pca)]).fit(X)
+
+    pipeline.set_params(pca=new_pca)
+
+    assert pipeline.named_steps["pca"] is new_pca
+    _assert_unfitted(pipeline)
+
+
+def test_set_params_equivalent_steps_replacement_is_effective():
+    X, _ = _xy()
+    old_pca = scp.PCA(n_components=2)
+    new_pca = scp.PCA(n_components=2)
+    pipeline = Pipeline([("pca", old_pca)]).fit(X)
+
+    pipeline.set_params(steps=[("pca", new_pca)])
+
+    assert pipeline.named_steps["pca"] is new_pca
+    _assert_unfitted(pipeline)
+
+
+@pytest.mark.parametrize(
+    "params, match",
+    [
+        ({"missing__dim": "x"}, "Invalid step name"),
+        ({"center__missing": "x"}, "Invalid nested parameter"),
+        ({"pca__svd_solver": "bad"}, "Invalid nested parameter"),
+        ({"unknown": 1}, "Invalid parameter"),
+    ],
+)
+def test_set_params_rejects_invalid_updates_transactionally(params, match):
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    ).fit(X)
+    original_steps = pipeline.steps
+    original_fitted_steps = pipeline.fitted_steps_
+
+    with pytest.raises(SpectroChemPyError, match=match):
+        pipeline.set_params(**params)
+
+    assert pipeline.steps is original_steps
+    assert pipeline.fitted_steps_ is original_fitted_steps
+    assert pipeline.named_steps["pca"].n_components == 2
+
+
+def test_set_params_mixed_update_is_transactional_when_later_update_fails():
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    ).fit(X)
+    original_steps = pipeline.steps
+    original_fitted_steps = pipeline.fitted_steps_
+
+    with pytest.raises(SpectroChemPyError, match="Invalid nested parameter"):
+        pipeline.set_params(center__dim="x", pca__svd_solver="bad")
+
+    assert pipeline.steps is original_steps
+    assert pipeline.named_steps["center"].dim == "y"
+    assert pipeline.fitted_steps_ is original_fitted_steps
+
+
+def test_set_params_rejects_replacement_that_violates_position():
+    X, _ = _xy()
+    pipeline = Pipeline(
+        [
+            ("center", scp.CenterTransformer(dim="y")),
+            ("pca", scp.PCA(n_components=2)),
+        ]
+    ).fit(X)
+    original_steps = pipeline.steps
+    original_fitted_steps = pipeline.fitted_steps_
+
+    with pytest.raises(SpectroChemPyError, match="not an allowlisted intermediate"):
+        pipeline.set_params(center=scp.PCA(n_components=1))
+
+    assert pipeline.steps is original_steps
+    assert pipeline.fitted_steps_ is original_fitted_steps
+
+
+def test_set_params_rejects_invalid_steps_replacement_transactionally():
+    X, _ = _xy()
+    pipeline = Pipeline([("pca", scp.PCA(n_components=2))]).fit(X)
+    original_steps = pipeline.steps
+    original_fitted_steps = pipeline.fitted_steps_
+
+    with pytest.raises(SpectroChemPyError, match="at least one"):
+        pipeline.set_params(steps=[])
+
+    assert pipeline.steps is original_steps
+    assert pipeline.fitted_steps_ is original_fitted_steps
+
+
+def test_set_params_effective_whole_step_replacement_invalidates_fitted_state():
+    X, _ = _xy()
+    pipeline = Pipeline([("pca", scp.PCA(n_components=2))]).fit(X)
+
+    pipeline.set_params(pca=scp.PCA(n_components=1))
+
+    _assert_unfitted(pipeline)
+
+
+def test_scientific_contracts_are_supplied_by_underlying_steps():
+    X, _ = _xy()
+    X[0, 0] = scp.MASKED
+    X_test = _test_x()
+    X_test[1, 2] = scp.MASKED
+    pipeline = Pipeline([("center", scp.CenterTransformer(dim="y"))]).fit(X)
+
+    transformed = pipeline.transform(X_test)
+
+    assert isinstance(transformed, scp.NDDataset)
+    assert transformed.dims == X.dims
+    assert transformed.units == X.units
+    assert transformed.coordset["x"] == X.coordset["x"]
+    assert transformed.coordset["y"] == X.coordset["y"]
+    assert np.ma.getmaskarray(transformed.masked_data)[1, 2]
+    assert transformed.meta.operator == "Alice"
+    assert "CenterTransformer applied" in transformed.history[-1]
+
+
+def test_train_test_reuses_learned_preprocessing_statistics():
+    X, _ = _xy()
+    X_test = _test_x()
+    pipeline = Pipeline([("center", scp.CenterTransformer(dim="y"))]).fit(X)
+    fitted_center = pipeline.fitted_named_steps_["center"]
+
+    transformed = pipeline.transform(X_test)
+    expected = X_test.masked_data - fitted_center.mean_
+
+    assert np.allclose(transformed.data, expected)

--- a/tests/test_utils/test_estimator_contract.py
+++ b/tests/test_utils/test_estimator_contract.py
@@ -49,6 +49,7 @@ from spectrochempy.processing.transformation.preprocessing_transformers import (
 from spectrochempy.utils._estimator import _clone_constructor_parameter
 from spectrochempy.utils._estimator import clone_unfitted
 from spectrochempy.utils._estimator import is_fitted
+from spectrochempy.utils._estimator import pipeline_v1_step_kind
 from spectrochempy.utils.exceptions import NotFittedError
 from spectrochempy.utils.exceptions import SpectroChemPyError
 
@@ -269,6 +270,25 @@ def test_clone_and_fitted_helpers_reject_unsupported_candidates(unsupported):
         clone_unfitted(unsupported)
     with pytest.raises(SpectroChemPyError, match="not supported"):
         is_fitted(unsupported)
+
+
+@pytest.mark.parametrize("transformer", _preprocessor_cases())
+def test_pipeline_v1_step_kind_classifies_preprocessors(transformer):
+    assert pipeline_v1_step_kind(transformer, final=False) == "intermediate"
+    assert pipeline_v1_step_kind(transformer, final=True) == "transformer"
+
+
+def test_pipeline_v1_step_kind_classifies_terminal_only_candidates():
+    assert pipeline_v1_step_kind(PCA(n_components=2), final=False) == "unsupported"
+    assert pipeline_v1_step_kind(PCA(n_components=2), final=True) == "transformer"
+    assert (
+        pipeline_v1_step_kind(PLSRegression(n_components=2), final=False)
+        == "unsupported"
+    )
+    assert (
+        pipeline_v1_step_kind(PLSRegression(n_components=2), final=True) == "estimator"
+    )
+    assert pipeline_v1_step_kind(SVD(), final=True) == "unsupported"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds the first public, minimal `scp.Pipeline` implementation for linear SpectroChemPy estimator composition.

Scope is intentionally limited to the accepted maintainer RFC:

- zero or more allowlisted preprocessing transformers followed by one allowlisted final transformer or supervised estimator;
- template ownership through `steps`, `named_steps`, and `get_params()`;
- clone-on-fit with fitted clones exposed through `fitted_steps_` and `fitted_named_steps_`;
- `fit(X, y=None)` only, with `y` routed only to supervised terminal estimators;
- public operations limited to `transform` / `fit_transform` for transformer-final pipelines and `predict` / `score` for estimator-final pipelines;
- transactional `set_params()` with nested `step__parameter` support and fitted-state invalidation.

No `make_pipeline`, generic workflow engine, advanced fit-parameter routing, sample-weight routing, or Baseline/SVD/PSD support is included.

