### PR TITLE
FIX: correct OMNIC SRS time-axis anchor and spectrum labels

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,8 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -19,6 +19,11 @@ New Features
   SpectroChemPy preprocessing transformers with a final transformer or
   supervised estimator.
 
+Bug Fixes
+~~~~~~~~~
+
+- correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
+
 Developer
 ~~~~~~~~~
 

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -1461,7 +1461,7 @@ def _read_srs(*args, **kwargs):
     if not return_bg:
         dataset.name = info["name"]
         _y = Coord(
-            np.around(np.linspace(info["firsty"], info["lasty"], info["ny"]), 3),
+            np.around(np.linspace(info["time_min"], info["lasty"], info["ny"]), 3),
             title="Time",
             units="minute",
             labels=names,
@@ -1722,7 +1722,13 @@ def _read_header(fid, pos, is_first_spectrum=True):
         # Hack because name seems not to be well read for srs
         out["name"] = out["name"].split("\n")[0]
         fid.seek(pos + 1002)
-        out["collection_length"] = fromfile(fid, "float32", 1) * 60
+        # The stored float32 at +1002 is the OMNIC series *minimum / first time*
+        # (in minutes). `collection_length` keeps the historical public meaning
+        # (that value converted to seconds); `time_min` is the same field kept in
+        # minutes, used as the time-axis start. Do not conflate the two.
+        collection_length = fromfile(fid, "float32", 1)
+        out["collection_length"] = collection_length * 60
+        out["time_min"] = collection_length
         fid.seek(pos + 1006)
         out["lasty"] = fromfile(fid, "float32", 1)
         fid.seek(pos + 1010)
@@ -1737,6 +1743,31 @@ def _read_header(fid, pos, is_first_spectrum=True):
             out["background_name"] = _readbtext(fid, pos + 208, 256)[10:]
 
     return out
+
+
+def _read_srs_spectra_name(fid, pos):
+    """
+    Read the 84-byte per-spectrum SRS name record and return its label.
+
+    The SRS spectrum record is exactly 84 bytes: a null-terminated human-readable
+    name followed by binary metadata and, after the record, the spectral bytes.
+    Reading beyond the record (as the historical 256-byte read did) leaks binary
+    metadata and spectrum data into the label, so this SRS-specific helper stops
+    at the first null and never inspects more than the 84-byte record.
+
+    `_readbtext` is intentionally left untouched to avoid regressions in the
+    shared SPA/SPG readers.
+    """
+    fid.seek(pos)
+    record = fid.read(84)
+    name = record.split(b"\x00", 1)[0]
+    try:
+        return name.decode("utf-8")
+    except UnicodeDecodeError:
+        try:
+            return name.decode("latin_1")
+        except UnicodeDecodeError:  # pragma: no cover
+            return name.decode("utf-8", errors="ignore")
 
 
 def _read_srs_spectra(fid, pos_data, n_spectra, n_points):
@@ -1757,7 +1788,7 @@ def _read_srs_spectra(fid, pos_data, n_spectra, n_points):
     # read the spectra/interferogram names and data
     # the first one....
     pos = pos_data
-    names.append(_readbtext(fid, pos, 256))
+    names.append(_read_srs_spectra_name(fid, pos))
     pos += 84
     fid.seek(pos)
     data[0, :] = fromfile(fid, dtype="float32", count=n_points)[:]
@@ -1765,7 +1796,7 @@ def _read_srs_spectra(fid, pos_data, n_spectra, n_points):
     # ... and the remaining ones:
     for i in np.arange(n_spectra)[1:]:
         pos += 16
-        names.append(_readbtext(fid, pos, 256))
+        names.append(_read_srs_spectra_name(fid, pos))
         pos += 84
         fid.seek(pos)
         data[i, :] = fromfile(fid, dtype="float32", count=n_points)[:]

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -7,6 +7,7 @@
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import spectrochempy as scp
@@ -214,3 +215,74 @@ def test_decode_experiment_info_block():
 @pytest.mark.skip(reason="Requires an SPG file with inconsistent x-axes (#863)")
 def test_allow_inconsistent_x_with_real_file():
     """Exercise both return paths once a representative sample is available."""
+
+
+def _srs_header(path):
+    """Locate the SRS series header the way `read_srs` does and return its info."""
+    from spectrochempy.core.readers.read_omnic import _read_header
+
+    sub_rs = b"\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00\x48\x43\x00\x50\x43\x47"
+    sub_tg = b"\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00"
+    with open(path, "rb") as fid:
+        bytestring = fid.read()
+    sub = sub_rs if bytestring.find(sub_rs, 1) > 0 else sub_tg
+    pos = bytestring.find(sub, 1)
+    index = [pos]
+    while pos != -1:
+        pos = bytestring.find(sub, pos + 1)
+        index.append(pos)
+    pos_info_data = np.array(index[:-1])[0] + (-152)
+    with open(path, "rb") as fid:
+        return _read_header(fid, pos_info_data)
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_time_axis_anchored_at_time_min():
+    """The SRS time axis must start from the series minimum/first time, not the
+    (mislabeled) `firsty` field which is really the regular step.
+
+    The public fixtures only differ from the step at sub-rounding precision
+    (the axis is rounded to 3 decimals), so this test pins the correct anchored
+    construction formula. The maintainer-only `series0001.srs` is the file where
+    the bug is numerically visible.
+    """
+    path = IRDATA / "omnic_series" / "GC_Demo.srs"
+    info = _srs_header(path)
+    nd = scp.read_srs(path)
+
+    y = nd.y.data
+    assert len(y) == info["ny"]
+    # Anchored at the series minimum (in minutes) and ending at `lasty`.
+    expected = np.around(np.linspace(info["time_min"], info["lasty"], info["ny"]), 3)
+    np.testing.assert_allclose(y, expected)
+    assert y[0] == np.around(info["time_min"], 3)
+    assert y[-1] == np.around(info["lasty"], 3)
+
+    # Guard the field separation: `firsty` is the step, not the axis start, and
+    # `time_min` is the same header field as `collection_length` kept in minutes.
+    assert info["time_min"] == np.float32(info["collection_length"] / 60)
+    assert info["time_min"] != info["firsty"]
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_labels_stop_at_record_boundary():
+    """SRS spectrum labels must contain only the human-readable name and must not
+    leak binary metadata or spectral bytes.
+
+    Regression: the per-spectrum SRS record is 84 bytes but labels were read
+    with a 256-byte window, so binary metadata and spectrum data were decoded
+    into the label.
+    """
+    path = IRDATA / "omnic_series" / "GC_Demo.srs"
+    info = _srs_header(path)
+    nd = scp.read_srs(path)
+
+    labels = nd.y.labels
+    assert len(labels) == info["ny"] == 788
+    assert labels[0] == "Linked spectrum at 0.025 min."
+    assert labels[1] == "Linked spectrum at 0.051 min."
+    # No label may contain non-text control bytes (the historical leak marker).
+    for label in labels:
+        for ch in label:
+            assert not (ord(ch) < 32 and ch not in "\n\t"), label
+    assert labels[-1].startswith("Linked spectrum at")


### PR DESCRIPTION
## Summary

This PR contains two narrowly scoped fixes for the OMNIC SRS series
reader identified through binary-format reverse engineering and
cross-validation against OMNIC.

### Correct SRS time-axis anchoring

The SRS series y/time axis was constructed from:

    linspace(firsty, lasty, ny)

Binary analysis showed that the field currently called `firsty` is the
regular time step, not the first time value.

The reader now obtains the series minimum/first time from the SRS header
field at +1002 and uses it to anchor the time axis, while preserving the
existing public `collection_length` semantics.

### Stop spectrum labels at the 84-byte record boundary

Each SRS spectrum starts with a fixed 84-byte name/metadata record.

The reader previously called `_readbtext(..., 256)`, allowing binary
metadata and spectral float bytes to leak into spectrum labels.

SRS spectrum names are now read from exactly the 84-byte record and
terminated at the first null byte. The shared `_readbtext` helper is
unchanged, avoiding changes to the SPA/SPG readers.

## Tests

Added focused regression tests using the existing `GC_Demo.srs`
test data:

- `test_read_srs_time_axis_anchored_at_time_min`
- `test_read_srs_labels_stop_at_record_boundary`

Targeted OMNIC reader tests pass.

## Scope

There is no public API signature change.

Behavioral changes are intentionally limited to correcting:
- the SRS series time coordinate;
- malformed SRS spectrum labels.

This PR does not change:
- spectral data values;
- x-axis / `reverse_x` behavior;
- background handling;
- SeriesProfile parsing;
- Chemigram/Area profile parsing;
- Gram-Schmidt parsing;
- unrelated OMNIC reader behavior.
