### PR TITLE
FIX: correct OMNIC SPA metadata semantics

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -86,7 +86,9 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
-ENH: modernize the OMNIC SPA reader using validated native-format semantics.
+ENH: modernize the OMNIC SPA reader using validated native-format semantics,
+including structured key-table parsing and corrected Experiment Information,
+Raman-frequency, and acquisition-date metadata.
 
 MAINT: Added a centralized reserved-root-symbol policy
 (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -57,7 +57,9 @@ Deprecations
 Developer
 ~~~~~~~~~
 
-ENH: modernize the OMNIC SPA reader using validated native-format semantics.
+ENH: modernize the OMNIC SPA reader using validated native-format semantics,
+including structured key-table parsing and corrected Experiment Information,
+Raman-frequency, and acquisition-date metadata.
 
 MAINT: Added a centralized reserved-root-symbol policy
 (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -939,18 +939,9 @@ def _read_spa(*args, **kwargs):
     # renaming has been done in the OS.
     spa_name = _readbtext(fid, 30, 256)
 
-    # The acquisition date (GMT) is at hex 128 = decimal 296.
-    # Second since 31/12/1899, 00:00
+    # The raw acquisition-time value is at file offset 296.
     fid.seek(296)
-    timestamp = fromfile(fid, dtype="uint32", count=1)
-    acqdate = datetime(1899, 12, 31, 0, 0, tzinfo=UTC) + timedelta(
-        seconds=int(timestamp),
-    )
-    acquisitiondate = acqdate
-
-    # Transform back to timestamp for storage in the Coord object
-    # use datetime.fromtimestamp(d, timezone.utc)) to transform back to datetime object
-    timestamp = acqdate.timestamp()
+    raw_timestamp = int(fromfile(fid, dtype="uint32", count=1))
 
     # The active key table is counted at +294 and consists of 16-byte records
     # beginning at +304. Terminators, padding, and post-table variant data are
@@ -961,6 +952,16 @@ def _read_spa(*args, **kwargs):
     #
 
     records = _read_spa_key_table(fid)
+    is_library_variant = any(record.key == 0x53 for record in records)
+    if is_library_variant:
+        acquisitiondate = None
+        timestamp = 0.0
+    else:
+        acqdate = datetime(1899, 12, 31, 0, 0, tzinfo=UTC) + timedelta(
+            seconds=raw_timestamp,
+        )
+        acquisitiondate = acqdate
+        timestamp = acqdate.timestamp()
     spa_comments = []  # several custom comments can be present
     _exp_info = None
     optical_velocity = None
@@ -1018,12 +1019,15 @@ def _read_spa(*args, **kwargs):
     else:
         title = "acquisition timestamp (GMT)"  # no ambiguity here
 
-    _y = Coord(
-        [timestamp],
-        title=title,
-        units="s",
-        labels=([acquisitiondate], [filename]),
-    )
+    if acquisitiondate is None:
+        _y = Coord([0], title="spectrum", units=None, labels=([None], [filename]))
+    else:
+        _y = Coord(
+            [timestamp],
+            title=title,
+            units="s",
+            labels=([acquisitiondate], [filename]),
+        )
 
     # useful when a part of the spectrum/ifg has been blanked:
     dataset.mask = np.isnan(dataset.data)
@@ -1068,7 +1072,7 @@ def _read_spa(*args, **kwargs):
     dataset.set_coordset(y=_y, x=_x)
     dataset.name = spa_name  # to be consistent with omnic behaviour
     dataset.filename = filename
-    if return_ifg != "background":
+    if return_ifg != "background" and acquisitiondate is not None:
         dataset.acquisition_date = acquisitiondate
     dataset.origin = "omnic"
 
@@ -1096,7 +1100,13 @@ def _read_spa(*args, **kwargs):
         # Retain compatibility with supported files that do not carry 0x6a.
         optical_velocity = info["optical_velocity"]
     dataset.meta.optical_velocity = optical_velocity
-    dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
+    if info["xtitle"] == "raman shift":
+        dataset.meta.laser_frequency = info["raman_excitation_frequency"] * ur("cm^-1")
+        dataset.meta.omnic_reference_frequency = info["reference_frequency"] * ur(
+            "cm^-1"
+        )
+    else:
+        dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
     dataset.meta.sample_spacing = info["sample_spacing"]
 
     if _exp_info is not None:
@@ -1758,6 +1768,8 @@ def _read_header(fid, pos, is_first_spectrum=True):
     out["reference_frequency"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 84)
     out["sample_spacing"] = fromfile(fid, "float32", 1)
+    fid.seek(pos + 96)
+    out["raman_excitation_frequency"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 188)
     out["optical_velocity"] = fromfile(fid, "float32", 1)
 
@@ -1931,39 +1943,35 @@ def _decode_experiment_info_block(data: bytes) -> dict | None:
     Returns
     -------
     dict or None
-        Dictionary with keys ``experiment_path``, ``experiment_file``,
-        ``accessory_name``, and/or ``experiment_title``, or None if the
-        block is not a valid subtype 0x79 block.
+        Dictionary with fixed-slot subtype-0x79 fields, or None if the block
+        is not a supported subtype.
     """
-    if len(data) < 50 or data[0] != 0x79:
+    if not data or data[0] != 0x79:
         return None
 
-    # Payload starts at byte 10 (10-byte header).
-    # Null-terminated fields appear sequentially:
-    #   [0] experiment_path   — full Windows path
-    #   [1] experiment_file   — experiment file name stored in the 0x79 block
-    #   [2] accessory_name    — accessory / compartment name
-    #   [3] experiment_title  — experiment description
-    payload = data[10:]
-    raw = payload.split(b"\x00")
-
-    decoded = [
-        f.decode("utf-8", errors="replace").strip("\x00").strip() for f in raw if f
-    ]
-
-    if not decoded:
-        return None
-
-    _FIELD_NAMES = [
-        "experiment_path",
-        "experiment_file",
-        "accessory_name",
-        "experiment_title",
-    ]
+    def _read_slot(start, end):
+        if start >= len(data):
+            return None
+        slot = data[start : min(end, len(data))]
+        value = slot.split(b"\x00", 1)[0]
+        if not value:
+            return None
+        return value.decode("utf-8", errors="replace").strip()
 
     result: dict[str, str] = {}
-    for i in range(min(len(decoded), len(_FIELD_NAMES))):
-        if decoded[i]:
-            result[_FIELD_NAMES[i]] = decoded[i]
+    for name, start, end in (
+        ("experiment_path", 10, 90),
+        ("experiment_title", 90, 154),
+        ("experiment_description", 154, 413),
+        ("accessory_name", 413, 670),
+    ):
+        value = _read_slot(start, end)
+        if value:
+            result[name] = value
 
-    return result
+    # Retain the historical key as a compatibility alias for the native title
+    # slot while exposing the corrected fixed-anchor names above.
+    if "experiment_title" in result:
+        result["experiment_file"] = result["experiment_title"]
+
+    return result or None

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -952,7 +952,13 @@ def _read_spa(*args, **kwargs):
     #
 
     records = _read_spa_key_table(fid)
-    is_library_variant = any(record.key == 0x53 for record in records)
+    has_library_text = any(record.key == 0x53 for record in records)
+    fid.seek(304 + 16 * len(records))
+    post_table_key = fid.read(1)
+    # This is the discriminator for the observed validated library/retrieved
+    # layout: 0x53 together with the post-table 0x01 grid. It is not a
+    # universal semantic interpretation of either structure.
+    is_library_variant = has_library_text and post_table_key == b"\x01"
     if is_library_variant:
         acquisitiondate = None
         timestamp = 0.0
@@ -1968,10 +1974,5 @@ def _decode_experiment_info_block(data: bytes) -> dict | None:
         value = _read_slot(start, end)
         if value:
             result[name] = value
-
-    # Retain the historical key as a compatibility alias for the native title
-    # slot while exposing the corrected fixed-anchor names above.
-    if "experiment_title" in result:
-        result["experiment_file"] = result["experiment_title"]
 
     return result or None

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -48,6 +48,20 @@ def test_read_omnic_local_wodger():
     assert str(nd1.y.units) == "s"
 
 
+def test_read_spg_experiment_info_uses_native_fixed_slots():
+    dataset = scp.read_spg(WODGER, sortbydate=False)
+
+    assert dataset.meta.omnic_experiment_path == (
+        r"C:\MYDOCU~1\omnic\Param\VLADIM~1.EXP"
+    )
+    assert dataset.meta.omnic_experiment_title == "Transmission"
+    assert dataset.meta.omnic_experiment_description == (
+        "This is the default experiment file."
+    )
+    assert dataset.meta.omnic_accessory_name == "None"
+    assert dataset.meta.omnic_experiment_file is None
+
+
 @pytest.mark.usefixtures("_skip_if_no_testdata")
 def test_read_omnic():
     # Class method opening a dialog (but for test it is preset)

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -287,6 +287,8 @@ def _synthetic_spa_with_optical_velocity(
     struct.pack_into("<I", content, 296, timestamp)
     for offset, (key, position, length) in zip((304, 320, 336), records):
         struct.pack_into("<BBII", content, offset, key, 0, position, length)
+    if library:
+        content[304 + 16 * len(records)] = 1
 
     header = 400
     struct.pack_into("<I", content, header + 4, 2)
@@ -404,7 +406,6 @@ def test_decode_experiment_info_block():
     result = _decode_experiment_info_block(block)
     assert result is not None
     assert result["experiment_path"] == r"C:\MYDOCU~1\omnic\Param\CARROU~2.EXP"
-    assert result["experiment_file"] == "CARROU~2.EXP"
     assert result["accessory_name"] == "iS50 Main Sample"
     assert result["experiment_title"] == "CARROU~2.EXP"
     assert (
@@ -424,7 +425,6 @@ def test_decode_experiment_info_block():
     assert result["experiment_path"] == "path"
     assert result["experiment_description"] == "description"
     assert result["accessory_name"] == "accessory"
-    assert "experiment_file" not in result
     assert "experiment_title" not in result
 
     # Short blocks are safely bounded and return available fields only.

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -259,7 +259,16 @@ def test_read_spa_key_table_rejects_truncated_table():
         _read_spa_key_table(io.BytesIO(content))
 
 
-def _synthetic_spa_with_optical_velocity(mirror, canonical=None):
+def _synthetic_spa_with_optical_velocity(
+    mirror,
+    canonical=None,
+    *,
+    xunits=1,
+    reference_frequency=15798.0,
+    raman_frequency=0.0,
+    timestamp=0,
+    library=False,
+):
     """Build a minimal SPA with optional canonical optical-velocity metadata."""
     content = bytearray(768)
     content[:18] = b"Spectral Data File"
@@ -268,20 +277,26 @@ def _synthetic_spa_with_optical_velocity(mirror, canonical=None):
     records = [(2, 400, 140)]
     if canonical is not None:
         records.append((106, 700, 56))
+    if library:
+        records.append((0x53, 0, 0))
     payload_position = 756 if canonical is not None else 700
+    if library and canonical is None:
+        payload_position = 700
     records.append((3, payload_position, 8))
     struct.pack_into("<H", content, 294, len(records))
+    struct.pack_into("<I", content, 296, timestamp)
     for offset, (key, position, length) in zip((304, 320, 336), records):
         struct.pack_into("<BBII", content, offset, key, 0, position, length)
 
     header = 400
     struct.pack_into("<I", content, header + 4, 2)
-    content[header + 8] = 1
+    content[header + 8] = xunits
     content[header + 12] = 17
     struct.pack_into("<ff", content, header + 16, 4000.0, 3999.0)
     struct.pack_into("<I", content, header + 68, 100)
-    struct.pack_into("<f", content, header + 80, 15798.0)
+    struct.pack_into("<f", content, header + 80, reference_frequency)
     struct.pack_into("<f", content, header + 84, 1.0)
+    struct.pack_into("<f", content, header + 96, raman_frequency)
     struct.pack_into("<f", content, header + 188, mirror)
     if canonical is not None:
         struct.pack_into("<f", content, 700 + 48, canonical)
@@ -319,6 +334,47 @@ def test_spa_falls_back_to_mirror_without_canonical_parameters(tmp_path):
     assert dataset.meta.optical_velocity == pytest.approx(8.8617)
 
 
+def test_spa_raman_uses_excitation_and_preserves_reference_frequency(tmp_path):
+    from spectrochempy.core.units import ur
+
+    path = tmp_path / "raman.spa"
+    path.write_bytes(
+        _synthetic_spa_with_optical_velocity(
+            8.8617,
+            xunits=0x20,
+            reference_frequency=15798.2,
+            raman_frequency=9395.0,
+        )
+    )
+
+    dataset = scp.read_spa(path)
+
+    assert dataset.meta.laser_frequency.to(ur("cm^-1")).magnitude == pytest.approx(
+        9395.0
+    )
+    assert dataset.meta.omnic_reference_frequency.to(
+        ur("cm^-1")
+    ).magnitude == pytest.approx(15798.2)
+    np.testing.assert_allclose(dataset.x.data, [4000.0, 3999.0])
+
+
+def test_spa_library_timestamp_is_not_promoted(tmp_path):
+    path = tmp_path / "library.spa"
+    path.write_bytes(
+        _synthetic_spa_with_optical_velocity(
+            8.8617,
+            timestamp=1577962800,
+            library=True,
+        )
+    )
+
+    dataset = scp.read_spa(path)
+
+    assert dataset.acquisition_date is None
+    assert dataset.y.title == "spectrum"
+    assert dataset.y.labels[0, 0] is None
+
+
 def test_allow_inconsistent_x_parameter_documented():
     assert "allow_inconsistent_x" in scp.read_spg.__doc__
     assert "allow_inconsistent_x" in scp.read_omnic.__doc__
@@ -326,69 +382,98 @@ def test_allow_inconsistent_x_parameter_documented():
 
 
 def test_decode_experiment_info_block():
-    """_decode_experiment_info_block correctly decodes 0x79 blocks."""
+    """Decode native fixed-slot subtype-0x79 Experiment Information blocks."""
     from spectrochempy.core.readers.read_omnic import _decode_experiment_info_block
 
-    # Helper to build a 0x79 block
-    def _build_block(*fields):
-        payload = b"\x00".join(f.encode("utf-8") for f in fields) + b"\x00"
-        header = bytes([0x79, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00])
-        block = header + payload
-        if len(block) < 60:
-            block += b"\x00" * (60 - len(block))
-        return block
+    def _build_block(fields, size=700, subtype=0x79):
+        block = bytearray(size)
+        block[0] = subtype
+        for offset, value in fields.items():
+            encoded = value.encode("utf-8") + b"\x00"
+            block[offset : offset + len(encoded)] = encoded
+        return bytes(block)
 
-    # Normal 4-field block
     block = _build_block(
-        r"C:\MYDOCU~1\omnic\Param\CARROU~2.EXP",
-        "CARROU~2.EXP",
-        "iS50 Main Sample",
-        "Default experiment for iS50 Main Sample Compartment",
+        {
+            10: r"C:\MYDOCU~1\omnic\Param\CARROU~2.EXP",
+            90: "CARROU~2.EXP",
+            154: "Default experiment for iS50 Main Sample Compartment",
+            413: "iS50 Main Sample",
+        }
     )
     result = _decode_experiment_info_block(block)
     assert result is not None
     assert result["experiment_path"] == r"C:\MYDOCU~1\omnic\Param\CARROU~2.EXP"
     assert result["experiment_file"] == "CARROU~2.EXP"
     assert result["accessory_name"] == "iS50 Main Sample"
+    assert result["experiment_title"] == "CARROU~2.EXP"
     assert (
-        result["experiment_title"]
+        result["experiment_description"]
         == "Default experiment for iS50 Main Sample Compartment"
     )
 
-    # Subtype 0x9e (System Status) -> None
+    # Unsupported subtype is ignored.
     bad = bytearray(block)
     bad[0] = 0x9E
     assert _decode_experiment_info_block(bytes(bad)) is None
 
-    # Too short -> None
-    assert _decode_experiment_info_block(b"\x00" * 40) is None
-
-    # Single field -> experiment_path only
-    block = _build_block(r"C:\path\to\file.spa")
+    # Empty middle slot does not compact later fixed fields.
+    block = _build_block({10: "path", 154: "description", 413: "accessory"})
     result = _decode_experiment_info_block(block)
     assert result is not None
-    assert result["experiment_path"] == r"C:\path\to\file.spa"
+    assert result["experiment_path"] == "path"
+    assert result["experiment_description"] == "description"
+    assert result["accessory_name"] == "accessory"
     assert "experiment_file" not in result
-    assert "accessory_name" not in result
     assert "experiment_title" not in result
 
-    # Three fields without title
-    block = _build_block(r"C:\ATR\crystal.exp", "crystal.exp", "ATR Crystal")
-    result = _decode_experiment_info_block(block)
-    assert result is not None
-    assert result["experiment_path"] == r"C:\ATR\crystal.exp"
-    assert result["experiment_file"] == "crystal.exp"
-    assert result["accessory_name"] == "ATR Crystal"
-    assert "experiment_title" not in result
+    # Short blocks are safely bounded and return available fields only.
+    result = _decode_experiment_info_block(_build_block({10: "short"}, size=40))
+    assert result == {"experiment_path": "short"}
 
-    # Unix-style path in field 0
-    block = _build_block("/home/omnic/param/test.exp", "test.exp", "iS50 Sample")
-    result = _decode_experiment_info_block(block)
-    assert result is not None
-    assert result["experiment_path"] == "/home/omnic/param/test.exp"
-    assert result["experiment_file"] == "test.exp"
-    assert result["accessory_name"] == "iS50 Sample"
-    assert "experiment_title" not in result
+
+def _synthetic_spa_with_experiment_blocks(blocks):
+    content = bytearray(5000)
+    content[:18] = b"Spectral Data File"
+    content[30:42] = b"synthetic.spa"
+    records = [(2, 400, 140)]
+    for index, block in enumerate(blocks):
+        position = 700 + index * 800
+        records.append((130, position, len(block)))
+        content[position : position + len(block)] = block
+    records.append((3, 4000, 8))
+    struct.pack_into("<H", content, 294, len(records))
+    for offset, (key, position, length) in zip(
+        range(304, 304 + 16 * len(records), 16), records
+    ):
+        struct.pack_into("<BBII", content, offset, key, 0, position, length)
+    header = 400
+    struct.pack_into("<I", content, header + 4, 2)
+    content[header + 8] = 1
+    content[header + 12] = 17
+    struct.pack_into("<ff", content, header + 16, 4000.0, 3999.0)
+    struct.pack_into("<I", content, header + 68, 100)
+    struct.pack_into("<f", content, header + 80, 15798.0)
+    struct.pack_into("<f", content, header + 84, 1.0)
+    struct.pack_into("<ff", content, 4000, 1.0, 2.0)
+    return bytes(content)
+
+
+def test_spa_uses_later_79_after_unsupported_82(tmp_path):
+    path = tmp_path / "experiment-info.spa"
+    unsupported = bytes([0x9D]) + b"\x00" * 699
+    supported = bytearray(700)
+    supported[0] = 0x79
+    supported[10:18] = b"native\x00\x00"
+    supported[90:99] = b"title\x00\x00\x00"
+    path.write_bytes(
+        _synthetic_spa_with_experiment_blocks([unsupported, bytes(supported)])
+    )
+
+    dataset = scp.read_spa(path)
+
+    assert dataset.meta.omnic_experiment_path == "native"
+    assert dataset.meta.omnic_experiment_title == "title"
 
 
 @pytest.mark.skip(reason="Requires an SPG file with inconsistent x-axes (#863)")

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -333,8 +333,8 @@ class TestOmnicCharacterization:
         # from the expected list.
         if dataset.meta.omnic_experiment_path is not None:
             assert isinstance(dataset.meta.omnic_experiment_path, str)
-        if dataset.meta.omnic_experiment_file is not None:
-            assert isinstance(dataset.meta.omnic_experiment_file, str)
+        if dataset.meta.omnic_experiment_description is not None:
+            assert isinstance(dataset.meta.omnic_experiment_description, str)
         if dataset.meta.omnic_accessory is not None:
             assert isinstance(dataset.meta.omnic_accessory, str)
         if dataset.meta.omnic_experiment_title is not None:
@@ -363,8 +363,8 @@ class TestOmnicCharacterization:
         )
         if dataset.meta.omnic_experiment_path is not None:
             assert isinstance(dataset.meta.omnic_experiment_path, str)
-        if dataset.meta.omnic_experiment_file is not None:
-            assert isinstance(dataset.meta.omnic_experiment_file, str)
+        if dataset.meta.omnic_experiment_description is not None:
+            assert isinstance(dataset.meta.omnic_experiment_description, str)
         if dataset.meta.omnic_accessory is not None:
             assert isinstance(dataset.meta.omnic_accessory, str)
         if dataset.meta.omnic_experiment_title is not None:


### PR DESCRIPTION
## Experiment Information

Native subtype `0x79` now uses validated fixed-slot decoding; unsupported subtypes are not misinterpreted, and later supported `0x79` records remain discoverable. The historical `experiment_file` alias is not retained because native `+90` is title/name text, not a universally established filename field.

The public `wodger.spg` fixture contains four `0x82` blocks: two `0x9e` system-status blocks and two `0x79` blocks. Its native `+10/+90/+154/+413/+670` values confirm the same fixed-slot layout for the shared SPG decoder.

## Raman

Reference and Raman excitation frequencies are distinguished correctly. Raman `laser_frequency` uses `+96`, while `+80` remains available as `meta.omnic_reference_frequency`.

## Library/retrieved timestamps

The controlled examined corpus contains `0x53` in all five library-derived files and in no examined ordinary acquired file; all five also have the post-table `0x01` grid. The reader uses that observed combination as the validated-corpus discriminator without assigning universal semantics to `0x53`.

## Tests

Added native-layout Experiment Information tests, a value-level public SPG fixed-slot regression, Raman metadata/X-axis tests, library timestamp tests, and retained the existing OMNIC reader regression coverage.

## Scope

Metadata correctness only; broader metadata exposure, First/Last X naming, and peak/ZPD cleanup are deferred.