### PR TITLE
REL: refresh 0.12.8 release notes

### DIFF
--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -81,10 +81,13 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
 
-- OMNIC Experiment Information no longer exposes
-  ``dataset.meta.omnic_experiment_file``. Use
+- Removed ``dataset.meta.omnic_experiment_file`` from OMNIC Experiment
+  Information. Despite its name, this field exposed the native experiment
+  title rather than a reliable filename and could therefore provide incorrect
+  provenance information. It was removed as a metadata-correctness fix rather
+  than retained through the normal deprecation cycle. Use
   ``dataset.meta.omnic_experiment_title`` for the native title/name field;
-  it is not a reliable filename. The separate description is now exposed as
+  the separate description is available as
   ``dataset.meta.omnic_experiment_description``. (#1605)
 
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,19 +19,21 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
-- Added ``scp.Pipeline``, a public minimal Pipelines class for linear,
-  reproducible composition of SpectroChemPy estimators: allowlisted
+- Added ``scp.Pipeline`` for linear, reproducible composition of SpectroChemPy
+  estimators: allowlisted
   preprocessing transformers optionally followed by a final transformer
   (``PCA``) or a supervised estimator (``PLSRegression``, ``LSTSQ``, ``NNLS``).
   Steps are templates cloned on fit (``fitted_steps_`` /
   ``fitted_named_steps_``); ``transform`` / ``fit_transform`` are available
   for transformer-final pipelines and ``predict`` / ``score`` for
   estimator-final pipelines, with nested ``set_params`` support and fitted-state
-   invalidation.
+  invalidation. (#1590)
 
-- Improve OMNIC SPA imports with corrected Experiment Information and Raman
-  metadata, additional acquisition metadata, and proper handling of
-  library/retrieved files without valid acquisition timestamps.
+- OMNIC ``.spa`` imports now expose additional acquisition metadata in
+  ``dataset.meta`` when available for the file variant: scan and FFT point
+  counts, sample and background scan counts and gains, interferogram peak
+  position, aperture, digitizer bit depth, filter settings, and reference
+  frequency. (#1606)
 
 .. section
 
@@ -43,20 +45,27 @@ Bug Fixes
   integration function ``simpson(dataset, dim='x')``, even when a plugin
   contributes a SIMPSON I/O reader; ``scp.read_simpson`` and
   ``scp.nmr.read_simpson`` remain the explicit file-reading surfaces and
-  ``dataset.simpson()`` is unchanged.
-- Correct OMNIC ``.spa`` interferogram optical-path-difference coordinates by
+  ``dataset.simpson()`` is unchanged. (#1599)
+- Corrected OMNIC ``.spa`` interferogram optical-path-difference coordinates by
   honoring the native header sample-spacing factor instead of always assuming
-  a doubled step.
-- Correct OMNIC ``.spa`` optical-velocity metadata by using the canonical
-  acquisition-parameter block when the legacy header mirror is blank.
-- Correct OMNIC ``.srs`` series time-axis anchoring (it now starts from the
-  recorded series minimum time) and fix per-spectrum labels, which no longer
-  include binary metadata leaked past the 84-byte record.
-- Normalize OMNIC ``.srs`` spectral series to the public ``read_spa``
+  a doubled step. (#1598)
+- Corrected OMNIC SPA metadata decoding: optical velocity now comes from the
+  canonical acquisition-parameter block when available, with a fallback for
+  older files; Raman ``laser_frequency`` now reports the excitation frequency
+  separately from ``reference_frequency``. Experiment Information in SPA and
+  SPG files now correctly distinguishes the path, title, description, and
+  accessory fields. (#1603, #1605, #1606)
+- Recognized library/retrieved OMNIC ``.spa`` variants no longer receive a
+  spurious acquisition date. They use an undated spectrum coordinate instead
+  of interpreting a non-acquisition header value as a timestamp. (#1605)
+- Corrected OMNIC ``.srs`` series time-axis anchoring (it now starts from the
+  recorded series minimum time) and fixed per-spectrum labels, which no longer
+  include binary metadata leaked past the 84-byte record. (#1593)
+- Normalized OMNIC ``.srs`` spectral series to the public ``read_spa``
   convention: wavenumbers are exposed descending with the intensity data
   matched to them. Rapid-scan interferograms keep their ascending data-points
   axis and records with an unrecognized X-axis type are left unchanged with a
-  warning.
+  warning. (#1594, #1595)
 
 
 .. section
@@ -72,6 +81,12 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 .. Add here new breaking changes (do not delete this comment)
 
+- OMNIC Experiment Information no longer exposes
+  ``dataset.meta.omnic_experiment_file``. Use
+  ``dataset.meta.omnic_experiment_title`` for the native title/name field;
+  it is not a reliable filename. The separate description is now exposed as
+  ``dataset.meta.omnic_experiment_description``. (#1605)
+
 
 .. section
 
@@ -81,7 +96,7 @@ Deprecations
 
 - The ``reverse_x`` keyword argument of ``read_srs`` is deprecated: SRS
   spectral orientation is now handled automatically. Supplying it (with any
-  value) emits a ``DeprecationWarning`` and is ignored.
+  value) emits a ``DeprecationWarning`` and is ignored. (#1594, #1595)
 
 
 .. section
@@ -90,21 +105,18 @@ Developer
 ~~~~~~~~~
 .. Add here developer changes (do not delete this comment)
 
-MAINT: Refactor the OMNIC SPA reader with structured native parsing and clearer
-signal, coordinate, metadata, Dataset construction, and reader-documentation
-paths.
+MAINT: Refactored the OMNIC SPA reader to separate native parsing, signal
+selection, coordinate construction, metadata attachment, and dataset
+finalization, preserving spectral and standalone/associated interferogram
+reading modes. (#1604, #1606, #1607)
 
-MAINT: Added a centralized reserved-root-symbol policy
-(``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
+MAINT: Centralized the reserved-root-symbol policy so plugins cannot shadow
 public ``scp`` symbols; conflicting plugin I/O namespaces are rejected at
 registration with a controlled warning while the ``read_<format>`` reader
 remains available through its explicit surfaces. (#1599)
 
-MAINT: Added the internal estimator-contract helpers required by the
-``Pipeline`` implementation: allowlist-based fitted-state inspection,
-unfitted cloning, canonical not-fitted behavior for supported transformers,
-and opt-in lifecycle invalidation for the accepted analysis terminal
-candidates. (#1589)
+MAINT: Standardized fitted-state inspection, unfitted cloning, and lifecycle
+invalidation for the estimators supported by ``Pipeline``. (#1589)
 
-DOC: Added developer-guide references for the OMNIC SRS and SPA file
-formats. (#1596, #1597)
+DOC: Expanded the Pipeline user guide and documented the validated OMNIC SRS
+and SPA file layouts and SPA reader behavior. (#1592, #1596, #1597, #1602, #1607)

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -63,10 +63,13 @@ Bug Fixes
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- OMNIC Experiment Information no longer exposes
-  ``dataset.meta.omnic_experiment_file``. Use
+- Removed ``dataset.meta.omnic_experiment_file`` from OMNIC Experiment
+  Information. Despite its name, this field exposed the native experiment
+  title rather than a reliable filename and could therefore provide incorrect
+  provenance information. It was removed as a metadata-correctness fix rather
+  than retained through the normal deprecation cycle. Use
   ``dataset.meta.omnic_experiment_title`` for the native title/name field;
-  it is not a reliable filename. The separate description is now exposed as
+  the separate description is available as
   ``dataset.meta.omnic_experiment_description``. (#1605)
 
 Deprecations

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,19 +15,21 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
-- Added ``scp.Pipeline``, a public minimal Pipelines class for linear,
-  reproducible composition of SpectroChemPy estimators: allowlisted
+- Added ``scp.Pipeline`` for linear, reproducible composition of SpectroChemPy
+  estimators: allowlisted
   preprocessing transformers optionally followed by a final transformer
   (``PCA``) or a supervised estimator (``PLSRegression``, ``LSTSQ``, ``NNLS``).
   Steps are templates cloned on fit (``fitted_steps_`` /
   ``fitted_named_steps_``); ``transform`` / ``fit_transform`` are available
   for transformer-final pipelines and ``predict`` / ``score`` for
   estimator-final pipelines, with nested ``set_params`` support and fitted-state
-   invalidation.
+  invalidation. (#1590)
 
-- Improve OMNIC SPA imports with corrected Experiment Information and Raman
-  metadata, additional acquisition metadata, and proper handling of
-  library/retrieved files without valid acquisition timestamps.
+- OMNIC ``.spa`` imports now expose additional acquisition metadata in
+  ``dataset.meta`` when available for the file variant: scan and FFT point
+  counts, sample and background scan counts and gains, interferogram peak
+  position, aperture, digitizer bit depth, filter settings, and reference
+  frequency. (#1606)
 
 Bug Fixes
 ~~~~~~~~~
@@ -36,46 +38,59 @@ Bug Fixes
   integration function ``simpson(dataset, dim='x')``, even when a plugin
   contributes a SIMPSON I/O reader; ``scp.read_simpson`` and
   ``scp.nmr.read_simpson`` remain the explicit file-reading surfaces and
-  ``dataset.simpson()`` is unchanged.
-- Correct OMNIC ``.spa`` interferogram optical-path-difference coordinates by
+  ``dataset.simpson()`` is unchanged. (#1599)
+- Corrected OMNIC ``.spa`` interferogram optical-path-difference coordinates by
   honoring the native header sample-spacing factor instead of always assuming
-  a doubled step.
-- Correct OMNIC ``.spa`` optical-velocity metadata by using the canonical
-  acquisition-parameter block when the legacy header mirror is blank.
-- Correct OMNIC ``.srs`` series time-axis anchoring (it now starts from the
-  recorded series minimum time) and fix per-spectrum labels, which no longer
-  include binary metadata leaked past the 84-byte record.
-- Normalize OMNIC ``.srs`` spectral series to the public ``read_spa``
+  a doubled step. (#1598)
+- Corrected OMNIC SPA metadata decoding: optical velocity now comes from the
+  canonical acquisition-parameter block when available, with a fallback for
+  older files; Raman ``laser_frequency`` now reports the excitation frequency
+  separately from ``reference_frequency``. Experiment Information in SPA and
+  SPG files now correctly distinguishes the path, title, description, and
+  accessory fields. (#1603, #1605, #1606)
+- Recognized library/retrieved OMNIC ``.spa`` variants no longer receive a
+  spurious acquisition date. They use an undated spectrum coordinate instead
+  of interpreting a non-acquisition header value as a timestamp. (#1605)
+- Corrected OMNIC ``.srs`` series time-axis anchoring (it now starts from the
+  recorded series minimum time) and fixed per-spectrum labels, which no longer
+  include binary metadata leaked past the 84-byte record. (#1593)
+- Normalized OMNIC ``.srs`` spectral series to the public ``read_spa``
   convention: wavenumbers are exposed descending with the intensity data
   matched to them. Rapid-scan interferograms keep their ascending data-points
   axis and records with an unrecognized X-axis type are left unchanged with a
-  warning.
+  warning. (#1594, #1595)
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- OMNIC Experiment Information no longer exposes
+  ``dataset.meta.omnic_experiment_file``. Use
+  ``dataset.meta.omnic_experiment_title`` for the native title/name field;
+  it is not a reliable filename. The separate description is now exposed as
+  ``dataset.meta.omnic_experiment_description``. (#1605)
 
 Deprecations
 ~~~~~~~~~~~~
 
 - The ``reverse_x`` keyword argument of ``read_srs`` is deprecated: SRS
   spectral orientation is now handled automatically. Supplying it (with any
-  value) emits a ``DeprecationWarning`` and is ignored.
+  value) emits a ``DeprecationWarning`` and is ignored. (#1594, #1595)
 
 Developer
 ~~~~~~~~~
 
-MAINT: Refactor the OMNIC SPA reader with structured native parsing and clearer
-signal, coordinate, metadata, Dataset construction, and reader-documentation
-paths.
+MAINT: Refactored the OMNIC SPA reader to separate native parsing, signal
+selection, coordinate construction, metadata attachment, and dataset
+finalization, preserving spectral and standalone/associated interferogram
+reading modes. (#1604, #1606, #1607)
 
-MAINT: Added a centralized reserved-root-symbol policy
-(``spectrochempy/lazyimport/root_symbols.py``) so plugins cannot shadow
+MAINT: Centralized the reserved-root-symbol policy so plugins cannot shadow
 public ``scp`` symbols; conflicting plugin I/O namespaces are rejected at
 registration with a controlled warning while the ``read_<format>`` reader
 remains available through its explicit surfaces. (#1599)
 
-MAINT: Added the internal estimator-contract helpers required by the
-``Pipeline`` implementation: allowlist-based fitted-state inspection,
-unfitted cloning, canonical not-fitted behavior for supported transformers,
-and opt-in lifecycle invalidation for the accepted analysis terminal
-candidates. (#1589)
+MAINT: Standardized fitted-state inspection, unfitted cloning, and lifecycle
+invalidation for the estimators supported by ``Pipeline``. (#1589)
 
-DOC: Added developer-guide references for the OMNIC SRS and SPA file
-formats. (#1596, #1597)
+DOC: Expanded the Pipeline user guide and documented the validated OMNIC SRS
+and SPA file layouts and SPA reader behavior. (#1592, #1596, #1597, #1602, #1607)


### PR DESCRIPTION
Consolidate the 0.12.8 release notes through #1607, incorporating the OMNIC SPA additions since #1600. Separate new acquisition metadata from reader corrections, document the removal of `omnic_experiment_file` and its replacement, and summarize internal refactoring at release level. Regenerate `latest.rst` using the project script.

Runtime changes and release publication are outside this PR; the notes remain at `0.12.8.dev` until the release workflow runs.

Validation: `pre-commit run --all-files` passed; both RST files passed docutils syntax parsing (with a local Sphinx `ref` role stand-in); `git diff --check` passed.

**Checklist**:

- [x] User-visible changes have been documented in the appropriate changelog sections.
- [x] Developer changes have been documented in the `Developer` section.
- [x] Title follows the prefix convention defined in `CONTRIBUTING.md`.
- [x] Changelog entry is present.
