### PR TITLE
DOC: expand Pipeline user guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,9 @@ The PR description should begin with:
 
 Keep the applicable checklist items from `.github/PULL_REQUEST_TEMPLATE.md`
 in the PR description, especially changelog, reference API, and title-prefix
-items. Mark them done or explain why they do not apply so reviewers can see
-that they were considered.
+items. Keep only the entries that apply and can be checked. Non-applicable
+unchecked entries add little review value and should normally be omitted rather
+than left as a long list of empty boxes.
 
 If a pull request adds or exposes a new public API symbol at top level
 (``spectrochempy.<name>`` / ``scp.<name>``), update

--- a/docs/sources/userguide/analysis/pipeline.py
+++ b/docs/sources/userguide/analysis/pipeline.py
@@ -1,3 +1,4 @@
+# %%
 """
 Pipeline.
 
@@ -6,14 +7,15 @@ Pipeline
 
 ``Pipeline`` composes a small, reproducible sequence of SpectroChemPy
 preprocessing transformers and a final transformer or supervised estimator.
-It is useful when the same fitted preprocessing must be applied consistently
-to calibration and test spectra.
+It is useful when you want to fit preprocessing and a model together, then
+reuse exactly the preprocessing learned from calibration spectra on new
+spectra.
 
-The steps passed to ``Pipeline`` are templates. Calling ``fit()`` clones those
-templates, fits the clones, and leaves the original step objects unchanged.
-Template steps remain available through ``steps`` and ``named_steps``. Fitted
-runtime clones are available after fitting through ``fitted_steps_`` and
-``fitted_named_steps_``.
+The first public version is intentionally modest. Its goal is not to replace a
+workflow engine or scikit-learn's full ``Pipeline`` API, but to make common
+SpectroChemPy estimator workflows easier to repeat without data leakage:
+preprocessing steps are fitted only when ``Pipeline.fit()`` is called, so test
+spectra do not accidentally influence centering or scaling statistics.
 """
 
 import numpy as np
@@ -21,22 +23,98 @@ import numpy as np
 import spectrochempy as scp
 
 rng = np.random.default_rng(42)
-wavenumbers = scp.Coord.linspace(1000.0, 1100.0, 24, title="wavenumber", units="cm^-1")
-samples = scp.Coord.arange(12, title="sample")
+wavenumbers = scp.Coord.linspace(1000.0, 1200.0, 80, title="wavenumber", units="cm^-1")
+concentration = np.linspace(0.1, 1.2, 12)
+samples = scp.Coord.arange(concentration.size, title="sample")
+
+band_a = np.exp(-0.5 * ((wavenumbers.data - 1060.0) / 12.0) ** 2)
+band_b = np.exp(-0.5 * ((wavenumbers.data - 1140.0) / 18.0) ** 2)
+baseline = 0.03 + 0.0005 * (wavenumbers.data - wavenumbers.data.mean())
+spectra = (
+    baseline
+    + concentration[:, None] * band_a
+    + 0.35 * concentration[:, None] * band_b
+    + rng.normal(scale=0.015, size=(concentration.size, wavenumbers.size))
+)
+
 dataset = scp.NDDataset(
-    rng.normal(size=(12, 24)),
+    spectra,
     coordset=[samples, wavenumbers],
     dims=["y", "x"],
     units="absorbance",
     title="calibration spectra",
 )
 target = scp.NDDataset(
-    np.linspace(0.1, 1.2, 12),
+    concentration,
     coordset=[samples.copy()],
     dims=["y"],
     units="mol/L",
     title="concentration",
 )
+_ = dataset.plot(show=False)
+
+# %%
+# A complete calibration/test example
+# -----------------------------------
+#
+# A typical supervised use is to fit preprocessing and regression together on a
+# calibration subset, then apply the fitted pipeline to separate test spectra.
+# The scaler below learns its statistics from ``X_cal`` only; those fitted
+# statistics are reused when predicting ``X_test``.
+
+test_indices = [2, 5, 8, 11]
+cal_indices = [i for i in range(concentration.size) if i not in test_indices]
+
+X_cal = dataset[cal_indices]
+y_cal = target[cal_indices]
+X_test = dataset[test_indices]
+y_test = target[test_indices]
+
+regression_pipeline = scp.Pipeline(
+    [
+        ("scale", scp.AutoscaleTransformer(dim="y")),
+        ("pls", scp.PLSRegression(n_components=2, scale=False)),
+    ]
+)
+
+regression_pipeline.fit(X_cal, y_cal)
+y_pred = regression_pipeline.predict(X_test)
+residuals = y_test - y_pred
+rmse = np.sqrt(np.mean(np.asarray(residuals.data) ** 2))
+
+summary = scp.NDDataset(
+    np.column_stack([y_test.data, y_pred.data, residuals.data]),
+    coordset=[
+        y_test.coordset[0].copy(),
+        scp.Coord(
+            np.arange(3),
+            labels=["observed", "predicted", "residual"],
+            title="quantity",
+        ),
+    ],
+    dims=["y", "x"],
+    units=y_test.units,
+    title=f"test predictions, RMSE = {rmse:.3f}",
+)
+summary
+
+# %%
+# The fitted final estimator can still be inspected directly. Here we reuse its
+# parity-plot helper and add the independent test predictions in red.
+
+fitted_pls = regression_pipeline.fitted_named_steps_["pls"]
+ax = fitted_pls.plot_parity(label="calibration", s=120, show=False)
+_ = fitted_pls.plot_parity(
+    y_test,
+    y_pred,
+    ax=ax,
+    s=120,
+    c="red",
+    label="test",
+    clear=False,
+    show=False,
+)
+_ = ax.legend(loc="lower right")
 
 # %%
 # Transformer-final pipelines
@@ -45,54 +123,61 @@ target = scp.NDDataset(
 # A transformer-final pipeline ends with a preprocessing transformer or with
 # ``PCA``. ``fit_transform(X)`` is equivalent to ``fit(X).transform(X)``.
 
-pipeline = scp.Pipeline(
+pca_pipeline = scp.Pipeline(
     [
         ("center", scp.CenterTransformer(dim="y")),
         ("pca", scp.PCA(n_components=3)),
     ]
 )
-scores = pipeline.fit_transform(dataset)
+scores = pca_pipeline.fit_transform(dataset)
 scores
-
-# %%
-# Estimator-final pipelines
-# -------------------------
-#
-# A supervised estimator-final pipeline passes ``y`` only to the final
-# estimator. Intermediate preprocessing steps receive only the transformed
-# ``NDDataset``.
-
-pipeline = scp.Pipeline(
-    [
-        ("scale", scp.AutoscaleTransformer(dim="y")),
-        ("pls", scp.PLSRegression(n_components=3)),
-    ]
-)
-pipeline.fit(dataset, target)
-predicted = pipeline.predict(dataset)
-predicted
 
 # %%
 # Template and fitted steps
 # -------------------------
 #
-# ``steps``, ``named_steps`` and ``get_params()`` describe the templates.
-# Learned runtime state lives on fitted clones.
+# The steps passed to ``Pipeline`` are templates. Calling ``fit()`` clones those
+# templates, fits the clones, and leaves the original step objects unchanged.
+# Template steps remain available through ``steps`` and ``named_steps``.
+# Learned runtime state is available after fitting through ``fitted_steps_``
+# and ``fitted_named_steps_``.
 
-print(pipeline.named_steps["scale"] is pipeline.fitted_named_steps_["scale"])
+print(
+    regression_pipeline.named_steps["scale"]
+    is regression_pipeline.fitted_named_steps_["scale"]
+)
+print(regression_pipeline.steps[0][1] is regression_pipeline.fitted_steps_[0][1])
 
 # %%
 # Nested parameters
 # -----------------
 #
-# Template parameters are visible and editable with ``step__parameter`` names.
-# Effective nested changes replace only the modified template step with an
-# unfitted clone and preserve untouched template instances. Explicit
-# replacement with another compatible instance is always effective, even when
-# the new instance has the same constructor parameters.
+# Template parameters are visible and editable with ``step__parameter`` names,
+# using the step name followed by a double underscore and the parameter name.
+# Any effective change invalidates the fitted state, so you must call
+# ``fit()`` again before using ``predict()`` or ``transform()``.
 
-pipeline.get_params(deep=True)["pls__n_components"]
-pipeline.set_params(pls__n_components=2)
+regression_pipeline.get_params(deep=True)["pls__n_components"]
+regression_pipeline.set_params(pls__n_components=1)
+regression_pipeline.fit(X_cal, y_cal)
+regression_pipeline.predict(X_test)
+
+# %%
+# What Pipeline v1 does and does not do
+# -------------------------------------
+#
+# ``Pipeline`` is deliberately linear. Steps are ordered ``(name, step)`` pairs,
+# intermediate steps must transform an ``NDDataset`` into another
+# ``NDDataset``, and the final step is either a transformer or a supervised
+# estimator. A final transformer supports ``transform()`` and
+# ``fit_transform()``. A final supervised estimator supports ``predict()`` and,
+# when available on that estimator, ``score()``.
+#
+# ``Pipeline`` does not choose train/test splits, run cross-validation, search
+# hyperparameters, cache intermediate results, branch into multiple paths, or
+# route arbitrary fit parameters. For cross-validation, the split loop must fit
+# a fresh pipeline inside each fold so that every preprocessing statistic stays
+# fold-local.
 
 # %%
 # Supported v1 classes

--- a/docs/sources/userguide/analysis/pipeline.py
+++ b/docs/sources/userguide/analysis/pipeline.py
@@ -1,23 +1,45 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     notebook_metadata_filter: all
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.7
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.10.8
+# ---
+
+# %% [markdown]
+# # Pipeline
+#
+# ``Pipeline`` composes a small, reproducible sequence of SpectroChemPy
+# preprocessing transformers and a final transformer or supervised estimator.
+# It is useful when you want to fit preprocessing and a model together, then
+# reuse exactly the preprocessing learned from calibration spectra on new
+# spectra.
+#
+# The first public version is intentionally modest. Its goal is not to replace a
+# workflow engine or scikit-learn's full ``Pipeline`` API, but to make common
+# SpectroChemPy estimator workflows easier to repeat without data leakage:
+# preprocessing steps are fitted only when ``Pipeline.fit()`` is called, so test
+# spectra do not accidentally influence centering or scaling statistics.
+
 # %%
-"""
-Pipeline.
-
-Pipeline
-========
-
-``Pipeline`` composes a small, reproducible sequence of SpectroChemPy
-preprocessing transformers and a final transformer or supervised estimator.
-It is useful when you want to fit preprocessing and a model together, then
-reuse exactly the preprocessing learned from calibration spectra on new
-spectra.
-
-The first public version is intentionally modest. Its goal is not to replace a
-workflow engine or scikit-learn's full ``Pipeline`` API, but to make common
-SpectroChemPy estimator workflows easier to repeat without data leakage:
-preprocessing steps are fitted only when ``Pipeline.fit()`` is called, so test
-spectra do not accidentally influence centering or scaling statistics.
-"""
-
 import numpy as np
 
 import spectrochempy as scp
@@ -53,7 +75,7 @@ target = scp.NDDataset(
 )
 _ = dataset.plot(show=False)
 
-# %%
+# %% [markdown]
 # A complete calibration/test example
 # -----------------------------------
 #
@@ -62,6 +84,7 @@ _ = dataset.plot(show=False)
 # The scaler below learns its statistics from ``X_cal`` only; those fitted
 # statistics are reused when predicting ``X_test``.
 
+# %%
 test_indices = [2, 5, 8, 11]
 cal_indices = [i for i in range(concentration.size) if i not in test_indices]
 
@@ -98,10 +121,11 @@ summary = scp.NDDataset(
 )
 summary
 
-# %%
+# %% [markdown]
 # The fitted final estimator can still be inspected directly. Here we reuse its
 # parity-plot helper and add the independent test predictions in red.
 
+# %%
 fitted_pls = regression_pipeline.fitted_named_steps_["pls"]
 ax = fitted_pls.plot_parity(label="calibration", s=120, show=False)
 _ = fitted_pls.plot_parity(
@@ -116,13 +140,14 @@ _ = fitted_pls.plot_parity(
 )
 _ = ax.legend(loc="lower right")
 
-# %%
+# %% [markdown]
 # Transformer-final pipelines
 # ---------------------------
 #
 # A transformer-final pipeline ends with a preprocessing transformer or with
 # ``PCA``. ``fit_transform(X)`` is equivalent to ``fit(X).transform(X)``.
 
+# %%
 pca_pipeline = scp.Pipeline(
     [
         ("center", scp.CenterTransformer(dim="y")),
@@ -132,7 +157,7 @@ pca_pipeline = scp.Pipeline(
 scores = pca_pipeline.fit_transform(dataset)
 scores
 
-# %%
+# %% [markdown]
 # Template and fitted steps
 # -------------------------
 #
@@ -142,13 +167,14 @@ scores
 # Learned runtime state is available after fitting through ``fitted_steps_``
 # and ``fitted_named_steps_``.
 
+# %%
 print(
     regression_pipeline.named_steps["scale"]
     is regression_pipeline.fitted_named_steps_["scale"]
 )
 print(regression_pipeline.steps[0][1] is regression_pipeline.fitted_steps_[0][1])
 
-# %%
+# %% [markdown]
 # Nested parameters
 # -----------------
 #
@@ -157,12 +183,13 @@ print(regression_pipeline.steps[0][1] is regression_pipeline.fitted_steps_[0][1]
 # Any effective change invalidates the fitted state, so you must call
 # ``fit()`` again before using ``predict()`` or ``transform()``.
 
+# %%
 regression_pipeline.get_params(deep=True)["pls__n_components"]
 regression_pipeline.set_params(pls__n_components=1)
 regression_pipeline.fit(X_cal, y_cal)
 regression_pipeline.predict(X_test)
 
-# %%
+# %% [markdown]
 # What Pipeline v1 does and does not do
 # -------------------------------------
 #
@@ -179,7 +206,7 @@ regression_pipeline.predict(X_test)
 # a fresh pipeline inside each fold so that every preprocessing statistic stays
 # fold-local.
 
-# %%
+# %% [markdown]
 # Supported v1 classes
 # --------------------
 #

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls_pipeline.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls_pipeline.py
@@ -1,0 +1,129 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+# ruff: noqa
+"""
+PLS regression with a Pipeline
+==============================
+
+This example predicts corn moisture from NIR spectra using a SpectroChemPy
+``Pipeline``. The pipeline learns preprocessing from the calibration spectra
+only, then reuses the fitted preprocessing when predicting validation spectra.
+"""
+
+# %%
+# Import the packages
+import numpy as np
+
+import spectrochempy as scp
+
+# %%
+# Load the corn NIR dataset
+# -------------------------
+# The data is available from the Eigenvector archive:
+try:
+    ds_list = scp.read("http://www.eigenvector.com/data/Corn/corn.mat", merge=False)
+except FileNotFoundError:
+    ds_list = None
+    print("Eigenvector corn dataset not reachable; skipping the remote Pipeline example.")
+else:
+    ds_list_names = [f"{i} : {ds.name}({ds.shape})" for i, ds in enumerate(ds_list)]
+    print(ds_list_names)
+
+# %%
+if ds_list is not None:
+    # %%
+    # Inspect the spectra and select moisture
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # The 5th dataset ``m5spec`` contains NIR spectra from 80 corn samples
+    # recorded on the same instrument. The properties to predict are in the
+    # ``propval`` dataset.
+    X = ds_list[4]
+    X.title = "reflectance"
+    X.x.title = "Wavelength"
+    X.x.units = "nm"
+    _ = X.plot(cmap=None, show=False)
+
+    Y = ds_list[3]
+    y = Y[:, "Moisture"]
+
+    # %%
+    # Split calibration and validation samples
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # Use regularly spaced samples after sorting by moisture so the validation
+    # set spans the concentration range instead of becoming a simple high-index
+    # holdout.
+    moisture_order = np.argsort(np.asarray(y.data).ravel())
+    validation_indices = sorted(moisture_order[3::4].tolist())
+    calibration_indices = [i for i in range(X.shape[0]) if i not in validation_indices]
+
+    X_cal = X[calibration_indices]
+    y_cal = y[calibration_indices]
+    X_val = X[validation_indices]
+    y_val = y[validation_indices]
+
+    # %%
+    # Fit preprocessing and PLS together
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # ``AutoscaleTransformer`` owns the centering/scaling step, so the internal
+    # scaling of ``PLSRegression`` is disabled to keep responsibilities clear.
+    pipeline = scp.Pipeline(
+        [
+            ("scale", scp.AutoscaleTransformer(dim="y")),
+            ("pls", scp.PLSRegression(n_components=5, scale=False)),
+        ]
+    )
+    pipeline.fit(X_cal, y_cal)
+
+    # %%
+    # Predict validation samples
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    y_val_pred = pipeline.predict(X_val)
+    residuals = y_val - y_val_pred
+    rmse_val = np.sqrt(np.mean(np.asarray(residuals.data) ** 2))
+    units = f" {y_val.units}" if y_val.units else ""
+    print(f"Validation RMSE: {rmse_val:.3f}{units}")
+
+    # %%
+    # Validate with a parity plot
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    fitted_pls = pipeline.fitted_named_steps_["pls"]
+    ax = fitted_pls.plot_parity(label="calibration", s=150, show=False)
+    _ = fitted_pls.plot_parity(
+        y_val,
+        y_val_pred,
+        ax=ax,
+        s=150,
+        c="red",
+        label="validation",
+        clear=False,
+        show=False,
+    )
+    _ = ax.legend(loc="lower right")
+    _ = ax.set_title(f"Corn moisture prediction, RMSE = {rmse_val:.3f}{units}")
+
+    # %%
+    # Template and fitted steps
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^
+    # The public ``steps`` and ``named_steps`` are templates. The fitted scaler
+    # used for validation is a fitted clone.
+    print(pipeline.named_steps["scale"] is pipeline.fitted_named_steps_["scale"])
+
+    # %%
+    # Updating a nested parameter
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # Any effective ``set_params()`` call invalidates fitted state. Fit again
+    # before predicting with the updated configuration.
+    pipeline.set_params(pls__n_components=4)
+    pipeline.fit(X_cal, y_cal)
+    _ = pipeline.predict(X_val)
+
+# %%
+# Uncomment the following line to display all figures when running the script
+# directly with Python.
+
+# %%
+
+# scp.show()

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls_pipeline.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls_pipeline.py
@@ -27,14 +27,15 @@ try:
     ds_list = scp.read("http://www.eigenvector.com/data/Corn/corn.mat", merge=False)
 except FileNotFoundError:
     ds_list = None
-    print("Eigenvector corn dataset not reachable; skipping the remote Pipeline example.")
+    print(
+        "Eigenvector corn dataset not reachable; skipping the remote Pipeline example."
+    )
 else:
     ds_list_names = [f"{i} : {ds.name}({ds.shape})" for i, ds in enumerate(ds_list)]
     print(ds_list_names)
 
 # %%
 if ds_list is not None:
-    # %%
     # Inspect the spectra and select moisture
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     # The 5th dataset ``m5spec`` contains NIR spectra from 80 corn samples
@@ -54,7 +55,8 @@ if ds_list is not None:
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     # Use regularly spaced samples after sorting by moisture so the validation
     # set spans the concentration range instead of becoming a simple high-index
-    # holdout.
+    # holdout. This deterministic split is used only for demonstration;
+    # real validation splits should follow the experimental design.
     moisture_order = np.argsort(np.asarray(y.data).ravel())
     validation_indices = sorted(moisture_order[3::4].tolist())
     calibration_indices = [i for i in range(X.shape[0]) if i not in validation_indices]

--- a/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls_pipeline.py
+++ b/src/spectrochempy/examples/analysis/b_crossdecomposition/plot_pls_pipeline.py
@@ -4,6 +4,7 @@
 # See full LICENSE agreement in the root directory.
 # ======================================================================================
 # ruff: noqa
+# sphinx_gallery_thumbnail_number = 2
 """
 PLS regression with a Pipeline
 ==============================


### PR DESCRIPTION
Summary:
- Expand the Pipeline user guide with a clearer user-facing v1 purpose statement.
- Add a complete synthetic calibration/test example with concentration-dependent bands, a distributed test split, and `AutoscaleTransformer` + `PLSRegression(scale=False)`.
- Show spectra, observed/predicted/residual values, RMSE, and a parity plot in the User Guide.
- Add a Sphinx-Gallery example using the corn NIR dataset: `plot_pls_pipeline.py`.
- Use the parity plot as the Gallery thumbnail for `plot_pls_pipeline.py`.
- Clarify `set_params()` invalidates fitted state and requires a new `fit()`.
- Document the main v1 limits: no split selection, cross-validation loop, hyperparameter search, caching, branching, or arbitrary fit-parameter routing.
- Clarify in `CONTRIBUTING.md` that PR descriptions should keep only applicable checked checklist items.
- Add the standard Jupytext metadata to the Pipeline user guide source so the docs build generates `pipeline.ipynb` and `pipeline.html`.

Out of scope:
- No runtime API changes.
- No reference API changes; the public `Pipeline` API reference entry was handled in #1591.
- No changelog entry; this is documentation-only and uses the `no-changelog` label.

Related:
- Follow-up to the minimal public `Pipeline` API.

**Checklist**:

- [x] Title follows the prefix convention defined in `CONTRIBUTING.md`.
- [x] Changelog entry is present or label `no-changelog` is applied.
