### PR TITLE
ENH: expose validated OMNIC SPA acquisition metadata

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -27,7 +27,13 @@ New Features
   ``fitted_named_steps_``); ``transform`` / ``fit_transform`` are available
   for transformer-final pipelines and ``predict`` / ``score`` for
   estimator-final pipelines, with nested ``set_params`` support and fitted-state
-  invalidation.
+   invalidation.
+
+- OMNIC SPA imports now expose corrected Experiment Information,
+  Raman reference/excitation metadata, and validated acquisition metadata for
+  scan geometry, gains, filters, aperture, and digitizer settings where
+  available; invalid library/retrieved timestamps are not promoted as
+  acquisition dates. (#1605, #1606)
 
 .. section
 
@@ -86,9 +92,10 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
-ENH: modernize the OMNIC SPA reader using validated native-format semantics,
-including structured key-table parsing and corrected Experiment Information,
-Raman-frequency, and acquisition-date metadata.
+MAINT: Continue modernizing the OMNIC SPA reader around the validated
+native-format model, including counted key-table parsing, shared native-block
+dispatch, consolidated acquisition-parameter parsing, and clearer internal
+coordinate/peak terminology. (#1604, #1605, #1606)
 
 MAINT: Added a centralized reserved-root-symbol policy
 (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -23,7 +23,13 @@ New Features
   ``fitted_named_steps_``); ``transform`` / ``fit_transform`` are available
   for transformer-final pipelines and ``predict`` / ``score`` for
   estimator-final pipelines, with nested ``set_params`` support and fitted-state
-  invalidation.
+   invalidation.
+
+- OMNIC SPA imports now expose corrected Experiment Information,
+  Raman reference/excitation metadata, and validated acquisition metadata for
+  scan geometry, gains, filters, aperture, and digitizer settings where
+  available; invalid library/retrieved timestamps are not promoted as
+  acquisition dates. (#1605, #1606)
 
 Bug Fixes
 ~~~~~~~~~
@@ -57,9 +63,10 @@ Deprecations
 Developer
 ~~~~~~~~~
 
-ENH: modernize the OMNIC SPA reader using validated native-format semantics,
-including structured key-table parsing and corrected Experiment Information,
-Raman-frequency, and acquisition-date metadata.
+MAINT: Continue modernizing the OMNIC SPA reader around the validated
+native-format model, including counted key-table parsing, shared native-block
+dispatch, consolidated acquisition-parameter parsing, and clearer internal
+coordinate/peak terminology. (#1604, #1605, #1606)
 
 MAINT: Added a centralized reserved-root-symbol policy
 (``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -1103,34 +1103,29 @@ def _read_spa(*args, **kwargs):
         # Retain compatibility with supported files that do not carry 0x6a.
         optical_velocity = info["optical_velocity"]
     dataset.meta.optical_velocity = optical_velocity
+    dataset.meta.reference_frequency = info["reference_frequency"] * ur("cm^-1")
     if info["xtitle"] == "raman shift":
         dataset.meta.laser_frequency = info["raman_excitation_frequency"] * ur("cm^-1")
-        dataset.meta.omnic_reference_frequency = info["reference_frequency"] * ur(
-            "cm^-1"
-        )
     else:
         dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
     dataset.meta.sample_spacing = info["sample_spacing"]
 
     if not is_library_variant:
-        dataset.meta.omnic_scan_points = int(info["scan_points"])
-        dataset.meta.omnic_interferogram_peak_position = int(info["peak_position"])
-        dataset.meta.omnic_sample_scans = int(info["sample_scans"])
-        dataset.meta.omnic_background_scans = int(info["background_scans"])
-        dataset.meta.omnic_fft_points = int(info["fft_points"])
-        dataset.meta.omnic_background_gain = float(info["background_gain"])
-        dataset.meta.omnic_aperture = float(info["aperture"])
-        for name in ("digitizer_bits", "sample_gain"):
-            if name in acquisition_parameters:
-                setattr(
-                    dataset.meta, f"omnic_{name}", int(acquisition_parameters[name])
-                )
+        dataset.meta.scan_points = int(info["scan_points"])
+        dataset.meta.interferogram_peak_position = int(info["peak_position"])
+        dataset.meta.sample_scans = int(info["sample_scans"])
+        dataset.meta.background_scans = int(info["background_scans"])
+        dataset.meta.fft_points = int(info["fft_points"])
+        dataset.meta.background_gain = float(info["background_gain"])
+        dataset.meta.aperture = float(info["aperture"])
+        if "digitizer_bits" in acquisition_parameters:
+            dataset.meta.digitizer_bits = int(acquisition_parameters["digitizer_bits"])
+        if "sample_gain" in acquisition_parameters:
+            dataset.meta.sample_gain = float(acquisition_parameters["sample_gain"])
         for name in ("high_pass", "low_pass"):
             if name in acquisition_parameters:
                 setattr(
-                    dataset.meta,
-                    f"omnic_{name}",
-                    acquisition_parameters[name] * ur("cm^-1"),
+                    dataset.meta, f"{name}_filter", float(acquisition_parameters[name])
                 )
 
     if _exp_info is not None:

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -13,6 +13,7 @@ __all__ = ["read_omnic", "read_spg", "read_spa", "read_srs"]
 
 import io
 import re
+import struct
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timedelta
@@ -970,7 +971,7 @@ def _read_spa(*args, **kwargs):
         timestamp = acqdate.timestamp()
     spa_comments = []  # several custom comments can be present
     _exp_info = None
-    optical_velocity = None
+    acquisition_parameters = {}
     for record in records:
         key = record.key
 
@@ -994,12 +995,7 @@ def _read_spa(*args, **kwargs):
             b_ifg_intensities = _read_spa_float32_payload(fid, record)
 
         elif key == 106:
-            # The 0x6a block is the canonical source for acquisition
-            # parameters.  The 0x02 header contains a variant-dependent mirror
-            # at +188, but newer layouts may leave that mirror blank.
-            if record.length >= 52:
-                fid.seek(record.position + 48)
-                optical_velocity = fromfile(fid, "float32", 1)
+            acquisition_parameters.update(_read_spa_acquisition_parameters(fid, record))
 
         elif key == 130 and _exp_info is None and record.length >= 50:
             fid.seek(record.position)
@@ -1045,14 +1041,14 @@ def _read_spa(*args, **kwargs):
 
         # now add coordinates
         nx = info["nx"]
-        firstx = info["firstx"]
-        lastx = info["lastx"]
+        native_last_x = info["native_last_x"]
+        native_first_x = info["native_first_x"]
         xunit = info["xunits"]
         xtitle = info["xtitle"]
 
         _x = Coord.linspace(
-            firstx,
-            lastx,
+            native_last_x,
+            native_first_x,
             int(nx),
             title=xtitle,
             units=xunit,
@@ -1102,6 +1098,7 @@ def _read_spa(*args, **kwargs):
     dataset._date = utcnow()
 
     dataset.meta.collection_length = info["collection_length"] / 100 * ur("s")
+    optical_velocity = acquisition_parameters.get("optical_velocity")
     if optical_velocity is None:
         # Retain compatibility with supported files that do not carry 0x6a.
         optical_velocity = info["optical_velocity"]
@@ -1115,6 +1112,27 @@ def _read_spa(*args, **kwargs):
         dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
     dataset.meta.sample_spacing = info["sample_spacing"]
 
+    if not is_library_variant:
+        dataset.meta.omnic_scan_points = int(info["scan_points"])
+        dataset.meta.omnic_interferogram_peak_position = int(info["peak_position"])
+        dataset.meta.omnic_sample_scans = int(info["sample_scans"])
+        dataset.meta.omnic_background_scans = int(info["background_scans"])
+        dataset.meta.omnic_fft_points = int(info["fft_points"])
+        dataset.meta.omnic_background_gain = float(info["background_gain"])
+        dataset.meta.omnic_aperture = float(info["aperture"])
+        for name in ("digitizer_bits", "sample_gain"):
+            if name in acquisition_parameters:
+                setattr(
+                    dataset.meta, f"omnic_{name}", int(acquisition_parameters[name])
+                )
+        for name in ("high_pass", "low_pass"):
+            if name in acquisition_parameters:
+                setattr(
+                    dataset.meta,
+                    f"omnic_{name}",
+                    acquisition_parameters[name] * ur("cm^-1"),
+                )
+
     if _exp_info is not None:
         for meta_key, val in _exp_info.items():
             setattr(dataset.meta, f"omnic_{meta_key}", val)
@@ -1126,6 +1144,7 @@ def _read_spa(*args, **kwargs):
         # the native sample spacing (spacing = sample_spacing / (2 * nu)).
         dataset.meta.interferogram = True
         dataset.meta.td = list(dataset.shape)
+        # This is the data-derived peak index, not formal physical ZPD.
         dataset.x._zpd = int(np.argmax(dataset)[-1])
         dataset.x.set_laser_frequency(
             frequency=info["reference_frequency"], sample_spacing=info["sample_spacing"]
@@ -1642,7 +1661,7 @@ def _read_header(fid, pos, is_first_spectrum=True):
         - last x value (float32), 20 bytes behind
         - ... unknown
         - scan points (UInt32), 28 bytes behind
-        - zpd (UInt32),  32 bytes behind
+        - interferogram peak position (UInt32), 32 bytes behind
         - number of scans (UInt32), 36 bytes behind
         - ... unknown
         - number of background scans (UInt32), 52 bytes behind
@@ -1754,26 +1773,41 @@ def _read_header(fid, pos, is_first_spectrum=True):
                 f"The nature of data is not recognized (key == {key}), title set to 'Intensity'"
             )
 
-    # firstx, lastx
+    # Native endpoint names follow OMNIC terminology: +16 is Last X and +20
+    # is First X. Historical aliases are retained for the shared readers.
     fid.seek(pos + 16)
-    out["firstx"] = fromfile(fid, "float32", 1)
+    out["native_last_x"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 20)
-    out["lastx"] = fromfile(fid, "float32", 1)
+    out["native_first_x"] = fromfile(fid, "float32", 1)
+    out["firstx"] = out["native_last_x"]
+    out["lastx"] = out["native_first_x"]
     fid.seek(pos + 28)
 
-    out["scan_pts"] = fromfile(fid, "uint32", 1)
+    out["scan_points"] = fromfile(fid, "uint32", 1)
+    out["scan_pts"] = out["scan_points"]
     fid.seek(pos + 32)
-    out["zpd"] = fromfile(fid, "uint32", 1)
+    out["peak_position"] = fromfile(fid, "uint32", 1)
+    out["zpd"] = out["peak_position"]
     fid.seek(pos + 36)
-    out["nscan"] = fromfile(fid, "uint32", 1)
+    out["sample_scans"] = fromfile(fid, "uint32", 1)
+    out["nscan"] = out["sample_scans"]
+    fid.seek(pos + 44)
+    out["fft_points"] = fromfile(fid, "uint32", 1)
+    fid.seek(pos + 48)
+    out["trailing_geometry"] = fromfile(fid, "uint32", 1)
     fid.seek(pos + 52)
-    out["nbkgscan"] = fromfile(fid, "uint32", 1)
+    out["background_scans"] = fromfile(fid, "uint32", 1)
+    out["nbkgscan"] = out["background_scans"]
+    fid.seek(pos + 56)
+    out["background_gain"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 68)
     out["collection_length"] = fromfile(fid, "uint32", 1)
     fid.seek(pos + 80)
     out["reference_frequency"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 84)
     out["sample_spacing"] = fromfile(fid, "float32", 1)
+    fid.seek(pos + 92)
+    out["aperture"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 96)
     out["raman_excitation_frequency"] = fromfile(fid, "float32", 1)
     fid.seek(pos + 188)
@@ -1919,6 +1953,26 @@ def _read_spa_float32_payload(fid, record):
     """Read a float32 payload referenced by an SPA key record."""
     fid.seek(record.position)
     return fromfile(fid, "float32", int(record.length / 4))
+
+
+def _read_spa_acquisition_parameters(fid, record):
+    """Read mature acquisition fields from the canonical 0x6a block."""
+    if record.length < 20:
+        return {}
+    fid.seek(record.position)
+    data = fid.read(record.length)
+    parameters = {}
+
+    if len(data) >= 20:
+        parameters["digitizer_bits"] = struct.unpack_from("<I", data, 16)[0]
+    if len(data) >= 28:
+        parameters["high_pass"] = struct.unpack_from("<f", data, 20)[0]
+        parameters["low_pass"] = struct.unpack_from("<f", data, 24)[0]
+    if len(data) >= 48:
+        parameters["sample_gain"] = struct.unpack_from("<f", data, 44)[0]
+    if len(data) >= 52:
+        parameters["optical_velocity"] = struct.unpack_from("<f", data, 48)[0]
+    return parameters
 
 
 def _getintensities(fid, pos):

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -282,6 +282,18 @@ def _synthetic_spa_with_optical_velocity(
     raman_frequency=0.0,
     timestamp=0,
     library=False,
+    scan_points=0,
+    peak_position=0,
+    sample_scans=0,
+    fft_points=0,
+    trailing_geometry=0,
+    background_scans=0,
+    background_gain=0.0,
+    aperture=0.0,
+    digitizer_bits=0,
+    high_pass=0.0,
+    low_pass=0.0,
+    sample_gain=0.0,
 ):
     """Build a minimal SPA with optional canonical optical-velocity metadata."""
     content = bytearray(768)
@@ -309,12 +321,24 @@ def _synthetic_spa_with_optical_velocity(
     content[header + 8] = xunits
     content[header + 12] = 17
     struct.pack_into("<ff", content, header + 16, 4000.0, 3999.0)
+    struct.pack_into("<I", content, header + 28, scan_points)
+    struct.pack_into("<I", content, header + 32, peak_position)
+    struct.pack_into("<I", content, header + 36, sample_scans)
+    struct.pack_into("<I", content, header + 44, fft_points)
+    struct.pack_into("<I", content, header + 48, trailing_geometry)
+    struct.pack_into("<I", content, header + 52, background_scans)
+    struct.pack_into("<f", content, header + 56, background_gain)
     struct.pack_into("<I", content, header + 68, 100)
     struct.pack_into("<f", content, header + 80, reference_frequency)
     struct.pack_into("<f", content, header + 84, 1.0)
+    struct.pack_into("<f", content, header + 92, aperture)
     struct.pack_into("<f", content, header + 96, raman_frequency)
     struct.pack_into("<f", content, header + 188, mirror)
     if canonical is not None:
+        struct.pack_into("<I", content, 700 + 16, digitizer_bits)
+        struct.pack_into("<f", content, 700 + 20, high_pass)
+        struct.pack_into("<f", content, 700 + 24, low_pass)
+        struct.pack_into("<f", content, 700 + 44, sample_gain)
         struct.pack_into("<f", content, 700 + 48, canonical)
     struct.pack_into("<ff", content, payload_position, 1.0, 2.0)
     return bytes(content)
@@ -348,6 +372,48 @@ def test_spa_falls_back_to_mirror_without_canonical_parameters(tmp_path):
     dataset = scp.read_spa(path)
 
     assert dataset.meta.optical_velocity == pytest.approx(8.8617)
+
+
+def test_spa_exposes_mature_acquisition_metadata(tmp_path):
+    from spectrochempy.core.units import ur
+
+    path = tmp_path / "acquisition-metadata.spa"
+    path.write_bytes(
+        _synthetic_spa_with_optical_velocity(
+            8.8617,
+            8.8617,
+            scan_points=1234,
+            peak_position=512,
+            sample_scans=8,
+            fft_points=4096,
+            trailing_geometry=2048,
+            background_scans=4,
+            background_gain=2.5,
+            aperture=75.0,
+            digitizer_bits=20,
+            high_pass=200.0,
+            low_pass=11000.0,
+            sample_gain=16.0,
+        )
+    )
+
+    dataset = scp.read_spa(path)
+
+    assert dataset.meta.omnic_scan_points == 1234
+    assert dataset.meta.omnic_interferogram_peak_position == 512
+    assert dataset.meta.omnic_sample_scans == 8
+    assert dataset.meta.omnic_background_scans == 4
+    assert dataset.meta.omnic_fft_points == 4096
+    assert dataset.meta.omnic_background_gain == pytest.approx(2.5)
+    assert dataset.meta.omnic_aperture == pytest.approx(75.0)
+    assert dataset.meta.omnic_digitizer_bits == 20
+    assert dataset.meta.omnic_sample_gain == pytest.approx(16.0)
+    assert dataset.meta.omnic_high_pass.to(ur("cm^-1")).magnitude == pytest.approx(
+        200.0
+    )
+    assert dataset.meta.omnic_low_pass.to(ur("cm^-1")).magnitude == pytest.approx(
+        11000.0
+    )
 
 
 def test_spa_raman_uses_excitation_and_preserves_reference_frequency(tmp_path):

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -375,8 +375,6 @@ def test_spa_falls_back_to_mirror_without_canonical_parameters(tmp_path):
 
 
 def test_spa_exposes_mature_acquisition_metadata(tmp_path):
-    from spectrochempy.core.units import ur
-
     path = tmp_path / "acquisition-metadata.spa"
     path.write_bytes(
         _synthetic_spa_with_optical_velocity(
@@ -393,27 +391,23 @@ def test_spa_exposes_mature_acquisition_metadata(tmp_path):
             digitizer_bits=20,
             high_pass=200.0,
             low_pass=11000.0,
-            sample_gain=16.0,
+            sample_gain=12.5,
         )
     )
 
     dataset = scp.read_spa(path)
 
-    assert dataset.meta.omnic_scan_points == 1234
-    assert dataset.meta.omnic_interferogram_peak_position == 512
-    assert dataset.meta.omnic_sample_scans == 8
-    assert dataset.meta.omnic_background_scans == 4
-    assert dataset.meta.omnic_fft_points == 4096
-    assert dataset.meta.omnic_background_gain == pytest.approx(2.5)
-    assert dataset.meta.omnic_aperture == pytest.approx(75.0)
-    assert dataset.meta.omnic_digitizer_bits == 20
-    assert dataset.meta.omnic_sample_gain == pytest.approx(16.0)
-    assert dataset.meta.omnic_high_pass.to(ur("cm^-1")).magnitude == pytest.approx(
-        200.0
-    )
-    assert dataset.meta.omnic_low_pass.to(ur("cm^-1")).magnitude == pytest.approx(
-        11000.0
-    )
+    assert dataset.meta.scan_points == 1234
+    assert dataset.meta.interferogram_peak_position == 512
+    assert dataset.meta.sample_scans == 8
+    assert dataset.meta.background_scans == 4
+    assert dataset.meta.fft_points == 4096
+    assert dataset.meta.background_gain == pytest.approx(2.5)
+    assert dataset.meta.aperture == pytest.approx(75.0)
+    assert dataset.meta.digitizer_bits == 20
+    assert dataset.meta.sample_gain == pytest.approx(12.5)
+    assert dataset.meta.high_pass_filter == pytest.approx(200.0)
+    assert dataset.meta.low_pass_filter == pytest.approx(11000.0)
 
 
 def test_spa_raman_uses_excitation_and_preserves_reference_frequency(tmp_path):
@@ -434,9 +428,9 @@ def test_spa_raman_uses_excitation_and_preserves_reference_frequency(tmp_path):
     assert dataset.meta.laser_frequency.to(ur("cm^-1")).magnitude == pytest.approx(
         9395.0
     )
-    assert dataset.meta.omnic_reference_frequency.to(
-        ur("cm^-1")
-    ).magnitude == pytest.approx(15798.2)
+    assert dataset.meta.reference_frequency.to(ur("cm^-1")).magnitude == pytest.approx(
+        15798.2
+    )
     np.testing.assert_allclose(dataset.x.data, [4000.0, 3999.0])
 
 


### PR DESCRIPTION
## User-visible metadata

SPA imports expose generic acquisition metadata using established scientific names:

* `scan_points`, `sample_scans`, `background_scans`, and `fft_points`;
* `interferogram_peak_position`;
* `sample_gain`, `background_gain`, and `aperture`;
* `digitizer_bits`, `high_pass_filter`, and `low_pass_filter`;
* generic `reference_frequency`;
* existing `sample_spacing`, `collection_length`, `optical_velocity`, and Raman `laser_frequency` behavior are preserved.

The canonical `0x6a` acquisition-parameter block is parsed once. Filter settings remain native numeric floats without attached units.

## OMNIC-specific metadata

Experiment Information remains under `omnic_experiment_path`, `omnic_experiment_title`, `omnic_experiment_description`, and `omnic_accessory_name`.

## Internal cleanup

SPA uses clearer native endpoint names (`native_last_x` / `native_first_x`) without changing coordinate orientation or values. Peak-position terminology is separated from the private data-derived `_zpd` origin mechanism.

## Changelog

The changelog has separate New Features and Developer entries. The `no-changelog` label is intentionally not applied.

## Tests

Added value-level acquisition metadata coverage, including fractional sample gain and unitless filter values, while retaining SPA, SPG, SRS, Raman, library-timestamp, optical-velocity, Experiment Information, sample-spacing, and coordinate regression coverage.

## Deferred

PR #4 will handle final Dataset/IFG construction cleanup, associated-IFG architecture, and broader unresolved format structures.