### PR TITLE
DOC: forbid release/ branch prefix for agent-created PR branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -625,6 +625,26 @@ Never propose unprefixed titles.
 
 ---
 
+# Branch Names
+
+Do **not** create branches starting with ``release/`` for pull requests.
+
+The ``release/`` prefix is reserved for the official publication process:
+
+* ``.github/workflows/publish_draft_new_release.yml`` creates a GitHub release
+  from any merged PR whose head branch starts with ``release/`` (the branch
+  name is decoded as the release version);
+* ``.github/workflows/pre-commit.yml`` skips CI pre-commit on ``release/``
+  head branches.
+
+A branch created by an agent must never carry the ``release/`` prefix, even
+for release-related chores such as consolidating changelog entries: it would
+trigger (or suppress) release machinery that does not belong to a normal PR.
+Use a descriptive non-reserved prefix instead (for example ``chore/``,
+``fix/``, ``docs/``, ``feat/``, ``refactor/``).
+
+---
+
 # Default Deliverable
 
 Unless explicitly delegated to finalize work, provide:


### PR DESCRIPTION
## Summary

Forbid the `release/` branch prefix for agent-created PR branches.

The `release/` prefix is reserved for the official publication process:

- `.github/workflows/publish_draft_new_release.yml` creates a GitHub release
  from any merged PR whose head branch starts with `release/` (the branch name
  is decoded as the release version);
- `.github/workflows/pre-commit.yml` skips CI pre-commit on `release/` head
  branches.

A PR branch named `release/…` triggers (or suppresses) release machinery that
does not belong to a normal PR, even for release-adjacent chores such as
consolidating changelog entries. The added rule directs agents to use
descriptive non-reserved prefixes (`chore/`, `fix/`, `docs/`, `feat/`,
`refactor/`) instead.

## Out of scope

- No workflow changes.
- No runtime/API changes.

## Checklist

- [x] Title follows the prefix convention defined in `CONTRIBUTING.md`.
- [x] Changelog entry is not applicable (documentation/process-only change;
      `no-changelog` label applied).
