### PR TITLE
FIX: normalize OMNIC SRS spectral orientation

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -30,6 +30,8 @@ Bug Fixes
 .. Add here new bug fixes (do not delete this comment)
 
 - correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
+- fixed OMNIC SRS X/data orientation and deprecated the ``reverse_x``
+  workaround
 
 
 .. section
@@ -51,6 +53,9 @@ Breaking Changes
 Deprecations
 ~~~~~~~~~~~~
 .. Add here new deprecations (do not delete this comment)
+
+- The ``reverse_x`` keyword argument of ``read_srs`` is deprecated: SRS
+  spectral orientation is now handled automatically
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -23,6 +23,14 @@ Bug Fixes
 ~~~~~~~~~
 
 - correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
+- fixed OMNIC SRS X/data orientation and deprecated the ``reverse_x``
+  workaround
+
+Deprecations
+~~~~~~~~~~~~
+
+- The ``reverse_x`` keyword argument of ``read_srs`` is deprecated: SRS
+  spectral orientation is now handled automatically
 
 Developer
 ~~~~~~~~~

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -27,6 +27,7 @@ from spectrochempy.core.units import ur
 from spectrochempy.utils._logging import info_
 from spectrochempy.utils.datetimeutils import UTC
 from spectrochempy.utils.datetimeutils import utcnow
+from spectrochempy.utils.decorators import warn_deprecated
 from spectrochempy.utils.file import fromfile
 
 
@@ -516,11 +517,24 @@ def read_srs(*paths, **kwargs):
     ----------------
     return_bg : bool, optional
         Default value is False. When set to 'True' returns the series background
+
+    .. note::
+       SRS **spectral** series are now read normalized to the public
+       SpectroChemPy convention used by :func:`read_spa`: the wavenumber X
+       coordinate is exposed descending (high to low wavenumber) with the
+       intensity data matched to it. This normalization is applied
+       automatically, per spectrum/background record, from each record's own
+       endpoints. Rapid-scan interferograms keep their ascending
+       data-points coordinate and are not treated as spectral data.
+
     reverse_x : bool, optional
-        Specifies whether to reverse the x-axis (wavenumber) data. Default is False.
-        In most srs files, the absorbance/intensity data are recorded from high to low
-        wavenumbers. However, in some cases the data maybe stored in low to high order.
-        If your data appear reversed, set 'reverse_x=True'.
+        .. deprecated::
+            No longer needed. Spectral orientation is handled automatically as
+            described above; this historical workaround (introduced for issue
+            #858) is now a no-op and will be removed according to the
+            SpectroChemPy deprecation policy. Passing ``reverse_x=True`` emits a
+            ``DeprecationWarning`` and is ignored.
+
     content : `bytes` object, optional
     Instead of passing a filename for further reading, a bytes content can be
     directly provided as bytes objects.
@@ -1143,7 +1157,21 @@ def _read_srs(*args, **kwargs):
     frombytes = kwargs.get("frombytes", False)
 
     return_bg = kwargs.get("return_bg", False)
-    reverse_x = kwargs.get("reverse_x", False)
+    if kwargs.get("reverse_x", False):
+        warn_deprecated(
+            "reverse_x",
+            subject="The `reverse_x` keyword argument of `read_srs`",
+            kind="keyword argument",
+            action="is deprecated",
+            replace=None,
+            policy=True,
+            extra_msg=(
+                "SRS spectral orientation is now handled automatically "
+                "(descending wavenumber, data matched to it). This option is a "
+                "no-op and will be removed according to SpectroChemPy policy."
+            ),
+            stacklevel=4,
+        )
 
     # in this case, filename is actually a byte content
     fid = io.BytesIO(filename) if frombytes else open(filename, "rb")  # noqa: SIM115
@@ -1432,12 +1460,29 @@ def _read_srs(*args, **kwargs):
                 # but the data are those of an ifg... For now need more examples
                 return None
 
-    # Create NDDataset Object for the series
-    if not return_bg:
-        dataset = NDDataset(data) if not reverse_x else NDDataset(data[:, ::-1])
+    # Create NDDataset object for the series / background.
+    #
+    # The raw SRS spectral intensity array is stored ascending-wavenumber, but
+    # the public SpectroChemPy / `read_spa` convention presents OMNIC spectra
+    # with descending wavenumber and data matched to it. Spectral records are
+    # normalized here using each record's own firstx/lastx endpoints (which may
+    # differ between the series header and the background header). Interferogram
+    # records (`xunits` is None, i.e. `xtitle` == "data points") keep the raw
+    # ascending data-points coordinate and are never reversed. `_read_header`
+    # returns raw firstx/lastx without reordering them.
+    is_interferogram = info["xunits"] is None
 
+    if is_interferogram:
+        data_out = data
+        x0, x1 = info["firstx"], info["lastx"]
     else:
-        dataset = NDDataset(np.expand_dims(data, axis=0))
+        data_out = data[::-1] if return_bg else data[:, ::-1]
+        x0, x1 = max(info["firstx"], info["lastx"]), min(info["firstx"], info["lastx"])
+
+    if return_bg:
+        dataset = NDDataset(np.expand_dims(data_out, axis=0))
+    else:
+        dataset = NDDataset(data_out)
 
     # in case part of the spectra/ifg has been blanked:
     dataset.mask = np.isnan(dataset.data)
@@ -1450,8 +1495,8 @@ def _read_srs(*args, **kwargs):
     # now add coordinates
 
     _x = Coord.linspace(
-        info["firstx"],
-        info["lastx"],
+        x0,
+        x1,
         int(info["nx"]),
         title=info["xtitle"],
         units=info["xunits"],
@@ -1714,10 +1759,6 @@ def _read_header(fid, pos, is_first_spectrum=True):
         out["history"] = _readbtext(fid, pos + 208, None)
 
     if filetype == "srs":
-        if out["nbkgscan"] == 0 and out["firstx"] > out["lastx"]:
-            # an interferogram in rapid scan mode
-            out["firstx"], out["lastx"] = out["lastx"], out["firstx"]
-
         out["name"] = _readbtext(fid, pos + 938, 256)
         # Hack because name seems not to be well read for srs
         out["name"] = out["name"].split("\n")[0]

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -286,3 +286,116 @@ def test_read_srs_labels_stop_at_record_boundary():
         for ch in label:
             assert not (ord(ch) < 32 and ch not in "\n\t"), label
     assert labels[-1].startswith("Linked spectrum at")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "rapid_scan_reprocessed.srs",
+        "GC_Demo.srs",
+        "high_speed.srs",
+        "TGA_demo.srs",
+    ],
+)
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_spectral_descending_by_default(name):
+    """Spectral SRS files must be exposed in the public descending-wavenumber
+    convention (like `read_spa`) without any manual reversal.
+
+    The raw SRS spectral array is stored ascending-wavenumber; `_read_srs`
+    normalizes it so the X axis runs high -> low wavenumber with the intensity
+    data matched to it.
+
+    Regression: before the fix these files either required `reverse_x=True`
+    (GC/TGA/high-speed) or were exposed ascending (`rapid_scan_reprocessed`).
+    """
+    nd = scp.read_srs(IRDATA / "omnic_series" / name)
+    x = np.asarray(nd.x)
+    # Spectral records carry real units (not None / data points).
+    assert nd.x.units is not None
+    assert x[0] > x[-1]  # descending wavenumber
+    # The first sample is associated with the high wavenumber (X[0]).
+    assert nd.shape[-1] == len(x)
+    assert getattr(nd.meta, "interferogram", None) is None
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_spectral_default_equals_former_reverse_x():
+    """The default read must now match what used to require `reverse_x=True`
+    (the documented issue #858 workaround), for every affected file.
+
+    Pinned endpoint values are the physical X/data association verified against
+    the legacy `reverse_x=True` orientation, which in turn follows the same
+    convention as the SPA-validated series storage.
+    """
+    cases = {
+        "GC_Demo.srs": (99.8824, "high_wavenumber"),
+        "high_speed.srs": (-0.0233, "high_wavenumber"),
+    }
+    for name, (expected_first, _) in cases.items():
+        nd = scp.read_srs(IRDATA / "omnic_series" / name)
+        data = np.asarray(nd.data)
+        x = np.asarray(nd.x)
+        # data[0] is the intensity at X[0] = high wavenumber (descending).
+        assert np.isclose(data[0, 0], expected_first, atol=1e-3)
+        assert x[0] > x[-1]
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_interferogram_not_reversed():
+    """`rapid_scan.srs` interferograms must remain on the interferogram path and
+    must not be treated as spectral data (no reversal, ascending OPD axis).
+    """
+    nd = scp.read_srs(IRDATA / "omnic_series" / "rapid_scan.srs")
+    assert nd.meta.interferogram is True
+    x = np.asarray(nd.x)
+    # Interferogram axis is optical path difference, exposed ascending, not a
+    # descending spectral wavenumber axis.
+    assert nd.x.title == "optical path difference"
+    assert x[0] < x[-1]
+    assert nd.shape == (643, 4160)
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_background_spectral_descending():
+    """Spectral backgrounds must be normalized per-record, using their own
+    (possibly reversed) firstx/lastx endpoints, to the same descending X as the
+    series.
+
+    Regression: background headers store firstx/lastx reversed relative to the
+    series header for the same grid; a single global header rule would expose
+    them mis-oriented.
+    """
+    for name in ["GC_Demo.srs", "high_speed.srs"]:
+        series = scp.read_srs(IRDATA / "omnic_series" / name)
+        bg = scp.read_srs(IRDATA / "omnic_series" / name, return_bg=True)
+        xbg = np.asarray(bg.x)
+        # Background uses the same descending wavenumber grid as the series.
+        assert xbg[0] > xbg[-1]
+        np.testing.assert_allclose(xbg, np.asarray(series.x), rtol=1e-4)
+        assert bg.shape == (1, series.shape[-1])
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_reverse_x_deprecated():
+    """`reverse_x` is a deprecated no-op: passing it emits a DeprecationWarning
+    and returns the same (correct, automatically normalized) result as the
+    default, so users of the #858 workaround keep getting correct data without
+    a double reversal.
+    """
+    path = IRDATA / "omnic_series" / "GC_Demo.srs"
+    default = scp.read_srs(path)
+    with pytest.warns(DeprecationWarning):
+        legacy = scp.read_srs(path, reverse_x=True)
+    np.testing.assert_allclose(np.asarray(legacy.data), np.asarray(default.data))
+    np.testing.assert_allclose(np.asarray(legacy.x), np.asarray(default.x))
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_and_read_spa_share_descending_convention():
+    """A corrected `read_srs` must expose spectral X with the same
+    descending-wavenumber, data-matched convention as `read_spa`."""
+    srs = scp.read_srs(IRDATA / "omnic_series" / "GC_Demo.srs")
+    spa = scp.read_spa(IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA")
+    assert np.asarray(srs.x)[0] > np.asarray(srs.x)[-1]
+    assert np.asarray(spa.x)[0] > np.asarray(spa.x)[-1]


### PR DESCRIPTION
## Summary

Fix OMNIC SRS spectral X/data orientation so spectral series are read correctly without requiring `reverse_x=True`.

Spectral SRS records are now normalized to the same descending-wavenumber convention as `read_spa()`, while rapid-scan interferograms remain unchanged.

The historical `reverse_x` workaround is deprecated and retained temporarily as a no-op to avoid double-reversing files for users who adopted it for issue #858.

## Changes

- remove the historical `nbkgscan`-based `firstx` / `lastx` swap from header decoding;
- normalize spectral SRS X/data orientation in `read_srs`;
- normalize spectral backgrounds from their own record endpoints;
- leave interferogram handling unchanged;
- deprecate `reverse_x`;
- add focused orientation regression tests.

## Validation

- targeted SRS / OMNIC reader tests pass;
- related OMNIC / FFT / API tests pass;
- pre-commit passes;
- independent maintainer-side validation against OMNIC-exported SPA confirms the corrected default orientation for `series0001.srs`.

## Compatibility

- affected spectral SRS files no longer require `reverse_x=True`;
- `rapid_scan_reprocessed.srs` is now exposed using the same descending-wavenumber convention as SPA spectra;
- rapid-scan interferograms are unchanged;
- `reverse_x` is deprecated.