### PR TITLE
FIX: tighten SRS deprecation and interferogram detection

### DIFF
--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -25,6 +25,7 @@ from spectrochempy.core.readers.importer import _importer_method
 from spectrochempy.core.readers.importer import _openfid
 from spectrochempy.core.units import ur
 from spectrochempy.utils._logging import info_
+from spectrochempy.utils._logging import warning_
 from spectrochempy.utils.datetimeutils import UTC
 from spectrochempy.utils.datetimeutils import utcnow
 from spectrochempy.utils.decorators import warn_deprecated
@@ -532,7 +533,8 @@ def read_srs(*paths, **kwargs):
             No longer needed. Spectral orientation is handled automatically as
             described above; this historical workaround (introduced for issue
             #858) is now a no-op and will be removed according to the
-            SpectroChemPy deprecation policy. Passing ``reverse_x=True`` emits a
+            SpectroChemPy deprecation policy. Supplying the ``reverse_x``
+            keyword (with any value, ``True`` or ``False``) emits a
             ``DeprecationWarning`` and is ignored.
 
     content : `bytes` object, optional
@@ -1157,7 +1159,7 @@ def _read_srs(*args, **kwargs):
     frombytes = kwargs.get("frombytes", False)
 
     return_bg = kwargs.get("return_bg", False)
-    if kwargs.get("reverse_x", False):
+    if "reverse_x" in kwargs:
         warn_deprecated(
             "reverse_x",
             subject="The `reverse_x` keyword argument of `read_srs`",
@@ -1467,17 +1469,38 @@ def _read_srs(*args, **kwargs):
     # with descending wavenumber and data matched to it. Spectral records are
     # normalized here using each record's own firstx/lastx endpoints (which may
     # differ between the series header and the background header). Interferogram
-    # records (`xunits` is None, i.e. `xtitle` == "data points") keep the raw
-    # ascending data-points coordinate and are never reversed. `_read_header`
-    # returns raw firstx/lastx without reordering them.
-    is_interferogram = info["xunits"] is None
-
-    if is_interferogram:
+    # records keep the raw ascending data-points coordinate and are never
+    # reversed. `_read_header` returns raw firstx/lastx without reordering them.
+    #
+    # The X axis is classified into one of three cases:
+    #
+    #   * spectral record: known physical spectral coordinate (xunit codes
+    #     1/3/4/32); normalize to the public descending-wavenumber convention.
+    #   * interferogram: explicit data-points axis (xunit code 2); keep the raw
+    #     ascending coordinate and leave data/order unchanged.
+    #   * unknown X-axis type: `xunits` is None but the axis is not a
+    #     data-points axis (the `_read_header` fallback for an unrecognized
+    #     x-unit code). Never silently classify this as an interferogram, and
+    #     do not apply spectral normalization to an axis whose meaning is
+    #     unknown. Leave the record in its raw storage orientation and warn.
+    if info["xunits"] is not None:
+        # spectral record
+        data_out = data[::-1] if return_bg else data[:, ::-1]
+        x0, x1 = max(info["firstx"], info["lastx"]), min(info["firstx"], info["lastx"])
+    elif info["xtitle"] == "data points":
+        # interferogram
         data_out = data
         x0, x1 = info["firstx"], info["lastx"]
     else:
-        data_out = data[::-1] if return_bg else data[:, ::-1]
-        x0, x1 = max(info["firstx"], info["lastx"]), min(info["firstx"], info["lastx"])
+        # unknown X-axis type
+        warning_(
+            "The nature of the SRS X axis is not recognized: "
+            "xunits is None and xtitle is "
+            f"{info['xtitle']!r}. The record is left in its raw storage "
+            "orientation and is not treated as an interferogram."
+        )
+        data_out = data
+        x0, x1 = info["firstx"], info["lastx"]
 
     if return_bg:
         dataset = NDDataset(np.expand_dims(data_out, axis=0))

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -342,10 +342,12 @@ def test_read_srs_spectral_default_equals_former_reverse_x():
 
 
 @pytest.mark.usefixtures("_skip_if_no_testdata")
-def test_read_srs_interferogram_not_reversed():
+def test_read_srs_interferogram_not_reversed(monkeypatch):
     """`rapid_scan.srs` interferograms must remain on the interferogram path and
-    must not be treated as spectral data (no reversal, ascending OPD axis).
-    """
+    must not be treated as spectral data (no reversal, ascending OPD axis, data
+    kept in raw storage order)."""
+    from spectrochempy.core.readers import read_omnic
+
     nd = scp.read_srs(IRDATA / "omnic_series" / "rapid_scan.srs")
     assert nd.meta.interferogram is True
     x = np.asarray(nd.x)
@@ -354,6 +356,22 @@ def test_read_srs_interferogram_not_reversed():
     assert nd.x.title == "optical path difference"
     assert x[0] < x[-1]
     assert nd.shape == (643, 4160)
+
+    # Data is kept in raw storage order (not spectral-normalized): reversing it
+    # reproduces the same file read as if it were a (reversed) spectral record.
+    real_read_header = read_omnic._read_header
+
+    def _forced_spectral(fid, pos, is_first_spectrum=True):
+        info = real_read_header(fid, pos, is_first_spectrum=is_first_spectrum)
+        info["xtitle"] = "wavenumbers"
+        info["xunits"] = "cm^-1"
+        return info
+
+    monkeypatch.setattr(read_omnic, "_read_header", _forced_spectral)
+    spectral = read_omnic._read_srs(
+        NDDataset(), IRDATA / "omnic_series" / "rapid_scan.srs"
+    )
+    np.testing.assert_allclose(np.asarray(nd.data)[:, ::-1], np.asarray(spectral.data))
 
 
 @pytest.mark.usefixtures("_skip_if_no_testdata")
@@ -378,17 +396,33 @@ def test_read_srs_background_spectral_descending():
 
 @pytest.mark.usefixtures("_skip_if_no_testdata")
 def test_read_srs_reverse_x_deprecated():
-    """`reverse_x` is a deprecated no-op: passing it emits a DeprecationWarning
-    and returns the same (correct, automatically normalized) result as the
-    default, so users of the #858 workaround keep getting correct data without
-    a double reversal.
-    """
+    """`reverse_x` is a deprecated no-op: supplying the keyword (with any value,
+    `True` or `False`) emits a `DeprecationWarning` and returns the same
+    (correct, automatically normalized) result as the default, so users of the
+    #858 workaround keep getting correct data without a double reversal."""
     path = IRDATA / "omnic_series" / "GC_Demo.srs"
     default = scp.read_srs(path)
     with pytest.warns(DeprecationWarning):
-        legacy = scp.read_srs(path, reverse_x=True)
-    np.testing.assert_allclose(np.asarray(legacy.data), np.asarray(default.data))
-    np.testing.assert_allclose(np.asarray(legacy.x), np.asarray(default.x))
+        legacy_true = scp.read_srs(path, reverse_x=True)
+    with pytest.warns(DeprecationWarning):
+        legacy_false = scp.read_srs(path, reverse_x=False)
+    np.testing.assert_allclose(np.asarray(legacy_true.data), np.asarray(default.data))
+    np.testing.assert_allclose(np.asarray(legacy_true.x), np.asarray(default.x))
+    np.testing.assert_allclose(np.asarray(legacy_false.data), np.asarray(default.data))
+    np.testing.assert_allclose(np.asarray(legacy_false.x), np.asarray(default.x))
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_no_reverse_x_keyword_no_deprecation():
+    """Omitting the `reverse_x` keyword entirely must not emit a
+    `DeprecationWarning`."""
+    import warnings
+
+    path = IRDATA / "omnic_series" / "GC_Demo.srs"
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        scp.read_srs(path)
+    assert not any(issubclass(warning.category, DeprecationWarning) for warning in w)
 
 
 @pytest.mark.usefixtures("_skip_if_no_testdata")
@@ -399,3 +433,49 @@ def test_read_srs_and_read_spa_share_descending_convention():
     spa = scp.read_spa(IRDATA / "subdir" / "20-50" / "7_CZ0-100_Pd_21.SPA")
     assert np.asarray(srs.x)[0] > np.asarray(srs.x)[-1]
     assert np.asarray(spa.x)[0] > np.asarray(spa.x)[-1]
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_unknown_xunits_not_interferogram(monkeypatch):
+    """A record whose X-unit code is unknown (`xunits is None` but not an
+    explicit data-points axis) must not be classified as an interferogram, must
+    not be spectral-normalized, and must emit a warning instead of silently
+    treating it as either an interferogram or a spectral record."""
+    import warnings
+
+    from spectrochempy.core.readers import read_omnic
+
+    real_read_header = read_omnic._read_header
+
+    def _forced(xtitle, xunits):
+        def _wrap(fid, pos, is_first_spectrum=True):
+            info = real_read_header(fid, pos, is_first_spectrum=is_first_spectrum)
+            info["xtitle"] = xtitle
+            info["xunits"] = xunits
+            return info
+
+        return _wrap
+
+    path = IRDATA / "omnic_series" / "GC_Demo.srs"
+
+    # Reference: the same file read as a spectral record (normalized to
+    # descending wavenumber).
+    monkeypatch.setattr(read_omnic, "_read_header", _forced("wavenumbers", "cm^-1"))
+    spectral = read_omnic._read_srs(NDDataset(), path)
+
+    # Unknown X-axis type: xunits is None but the axis is not data points.
+    monkeypatch.setattr(read_omnic, "_read_header", _forced("xaxis", None))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        unknown = read_omnic._read_srs(NDDataset(), path)
+
+    # An explicit warning is emitted about the unrecognized X axis.
+    assert any("X axis is not recognized" in str(x.message) for x in w)
+    # Not classified as an interferogram (no interferogram metadata).
+    assert getattr(unknown.meta, "interferogram", None) is None
+    assert unknown.x.title == "xaxis"
+    # Left in raw storage orientation: the data is NOT spectral-normalized
+    # (it is the reverse of the normalized spectral read).
+    np.testing.assert_allclose(
+        np.asarray(unknown.data)[:, ::-1], np.asarray(spectral.data)
+    )


### PR DESCRIPTION
## Summary of changes

Two focused follow-up corrections to the recent SRS orientation work, following the discussion in PR#1594.

1. **`reverse_x` deprecation now triggers on presence, not just `True`**
   The deprecated `reverse_x` keyword argument of `read_srs` previously emitted a
   `DeprecationWarning` only when `reverse_x=True` was passed. Since the keyword
   itself is deprecated, an explicit `reverse_x=False` must also warn. The guard is
   now `if "reverse_x" in kwargs:`, and the option remains a no-op.

2. **Distinguish explicit data-points interferograms from unknown X-unit records**
   The orientation/classification logic previously used `xunits is None` to select
   the interferogram path, which conflated:
   - a genuine rapid-scan interferogram with a "data points" X axis (xunit code 2);
   - a record whose X-unit code is simply unknown (`xunits is None`, `xtitle == "xaxis"`).
   The reader now classifies the X axis into three explicit cases:
   - **spectral record**: known spectral X units → existing descending-wavenumber
     normalization (unchanged);
   - **interferogram**: explicit data-points axis → kept raw/ascending, data/order
     unchanged, existing metadata behavior preserved;
   - **unknown X-axis type**: `xunits is None` but not a data-points axis → not
     classified as an interferogram and not spectral-normalized; left in raw
     storage orientation with an explicit warning.

   No new public API or metadata field is introduced.

## Out of scope

- The current spectral X/data orientation normalization is unchanged.
- SPA/SPG readers, time-axis logic, label parsing, SeriesProfile/Gram-Schmidt
  handling, public SRS format documentation, and acquisition-date decoding behavior
  are all unchanged.

## Changelog

- `docs/sources/whatsnew/changelog.rst` (and regenerated `latest.rst`).

## Tests added/updated (`tests/test_core/test_readers/test_read_omnic.py`)

- `test_read_srs_reverse_x_deprecated`: `reverse_x=True` and `reverse_x=False` both
  emit `DeprecationWarning` and remain no-ops.
- `test_read_srs_no_reverse_x_keyword_no_deprecation`: omission emits no warning.
- `test_read_srs_interferogram_not_reversed` (strengthened): genuine rapid-scan
  interferogram still classified as interferogram; data/order unchanged.
- `test_read_srs_unknown_xunits_not_interferogram`: unknown X-unit record is not an
  interferogram, not spectral-normalized, and warns.

## Validation

- Targeted `read_srs` tests (deprecation, interferogram classification, unknown-X): pass.
- Full `test_read_omnic.py`: 19 pass, 1 skip (pre-existing stub).
- `test_reader_semantic_characterization.py` OMNIC/SRS/SPA: pass.
- pre-commit: clean on all changed files.