### PR TITLE
FIX: correct OMNIC SPA interferogram OPD step for native sample spacing

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,8 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- correct OMNIC SPA interferogram optical path difference coordinates by
+  honoring the native sample-spacing factor
 - correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
 - fixed OMNIC SRS X/data orientation and deprecated the ``reverse_x``
   workaround

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,8 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- correct OMNIC SPA interferogram optical path difference coordinates by
+  honoring the native sample-spacing factor
 - correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
 - fixed OMNIC SRS X/data orientation and deprecated the ``reverse_x``
   workaround

--- a/src/spectrochempy/core/dataset/coord.py
+++ b/src/spectrochempy/core/dataset/coord.py
@@ -791,7 +791,7 @@ class Coord(NDMath, NDArray):
     # Public methods and properties
     # ----------------------------------------------------------------------------------
 
-    def set_laser_frequency(self, frequency=None):
+    def set_laser_frequency(self, frequency=None, sample_spacing=None):
         r"""
         Set the laser frequency.
 
@@ -800,11 +800,20 @@ class Coord(NDMath, NDArray):
         difference to time. The laser frequency is also used to calculate
         the wavenumber axis.
 
+        The optical path difference step is derived from both the laser
+        frequency and the (native) sample spacing factor:
+        ``spacing = sample_spacing / (2 * frequency)``.
+
         Parameters
         ----------
         frequency : `float` or `Quantity`, optional, default=15798.26 * ur("cm^-1")
             The laser frequency in cm^-1 or Hz. If the value is in cm^-1, the
             frequency is converted to Hz using the current speed of light value.
+        sample_spacing : `float`, optional, default=None
+            Native sample spacing factor (e.g. ``1.0`` or ``2.0``) used to
+            derive the optical path difference step. When ``None``, the value
+            previously stored in the metadata is used, falling back to ``2.0``
+            (i.e. an optical path difference step of ``1 / frequency``).
 
         """
         if frequency is None:
@@ -816,6 +825,10 @@ class Coord(NDMath, NDArray):
         frequency.ito("Hz")
         self.meta.laser_frequency = frequency
 
+        if sample_spacing is None:
+            sample_spacing = self.meta.get("sample_spacing", 2.0)
+        self.meta.sample_spacing = sample_spacing
+
         if self._use_time:
             spacing = 1.0 / frequency
             spacing.ito("picoseconds")
@@ -825,7 +838,7 @@ class Coord(NDMath, NDArray):
 
         else:
             frequency.ito("cm^-1")
-            spacing = 1.0 / frequency
+            spacing = sample_spacing / (2.0 * frequency)
             spacing.ito("mm")
             offset = -spacing.m * self._zpd
             self._data = np.arange(self.shape[-1]) * spacing.m + offset

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -1133,6 +1133,7 @@ def _read_spa(*args, **kwargs):
     dataset.meta.collection_length = info["collection_length"] / 100 * ur("s")
     dataset.meta.optical_velocity = info["optical_velocity"]
     dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
+    dataset.meta.sample_spacing = info["sample_spacing"]
 
     if _exp_info is not None:
         for meta_key, val in _exp_info.items():
@@ -1141,11 +1142,14 @@ def _read_spa(*args, **kwargs):
             dataset.description = _exp_info["experiment_title"]
 
     if dataset.x.units is None and dataset.x.title == "data points":
-        # interferogram
+        # interferogram: build the OPD axis from the reference frequency and
+        # the native sample spacing (spacing = sample_spacing / (2 * nu)).
         dataset.meta.interferogram = True
         dataset.meta.td = list(dataset.shape)
         dataset.x._zpd = int(np.argmax(dataset)[-1])
-        dataset.x.set_laser_frequency()
+        dataset.x.set_laser_frequency(
+            frequency=info["reference_frequency"], sample_spacing=info["sample_spacing"]
+        )
         dataset.x._use_time_axis = (
             False  # True to have time, else it will be optical path difference
         )
@@ -1775,6 +1779,8 @@ def _read_header(fid, pos, is_first_spectrum=True):
     out["collection_length"] = fromfile(fid, "uint32", 1)
     fid.seek(pos + 80)
     out["reference_frequency"] = fromfile(fid, "float32", 1)
+    fid.seek(pos + 84)
+    out["sample_spacing"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 188)
     out["optical_velocity"] = fromfile(fid, "float32", 1)
 

--- a/tests/test_core/test_dataset/test_coord.py
+++ b/tests/test_core/test_dataset/test_coord.py
@@ -613,3 +613,33 @@ def test_coord_deepcopy_isolation():
     assert c0.title == "wavenumber"
     c1._data[0] = 9999
     assert c0.data[0] == 4000.0
+
+
+def test_coord_set_laser_frequency_sample_spacing():
+    """OPD step honors the native sample spacing: step = ss / (2 * nu).
+
+    The default path (no sample spacing given, as used by the SPC and SRS
+    readers) must keep the legacy ``1 / nu`` step.
+    """
+    nu = 15798.26 * ur("cm^-1")
+
+    # default: 1 / nu step (legacy behavior preserved for SPC/SRS callers)
+    a = Coord(np.zeros(10))
+    a._zpd = 3
+    a.set_laser_frequency(frequency=nu)
+    step = a._data[1] - a._data[0]
+    assert a.units == ur("mm")
+    assert a.title == "optical path difference"
+    assert step == pytest.approx(1.0 / 15798.26 * 10.0, rel=1e-5)
+
+    # explicit sample spacing 2.0 gives the same 1 / nu step
+    b = Coord(np.zeros(10))
+    b._zpd = 3
+    b.set_laser_frequency(frequency=nu, sample_spacing=2.0)
+    assert b._data[1] - b._data[0] == pytest.approx(step, rel=1e-12)
+
+    # explicit sample spacing 1.0 halves the step
+    c = Coord(np.zeros(10))
+    c._zpd = 3
+    c.set_laser_frequency(frequency=nu, sample_spacing=1.0)
+    assert c._data[1] - c._data[0] == pytest.approx(0.5 * step, rel=1e-12)

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -92,6 +92,63 @@ def test_read_omnic():
     )
     assert a is None
 
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_spa_ifg_sample_spacing_factor1():
+    """SPA sample interferogram: OPD step honors the native sample spacing.
+
+    The header of ``carroucell_samp/2-BaSO4_0.SPA`` records a sample spacing
+    of 1.0 together with a reference frequency of 15798.259765625 cm^-1, so
+    the optical path difference step must be ``1 / (2 * nu)`` rather than the
+    former (2x too large) ``1 / nu``.
+    """
+    from spectrochempy.core.units import ur
+
+    nu = 15798.259765625  # reference frequency stored in the file (+80)
+    nd = scp.read_spa(IRDATA / "carroucell_samp" / "2-BaSO4_0.SPA", return_ifg="sample")
+    x = nd.x
+
+    assert x.units == ur("mm")
+    assert x.title == "optical path difference"
+    assert nd.meta.sample_spacing == 1.0
+
+    step = x._data[1] - x._data[0]
+    expected_step = 1.0 / (2.0 * nu) * 10.0  # cm -> mm
+    assert step == pytest.approx(expected_step, rel=1e-5)
+    # make sure we are not back to the pre-fix (wrong) 1 / nu step
+    legacy_step = 1.0 / nu * 10.0
+    assert step != pytest.approx(legacy_step, rel=1e-3)
+
+    # origin kept at the interferogram peak
+    zpd = int(np.argmax(nd)[-1])
+    assert x._data[zpd] == 0.0
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_spa_ifg_sample_spacing_factor2():
+    """SPA interferogram with native sample spacing 2.0 keeps the 1/nu step.
+
+    ``interferogram/interfero.SPA`` records a sample spacing of 2.0, so the
+    step ``2 / (2 * nu) = 1 / nu`` must remain unchanged.
+    """
+    from spectrochempy.core.units import ur
+
+    nu = 15798.259765625  # reference frequency stored in the file (+80)
+    nd = scp.read_spa(IRDATA / "interferogram" / "interfero.SPA")
+    x = nd.x
+
+    assert x.units == ur("mm")
+    assert x.title == "optical path difference"
+    assert nd.meta.sample_spacing == 2.0
+
+    step = x._data[1] - x._data[0]
+    expected_step = 2.0 / (2.0 * nu) * 10.0  # = 1 / nu
+    assert step == pytest.approx(expected_step, rel=1e-5)
+
+    # origin kept at the interferogram peak
+    zpd = int(np.argmax(nd)[-1])
+    assert x._data[zpd] == 0.0
+
     # rapid_sca series
     a = scp.read_srs("irdata/omnic_series/rapid_scan.srs")
     assert str(a) == "NDDataset: [float64] V (shape: (y:643, x:4160))"


### PR DESCRIPTION
## Summary

Correct the optical-path-difference (OPD) coordinates of OMNIC SPA
interferograms read with `return_ifg="sample"` (and standalone
interferogram files) so that they honor the native **Sample spacing**
field recorded in the file header.

The OPD step is now computed as

```text
spacing = sample_spacing / (2 * reference_frequency)
```

with the origin still anchored at the interferogram peak (`argmax`).
Previously only `1 / reference_frequency` was used, which is 2x too large
for files whose header records a sample spacing of 1.0 (the most common
configuration for these instruments).

- `read_omnic`: parse the new `sample_spacing` field (+84 in the 0x02
  general header block, `float32`) next to the already-parsed
  `reference_frequency` (+80), expose it as `dataset.meta.sample_spacing`,
  and pass both values when building the interferogram coordinate.
- `Coord.set_laser_frequency`: new optional `sample_spacing` parameter
  (default `None` -> fallback to `2.0`, i.e. the previous `1 / nu` step),
  keeping the SPC and SRS reader paths byte-for-byte behavior-identical.

## Out of scope

- Standalone `0x03` interferogram block detection.
- OMNIC Experiment-Information header fixes.
- Acquisition-date guards.
- Optical-velocity fallback or ZPD-naming changes.
- SRS series interferogram handling (unchanged, factor not applied there).
- OMNIC file-format reference documentation (separate DOC campaign).

## Evidence

For `carroucell_samp/2-BaSO4_0.SPA` (sample spacing 1.0,
ν = 15798.259765625 cm⁻¹): the read-back OPD step is now
`1/(2ν)` = 0.316491 µm/pt (was 0.632981 µm/pt, ratio 2.0), origin still at
the peak. For `interferogram/interfero.SPA` (sample spacing 2.0): step
`2/(2ν) = 1/ν` is preserved exactly, so the FFT chain and existing FTIR
tests are unaffected.

## Tests and validation

- New: SPA factor-1 and factor-2 IFG regression tests (actual read-back
  coordinates, exact float checks, peak-origin zero).
- New: `Coord.set_laser_frequency` unit test locking the default
  (`1/ν`) path used by the SPC and SRS readers.
- Re-run: `test_read_omnic.py`, `test_read_spc.py`, `test_ftir_fft.py`,
  `test_coord.py` — 94 passed, 1 skipped (pre-existing).
- `pre-commit run --all-files` clean (regenerated `latest.rst` from
  `changelog.rst` included in the commit).

**Checklist**:
- [x] Tests have been added.
- [x] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
- [x] Title follows the prefix convention defined in `CONTRIBUTING.md`.
- [x] Changelog entry is present.