### PR TITLE
REL: consolidate 0.12.8 release notes

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,9 +19,15 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
-- Added ``Pipeline`` for linear, reproducible composition of allowlisted
-  SpectroChemPy preprocessing transformers with a final transformer or
-  supervised estimator.
+- Added ``scp.Pipeline``, a public minimal Pipelines class for linear,
+  reproducible composition of SpectroChemPy estimators: allowlisted
+  preprocessing transformers optionally followed by a final transformer
+  (``PCA``) or a supervised estimator (``PLSRegression``, ``LSTSQ``, ``NNLS``).
+  Steps are templates cloned on fit (``fitted_steps_`` /
+  ``fitted_named_steps_``); ``transform`` / ``fit_transform`` are available
+  for transformer-final pipelines and ``predict`` / ``score`` for
+  estimator-final pipelines, with nested ``set_params`` support and fitted-state
+  invalidation.
 
 .. section
 
@@ -29,16 +35,22 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
-- fixed ``scp.simpson`` so it always resolves to the public numerical
-  integration function, even when a plugin contributes a SIMPSON I/O
-  reader; conflicting plugin short namespaces are rejected instead of
-  silently shadowing a core symbol (``scp.read_simpson`` remains the
-  explicit reader surface)
-- correct OMNIC SPA interferogram optical path difference coordinates by
-  honoring the native sample-spacing factor
-- correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
-- fixed OMNIC SRS X/data orientation and deprecated the ``reverse_x``
-  workaround
+- Fixed ``scp.simpson`` so it always resolves to the public numerical
+  integration function ``simpson(dataset, dim='x')``, even when a plugin
+  contributes a SIMPSON I/O reader; ``scp.read_simpson`` and
+  ``scp.nmr.read_simpson`` remain the explicit file-reading surfaces and
+  ``dataset.simpson()`` is unchanged.
+- Correct OMNIC ``.spa`` interferogram optical-path-difference coordinates by
+  honoring the native header sample-spacing factor instead of always assuming
+  a doubled step.
+- Correct OMNIC ``.srs`` series time-axis anchoring (it now starts from the
+  recorded series minimum time) and fix per-spectrum labels, which no longer
+  include binary metadata leaked past the 84-byte record.
+- Normalize OMNIC ``.srs`` spectral series to the public ``read_spa``
+  convention: wavenumbers are exposed descending with the intensity data
+  matched to them. Rapid-scan interferograms keep their ascending data-points
+  axis and records with an unrecognized X-axis type are left unchanged with a
+  warning.
 
 
 .. section
@@ -62,7 +74,8 @@ Deprecations
 .. Add here new deprecations (do not delete this comment)
 
 - The ``reverse_x`` keyword argument of ``read_srs`` is deprecated: SRS
-  spectral orientation is now handled automatically
+  spectral orientation is now handled automatically. Supplying it (with any
+  value) emits a ``DeprecationWarning`` and is ignored.
 
 
 .. section
@@ -71,13 +84,17 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
-- Added a centralized reserved-root-symbol policy
-  (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
-  public ``scp`` symbols; conflicting plugin I/O namespaces are rejected
-  with a controlled warning while the ``read_<format>`` reader is preserved
-- Added the internal estimator-contract helpers required before a future
-  ``Pipeline`` implementation: allowlist-based fitted-state inspection,
-  unfitted cloning, canonical not-fitted behavior for supported transformers,
-  and lifecycle invalidation for accepted analysis terminal candidates.
-- Added a developer-guide reference for the OMNIC SRS file format.
-- DOC: Added a developer-guide reference for the OMNIC SPA file format. (#1597)
+MAINT: Added a centralized reserved-root-symbol policy
+(``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
+public ``scp`` symbols; conflicting plugin I/O namespaces are rejected at
+registration with a controlled warning while the ``read_<format>`` reader
+remains available through its explicit surfaces. (#1599)
+
+MAINT: Added the internal estimator-contract helpers required by the
+``Pipeline`` implementation: allowlist-based fitted-state inspection,
+unfitted cloning, canonical not-fitted behavior for supported transformers,
+and opt-in lifecycle invalidation for the accepted analysis terminal
+candidates. (#1589)
+
+DOC: Added a developer-guide reference for the OMNIC SRS file format. (#1596)
+DOC: Added a developer-guide reference for the OMNIC SPA file format. (#1597)

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -96,5 +96,5 @@ unfitted cloning, canonical not-fitted behavior for supported transformers,
 and opt-in lifecycle invalidation for the accepted analysis terminal
 candidates. (#1589)
 
-DOC: Added a developer-guide reference for the OMNIC SRS file format. (#1596)
-DOC: Added a developer-guide reference for the OMNIC SPA file format. (#1597)
+DOC: Added developer-guide references for the OMNIC SRS and SPA file
+formats. (#1596, #1597)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,40 +15,57 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
-- Added ``Pipeline`` for linear, reproducible composition of allowlisted
-  SpectroChemPy preprocessing transformers with a final transformer or
-  supervised estimator.
+- Added ``scp.Pipeline``, a public minimal Pipelines class for linear,
+  reproducible composition of SpectroChemPy estimators: allowlisted
+  preprocessing transformers optionally followed by a final transformer
+  (``PCA``) or a supervised estimator (``PLSRegression``, ``LSTSQ``, ``NNLS``).
+  Steps are templates cloned on fit (``fitted_steps_`` /
+  ``fitted_named_steps_``); ``transform`` / ``fit_transform`` are available
+  for transformer-final pipelines and ``predict`` / ``score`` for
+  estimator-final pipelines, with nested ``set_params`` support and fitted-state
+  invalidation.
 
 Bug Fixes
 ~~~~~~~~~
 
-- fixed ``scp.simpson`` so it always resolves to the public numerical
-  integration function, even when a plugin contributes a SIMPSON I/O
-  reader; conflicting plugin short namespaces are rejected instead of
-  silently shadowing a core symbol (``scp.read_simpson`` remains the
-  explicit reader surface)
-- correct OMNIC SPA interferogram optical path difference coordinates by
-  honoring the native sample-spacing factor
-- correct OMNIC SRS series time-axis anchor and 84-byte spectrum labels
-- fixed OMNIC SRS X/data orientation and deprecated the ``reverse_x``
-  workaround
+- Fixed ``scp.simpson`` so it always resolves to the public numerical
+  integration function ``simpson(dataset, dim='x')``, even when a plugin
+  contributes a SIMPSON I/O reader; ``scp.read_simpson`` and
+  ``scp.nmr.read_simpson`` remain the explicit file-reading surfaces and
+  ``dataset.simpson()`` is unchanged.
+- Correct OMNIC ``.spa`` interferogram optical-path-difference coordinates by
+  honoring the native header sample-spacing factor instead of always assuming
+  a doubled step.
+- Correct OMNIC ``.srs`` series time-axis anchoring (it now starts from the
+  recorded series minimum time) and fix per-spectrum labels, which no longer
+  include binary metadata leaked past the 84-byte record.
+- Normalize OMNIC ``.srs`` spectral series to the public ``read_spa``
+  convention: wavenumbers are exposed descending with the intensity data
+  matched to them. Rapid-scan interferograms keep their ascending data-points
+  axis and records with an unrecognized X-axis type are left unchanged with a
+  warning.
 
 Deprecations
 ~~~~~~~~~~~~
 
 - The ``reverse_x`` keyword argument of ``read_srs`` is deprecated: SRS
-  spectral orientation is now handled automatically
+  spectral orientation is now handled automatically. Supplying it (with any
+  value) emits a ``DeprecationWarning`` and is ignored.
 
 Developer
 ~~~~~~~~~
 
-- Added a centralized reserved-root-symbol policy
-  (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
-  public ``scp`` symbols; conflicting plugin I/O namespaces are rejected
-  with a controlled warning while the ``read_<format>`` reader is preserved
-- Added the internal estimator-contract helpers required before a future
-  ``Pipeline`` implementation: allowlist-based fitted-state inspection,
-  unfitted cloning, canonical not-fitted behavior for supported transformers,
-  and lifecycle invalidation for accepted analysis terminal candidates.
-- Added a developer-guide reference for the OMNIC SRS file format.
-- DOC: Added a developer-guide reference for the OMNIC SPA file format. (#1597)
+MAINT: Added a centralized reserved-root-symbol policy
+(``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
+public ``scp`` symbols; conflicting plugin I/O namespaces are rejected at
+registration with a controlled warning while the ``read_<format>`` reader
+remains available through its explicit surfaces. (#1599)
+
+MAINT: Added the internal estimator-contract helpers required by the
+``Pipeline`` implementation: allowlist-based fitted-state inspection,
+unfitted cloning, canonical not-fitted behavior for supported transformers,
+and opt-in lifecycle invalidation for the accepted analysis terminal
+candidates. (#1589)
+
+DOC: Added a developer-guide reference for the OMNIC SRS file format. (#1596)
+DOC: Added a developer-guide reference for the OMNIC SPA file format. (#1597)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -67,5 +67,5 @@ unfitted cloning, canonical not-fitted behavior for supported transformers,
 and opt-in lifecycle invalidation for the accepted analysis terminal
 candidates. (#1589)
 
-DOC: Added a developer-guide reference for the OMNIC SRS file format. (#1596)
-DOC: Added a developer-guide reference for the OMNIC SPA file format. (#1597)
+DOC: Added developer-guide references for the OMNIC SRS and SPA file
+formats. (#1596, #1597)


### PR DESCRIPTION
## Summary

This PR consolidates the SpectroChemPy **0.12.8** release notes. It only
touches the changelog sources:

- `docs/sources/whatsnew/changelog.rst`
- `docs/sources/whatsnew/latest.rst` (regenerated through the official
  `update_version_and_release_notes` hook)

No tag, package, or GitHub release is created by this PR. The publication
steps listed under *Actions remaining* are intentionally left to the
maintainers.

## Inventory

Audited range: `spectrochempy-v0.12.7..master`.

- Base tag SHA: `spectrochempy-v0.12.7` → `2864461268d70d889bc019e0203fc0cb710d43c8`
- Master audited at: `250ccd5268d904657f194600af94771e8e72ae37` (merge of #1599, sync of upstream `master`)
- 11 commits with PRs, all merged since 0.12.7

| PR | Title | Category |
|----|-------|----------|
| #1589 | MAINT: harden estimator contract for future pipeline | Developer / internal |
| #1590 | ENH: add minimal estimator Pipeline | New public feature |
| #1591 | DOC: clarify PR checklist API reference guidance | Contributor-process docs (no changelog entry, per its own description) |
| #1592 | DOC: expand Pipeline user guide | Documentation of the new feature |
| #1593 | FIX: correct OMNIC SRS time-axis anchor and spectrum labels | User-facing bug fix |
| #1594 | FIX: normalize OMNIC SRS spectral orientation | User-facing bug fix + deprecation of `reverse_x` |
| #1595 | FIX: tighten SRS deprecation and interferogram detection | User-facing bug fix |
| #1596 | DOC: add standalone OMNIC SRS format reference | Developer documentation |
| #1597 | DOC: add OMNIC SPA file format reference | Developer documentation |
| #1598 | FIX: correct OMNIC SPA interferogram OPD step for native sample spacing | User-facing bug fix |
| #1599 | FIX: keep `scp.simpson` as the integration function when the SIMPSON reader plugin is installed | User-facing bug fix + developer policy |

## Consolidation decisions

- **New Features**: `scp.Pipeline` with its actual v1 scope (allowlisted
  preprocessing transformers + optional final `PCA` or supervised estimator
  `PLSRegression` / `LSTSQ` / `NNLS`; clone-on-fit of templates;
  `transform`/`fit_transform` or `predict`/`score` depending on the final
  step; nested `set_params`). The entry deliberately does not promise
  support for estimators outside the v1 allowlist.
- **Bug Fixes**: split the OMNIC SRS cluster into distinguishable
  user-facing outcomes (time-axis anchor + 84-byte labels; spectral
  orientation normalized to the `read_spa` convention with rapid-scan
  interferograms and unknown X-axis types handled separately), kept the SPA
  OPD fix separate, and restored `scp.simpson` as the numerical integration
  function (`scp.read_simpson` / `scp.nmr.read_simpson` remain the explicit
  reader surfaces; `dataset.simpson()` unchanged).
- **Deprecations**: `reverse_x` of `read_srs` is deprecated (no-op, warns,
  ignored) — separated from the bug-fix entries.
- **Developer**: entries use the mandated prefixes
  (`MAINT:` for the reserved-root-symbol policy and estimator-contract
  helpers; `DOC:` for the OMNIC SRS/SPA format references) with PR numbers,
  per `CONTRIBUTING.md`. Private implementation symbols
  (`_IONamespace`, `_LAZY_IMPORTS`, `_REJECTED_IO_NAMESPACES`) are not
  exposed in user-facing notes.
- **Excluded**: #1591 explicitly declares no changelog entry
  (contributor-process documentation).

## Compatibility notes for 0.12.8

The audited changes justify a **patch** release rather than 0.13.0:

- All changes are bug fixes, additive features, or documentation; nothing is
  removed or renamed.
- The only behavior change by default is the OMNIC `.srs` spectral
  orientation, which is now normalized to the public descending-wavenumber
  convention (matching `read_spa`); this corrects previously mis-oriented
  data, and the historical `reverse_x` workaround is deprecated with a
  warning. OMNIC `.spa` interferogram OPD coordinates are corrected for
  native sample-spacing-1.0 files (spacing-2.0 files are unchanged).
- The `scp.simpson` fix is effective even with the published `spectrochempy-nmr`
  0.1.10 (which still declares the `simpson` I/O namespace): the core refuses
  the colliding plugin namespace at registration while keeping the reader
  available through `scp.read_simpson` / `scp.nmr.read_simpson`.

## Validation

- `pre-commit run --all-files` — all hooks passed (including
  `update_version_and_release_notes`, which regenerated `latest.rst`).
- The full test suite, documentation build, and distribution smoke tests are
  intentionally delegated to CI for this release-preparation PR, as agreed.

## Files changed

- `docs/sources/whatsnew/changelog.rst`
- `docs/sources/whatsnew/latest.rst`

## Actions remaining for the 0.12.8 publication (not done here)

1. Tag `spectrochempy-v0.12.8` on master and create the GitHub release
   (maintainers; via the official release workflows).
2. Publish PyPI/conda artifacts.
3. Recommended: publish `spectrochempy-nmr` 0.1.11 (it has 1 commit / 1 file
   modified since tag 0.1.10 — removal of the `simpson` I/O namespace — per
   `plugin_version_status.py`). This is not required for the `scp.simpson`
   fix to work but aligns the published plugin with the new policy.

**Checklist**:

- [x] User-visible changes have been documented in the appropriate section of `docs/sources/whatsnew/changelog.rst`.
- [x] Developer changes (tests, CI, refactoring, tooling) have been documented in the `Developer` section of `docs/sources/whatsnew/changelog.rst`.
- [x] Title follows the prefix convention defined in `CONTRIBUTING.md` (or label `non-standard-prefix` is applied).
- [x] Changelog entry is present (or label `no-changelog` is applied).