### PR TITLE
DOC: clarify PR checklist API reference guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,12 @@
 
 **Checklist**:
 
-<!-- delete unused entries -->
+<!-- delete unused optional entries, but keep the compliance entries that apply to this PR -->
 - [ ] Close the #xxxx.
 - [ ] Tests have been added.
 - [ ] `pyproject.toml` file has been updated with new dependencies.
 - [ ] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
-- [ ] Developer changes (tests, CI, refactoring, tooling) have been documented in the ``Developer`` section of `docs/sources/whatsnew/changelog.rst`.
+- [ ] Developer changes (tests, CI, refactoring, tooling) have been documented in the `Developer` section of `docs/sources/whatsnew/changelog.rst`.
 - [ ] The new API methods have been included in a section of `docs/sources/reference/index.rst`.
 - [ ] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
 - [ ] Changelog entry is present (or label `no-changelog` is applied).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,11 @@ The PR description should begin with:
 2. what is intentionally out of scope;
 3. references to related issues and PRs when applicable.
 
+Keep the applicable checklist items from `.github/PULL_REQUEST_TEMPLATE.md`
+in the PR description, especially changelog, reference API, and title-prefix
+items. Mark them done or explain why they do not apply so reviewers can see
+that they were considered.
+
 If a pull request adds or exposes a new public API symbol at top level
 (``spectrochempy.<name>`` / ``scp.<name>``), update
 `docs/sources/reference/index.rst` in the appropriate section so the symbol

--- a/docs/sources/devguide/contributing.rst
+++ b/docs/sources/devguide/contributing.rst
@@ -159,6 +159,13 @@ checks matching your change have been run locally when practical:
 * ``pre-commit run --all-files`` for formatting and generated docs files before
   the final commit when practical
 
+Keep the applicable checklist items from the template in the pull request
+description so reviewers can see whether changelog, reference API, and
+title-prefix requirements were considered. For any new public top-level API symbol
+(``spectrochempy.<name>`` / ``scp.<name>``), the relevant checklist item means
+adding the symbol to the appropriate section of
+``docs/sources/reference/index.rst``.
+
 Tips for Success
 ----------------
 

--- a/docs/sources/reference/index.rst
+++ b/docs/sources/reference/index.rst
@@ -349,16 +349,6 @@ Chemometric preprocessing
     RobustScaleTransformer
     LogTransformer
 
-Pipeline composition
-====================
-
-.. autosummary::
-    :nosignatures:
-    :toctree: generated/
-
-    Pipeline
-
-
 Indexing
 ========
 
@@ -654,6 +644,16 @@ Miscellaneous
 ********
 Analysis
 ********
+
+
+Pipeline composition
+====================
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+
+    Pipeline
 
 
 Linear regression


### PR DESCRIPTION
Summary:
- Clarify that PR descriptions should keep the applicable checklist items from `.github/PULL_REQUEST_TEMPLATE.md`.
- Make the public API reference requirement explicit for new top-level API symbols.
- Place `Pipeline` explicitly in `docs/sources/reference/index.rst` under `Analysis` > `Pipeline composition`.

Out of scope:
- No runtime API changes.
- No strict CI check for the full pull request template body.
- No changelog entry; this is a contributor-process documentation update.

Related:
- Follow-up to the Pipeline API review checklist.

**Checklist**:

- [ ] Close the #xxxx.
- [ ] Tests have been added.
- [ ] `pyproject.toml` file has been updated with new dependencies.
- [ ] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
- [ ] Developer changes (tests, CI, refactoring, tooling) have been documented in the `Developer` section of `docs/sources/whatsnew/changelog.rst`.
- [x] The new API methods have been included in a section of `docs/sources/reference/index.rst`.
- [x] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
- [x] Changelog entry is present (or label `no-changelog` is applied).
- [ ] If you are a new contributor, you have added your name (affiliation and ORCID
      if you have one) in the `zenodo.json` in the field contributors field. _Be careful
      not to break the json format (check the content of the file with the
      [JSON Validator](https://jsonformatter.curiousconcept.com/))_.
