### PR TITLE
FIX: read SPA optical velocity from canonical parameter block

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -43,6 +43,8 @@ Bug Fixes
 - Correct OMNIC ``.spa`` interferogram optical-path-difference coordinates by
   honoring the native header sample-spacing factor instead of always assuming
   a doubled step.
+- Correct OMNIC ``.spa`` optical-velocity metadata by using the canonical
+  acquisition-parameter block when the legacy header mirror is blank.
 - Correct OMNIC ``.srs`` series time-axis anchoring (it now starts from the
   recorded series minimum time) and fix per-spectrum labels, which no longer
   include binary metadata leaked past the 84-byte record.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -36,6 +36,8 @@ Bug Fixes
 - Correct OMNIC ``.spa`` interferogram optical-path-difference coordinates by
   honoring the native header sample-spacing factor instead of always assuming
   a doubled step.
+- Correct OMNIC ``.spa`` optical-velocity metadata by using the canonical
+  acquisition-parameter block when the legacy header mirror is blank.
 - Correct OMNIC ``.srs`` series time-axis anchoring (it now starts from the
   recorded series minimum time) and fix per-spectrum labels, which no longer
   include binary metadata leaked past the 84-byte record.

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -989,6 +989,7 @@ def _read_spa(*args, **kwargs):
     pos = 304
     spa_comments = []  # several custom comments can be present
     _exp_info = None
+    optical_velocity = None
     while "continue":
         fid.seek(pos)
         key = fromfile(fid, dtype="uint8", count=1)
@@ -1024,6 +1025,18 @@ def _read_spa(*args, **kwargs):
 
         elif key == 103 and return_ifg == "background":
             b_ifg_intensities = _getintensities(fid, pos)
+
+        elif key == 106:
+            # The 0x6a block is the canonical source for acquisition
+            # parameters.  The 0x02 header contains a variant-dependent mirror
+            # at +188, but newer layouts may leave that mirror blank.
+            fid.seek(pos + 2)
+            parameters_pos = fromfile(fid, "uint32", 1)
+            fid.seek(pos + 6)
+            parameters_len = fromfile(fid, "uint32", 1)
+            if parameters_len >= 52:
+                fid.seek(parameters_pos + 48)
+                optical_velocity = fromfile(fid, "float32", 1)
 
         elif key == 130 and _exp_info is None:
             fid.seek(pos + 2)
@@ -1135,7 +1148,10 @@ def _read_spa(*args, **kwargs):
     dataset._date = utcnow()
 
     dataset.meta.collection_length = info["collection_length"] / 100 * ur("s")
-    dataset.meta.optical_velocity = info["optical_velocity"]
+    if optical_velocity is None:
+        # Retain compatibility with supported files that do not carry 0x6a.
+        optical_velocity = info["optical_velocity"]
+    dataset.meta.optical_velocity = optical_velocity
     dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
     dataset.meta.sample_spacing = info["sample_spacing"]
 

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -198,14 +198,18 @@ def test_return_ifg_validation(tmp_path):
     assert any("Invalid return_ifg value" in str(warning.message) for warning in w)
 
 
-def _synthetic_spa_with_optical_velocity(mirror, canonical):
-    """Build a minimal SPA containing both optical-velocity representations."""
+def _synthetic_spa_with_optical_velocity(mirror, canonical=None):
+    """Build a minimal SPA with optional canonical optical-velocity metadata."""
     content = bytearray(768)
     content[:18] = b"Spectral Data File"
     content[30:42] = b"synthetic.spa"
-    struct.pack_into("<H", content, 294, 3)
 
-    records = ((2, 400, 140), (106, 700, 56), (3, 756, 8))
+    records = [(2, 400, 140)]
+    if canonical is not None:
+        records.append((106, 700, 56))
+    payload_position = 756 if canonical is not None else 700
+    records.append((3, payload_position, 8))
+    struct.pack_into("<H", content, 294, len(records))
     for offset, (key, position, length) in zip((304, 320, 336), records):
         struct.pack_into("<BBII", content, offset, key, 0, position, length)
 
@@ -218,29 +222,40 @@ def _synthetic_spa_with_optical_velocity(mirror, canonical):
     struct.pack_into("<f", content, header + 80, 15798.0)
     struct.pack_into("<f", content, header + 84, 1.0)
     struct.pack_into("<f", content, header + 188, mirror)
-    struct.pack_into("<f", content, 700 + 48, canonical)
-    struct.pack_into("<ff", content, 756, 1.0, 2.0)
+    if canonical is not None:
+        struct.pack_into("<f", content, 700 + 48, canonical)
+    struct.pack_into("<ff", content, payload_position, 1.0, 2.0)
     return bytes(content)
 
 
 def test_spa_uses_canonical_optical_velocity(tmp_path):
     """The 0x6a value wins over the legacy 0x02 header mirror."""
     path = tmp_path / "canonical.spa"
-    path.write_bytes(_synthetic_spa_with_optical_velocity(0.0, 0.3165))
+    path.write_bytes(_synthetic_spa_with_optical_velocity(0.0, 8.8617))
 
     dataset = scp.read_spa(path)
 
-    assert dataset.meta.optical_velocity == pytest.approx(0.3165)
+    assert dataset.meta.optical_velocity == pytest.approx(8.8617)
 
 
 def test_spa_preserves_matching_optical_velocity_layout(tmp_path):
     """The canonical and mirrored values remain unchanged when they agree."""
     path = tmp_path / "matching.spa"
-    path.write_bytes(_synthetic_spa_with_optical_velocity(0.3165, 0.3165))
+    path.write_bytes(_synthetic_spa_with_optical_velocity(8.8617, 8.8617))
 
     dataset = scp.read_spa(path)
 
-    assert dataset.meta.optical_velocity == pytest.approx(0.3165)
+    assert dataset.meta.optical_velocity == pytest.approx(8.8617)
+
+
+def test_spa_falls_back_to_mirror_without_canonical_parameters(tmp_path):
+    """The legacy mirror remains supported when no 0x6a record is present."""
+    path = tmp_path / "legacy.spa"
+    path.write_bytes(_synthetic_spa_with_optical_velocity(8.8617))
+
+    dataset = scp.read_spa(path)
+
+    assert dataset.meta.optical_velocity == pytest.approx(8.8617)
 
 
 def test_allow_inconsistent_x_parameter_documented():

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -5,6 +5,7 @@
 # ======================================================================================
 # ruff: noqa
 
+import struct
 from pathlib import Path
 
 import numpy as np
@@ -195,6 +196,51 @@ def test_return_ifg_validation(tmp_path):
     assert result is None
     assert len(w) >= 1
     assert any("Invalid return_ifg value" in str(warning.message) for warning in w)
+
+
+def _synthetic_spa_with_optical_velocity(mirror, canonical):
+    """Build a minimal SPA containing both optical-velocity representations."""
+    content = bytearray(768)
+    content[:18] = b"Spectral Data File"
+    content[30:42] = b"synthetic.spa"
+    struct.pack_into("<H", content, 294, 3)
+
+    records = ((2, 400, 140), (106, 700, 56), (3, 756, 8))
+    for offset, (key, position, length) in zip((304, 320, 336), records):
+        struct.pack_into("<BBII", content, offset, key, 0, position, length)
+
+    header = 400
+    struct.pack_into("<I", content, header + 4, 2)
+    content[header + 8] = 1
+    content[header + 12] = 17
+    struct.pack_into("<ff", content, header + 16, 4000.0, 3999.0)
+    struct.pack_into("<I", content, header + 68, 100)
+    struct.pack_into("<f", content, header + 80, 15798.0)
+    struct.pack_into("<f", content, header + 84, 1.0)
+    struct.pack_into("<f", content, header + 188, mirror)
+    struct.pack_into("<f", content, 700 + 48, canonical)
+    struct.pack_into("<ff", content, 756, 1.0, 2.0)
+    return bytes(content)
+
+
+def test_spa_uses_canonical_optical_velocity(tmp_path):
+    """The 0x6a value wins over the legacy 0x02 header mirror."""
+    path = tmp_path / "canonical.spa"
+    path.write_bytes(_synthetic_spa_with_optical_velocity(0.0, 0.3165))
+
+    dataset = scp.read_spa(path)
+
+    assert dataset.meta.optical_velocity == pytest.approx(0.3165)
+
+
+def test_spa_preserves_matching_optical_velocity_layout(tmp_path):
+    """The canonical and mirrored values remain unchanged when they agree."""
+    path = tmp_path / "matching.spa"
+    path.write_bytes(_synthetic_spa_with_optical_velocity(0.3165, 0.3165))
+
+    dataset = scp.read_spa(path)
+
+    assert dataset.meta.optical_velocity == pytest.approx(0.3165)
 
 
 def test_allow_inconsistent_x_parameter_documented():


### PR DESCRIPTION
## Problem

Some SPA layout variants leave the `0x02 +188` optical-velocity mirror blank, causing `dataset.meta.optical_velocity` to be exposed incorrectly.

## Fix

Read the canonical optical velocity from the `0x6a` acquisition-parameter block, preserving the existing public metadata name and falling back to the legacy mirror only when `0x6a` is absent.

## Tests

* Added a synthetic newer-layout discriminating case where the mirror is zero and `0x6a +48` is non-zero.
* Added an existing-layout regression where mirror and canonical values agree.
* Ran focused OMNIC reader and metadata characterization tests.

## Scope

Only optical-velocity sourcing and minimal supporting parser logic.