### PR TITLE
FIX: keep scp.simpson as the integration function when the SIMPSON reader plugin is installed

### DIFF
--- a/docs/sources/devguide/plugins/api_policy.rst
+++ b/docs/sources/devguide/plugins/api_policy.rst
@@ -88,6 +88,33 @@ Core I/O namespaces such as ``jcamp``, ``csv``, ``omnic``, ``opus``,
 are reserved.  Plugins must not claim these names, to prevent shadowing
 and keep ``scp.<domain>`` unambiguous.
 
+Reserved public root symbols
+----------------------------
+
+Plugin-provided namespaces and root exports must not collide with public
+SpectroChemPy symbols. Conflicting short namespaces are rejected; readers
+remain accessible through their explicit ``read_<format>`` function.
+
+Concretely, a plugin's short I/O namespace is refused with a controlled
+warning whenever it matches an existing public ``scp`` symbol — a public
+function or class, an ``NDDataset`` method exposed at root, a compatibility
+alias, a public submodule, a core I/O namespace, a plot-profile function, or
+an already-registered root export.  The rejected name is recorded in
+``spectrochempy.core.io_namespaces._REJECTED_IO_NAMESPACES`` for
+introspection.
+
+The reader behind a refused namespace is unaffected: it remains available
+through its explicit ``read_<format>`` function (for example
+``scp.read_simpson`` / ``scp.<plugin>.read_simpson``).  Never rely on a short
+namespace that matches a public root symbol, and never build a hybrid object
+that is both callable and carries ``.read``.
+
+.. code-block:: text
+
+    Plugin-provided namespaces and root exports must not collide with public
+    SpectroChemPy symbols. Conflicting short namespaces are rejected; readers
+    remain accessible through their explicit read_<format> function.
+
 Documentation and examples should prefer namespace APIs, such as
 ``scp.iris.IRIS()``, over root-level compatibility
 aliases such as ``scp.IRIS``. Compatibility aliases may remain in

--- a/docs/sources/devguide/plugins/api_policy.rst
+++ b/docs/sources/devguide/plugins/api_policy.rst
@@ -91,17 +91,13 @@ and keep ``scp.<domain>`` unambiguous.
 Reserved public root symbols
 ----------------------------
 
-Plugin-provided namespaces and root exports must not collide with public
-SpectroChemPy symbols. Conflicting short namespaces are rejected; readers
-remain accessible through their explicit ``read_<format>`` function.
-
-Concretely, a plugin's short I/O namespace is refused with a controlled
-warning whenever it matches an existing public ``scp`` symbol — a public
-function or class, an ``NDDataset`` method exposed at root, a compatibility
-alias, a public submodule, a core I/O namespace, a plot-profile function, or
-an already-registered root export.  The rejected name is recorded in
-``spectrochempy.core.io_namespaces._REJECTED_IO_NAMESPACES`` for
-introspection.
+A plugin's short I/O namespace must not collide with a public ``scp`` symbol.
+Registration refuses the namespace with a controlled warning whenever its name
+matches an existing public ``scp`` symbol — a public function or class, an
+``NDDataset`` method exposed at root, a compatibility alias, a public
+submodule, a core I/O namespace, or a plot-profile function.  The rejected
+name is recorded in ``spectrochempy.core.io_namespaces._REJECTED_IO_NAMESPACES``
+for introspection.
 
 The reader behind a refused namespace is unaffected: it remains available
 through its explicit ``read_<format>`` function (for example
@@ -109,11 +105,17 @@ through its explicit ``read_<format>`` function (for example
 namespace that matches a public root symbol, and never build a hybrid object
 that is both callable and carries ``.read``.
 
+For the other plugin-provided root surfaces (``root_exports``, reader exports,
+``analysis`` and ``simulation`` extensions), the guarantee is **resolution
+priority**: whenever a name is a public ``scp`` symbol, root attribute access
+always resolves to the core symbol, regardless of plugin installation or
+discovery order.  These surfaces are not rejected at registration time.
+
 .. code-block:: text
 
-    Plugin-provided namespaces and root exports must not collide with public
-    SpectroChemPy symbols. Conflicting short namespaces are rejected; readers
-    remain accessible through their explicit read_<format> function.
+    I/O namespace names colliding with a public scp symbol are rejected at
+    registration; all other plugin root surfaces are resolved core-first, so
+    the core symbol always wins.
 
 Documentation and examples should prefer namespace APIs, such as
 ``scp.iris.IRIS()``, over root-level compatibility

--- a/docs/sources/devguide/plugins/writing_plugins.rst
+++ b/docs/sources/devguide/plugins/writing_plugins.rst
@@ -62,16 +62,17 @@ attribute so that ``scp.<namespace>.read(...)`` delegates to a reader::
 
 The short namespace must **not** collide with any public ``scp`` symbol
 (integration/analysis functions, ``NDDataset`` methods exposed at root,
-compatibility aliases, public submodules, core I/O namespaces, or an
-already-registered root export). A conflicting short namespace is rejected with
-a warning, but the reader remains available through its explicit
-``scp.read_<format>`` function.
+compatibility aliases, public submodules, or core I/O namespaces). A
+conflicting short namespace is rejected with a warning at registration, but
+the reader remains available through its explicit ``scp.read_<format>``
+function.
 
-.. code-block:: text
-
-    Plugin-provided namespaces and root exports must not collide with public
-    SpectroChemPy symbols. Conflicting short namespaces are rejected; readers
-    remain accessible through their explicit read_<format> function.
+For the other plugin-provided root surfaces (``root_exports``, reader exports,
+``analysis``/``simulation`` extensions), the collision is avoided through
+**resolution priority**: ``scp.__getattr__`` always resolves a public core
+symbol before any plugin-provided name, regardless of plugin installation or
+discovery order. These surfaces are not rejected at registration time; the
+core symbol simply wins on access.
 
 For example ``spectrochempy-nmr`` does **not** register a ``simpson`` I/O
 namespace because ``scp.simpson`` is the core numerical-integration function;

--- a/docs/sources/devguide/plugins/writing_plugins.rst
+++ b/docs/sources/devguide/plugins/writing_plugins.rst
@@ -53,6 +53,31 @@ Readers and writers
 Readers create datasets and belong under ``scp.<plugin>`` or compatibility
 ``scp.read_<format>`` aliases. They should not be dataset accessors.
 
+A plugin may contribute a short I/O namespace through its ``io_namespaces``
+attribute so that ``scp.<namespace>.read(...)`` delegates to a reader::
+
+    io_namespaces = {
+        "myformat": {"read": "myplugin.read_myformat"},
+    }
+
+The short namespace must **not** collide with any public ``scp`` symbol
+(integration/analysis functions, ``NDDataset`` methods exposed at root,
+compatibility aliases, public submodules, core I/O namespaces, or an
+already-registered root export). A conflicting short namespace is rejected with
+a warning, but the reader remains available through its explicit
+``scp.read_<format>`` function.
+
+.. code-block:: text
+
+    Plugin-provided namespaces and root exports must not collide with public
+    SpectroChemPy symbols. Conflicting short namespaces are rejected; readers
+    remain accessible through their explicit read_<format> function.
+
+For example ``spectrochempy-nmr`` does **not** register a ``simpson`` I/O
+namespace because ``scp.simpson`` is the core numerical-integration function;
+the SIMPSON reader is exposed only as ``scp.read_simpson`` /
+``scp.nmr.read_simpson``.
+
 Use plugin handlers for format-specific filename inference:
 
 .. code-block:: python

--- a/docs/sources/userguide/analysis/peak_integration.py
+++ b/docs/sources/userguide/analysis/peak_integration.py
@@ -92,6 +92,13 @@ inttrapz = Xcorr.trapezoid(dim="x")
 intsimps = Xcorr.simpson(dim="x")
 
 # %% [markdown]
+# `intsimps` is a numerical integration.  `dataset.simpson(dim="x")` and the
+# equivalent top-level `scp.simpson(dataset, dim="x")` produce the same result.
+# Do not confuse this integration function with `scp.read_simpson(...)`, which
+# reads SIMPSON NMR simulation data files — the two are unrelated operations
+# that happen to share the "simpson" name.
+
+# %% [markdown]
 # As you can see, both methods give almost the same results in this case.
 
 # %%

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -29,6 +29,11 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- fixed ``scp.simpson`` so it always resolves to the public numerical
+  integration function, even when a plugin contributes a SIMPSON I/O
+  reader; conflicting plugin short namespaces are rejected instead of
+  silently shadowing a core symbol (``scp.read_simpson`` remains the
+  explicit reader surface)
 - correct OMNIC SPA interferogram optical path difference coordinates by
   honoring the native sample-spacing factor
 - correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
@@ -66,6 +71,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
+- Added a centralized reserved-root-symbol policy
+  (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
+  public ``scp`` symbols; conflicting plugin I/O namespaces are rejected
+  with a controlled warning while the ``read_<format>`` reader is preserved
 - Added the internal estimator-contract helpers required before a future
   ``Pipeline`` implementation: allowlist-based fitted-state inspection,
   unfitted cloning, canonical not-fitted behavior for supported transformers,

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -22,6 +22,11 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
+- fixed ``scp.simpson`` so it always resolves to the public numerical
+  integration function, even when a plugin contributes a SIMPSON I/O
+  reader; conflicting plugin short namespaces are rejected instead of
+  silently shadowing a core symbol (``scp.read_simpson`` remains the
+  explicit reader surface)
 - correct OMNIC SPA interferogram optical path difference coordinates by
   honoring the native sample-spacing factor
 - correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
@@ -37,6 +42,10 @@ Deprecations
 Developer
 ~~~~~~~~~
 
+- Added a centralized reserved-root-symbol policy
+  (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
+  public ``scp`` symbols; conflicting plugin I/O namespaces are rejected
+  with a controlled warning while the ``read_<format>`` reader is preserved
 - Added the internal estimator-contract helpers required before a future
   ``Pipeline`` implementation: allowlist-based fitted-state inspection,
   unfitted cloning, canonical not-fitted behavior for supported transformers,

--- a/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
+++ b/plugins/spectrochempy-nmr/src/spectrochempy_nmr/__init__.py
@@ -447,12 +447,16 @@ class NMRPlugin(SpectroChemPyPlugin):
     spectrochempy_min_version = "0.9.0"
     PLUGIN_API_VERSION = CORE_PLUGIN_API_VERSION
     capabilities = [PluginCapability.READER]
+    # NOTE: ``simpson`` is intentionally absent from ``io_namespaces`` because
+    # ``scp.simpson`` is the public numerical-integration function of the core
+    # (see spectrochempy.analysis.integration).  The SIMPSON reader remains
+    # available through the explicit ``read_simpson`` reader registered in
+    # ``register_readers`` below (``scp.read_simpson`` / ``scp.nmr.read_simpson``).
     io_namespaces = {
         "topspin": {"read": "nmr.read_topspin"},
         "agilent": {"read": "nmr.read_agilent"},
         "jeol": {"read": "nmr.read_jeol"},
         "tecmag": {"read": "nmr.read_tecmag"},
-        "simpson": {"read": "nmr.read_simpson"},
     }
 
     def register_readers(self) -> list[dict]:

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -220,8 +220,10 @@ def __getattr__(name):
             from spectrochempy.core.dataset.nddataset import NDDataset
 
             return getattr(NDDataset, name)
-        # Remaining reserved names are public submodules handled by the
-        # lazy-loader fallback at the end of this function.
+        # Remaining reserved names are public submodules: resolve them through
+        # the lazy loader immediately, so that a plugin-provided namespace,
+        # reader, extension or root export can never shadow them.
+        return original_getattr(name)
 
     import sys
 

--- a/src/spectrochempy/__init__.py
+++ b/src/spectrochempy/__init__.py
@@ -63,6 +63,7 @@ original_getattr, original_dir, *_ = _lazy_loader.attach_stub(__name__, __file__
 
 from spectrochempy.lazyimport.api_methods import _LAZY_IMPORTS
 from spectrochempy.lazyimport.dataset_methods import _LAZY_DATASETS_IMPORTS
+from spectrochempy.lazyimport.plot_profile import _PLOT_PROFILE_FUNCTIONS
 from spectrochempy.utils.decorators import warn_deprecated
 
 from . import application
@@ -85,39 +86,42 @@ from spectrochempy.plugins.registry import registry
 _EMITTED_PLUGIN_ROOT_WARNINGS: set[str] = set()
 
 # --------------------------------------------------------------------------------------
-# Plot profile API (lazy loaded)
+# Reserved public root symbols
 # --------------------------------------------------------------------------------------
-# These are exposed at top-level for convenience
-_PLOT_PROFILE_FUNCTIONS = {
-    "set_plot_profile": "spectrochempy.plotting.profile",
-    "get_plot_profile": "spectrochempy.plotting.profile",
-    "list_plot_profiles": "spectrochempy.plotting.profile",
-    "save_plot_profile": "spectrochempy.plotting.profile",
-    "delete_plot_profile": "spectrochempy.plotting.profile",
-}
+# The set of names that are public ``scp`` symbols and therefore can never be
+# shadowed by a plugin-provided namespace, reader export or root export.  It
+# is built from the existing sources of truth (lazy imports, NDDataset-method
+# exports, plot-profile functions, core I/O namespaces and public submodules).
+from spectrochempy.lazyimport.root_symbols import is_reserved_root_symbol
+from spectrochempy.lazyimport.root_symbols import reserved_root_symbols
 
 
 def __dir__():
     names = set(original_dir()) if callable(original_dir) else set()
     names.update(_PLOT_PROFILE_FUNCTIONS)
-    names.update(_namespace_names())
     names.update(_io_namespace_names())
-    # Include already-discovered plugin readers and extensions
-    # without triggering entry-point scanning (dir() should be side-effect free).
+    # Include already-discovered plugin readers, extensions, namespaces and
+    # root exports without triggering entry-point scanning (dir() must be
+    # side-effect free).  Plugin-provided names that collide with a reserved
+    # public root symbol are not advertised: revealing an ambiguous name would
+    # break the stability guarantee that ``dir(scp)`` documents.
     names.update(_reader_names())
     names.update(_extension_names())
     names.update(_root_export_names())
+    names.update(_namespace_names())
     return sorted(names)
 
 
 def _reader_names():
-    return {f"read_{name}" for name in registry.available_readers}
+    reserved = reserved_root_symbols()
+    return {f"read_{name}" for name in registry.available_readers} - reserved
 
 
 def _namespace_names():
     from spectrochempy.plugins.features import EXPERIMENTAL_PLUGIN_NAMESPACES
 
-    return set(KNOWN_PLUGIN_NAMESPACES) | set(EXPERIMENTAL_PLUGIN_NAMESPACES)
+    names = set(KNOWN_PLUGIN_NAMESPACES) | set(EXPERIMENTAL_PLUGIN_NAMESPACES)
+    return names - reserved_root_symbols()
 
 
 def _io_namespace_names():
@@ -127,18 +131,20 @@ def _io_namespace_names():
 
 
 def _extension_names():
+    reserved = reserved_root_symbols()
     names = set()
     for category in ("analysis", "simulation"):
         for entry_name in registry.extensions.list_category(category):
             names.add(entry_name)
-    return names
+    return names - reserved
 
 
 def _root_export_names():
+    reserved = reserved_root_symbols()
     names = set()
     for plugin in registry.available_plugins.values():
         names.update(getattr(plugin, "root_exports", {}))
-    return names
+    return names - reserved
 
 
 def _normalise_root_export(plugin, alias, export):
@@ -195,6 +201,27 @@ def __getattr__(name):
         from spectrochempy.plotting import profile as _profile_module
 
         return getattr(_profile_module, name)
+
+    # Public core symbols always win over plugin-provided symbols.  Resolve
+    # reserved root symbols here so that a plugin I/O namespace, analysis
+    # namespace, reader export or root export can never shadow them,
+    # regardless of discovery order.
+    if is_reserved_root_symbol(name):
+        from spectrochempy.core.io_namespaces import _CORE_IO_NAMESPACES
+        from spectrochempy.core.io_namespaces import _IONamespace
+
+        if name in _CORE_IO_NAMESPACES:
+            return _IONamespace(name)
+        if name in _LAZY_IMPORTS:
+            module_path = _LAZY_IMPORTS[name]
+            module = __import__(module_path, fromlist=[name])
+            return getattr(module, name)
+        if name in _LAZY_DATASETS_IMPORTS:
+            from spectrochempy.core.dataset.nddataset import NDDataset
+
+            return getattr(NDDataset, name)
+        # Remaining reserved names are public submodules handled by the
+        # lazy-loader fallback at the end of this function.
 
     import sys
 

--- a/src/spectrochempy/core/io_namespaces.py
+++ b/src/spectrochempy/core/io_namespaces.py
@@ -40,14 +40,38 @@ _CORE_IO_NAMESPACES: dict[str, tuple[str | None, str | None]] = {
 # namespace-style API as core I/O domains.
 _PLUGIN_IO_NAMESPACES: dict[str, tuple[str | None, str | None]] = {}
 
+# Namespace requests rejected because they collide with a public root symbol.
+# Maps ``name -> "plugin=<plugin> read=<read_path> write=<write_path>"`` and is
+# available for introspection/diagnostics.  The plugin itself remains fully
+# functional; only the conflicting short namespace is refused.
+_REJECTED_IO_NAMESPACES: dict[str, str] = {}
+
+
+def _namespace_owner(name: str) -> str | None:
+    """Return the plugin an I/O namespace was contributed by, if known."""
+    read_path = None
+    for _name, (_read, _write) in _PLUGIN_IO_NAMESPACES.items():
+        if _name == name:
+            read_path = _read
+            break
+    if not read_path or "." not in read_path:
+        return None
+    return read_path.split(".", 1)[0]
+
 
 def register_io_namespace(
     name: str,
     read_path: str | None = None,
     write_path: str | None = None,
-) -> None:
+    plugin: str | None = None,
+) -> bool:
     """
     Register a plugin-contributed I/O namespace.
+
+    Names that collide with a public ``scp`` root symbol are rejected with a
+    controlled warning instead of silently shadowing the core API.  The
+    reader behind ``read_<name>`` remains available through its explicit
+    top-level function.
 
     Parameters
     ----------
@@ -58,8 +82,61 @@ def register_io_namespace(
         the ``spectrochempy`` package (for example ``nmr.read_topspin``).
     write_path : str or None
         Dotted attribute path resolving to the write function, if any.
+    plugin : str or None
+        Name of the contributing plugin, used in diagnostics.
+
+    Returns
+    -------
+    bool
+        ``True`` when the namespace was registered, ``False`` when it was
+        rejected because of a reserved-name collision (or because a core
+        namespace already owns the name).
     """
+    import warnings
+
+    from spectrochempy.lazyimport.root_symbols import is_reserved_root_symbol
+
+    if name in _CORE_IO_NAMESPACES:
+        _REJECTED_IO_NAMESPACES[
+            name
+        ] = f"plugin={plugin or 'unknown'} core namespace '{name}'"
+        warnings.warn(
+            f"Refusing plugin I/O namespace '{name}' (plugin={plugin or 'unknown'}): "
+            f"'{name}' is already a core I/O namespace.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return False
+
+    if is_reserved_root_symbol(name):
+        _REJECTED_IO_NAMESPACES[
+            name
+        ] = f"plugin={plugin or 'unknown'} read={read_path} write={write_path}"
+        if read_path and "." in read_path:
+            reader_surface = f"scp.{read_path.rsplit('.', 1)[-1]}"
+        else:
+            reader_surface = f"scp.read_{name}"
+        warnings.warn(
+            f"Refusing plugin I/O namespace '{name}' (plugin={plugin or 'unknown'}): "
+            f"'{name}' is a reserved public SpectroChemPy symbol. Use "
+            f"'{reader_surface}' instead.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return False
+
+    if name in _PLUGIN_IO_NAMESPACES:
+        warnings.warn(
+            f"I/O namespace '{name}' (plugin={plugin or 'unknown'}) is already "
+            f"registered by plugin '{_namespace_owner(name) or 'unknown'}'; "
+            "keeping the first registration.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return False
+
     _PLUGIN_IO_NAMESPACES[name] = (read_path, write_path)
+    return True
 
 
 def unregister_io_namespace(name: str) -> None:

--- a/src/spectrochempy/lazyimport/plot_profile.py
+++ b/src/spectrochempy/lazyimport/plot_profile.py
@@ -1,0 +1,27 @@
+# ======================================================================================
+# Copyright (©) 2015-2026 LCS
+# Laboratoire Catalyse et Spectrochimie, Caen, France.
+#
+# This software is a computer program whose purpose is to provide a framework
+# for processing, analysing and modelling *Spectro*scopic
+# data for *Chem*istry with *Py*thon (SpectroChemPy).
+#
+# This software is governed by the CeCILL-B license under French law.
+# ======================================================================================
+
+"""
+Plot profile API functions exposed at the ``spectrochempy`` root.
+
+This is the single source of truth for the plot profile convenience
+functions.  It is used both by the root ``__getattr__``/``__dir__``
+implementation and by the reserved-name policy protecting public root
+symbols from plugin collisions.
+"""
+
+_PLOT_PROFILE_FUNCTIONS = {
+    "set_plot_profile": "spectrochempy.plotting.profile",
+    "get_plot_profile": "spectrochempy.plotting.profile",
+    "list_plot_profiles": "spectrochempy.plotting.profile",
+    "save_plot_profile": "spectrochempy.plotting.profile",
+    "delete_plot_profile": "spectrochempy.plotting.profile",
+}

--- a/src/spectrochempy/lazyimport/root_symbols.py
+++ b/src/spectrochempy/lazyimport/root_symbols.py
@@ -13,8 +13,17 @@
 Reserved public root symbols of ``spectrochempy``.
 
 This module computes, from existing sources of truth, the set of names that
-are public at the ``scp`` root and therefore can never be silently shadowed
-by a plugin-provided symbol (namespace, reader export, root export, …).
+are public at the ``scp`` root.  These names are protected against plugin
+collisions in two ways:
+
+- the plugin manager rejects a plugin I/O namespace whose name collides with
+  one of these symbols (see ``register_io_namespace``);
+- the root ``__getattr__`` always resolves these names to the core symbol,
+  regardless of plugin installation or discovery order.
+
+Other plugin-provided root surfaces (``root_exports``, reader exports,
+``analysis``/``simulation`` extensions) are not rejected at registration
+time; they are protected only by the resolution priority above.
 
 Sources of truth used:
 
@@ -29,12 +38,6 @@ Sources of truth used:
   namespace names;
 - the public submodules declared in ``spectrochempy/__init__.pyi`` (the same
   source that ``lazy_loader.attach_stub`` parses at import time).
-
-Plugin maintainers and the plugin manager use
-:func:`is_reserved_root_symbol` to reject registered names that would collide
-with a public root symbol, and the root ``__getattr__`` guarantees that
-reserved names always resolve to the core symbol regardless of discovery
-order.
 """
 
 from __future__ import annotations

--- a/src/spectrochempy/lazyimport/root_symbols.py
+++ b/src/spectrochempy/lazyimport/root_symbols.py
@@ -1,0 +1,104 @@
+# ======================================================================================
+# Copyright (©) 2015-2026 LCS
+# Laboratoire Catalyse et Spectrochimie, Caen, France.
+#
+# This software is a computer program whose purpose is to provide a framework
+# for processing, analysing and modelling *Spectro*scopic
+# data for *Chem*istry with *Py*thon (SpectroChemPy).
+#
+# This software is governed by the CeCILL-B license under French law.
+# ======================================================================================
+
+"""
+Reserved public root symbols of ``spectrochempy``.
+
+This module computes, from existing sources of truth, the set of names that
+are public at the ``scp`` root and therefore can never be silently shadowed
+by a plugin-provided symbol (namespace, reader export, root export, …).
+
+Sources of truth used:
+
+- ``_LAZY_IMPORTS`` (``spectrochempy.lazyimport.api_methods``) — public
+  functions, classes, constants and compatibility aliases exposed at root;
+- ``_LAZY_DATASETS_IMPORTS``
+  (``spectrochempy.lazyimport.dataset_methods``) — ``NDDataset`` methods
+  exposed at root;
+- ``_PLOT_PROFILE_FUNCTIONS``
+  (``spectrochempy.lazyimport.plot_profile``) — plotting profile API;
+- ``_CORE_IO_NAMESPACES`` (``spectrochempy.core.io_namespaces``) — core I/O
+  namespace names;
+- the public submodules declared in ``spectrochempy/__init__.pyi`` (the same
+  source that ``lazy_loader.attach_stub`` parses at import time).
+
+Plugin maintainers and the plugin manager use
+:func:`is_reserved_root_symbol` to reject registered names that would collide
+with a public root symbol, and the root ``__getattr__`` guarantees that
+reserved names always resolve to the core symbol regardless of discovery
+order.
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+from spectrochempy.lazyimport.api_methods import _LAZY_IMPORTS
+from spectrochempy.lazyimport.dataset_methods import _LAZY_DATASETS_IMPORTS
+from spectrochempy.lazyimport.plot_profile import _PLOT_PROFILE_FUNCTIONS
+
+_ROOT_STUB = Path(__file__).resolve().parent.parent / "__init__.pyi"
+
+
+def _submodule_names() -> frozenset[str]:
+    """
+    Return the public submodule names declared in the root stub.
+
+    The stub is the same source that ``lazy_loader.attach_stub`` uses at
+    import time, so the result never diverges from the runtime module list.
+    """
+    import ast
+
+    if _ROOT_STUB.exists():
+        try:
+            tree = ast.parse(_ROOT_STUB.read_text(encoding="utf-8"))
+        except SyntaxError:
+            return frozenset()
+        names: set[str] = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.level == 1
+                and node.module is None
+            ):
+                names.update(alias.name for alias in node.names)
+        return frozenset(names)
+    return frozenset()
+
+
+def _core_io_namespaces() -> frozenset[str]:
+    from spectrochempy.core.io_namespaces import _CORE_IO_NAMESPACES
+
+    return frozenset(_CORE_IO_NAMESPACES)
+
+
+@functools.lru_cache(maxsize=1)
+def reserved_root_symbols() -> frozenset[str]:
+    """
+    Return the set of names that are public ``scp`` symbols.
+
+    The result is cached; it depends only on the core package layout, which is
+    static after import.  Core I/O namespaces are imported lazily to avoid an
+    import cycle at startup.
+    """
+    return frozenset(
+        set(_LAZY_IMPORTS)
+        | set(_LAZY_DATASETS_IMPORTS)
+        | set(_PLOT_PROFILE_FUNCTIONS)
+        | _core_io_namespaces()
+        | _submodule_names()
+    )
+
+
+def is_reserved_root_symbol(name: str) -> bool:
+    """Return ``True`` when *name* is a public ``scp`` root symbol."""
+    return name in reserved_root_symbols()

--- a/src/spectrochempy/plugins/manager.py
+++ b/src/spectrochempy/plugins/manager.py
@@ -162,7 +162,7 @@ class PluginManager:
             for ns_name, ns_spec in io_namespaces.items():
                 read_path = ns_spec.get("read")
                 write_path = ns_spec.get("write")
-                register_io_namespace(ns_name, read_path, write_path)
+                register_io_namespace(ns_name, read_path, write_path, plugin=name)
 
     # ------------------------------------------------------------------
     # Declarative hook collection

--- a/tests/test_plugins/test_root_symbol_collisions.py
+++ b/tests/test_plugins/test_root_symbol_collisions.py
@@ -11,6 +11,14 @@ Verifies that public ``scp`` root symbols can never be silently shadowed by a
 plugin-provided I/O namespace, root export, analysis/simulation extension or
 reader export, and that the reserved-name policy is deterministic regardless
 of plugin installation or discovery order.
+
+Two complementary guarantees are tested:
+
+- registration-time rejection of plugin **I/O namespaces** whose name
+  collides with a public ``scp`` root symbol (``register_io_namespace``);
+- **resolution priority**: for every plugin root surface (reader exports,
+  ``root_exports``, ``analysis``/``simulation`` extensions), root attribute
+  access always resolves a public core symbol first.
 """
 
 import subprocess
@@ -246,7 +254,7 @@ def test_dir_read_simpson_present():
 
 
 # -----------------------------------------------------------------------------
-# Root/analysis/extension shadowing (defense-in-depth)
+# Reserved-name set construction (defense-in-depth)
 # -----------------------------------------------------------------------------
 
 
@@ -261,12 +269,21 @@ def test_dataset_method_symbol_is_reserved():
     assert is_reserved_root_symbol("simpson")
 
 
-def test_reserved_name_wins_even_if_badly_registered(clean_plugin_namespaces):
-    # Even if a callable root export were somehow still in the registry, the
-    # reserved-name fast path in __getattr__ must keep the core symbol.
-    from spectrochempy.lazyimport.root_symbols import reserved_root_symbols
+def test_reserved_name_wins_over_root_export_collision(clean_plugin_namespaces):
+    # Inject a plugin that registers ``simpson`` as a root export.  The
+    # reserved-name fast path must still return the core integration function.
+    from spectrochempy.plugins.manager import plugin_manager
 
-    reserved = reserved_root_symbols()
-    assert "simpson" in reserved
-    obj = scp.simpson
-    assert obj.__module__ == "spectrochempy.analysis.integration.integrate"
+    class _CollisionPlugin:
+        name = "collision-test"
+        version = "1.0.0"
+        root_exports = {"simpson": {"target": "read_simpson", "namespace": "nmr"}}
+
+    original_plugins = plugin_manager.list_plugins
+    plugin_manager.list_plugins = lambda: [*original_plugins(), _CollisionPlugin()]
+    try:
+        obj = scp.simpson
+        assert obj.__module__ == "spectrochempy.analysis.integration.integrate"
+        assert not callable(getattr(obj, "read", None))
+    finally:
+        plugin_manager.list_plugins = original_plugins

--- a/tests/test_plugins/test_root_symbol_collisions.py
+++ b/tests/test_plugins/test_root_symbol_collisions.py
@@ -287,3 +287,29 @@ def test_reserved_name_wins_over_root_export_collision(clean_plugin_namespaces):
         assert not callable(getattr(obj, "read", None))
     finally:
         plugin_manager.list_plugins = original_plugins
+
+
+def test_reserved_submodule_wins_over_extension_collision():
+    # A plugin extension named after a public submodule must not shadow it:
+    # ``scp.analysis`` stays the core submodule and is not replaced by the
+    # plugin-provided extension object.
+    import spectrochempy.analysis as core_analysis
+    from spectrochempy.plugins.registry import registry
+
+    registry.extensions.register(
+        "analysis",
+        "analysis",
+        "PLUGIN_ANALYSIS_OBJECT",
+        description="collision with the public submodule",
+    )
+    try:
+        obj = scp.analysis
+        assert obj is core_analysis
+        assert obj != "PLUGIN_ANALYSIS_OBJECT"
+        # ``dir(scp)`` still advertises ``analysis`` (the core submodule), and
+        # does not surface any plugin-provided extension object.
+        names = dir(scp)
+        assert "analysis" in names
+        assert all(name != "PLUGIN_ANALYSIS_OBJECT" for name in names)
+    finally:
+        registry.extensions._extensions.pop("analysis", None)

--- a/tests/test_plugins/test_root_symbol_collisions.py
+++ b/tests/test_plugins/test_root_symbol_collisions.py
@@ -1,0 +1,272 @@
+# ======================================================================================
+# Copyright (©) 2014-2026 Laboratoire Catalyse et Spectrochimie (LCS), Caen, France.
+# CeCILL-B FREE SOFTWARE LICENSE AGREEMENT
+# See full LICENSE agreement in the root directory.
+# ======================================================================================
+
+"""
+Top-level symbol collision policy tests.
+
+Verifies that public ``scp`` root symbols can never be silently shadowed by a
+plugin-provided I/O namespace, root export, analysis/simulation extension or
+reader export, and that the reserved-name policy is deterministic regardless
+of plugin installation or discovery order.
+"""
+
+import subprocess
+import sys
+import textwrap
+import warnings
+
+import numpy as np
+import pytest
+
+import spectrochempy as scp
+from spectrochempy.core.io_namespaces import _CORE_IO_NAMESPACES
+from spectrochempy.core.io_namespaces import _PLUGIN_IO_NAMESPACES
+from spectrochempy.core.io_namespaces import _REJECTED_IO_NAMESPACES
+from spectrochempy.core.io_namespaces import register_io_namespace
+from spectrochempy.lazyimport.root_symbols import is_reserved_root_symbol
+
+
+def _fresh_interpreter(code: str) -> str:
+    """Run *code* in a clean subprocess and return combined stdout+stderr."""
+    env = {"PYTHONPATH": ":".join(sys.path)}
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    return (result.stdout + result.stderr).strip()
+
+
+# -----------------------------------------------------------------------------
+# Integration symbol stays the public scientific function
+# -----------------------------------------------------------------------------
+
+
+def test_simpson_callable_without_relying_on_plugin():
+    assert callable(scp.simpson)
+
+
+def test_simpson_is_integration_function():
+    assert scp.simpson.__module__ == "spectrochempy.analysis.integration.integrate"
+    assert scp.simpson is not scp.read_simpson
+
+
+def test_top_level_simpson_matches_dataset_simpson():
+    y = scp.Coord(np.arange(4.0), title="sample", units="s")
+    x = scp.Coord(np.linspace(0.0, 4.0, 9), title="wavelength", units="cm^-1")
+    xx, yy = np.meshgrid(x.data, y.data)
+    dataset = scp.NDDataset(
+        xx**2 + 2.0 * yy, coordset=[y, x], units="absorbance", title="synthetic"
+    )
+
+    actual = scp.simpson(dataset, dim="x")
+    expected = dataset.simpson(dim="x")
+    assert np.array_equal(actual.data, expected.data)
+
+
+def test_read_simpson_kept():
+    assert callable(scp.read_simpson)
+
+
+def test_simpson_not_advertised_as_io_namespace_in_dir():
+    ns = getattr(scp, "simpson", None)
+    assert ns is not None
+    assert not callable(getattr(ns, "read", None))
+
+
+# -----------------------------------------------------------------------------
+# Registration-time validation
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_plugin_namespaces():
+    """Snapshot and restore plugin-contributed I/O namespaces around a test."""
+    saved = dict(_PLUGIN_IO_NAMESPACES)
+    rejected = dict(_REJECTED_IO_NAMESPACES)
+    yield
+    _PLUGIN_IO_NAMESPACES.clear()
+    _PLUGIN_IO_NAMESPACES.update(saved)
+    _REJECTED_IO_NAMESPACES.clear()
+    _REJECTED_IO_NAMESPACES.update(rejected)
+
+
+def test_reserved_namespace_rejected(clean_plugin_namespaces):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ok = register_io_namespace("simpson", "nmr.read_simpson", plugin="nmr-test")
+
+    assert ok is False
+    assert "simpson" not in _PLUGIN_IO_NAMESPACES
+    assert "simpson" in _REJECTED_IO_NAMESPACES
+    assert any("simpson" in str(w.message) for w in caught)
+    assert any("plugin=nmr-test" in str(w.message) for w in caught)
+
+
+def test_non_reserved_namespace_accepted(clean_plugin_namespaces):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ok = register_io_namespace("nmrtest", "nmr.read_agilent", plugin="nmr-test")
+
+    assert ok is True
+    assert "nmrtest" in _PLUGIN_IO_NAMESPACES
+    assert not any("Refusing" in str(w.message) for w in caught)
+
+
+def test_core_namespace_cannot_be_overridden(clean_plugin_namespaces):
+    # A plugin asking for an existing core namespace must be refused.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ok = register_io_namespace("jcamp", "plugin.read_jcamp", plugin="plugin-test")
+
+    assert ok is False
+    assert "jcamp" not in _PLUGIN_IO_NAMESPACES
+    assert any("jcamp" in str(w.message) for w in caught)
+
+
+def test_reserved_symbol_rejection_keeps_reader_available():
+    # Rejecting the ``simpson`` namespace must not remove ``read_simpson``.
+    assert callable(scp.read_simpson)
+
+
+def test_status_introspection_after_rejection(clean_plugin_namespaces):
+    register_io_namespace("simpson", "nmr.read_simpson", plugin="nmr")
+    assert "simpson" in _REJECTED_IO_NAMESPACES
+    assert "read_simpson" in _REJECTED_IO_NAMESPACES["simpson"]
+
+
+# -----------------------------------------------------------------------------
+# Reserved-name set construction
+# -----------------------------------------------------------------------------
+
+
+def test_reserved_set_covers_public_symbols():
+    for name in ("simpson", "simps", "trapezoid", "Coord", "NDDataset", "read_jcamp"):
+        assert is_reserved_root_symbol(name)
+
+
+def test_reserved_set_covers_dataset_methods():
+    assert is_reserved_root_symbol("find_peaks")
+
+
+def test_reserved_set_covers_io_namespaces():
+    for ns in _CORE_IO_NAMESPACES:
+        assert is_reserved_root_symbol(ns)
+
+
+def test_reserved_set_covers_plot_profiles():
+    assert is_reserved_root_symbol("set_plot_profile")
+
+
+def test_unrelated_name_not_reserved():
+    assert not is_reserved_root_symbol("nmrtestanalysis")
+
+
+# -----------------------------------------------------------------------------
+# Deterministic resolution regardless of access / discovery order
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dataset_for_order():
+    x = scp.Coord(np.linspace(0.0, 4.0, 9), title="x", units="cm^-1")
+    return scp.NDDataset(np.arange(9.0) ** 2, coordset=[x], units="absorbance")
+
+
+def test_simpson_stack_semantics_stable_across_dir_and_order(dataset_for_order):
+    d1 = dataset_for_order
+    before_dir = scp.simpson(d1, dim="x").data.copy()
+
+    # Access the reader and dir() in different orders; the integration result
+    # must not change.
+    _ = scp.read_simpson
+    _ = dir(scp)
+    d2 = scp.Coord(np.linspace(0.0, 4.0, 9), title="x", units="cm^-1")
+    dataset2 = scp.NDDataset(np.arange(9.0) ** 2, coordset=[d2], units="absorbance")
+    after = scp.simpson(dataset2, dim="x").data
+    assert np.array_equal(before_dir, after)
+
+
+def test_subprocess_reader_first_does_not_mask_integration():
+    code = textwrap.dedent(
+        """
+        import spectrochempy as scp
+        # Reader-first ordering.
+        _ = scp.read_simpson
+        assert callable(scp.simpson), "integration masked when reader accessed first"
+        s = scp.simpson
+        assert s.__module__ == "spectrochempy.analysis.integration.integrate"
+        print("OK")
+        """
+    )
+    out = _fresh_interpreter(code)
+    assert "OK" in out
+
+
+def test_subprocess_integration_does_not_block_reader():
+    code = textwrap.dedent(
+        """
+        import spectrochempy as scp
+        assert callable(scp.simpson)
+        _ = scp.simpson
+        assert callable(scp.read_simpson), "reader masked after integration access"
+        print("OK")
+        """
+    )
+    out = _fresh_interpreter(code)
+    assert "OK" in out
+
+
+# -----------------------------------------------------------------------------
+# dir() stability
+# -----------------------------------------------------------------------------
+
+
+def test_dir_does_not_advertise_rejected_namespace(clean_plugin_namespaces):
+    register_io_namespace("simpson", "nmr.read_simpson", plugin="nmr-test")
+    # `simpson` is a lazy top-level integration function (like `fft`/`smooth`)
+    # and, following the existing convention, is not advertised in ``dir()``.
+    # The essential invariant is that it resolves to the callable integration
+    # function and is never exposed as an ambiguous I/O namespace.
+    ns = getattr(scp, "simpson", None)
+    assert callable(ns)
+    assert not callable(getattr(ns, "read", None))
+
+
+def test_dir_read_simpson_present():
+    # Accessing the reader triggers plugin discovery; the explicit reader
+    # surface must then be advertised (and never removed by the collision fix).
+    assert callable(scp.read_simpson)
+    assert "read_simpson" in dir(scp)
+
+
+# -----------------------------------------------------------------------------
+# Root/analysis/extension shadowing (defense-in-depth)
+# -----------------------------------------------------------------------------
+
+
+def test_dataset_method_symbol_is_reserved():
+    # ``simpson`` is a public NDDataset method exported at root; it must be a
+    # reserved root symbol that a plugin cannot shadow.  The method lives on
+    # the instance (via dataset-level ``__getattr__``), not directly on the
+    # class, so check via a real instance.
+    x = scp.Coord([0.0, 1.0, 2.0], title="x", units="cm^-1")
+    ds = scp.NDDataset([1.0, 1.0, 1.0], coordset=[x], units="absorbance")
+    assert hasattr(ds, "simpson")
+    assert is_reserved_root_symbol("simpson")
+
+
+def test_reserved_name_wins_even_if_badly_registered(clean_plugin_namespaces):
+    # Even if a callable root export were somehow still in the registry, the
+    # reserved-name fast path in __getattr__ must keep the core symbol.
+    from spectrochempy.lazyimport.root_symbols import reserved_root_symbols
+
+    reserved = reserved_root_symbols()
+    assert "simpson" in reserved
+    obj = scp.simpson
+    assert obj.__module__ == "spectrochempy.analysis.integration.integrate"

--- a/tests/test_plugins/test_root_symbol_collisions.py
+++ b/tests/test_plugins/test_root_symbol_collisions.py
@@ -290,26 +290,27 @@ def test_reserved_name_wins_over_root_export_collision(clean_plugin_namespaces):
 
 
 def test_reserved_submodule_wins_over_extension_collision():
-    # A plugin extension named after a public submodule must not shadow it:
-    # ``scp.analysis`` stays the core submodule and is not replaced by the
-    # plugin-provided extension object.
-    import spectrochempy.analysis as core_analysis
-    from spectrochempy.plugins.registry import registry
+    # Subprocess isolation: a fresh interpreter resolves ``scp.analysis`` for
+    # the first time (through ``scp.__getattr__``) while a plugin extension
+    # collision is present.  ``scp.analysis`` must stay the core submodule.
+    code = textwrap.dedent(
+        """
+        import types
 
-    registry.extensions.register(
-        "analysis",
-        "analysis",
-        "PLUGIN_ANALYSIS_OBJECT",
-        description="collision with the public submodule",
-    )
-    try:
+        import spectrochempy as scp
+        from spectrochempy.plugins.registry import registry
+
+        registry.extensions.register(
+            "analysis",
+            "analysis",
+            "PLUGIN_ANALYSIS_OBJECT",
+            description="collision with the public submodule",
+        )
+
         obj = scp.analysis
-        assert obj is core_analysis
-        assert obj != "PLUGIN_ANALYSIS_OBJECT"
-        # ``dir(scp)`` still advertises ``analysis`` (the core submodule), and
-        # does not surface any plugin-provided extension object.
-        names = dir(scp)
-        assert "analysis" in names
-        assert all(name != "PLUGIN_ANALYSIS_OBJECT" for name in names)
-    finally:
-        registry.extensions._extensions.pop("analysis", None)
+        assert isinstance(obj, types.ModuleType)
+        assert obj.__name__ == "spectrochempy.analysis"
+        print("OK")
+        """
+    )
+    assert "OK" in _fresh_interpreter(code)


### PR DESCRIPTION
## Summary

Plugin-contributed I/O namespaces could shadow public core root symbols. With `spectrochempy-nmr` installed, `scp.simpson` resolved to an `_IONamespace` (with `.read`, not callable) instead of the numerical-integration function, because the root `__getattr__` called `plugin_manager.discover()` before testing `_is_io_namespace(name)`.

This is a **published regression** present since release 0.10.2 (I/O namespace API #1282, SIMPSON reader #1427) whenever the NMR plugin is installed — not just on `master`.

## Changes

- **Reserved-root-symbol policy** (`src/spectrochempy/lazyimport/root_symbols.py`): a single `reserved_root_symbols()` / `is_reserved_root_symbol()` built from existing sources of truth — `_LAZY_IMPORTS`, `_LAZY_DATASETS_IMPORTS`, `_PLOT_PROFILE_FUNCTIONS` (new module `plot_profile.py`), `_CORE_IO_NAMESPACES`, and public submodules. No diverging manual list.
- **`register_io_namespace`** (`core/io_namespaces.py`): rejects a conflicting short namespace with a controlled `RuntimeWarning` (identifying the plugin, the requested name and the protected symbol) and records it in `_REJECTED_IO_NAMESPACES` for introspection. The plugin's reader stays fully available via `scp.read_<format>`.
- **Root `__getattr__`/`__dir__`** (`__init__.py`): reserved names always resolve to the core symbol regardless of plugin installation or discovery order; no ambiguous name is advertised in `dir(scp)`.
- **Plugin `spectrochempy-nmr`**: removed the conflicting `"simpson"` I/O namespace. The SIMPSON reader remains registered (`scp.read_simpson`, `scp.nmr.read_simpson`).
- **Docs**: plugin writing guide + API policy sections on reserved root symbols, user note distinguishing integration from `read_simpson`, changelog/latest fragments.

## Priority rule

1. public core symbols/functions/classes;
2. `NDDataset` public methods exposed at root;
3. compatibility aliases;
4. submodules and core I/O namespaces;
5. plugin namespaces/readers/root exports **only** when no collision.

A plugin can never silently replace a public function, class, `NDDataset` method, compatibility alias, public submodule, or core I/O namespace.

## Compatibility

- `scp.simpson` / `dataset.simpson` integration: unchanged, numerically identical.
- SIMPSON reader surface: `scp.read_simpson(...)`, `scp.nmr.read_simpson(...)` — unchanged.
- No hybrid callable-with-`.read` object introduced.

## Tests

22 new tests in `tests/test_plugins/test_root_symbol_collisions.py` (callable resolution, numerical equivalence, `dir()` stability, subprocess discovery-order independence, registration rejection + reader preservation, introspection). Full affected suites green; `pre-commit run --all-files` clean.