### PR TITLE
FIX: restore and secure Conda publication for official plugins

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -34,7 +34,9 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel in-progress builds for stable releases or tags.
+  # Only cancel draft/dev builds when a newer push arrives on the same ref.
+  cancel-in-progress: ${{ !startsWith(github.ref_name, 'spectrochempy-v') && !contains(github.ref_name, '-v') }}
 
 jobs:
   classify-pr-scope:
@@ -83,6 +85,45 @@ jobs:
               stream.write(f"docs_only={'true' if docs_only else 'false'}\n")
           print(f"docs_only={docs_only}")
           PY
+
+  detect-release-scope:
+    name: Detect release scope
+    runs-on: ubuntu-latest
+    outputs:
+      is_core_release: ${{ steps.detect.outputs.is_core_release }}
+      is_plugin_release: ${{ steps.detect.outputs.is_plugin_release }}
+      plugin_name: ${{ steps.detect.outputs.plugin_name }}
+      plugin_version: ${{ steps.detect.outputs.plugin_version }}
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Detect release type
+        id: detect
+        run: |
+          python3 .github/workflows/scripts/conda_publish.py verify-tag \
+            "${{ github.ref_name }}" 2>/dev/null && IS_PLUGIN=true || IS_PLUGIN=false
+
+          if [[ "${{ github.ref_name }}" == spectrochempy-v* ]] && [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "is_core_release=true" >> "$GITHUB_OUTPUT"
+            echo "is_plugin_release=false" >> "$GITHUB_OUTPUT"
+            echo "Detected: core release (${{ github.ref_name }})"
+          elif [[ "$IS_PLUGIN" == "true" ]] && [[ "${{ github.event_name }}" == "release" ]]; then
+            PLUGIN=$(echo "${{ github.ref_name }}" | sed 's/-v[0-9.]*$//')
+            VERSION=$(echo "${{ github.ref_name }}" | sed 's/^.*-v//')
+            echo "is_core_release=false" >> "$GITHUB_OUTPUT"
+            echo "is_plugin_release=true" >> "$GITHUB_OUTPUT"
+            echo "plugin_name=$PLUGIN" >> "$GITHUB_OUTPUT"
+            echo "plugin_version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Detected: plugin release ($PLUGIN v$VERSION)"
+          else
+            echo "is_core_release=false" >> "$GITHUB_OUTPUT"
+            echo "is_plugin_release=false" >> "$GITHUB_OUTPUT"
+            echo "Detected: non-release event (${{ github.event_name }}, ref=${{ github.ref_name }})"
+          fi
 
   build-and-publish_pypi:
     name: Build and publish distribution to PyPI
@@ -283,11 +324,16 @@ jobs:
   discover-conda-plugins:
     name: Discover plugins with conda recipes
     runs-on: ubuntu-latest
-    needs: [classify-pr-scope, build_and_publish_conda_package]
+    # For push/PR: core build produces the local channel artifact used by
+    # plugin builds below.  For plugin releases: core resolves from the
+    # spectrocat channel, so no dependency is needed.
+    needs: [classify-pr-scope, detect-release-scope]
     if: >
       github.repository == 'spectrochempy/spectrochempy' &&
       (github.event_name != 'pull_request' ||
-      needs.classify-pr-scope.outputs.docs_only != 'true')
+      needs.classify-pr-scope.outputs.docs_only != 'true') &&
+      # Skip discovery for core releases (no plugin builds needed)
+      !(github.event_name == 'release' && needs.detect-release-scope.outputs.is_core_release == 'true')
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
@@ -296,6 +342,11 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
       - name: Set plugin matrix
         id: set-matrix
@@ -307,15 +358,15 @@ jobs:
               echo "Skipping $name (developer template, not publishable)"
               continue
             fi
-            # Check for the Official Plugin marker.
-            if ! python3 -c "
-            import tomllib, sys
-            data = tomllib.loads(open('${dir}pyproject.toml').read())
-            sc = data.get('tool', {}).get('spectrochempy', {})
-            sys.exit(0 if sc.get('official-plugin') is True else 1)
-            " 2>/dev/null; then
+            # Check for the Official Plugin marker using the shared module.
+            python3 .github/workflows/scripts/conda_publish.py is-official "${dir%/}" >/dev/null 2>&1
+            rc=$?
+            if [ "$rc" -eq 1 ]; then
               echo "Skipping $name (not declared official)"
               continue
+            elif [ "$rc" -ne 0 ]; then
+              echo "::error::Official marker check failed for $name (exit $rc)"
+              exit 1
             fi
             if [ -f "${dir}recipe.yaml" ] || [ -f "${dir}meta.yaml" ]; then
               recipe_file="recipe.yaml"
@@ -337,9 +388,13 @@ jobs:
   build_and_publish_conda_plugins:
     name: Build and publish conda plugin packages to Anaconda.org
     runs-on: ubuntu-latest
-    needs: [classify-pr-scope, discover-conda-plugins]
+    # Depends on core build for the local channel artifact.
+    needs: [classify-pr-scope, discover-conda-plugins, build_and_publish_conda_package]
+    # Only run for push/PR events (not plugin releases — those are handled
+    # by build_and_publish_plugin_conda_release below).
     if: |
       github.repository == 'spectrochempy/spectrochempy' &&
+      github.event_name != 'release' &&
       (github.event_name != 'pull_request' ||
       needs.classify-pr-scope.outputs.docs_only != 'true') &&
       needs.discover-conda-plugins.outputs.matrix != '{}' &&
@@ -518,3 +573,193 @@ jobs:
           done
 
           echo "::notice::Plugin ${{ matrix.plugin.name }} uploaded to Anaconda label: main"
+
+  # ---------------------------------------------------------------------------
+  # Plugin release Conda builds
+  # ---------------------------------------------------------------------------
+  # When a plugin release tag (spectrochempy-XXX-vY.Z.W) is published, this
+  # job builds and publishes ONLY that plugin's Conda package.  It runs
+  # independently from the core build to avoid depending on a core artifact
+  # that is not produced for plugin-only releases.
+
+  build_and_publish_plugin_conda_release:
+    name: "Conda release: ${{ needs.detect-release-scope.outputs.plugin_name }}"
+    needs: [classify-pr-scope, detect-release-scope, discover-conda-plugins]
+    if: |
+      github.repository == 'spectrochempy/spectrochempy' &&
+      needs.detect-release-scope.outputs.is_plugin_release == 'true' &&
+      needs.discover-conda-plugins.outputs.matrix != '{}' &&
+      needs.discover-conda-plugins.outputs.matrix != ''
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout tag commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Verify plugin in discovered matrix
+        run: |
+          PLUGIN="${{ needs.detect-release-scope.outputs.plugin_name }}"
+          MATRIX="${{ needs.discover-conda-plugins.outputs.matrix }}"
+          if ! echo "$MATRIX" | grep -q "\"name\":\"$PLUGIN\""; then
+            echo "::error::Plugin $PLUGIN not found in discovered conda plugins matrix"
+            echo "Matrix: $MATRIX"
+            exit 1
+          fi
+          echo "Plugin $PLUGIN confirmed in conda plugins matrix"
+
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-file: environments/environment_build.yml
+          environment-name: scpy_build
+          create-args: >-
+            python=3.11
+          cache-environment: true
+
+      - name: Extract plugin recipe info from matrix
+        id: recipe-info
+        run: |
+          PLUGIN="${{ needs.detect-release-scope.outputs.plugin_name }}"
+          python3 -c "
+          import json, sys
+          matrix = json.loads('''${{ needs.discover-conda-plugins.outputs.matrix }}''')
+          for p in matrix.get('plugin', []):
+              if p['name'] == '$PLUGIN':
+                  print(f\"recipe={p['recipe']}\")
+                  print(f\"recipe_file={p['recipe_file']}\")
+                  with open('$GITHUB_OUTPUT', 'a') as f:
+                      f.write(f\"recipe={p['recipe']}\n\")
+                      f.write(f\"recipe_file={p['recipe_file']}\n\")
+                  sys.exit(0)
+          print(f'::error::Plugin $PLUGIN not in matrix', file=sys.stderr)
+          sys.exit(1)
+          "
+
+      - name: Build conda plugin package
+        uses: prefix-dev/rattler-build-action@v0.2.39
+        env:
+          CONDA_BLD_PATH: ../output
+        with:
+          recipe-path: ${{ steps.recipe-info.outputs.recipe }}/${{ steps.recipe-info.outputs.recipe_file }}
+          upload-artifact: false
+          build-args: >-
+            -c conda-forge
+            -c spectrocat
+
+      - name: Move conda build output
+        run: |
+          mv ../output .
+
+      - name: Verify built package matches tag
+        run: |
+          PLUGIN="${{ needs.detect-release-scope.outputs.plugin_name }}"
+          VERSION="${{ needs.detect-release-scope.outputs.plugin_version }}"
+
+          echo "=== Built packages ==="
+          find output -type f \( -name "*.conda" -o -name "*.tar.bz2" \)
+
+          FOUND=0
+          for pkg in output/**/*.conda output/**/*.tar.bz2; do
+            if [[ -f "$pkg" ]] && [[ "$(basename "$pkg")" == "$PLUGIN-$VERSION"* ]]; then
+              echo "Found matching package: $pkg"
+              FOUND=1
+            fi
+          done
+
+          if [ "$FOUND" -eq 0 ]; then
+            echo "::error::No conda package found matching $PLUGIN==$VERSION"
+            echo "Built packages:"
+            find output -type f \( -name "*.conda" -o -name "*.tar.bz2" \)
+            exit 1
+          fi
+
+          echo "Package verification passed: $PLUGIN==$VERSION"
+
+      - name: Upload conda build artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: conda-plugin-release-${{ needs.detect-release-scope.outputs.plugin_name }}
+          path: |
+            output/**/*.conda
+            output/**/*.tar.bz2
+          retention-days: 30
+
+      - name: Upload plugin to Anaconda.org (main label)
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+
+          PLUGIN="${{ needs.detect-release-scope.outputs.plugin_name }}"
+          VERSION="${{ needs.detect-release-scope.outputs.plugin_version }}"
+
+          echo "Stable plugin release: uploading $PLUGIN==$VERSION to Anaconda label: main"
+
+          if [ -z "${ANACONDA_API_TOKEN:-}" ]; then
+            echo "::error::ANACONDA_API_TOKEN is not set. Cannot upload to Anaconda.org."
+            exit 1
+          fi
+
+          packages=(output/**/*.tar.bz2 output/**/*.conda)
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "::error::No conda packages found in output/"
+            exit 1
+          fi
+
+          for package in "${packages[@]}"; do
+            basename=$(basename "$package")
+            if [[ "$basename" == spectrochempy-[0-9]* ]]; then
+              echo "Skipping core package (already uploaded): $package"
+              continue
+            fi
+            echo "Uploading $package with label: main"
+            anaconda --token "$ANACONDA_API_TOKEN" upload --force -l "main" "$package"
+          done
+
+          echo "::notice::Plugin $PLUGIN==$VERSION uploaded to Anaconda label: main"
+
+      - name: Verify upload
+        run: |
+          PLUGIN="${{ needs.detect-release-scope.outputs.plugin_name }}"
+          VERSION="${{ needs.detect-release-scope.outputs.plugin_version }}"
+          echo "Verifying $PLUGIN==$VERSION is now on Anaconda main..."
+
+          LABELS=$(python3 -c "
+          import json, urllib.request
+          url = 'https://api.anaconda.org/package/spectrocat/$PLUGIN'
+          try:
+              req = urllib.request.Request(url, headers={'Accept': 'application/json'})
+              with urllib.request.urlopen(req, timeout=30) as resp:
+                  data = json.loads(resp.read().decode())
+              for v in data.get('versions', []):
+                  if v.get('version') == '$VERSION':
+                      labels = [l.get('name','') for l in v.get('labels', [])]
+                      print(' '.join(labels))
+                      raise SystemExit(0)
+          except SystemExit:
+              raise
+          except Exception:
+              pass
+          print('NOT_FOUND')
+          ")
+
+          if echo "$LABELS" | grep -q "main"; then
+            echo "SUCCESS: $PLUGIN==$VERSION is on main label (labels: $LABELS)"
+          else
+            echo "::warning::Upload verification: $PLUGIN==$VERSION labels: $LABELS"
+            echo "The package may take a few minutes to appear on Anaconda.org."
+          fi

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -96,6 +96,11 @@ jobs:
       plugin_version: ${{ steps.detect.outputs.plugin_version }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -105,7 +110,7 @@ jobs:
         id: detect
         run: |
           python3 .github/workflows/scripts/conda_publish.py verify-tag \
-            "${{ github.ref_name }}" 2>/dev/null && IS_PLUGIN=true || IS_PLUGIN=false
+            "${{ github.ref_name }}" && IS_PLUGIN=true || IS_PLUGIN=false
 
           if [[ "${{ github.ref_name }}" == spectrochempy-v* ]] && [[ "${{ github.event_name }}" == "release" ]]; then
             echo "is_core_release=true" >> "$GITHUB_OUTPUT"
@@ -359,14 +364,20 @@ jobs:
               continue
             fi
             # Check for the Official Plugin marker using the shared module.
-            python3 .github/workflows/scripts/conda_publish.py is-official "${dir%/}" >/dev/null 2>&1
-            rc=$?
-            if [ "$rc" -eq 1 ]; then
-              echo "Skipping $name (not declared official)"
-              continue
-            elif [ "$rc" -ne 0 ]; then
+            # is-official exits 0 (official), 1 (not official) or 2
+            # (evaluation error).  With set -e the non-zero exit codes would
+            # abort the step, so the check must run inside an if/else and the
+            # return code must be captured explicitly.
+            if python3 .github/workflows/scripts/conda_publish.py is-official "${dir%/}"; then
+              :
+            else
+              rc=$?
+              if [ "$rc" -eq 1 ]; then
+                echo "Skipping $name (not declared official)"
+                continue
+              fi
               echo "::error::Official marker check failed for $name (exit $rc)"
-              exit 1
+              exit "$rc"
             fi
             if [ -f "${dir}recipe.yaml" ] || [ -f "${dir}meta.yaml" ]; then
               recipe_file="recipe.yaml"
@@ -619,6 +630,15 @@ jobs:
           fi
           echo "Plugin $PLUGIN confirmed in conda plugins matrix"
 
+      - name: Validate plugin metadata against the tag
+        run: |
+          PLUGIN="${{ needs.detect-release-scope.outputs.plugin_name }}"
+          VERSION="${{ needs.detect-release-scope.outputs.plugin_version }}"
+          # Blocking: pyproject.toml / __init__.py / recipe versions must all
+          # match the release tag version, read from the exact tag checkout.
+          python3 .github/workflows/scripts/conda_publish.py validate-release \
+            "plugins/$PLUGIN" "$VERSION"
+
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v3
         with:
@@ -672,14 +692,14 @@ jobs:
 
           FOUND=0
           for pkg in output/**/*.conda output/**/*.tar.bz2; do
-            if [[ -f "$pkg" ]] && [[ "$(basename "$pkg")" == "$PLUGIN-$VERSION"* ]]; then
+            if [[ -f "$pkg" ]] && [[ "$(basename "$pkg")" == "$PLUGIN-$VERSION-"* ]]; then
               echo "Found matching package: $pkg"
               FOUND=1
             fi
           done
 
           if [ "$FOUND" -eq 0 ]; then
-            echo "::error::No conda package found matching $PLUGIN==$VERSION"
+            echo "::error::No conda package found matching $PLUGIN==$VERSION (exact version)"
             echo "Built packages:"
             find output -type f \( -name "*.conda" -o -name "*.tar.bz2" \)
             exit 1
@@ -726,40 +746,15 @@ jobs:
               echo "Skipping core package (already uploaded): $package"
               continue
             fi
-            echo "Uploading $package with label: main"
-            anaconda --token "$ANACONDA_API_TOKEN" upload --force -l "main" "$package"
+            # Shared uploader: refuses to overwrite an already-published
+            # version, verifies the artifact name/version and polls the
+            # /files API after the upload.
+            python3 .github/workflows/scripts/conda_publish.py upload-conda \
+              "$package" \
+              --plugin "$PLUGIN" \
+              --version "$VERSION" \
+              --owner spectrocat \
+              --label main
           done
 
           echo "::notice::Plugin $PLUGIN==$VERSION uploaded to Anaconda label: main"
-
-      - name: Verify upload
-        run: |
-          PLUGIN="${{ needs.detect-release-scope.outputs.plugin_name }}"
-          VERSION="${{ needs.detect-release-scope.outputs.plugin_version }}"
-          echo "Verifying $PLUGIN==$VERSION is now on Anaconda main..."
-
-          LABELS=$(python3 -c "
-          import json, urllib.request
-          url = 'https://api.anaconda.org/package/spectrocat/$PLUGIN'
-          try:
-              req = urllib.request.Request(url, headers={'Accept': 'application/json'})
-              with urllib.request.urlopen(req, timeout=30) as resp:
-                  data = json.loads(resp.read().decode())
-              for v in data.get('versions', []):
-                  if v.get('version') == '$VERSION':
-                      labels = [l.get('name','') for l in v.get('labels', [])]
-                      print(' '.join(labels))
-                      raise SystemExit(0)
-          except SystemExit:
-              raise
-          except Exception:
-              pass
-          print('NOT_FOUND')
-          ")
-
-          if echo "$LABELS" | grep -q "main"; then
-            echo "SUCCESS: $PLUGIN==$VERSION is on main label (labels: $LABELS)"
-          else
-            echo "::warning::Upload verification: $PLUGIN==$VERSION labels: $LABELS"
-            echo "The package may take a few minutes to appear on Anaconda.org."
-          fi

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -333,11 +333,11 @@ jobs:
     # plugin builds below.  For plugin releases: core resolves from the
     # spectrocat channel, so no dependency is needed.
     needs: [classify-pr-scope, detect-release-scope]
+    # Skip discovery for core releases (no plugin builds needed)
     if: >
       github.repository == 'spectrochempy/spectrochempy' &&
       (github.event_name != 'pull_request' ||
       needs.classify-pr-scope.outputs.docs_only != 'true') &&
-      # Skip discovery for core releases (no plugin builds needed)
       !(github.event_name == 'release' && needs.detect-release-scope.outputs.is_core_release == 'true')
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/repair_conda_plugin_release.yml
+++ b/.github/workflows/repair_conda_plugin_release.yml
@@ -7,8 +7,13 @@ name: Repair plugin Conda publication
 #
 # Safety guarantees:
 #   - Tag must match <plugin_name>-v<version> pattern
-#   - Plugin must be declared official
-#   - Version is extracted from the tag and verified against metadata
+#   - Plugin must be declared official (evaluation failure = abort)
+#   - The release is validated from the exact tag checkout: the version from
+#     pyproject.toml, __init__.py (when declared) and the recipe must all
+#     match the tag version — any mismatch is blocking
+#   - A recipe (recipe.yaml / meta.yaml) must exist at the tag
+#   - Upload refuses to overwrite a version already published on the target
+#     label unless allow_override=true (explicit, documented derogation)
 #   - Default mode is dry-run (no upload)
 #   - Upload requires explicit confirmation and an environment approval
 #   - Never touches PyPI, GitHub releases, or git tags
@@ -34,6 +39,11 @@ on:
         required: false
         default: false
         type: boolean
+      allow_override:
+        description: "Dangerous: allow replacing an already-published version on the main label (explicit derogation). Ignored in dry-run mode."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -46,8 +56,8 @@ jobs:
     outputs:
       plugin: ${{ steps.validate.outputs.plugin }}
       version: ${{ steps.validate.outputs.version }}
-      recipe_path: ${{ steps.validate.outputs.recipe_path }}
-      recipe_file: ${{ steps.validate.outputs.recipe_file }}
+      recipe_path: ${{ steps.recipe.outputs.recipe_path }}
+      recipe_file: ${{ steps.recipe.outputs.recipe_file }}
 
     steps:
       - name: Checkout code
@@ -72,17 +82,37 @@ jobs:
           echo "plugin=$PLUGIN" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Verify plugin is official
-          python3 .github/workflows/scripts/validate_official_plugin.py \
+          # Verify plugin is official.  is-official exits 0 (official),
+          # 1 (not official) or 2 (evaluation error) — any non-zero aborts.
+          python3 .github/workflows/scripts/conda_publish.py is-official \
             "plugins/$PLUGIN"
 
-          # Verify tag exists
-          if ! git ls-remote --tags origin "refs/tags/${{ inputs.tag }}" | grep -q "${{ inputs.tag }}"; then
-            echo "::error::Tag ${{ inputs.tag }} does not exist in the remote repository"
-            exit 1
-          fi
+          echo "Inputs valid: $PLUGIN v$VERSION is an official plugin"
 
-          # Find recipe file
+      - name: Stash validation tooling from master
+        run: |
+          # The release tag predates the shared validation script.  Copy the
+          # master version out of the tree so it survives the tag checkout.
+          cp .github/workflows/scripts/conda_publish.py /tmp/conda_publish.py
+
+      - name: Checkout release tag
+        run: |
+          git checkout --detach "${{ inputs.tag }}"
+
+      - name: Validate metadata against the tag
+        run: |
+          PLUGIN="${{ steps.validate.outputs.plugin }}"
+          VERSION="${{ steps.validate.outputs.version }}"
+          # Blocking: pyproject.toml / __init__.py (when declared) / recipe
+          # versions must all match the tag version, read from the exact tag
+          # checkout.  Any mismatch fails the job before building.
+          python3 /tmp/conda_publish.py validate-release \
+            "plugins/$PLUGIN" "$VERSION"
+
+      - name: Find recipe file
+        id: recipe
+        run: |
+          PLUGIN="${{ steps.validate.outputs.plugin }}"
           RECIPE_DIR="plugins/$PLUGIN"
           if [ -f "$RECIPE_DIR/recipe.yaml" ]; then
             echo "recipe_path=$RECIPE_DIR" >> "$GITHUB_OUTPUT"
@@ -91,56 +121,29 @@ jobs:
             echo "recipe_path=$RECIPE_DIR" >> "$GITHUB_OUTPUT"
             echo "recipe_file=meta.yaml" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::No recipe.yaml or meta.yaml found for $PLUGIN"
+            echo "::error::No recipe.yaml or meta.yaml found for $PLUGIN at tag ${{ inputs.tag }}"
             exit 1
           fi
 
-          # Verify version consistency across sources
-          PYPROJ_VER=$(python3 -c "
-          import re, sys
-          text = open('plugins/$PLUGIN/pyproject.toml').read().split('[project]', 1)[-1]
-          m = re.search(r'^version\s*=\"([^\"]+)\"', text, re.MULTILINE)
-          print(m.group(1) if m else '')
-          ")
-          echo "pyproject.toml version: $PYPROJ_VER"
-          if [ "$PYPROJ_VER" != "$VERSION" ]; then
-            echo "::warning::pyproject.toml version ($PYPROJ_VER) differs from tag version ($VERSION)"
-          fi
-
-          echo "Validation passed for $PLUGIN v$VERSION"
-
       - name: Check existing Conda package
         run: |
-          VERSION="${{ steps.validate.outputs.version }}"
           PLUGIN="${{ steps.validate.outputs.plugin }}"
-          echo "Checking if $PLUGIN==$VERSION already exists on Conda..."
-
-          EXISTING=$(python3 -c "
-          from __future__ import annotations
-          import json, urllib.request, urllib.error
-          url = 'https://api.anaconda.org/package/spectrocat/$PLUGIN'
-          try:
-              req = urllib.request.Request(url, headers={'Accept': 'application/json'})
-              with urllib.request.urlopen(req, timeout=30) as resp:
-                  data = json.loads(resp.read().decode())
-              for v in data.get('versions', []):
-                  if v.get('version') == '$VERSION':
-                      labels = [l.get('name','') for l in v.get('labels', [])]
-                      print(f'exists:{\":\".join(labels)}')
-                      raise SystemExit(0)
-          except SystemExit:
-              raise
-          except Exception:
-              pass
-          print('not_found')
-          ")
-
-          if [[ "$EXISTING" == exists:* ]]; then
-            LABELS="${EXISTING#exists:}"
-            echo "::warning::$PLUGIN==$VERSION already exists on Conda with labels: $LABELS"
-            echo "The package may already be published. Proceeding anyway (upload uses --force)."
-          else
+          VERSION="${{ steps.validate.outputs.version }}"
+          # Informational: uses the /files API via the shared module.  The
+          # publish job re-checks authoritatively and refuses to overwrite
+          # without allow_override.
+          set +e
+          python3 /tmp/conda_publish.py conda-state "$PLUGIN" "$VERSION" --owner spectrocat
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "::warning::$PLUGIN==$VERSION already exists on Conda (labels above)."
+            echo "To republish it anyway, re-run with allow_override=true (explicit derogation)."
+          elif [ "$rc" -eq 1 ]; then
             echo "$PLUGIN==$VERSION not found on Conda. Publication needed."
+          else
+            echo "::warning::Could not query Anaconda.org for $PLUGIN==$VERSION (exit $rc)."
+            echo "The publish job will re-check before uploading."
           fi
 
   build:
@@ -191,21 +194,25 @@ jobs:
           PLUGIN="${{ needs.validate.outputs.plugin }}"
           VERSION="${{ needs.validate.outputs.version }}"
 
-          # Verify the built package matches expected name and version
+          # Verify the built package matches the exact expected name and version.
+          # The version must be followed by a '-' (build string) so that a
+          # version like 0.1.1 cannot match an artifact built at 0.1.11.
           FOUND=0
           for pkg in output/**/*.conda output/**/*.tar.bz2; do
-            if [[ -f "$pkg" ]] && [[ "$(basename "$pkg")" == "$PLUGIN-"* ]]; then
+            if [[ -f "$pkg" ]] && [[ "$(basename "$pkg")" == "$PLUGIN-$VERSION-"* ]]; then
               echo "Found matching package: $pkg"
               FOUND=1
             fi
           done
 
           if [ "$FOUND" -eq 0 ]; then
-            echo "::error::No conda package found matching $PLUGIN"
+            echo "::error::No conda package found matching $PLUGIN==$VERSION (exact version)"
+            echo "Built packages:"
+            find output -type f \( -name "*.conda" -o -name "*.tar.bz2" \)
             exit 1
           fi
 
-          echo "Package verification passed."
+          echo "Package verification passed: $PLUGIN==$VERSION"
 
       - name: Upload conda build artifacts
         if: ${{ !env.ACT }}
@@ -233,6 +240,20 @@ jobs:
         shell: bash -l {0}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install anaconda-client
+        run: |
+          # The upload runs on a fresh runner without the Micromamba build
+          # environment, so the anaconda CLI must be installed explicitly.
+          python -m pip install anaconda-client
+
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
@@ -254,6 +275,12 @@ jobs:
             exit 1
           fi
 
+          OVERRIDE=""
+          if [ "${{ inputs.allow_override }}" = "true" ]; then
+            OVERRIDE="--allow-override"
+            echo "::warning::allow_override=true: an already-published version may be replaced."
+          fi
+
           echo "Uploading $PLUGIN==$VERSION to Anaconda label: main"
 
           packages=(/tmp/conda-pkg/**/*.tar.bz2 /tmp/conda-pkg/**/*.conda)
@@ -263,36 +290,24 @@ jobs:
           fi
 
           for package in "${packages[@]}"; do
+            basename=$(basename "$package")
+            if [[ "$basename" == spectrochempy-[0-9]* ]]; then
+              echo "Skipping core package (already uploaded): $package"
+              continue
+            fi
             echo "Uploading $package"
-            anaconda --token "$ANACONDA_API_TOKEN" upload --force -l "main" "$package"
+            # Shared uploader: verifies the artifact name/version, refuses to
+            # overwrite a version already on the label unless allow_override,
+            # and polls the /files API after the upload to confirm.
+            python3 .github/workflows/scripts/conda_publish.py upload-conda \
+              "$package" \
+              --plugin "$PLUGIN" \
+              --version "$VERSION" \
+              --owner spectrocat \
+              --label main $OVERRIDE
           done
 
           echo "::notice::Successfully uploaded $PLUGIN==$VERSION to Anaconda main label"
-
-      - name: Verify upload
-        run: |
-          PLUGIN="${{ needs.validate.outputs.plugin }}"
-          VERSION="${{ needs.validate.outputs.version }}"
-          echo "Verifying $PLUGIN==$VERSION is now on Anaconda main..."
-
-          LABELS=$(python3 -c "
-          import json, urllib.request
-          url = 'https://api.anaconda.org/package/spectrocat/$PLUGIN'
-          req = urllib.request.Request(url, headers={'Accept': 'application/json'})
-          with urllib.request.urlopen(req, timeout=30) as resp:
-              data = json.loads(resp.read().decode())
-          for v in data.get('versions', []):
-              if v.get('version') == '$VERSION':
-                  print(' '.join([l.get('name','') for l in v.get('labels', [])]))
-                  raise SystemExit(0)
-          print('NOT_FOUND')
-          ")
-
-          if echo "$LABELS" | grep -q "main"; then
-            echo "SUCCESS: $PLUGIN==$VERSION is on main label"
-          else
-            echo "::warning::Upload may not have completed. Labels: $LABELS"
-          fi
 
   dry-run-summary:
     name: Dry-run summary
@@ -318,6 +333,8 @@ jobs:
           echo "dry_run: false" >> "$GITHUB_STEP_SUMMARY"
           echo "confirm_upload: true" >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "To *replace* an already-published version on main, also set \`allow_override: true\` (explicit derogation, otherwise the upload is refused)." >> "$GITHUB_STEP_SUMMARY"
 
           echo ""
           echo "=== DRY RUN COMPLETE ==="

--- a/.github/workflows/repair_conda_plugin_release.yml
+++ b/.github/workflows/repair_conda_plugin_release.yml
@@ -1,0 +1,328 @@
+name: Repair plugin Conda publication
+
+# Manual workflow to build and publish a single plugin's Conda package
+# from an existing release tag.  Used to recover from historical publication
+# failures where the GitHub release and PyPI upload succeeded but the
+# Conda package was not published to spectrocat/main.
+#
+# Safety guarantees:
+#   - Tag must match <plugin_name>-v<version> pattern
+#   - Plugin must be declared official
+#   - Version is extracted from the tag and verified against metadata
+#   - Default mode is dry-run (no upload)
+#   - Upload requires explicit confirmation and an environment approval
+#   - Never touches PyPI, GitHub releases, or git tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin_name:
+        description: "Plugin package name (e.g. spectrochempy-nmr)"
+        required: true
+        type: string
+      tag:
+        description: "Existing release tag (e.g. spectrochempy-nmr-v0.1.11)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry-run mode: build but do not upload (recommended)"
+        required: true
+        default: true
+        type: boolean
+      confirm_upload:
+        description: "Set to true ONLY after verifying the dry-run output (ignored in dry-run mode)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate tag and plugin
+    runs-on: ubuntu-latest
+    if: github.repository == 'spectrochempy/spectrochempy'
+    outputs:
+      plugin: ${{ steps.validate.outputs.plugin }}
+      version: ${{ steps.validate.outputs.version }}
+      recipe_path: ${{ steps.validate.outputs.recipe_path }}
+      recipe_file: ${{ steps.validate.outputs.recipe_file }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Validate inputs
+        id: validate
+        run: |
+          python3 .github/workflows/scripts/conda_publish.py verify-tag \
+            "${{ inputs.tag }}" --plugin "${{ inputs.plugin_name }}"
+
+          PLUGIN="${{ inputs.plugin_name }}"
+          VERSION=$(echo "${{ inputs.tag }}" | sed -n 's/^.*-v\([0-9.]*\)$/\1/p')
+
+          echo "plugin=$PLUGIN" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # Verify plugin is official
+          python3 .github/workflows/scripts/validate_official_plugin.py \
+            "plugins/$PLUGIN"
+
+          # Verify tag exists
+          if ! git ls-remote --tags origin "refs/tags/${{ inputs.tag }}" | grep -q "${{ inputs.tag }}"; then
+            echo "::error::Tag ${{ inputs.tag }} does not exist in the remote repository"
+            exit 1
+          fi
+
+          # Find recipe file
+          RECIPE_DIR="plugins/$PLUGIN"
+          if [ -f "$RECIPE_DIR/recipe.yaml" ]; then
+            echo "recipe_path=$RECIPE_DIR" >> "$GITHUB_OUTPUT"
+            echo "recipe_file=recipe.yaml" >> "$GITHUB_OUTPUT"
+          elif [ -f "$RECIPE_DIR/meta.yaml" ]; then
+            echo "recipe_path=$RECIPE_DIR" >> "$GITHUB_OUTPUT"
+            echo "recipe_file=meta.yaml" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::No recipe.yaml or meta.yaml found for $PLUGIN"
+            exit 1
+          fi
+
+          # Verify version consistency across sources
+          PYPROJ_VER=$(python3 -c "
+          import re, sys
+          text = open('plugins/$PLUGIN/pyproject.toml').read().split('[project]', 1)[-1]
+          m = re.search(r'^version\s*=\"([^\"]+)\"', text, re.MULTILINE)
+          print(m.group(1) if m else '')
+          ")
+          echo "pyproject.toml version: $PYPROJ_VER"
+          if [ "$PYPROJ_VER" != "$VERSION" ]; then
+            echo "::warning::pyproject.toml version ($PYPROJ_VER) differs from tag version ($VERSION)"
+          fi
+
+          echo "Validation passed for $PLUGIN v$VERSION"
+
+      - name: Check existing Conda package
+        run: |
+          VERSION="${{ steps.validate.outputs.version }}"
+          PLUGIN="${{ steps.validate.outputs.plugin }}"
+          echo "Checking if $PLUGIN==$VERSION already exists on Conda..."
+
+          EXISTING=$(python3 -c "
+          from __future__ import annotations
+          import json, urllib.request, urllib.error
+          url = 'https://api.anaconda.org/package/spectrocat/$PLUGIN'
+          try:
+              req = urllib.request.Request(url, headers={'Accept': 'application/json'})
+              with urllib.request.urlopen(req, timeout=30) as resp:
+                  data = json.loads(resp.read().decode())
+              for v in data.get('versions', []):
+                  if v.get('version') == '$VERSION':
+                      labels = [l.get('name','') for l in v.get('labels', [])]
+                      print(f'exists:{\":\".join(labels)}')
+                      raise SystemExit(0)
+          except SystemExit:
+              raise
+          except Exception:
+              pass
+          print('not_found')
+          ")
+
+          if [[ "$EXISTING" == exists:* ]]; then
+            LABELS="${EXISTING#exists:}"
+            echo "::warning::$PLUGIN==$VERSION already exists on Conda with labels: $LABELS"
+            echo "The package may already be published. Proceeding anyway (upload uses --force)."
+          else
+            echo "$PLUGIN==$VERSION not found on Conda. Publication needed."
+          fi
+
+  build:
+    name: Build Conda package
+    needs: validate
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-file: environments/environment_build.yml
+          environment-name: scpy_build
+          create-args: >-
+            python=3.11
+          cache-environment: true
+
+      - name: Build conda plugin package
+        uses: prefix-dev/rattler-build-action@v0.2.39
+        env:
+          CONDA_BLD_PATH: ../output
+        with:
+          recipe-path: ${{ needs.validate.outputs.recipe_path }}/${{ needs.validate.outputs.recipe_file }}
+          upload-artifact: false
+          build-args: >-
+            -c conda-forge
+            -c spectrocat
+
+      - name: Move conda build output
+        run: |
+          mv ../output .
+
+      - name: Verify built package
+        run: |
+          echo "=== Built packages ==="
+          find output -type f \( -name "*.conda" -o -name "*.tar.bz2" \)
+
+          PLUGIN="${{ needs.validate.outputs.plugin }}"
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          # Verify the built package matches expected name and version
+          FOUND=0
+          for pkg in output/**/*.conda output/**/*.tar.bz2; do
+            if [[ -f "$pkg" ]] && [[ "$(basename "$pkg")" == "$PLUGIN-"* ]]; then
+              echo "Found matching package: $pkg"
+              FOUND=1
+            fi
+          done
+
+          if [ "$FOUND" -eq 0 ]; then
+            echo "::error::No conda package found matching $PLUGIN"
+            exit 1
+          fi
+
+          echo "Package verification passed."
+
+      - name: Upload conda build artifacts
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: conda-repair-${{ needs.validate.outputs.plugin }}
+          path: |
+            output/**/*.conda
+            output/**/*.tar.bz2
+          retention-days: 30
+
+  publish:
+    name: Publish to Conda main
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    if: |
+      inputs.dry_run != true &&
+      inputs.confirm_upload == true
+    environment:
+      name: conda-publish
+      url: https://anaconda.org/spectrocat
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: conda-repair-${{ needs.validate.outputs.plugin }}
+          path: /tmp/conda-pkg
+
+      - name: Upload to Anaconda.org (main label)
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+
+          PLUGIN="${{ needs.validate.outputs.plugin }}"
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          if [ -z "${ANACONDA_API_TOKEN:-}" ]; then
+            echo "::error::ANACONDA_API_TOKEN is not set. Cannot upload to Anaconda.org."
+            exit 1
+          fi
+
+          echo "Uploading $PLUGIN==$VERSION to Anaconda label: main"
+
+          packages=(/tmp/conda-pkg/**/*.tar.bz2 /tmp/conda-pkg/**/*.conda)
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "::error::No conda packages found in artifact"
+            exit 1
+          fi
+
+          for package in "${packages[@]}"; do
+            echo "Uploading $package"
+            anaconda --token "$ANACONDA_API_TOKEN" upload --force -l "main" "$package"
+          done
+
+          echo "::notice::Successfully uploaded $PLUGIN==$VERSION to Anaconda main label"
+
+      - name: Verify upload
+        run: |
+          PLUGIN="${{ needs.validate.outputs.plugin }}"
+          VERSION="${{ needs.validate.outputs.version }}"
+          echo "Verifying $PLUGIN==$VERSION is now on Anaconda main..."
+
+          LABELS=$(python3 -c "
+          import json, urllib.request
+          url = 'https://api.anaconda.org/package/spectrocat/$PLUGIN'
+          req = urllib.request.Request(url, headers={'Accept': 'application/json'})
+          with urllib.request.urlopen(req, timeout=30) as resp:
+              data = json.loads(resp.read().decode())
+          for v in data.get('versions', []):
+              if v.get('version') == '$VERSION':
+                  print(' '.join([l.get('name','') for l in v.get('labels', [])]))
+                  raise SystemExit(0)
+          print('NOT_FOUND')
+          ")
+
+          if echo "$LABELS" | grep -q "main"; then
+            echo "SUCCESS: $PLUGIN==$VERSION is on main label"
+          else
+            echo "::warning::Upload may not have completed. Labels: $LABELS"
+          fi
+
+  dry-run-summary:
+    name: Dry-run summary
+    needs: [validate, build]
+    runs-on: ubuntu-latest
+    if: inputs.dry_run == true
+
+    steps:
+      - name: Print dry-run summary
+        run: |
+          PLUGIN="${{ needs.validate.outputs.plugin }}"
+          VERSION="${{ needs.validate.outputs.version }}"
+
+          echo "## Dry-run summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Plugin**: \`$PLUGIN\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tag**: \`${{ inputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Mode**: Dry-run (no upload performed)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "To publish, re-run with:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "dry_run: false" >> "$GITHUB_STEP_SUMMARY"
+          echo "confirm_upload: true" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+
+          echo ""
+          echo "=== DRY RUN COMPLETE ==="
+          echo "Plugin: $PLUGIN"
+          echo "Version: $VERSION"
+          echo "Artifact: conda-repair-$PLUGIN"
+          echo ""
+          echo "No upload was performed. To upload, re-run with dry_run=false and confirm_upload=true."

--- a/.github/workflows/scripts/conda_publish.py
+++ b/.github/workflows/scripts/conda_publish.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+"""Shared helpers for Conda plugin publication and verification.
+
+Provides functions for:
+- Parsing and validating plugin tags
+- Querying Anaconda.org for package versions and labels
+- Verifying release consistency across GitHub / PyPI / Conda
+- Building Conda packages from a specific git tag
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+TAG_RE = re.compile(
+    r"^(?P<plugin>spectrochempy-[a-z0-9-]+)-v(?P<version>\d+\.\d+\.\d+)$"
+)
+
+PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
+ANACONDA_FILES_URL = "https://api.anaconda.org/package/{owner}/{package}/files"
+
+
+def parse_plugin_tag(tag: str) -> tuple[str, str] | None:
+    """Parse a plugin tag into (plugin_name, version) or None if invalid."""
+    match = TAG_RE.match(tag)
+    if not match:
+        return None
+    return match.group("plugin"), match.group("version")
+
+
+def validate_tag_format(tag: str, expected_plugin: str | None = None) -> tuple[str, str]:
+    """Validate a plugin tag and return (plugin_name, version).
+
+    Raises ValueError with a clear diagnostic if the tag is invalid.
+    """
+    result = parse_plugin_tag(tag)
+    if result is None:
+        raise ValueError(
+            f"Tag '{tag}' does not match the plugin release pattern "
+            f"'<plugin_name>-v<version>' (e.g. spectrochempy-nmr-v0.1.1)"
+        )
+    plugin, version = result
+    if expected_plugin and plugin != expected_plugin:
+        raise ValueError(
+            f"Tag '{tag}' belongs to plugin '{plugin}', "
+            f"but expected plugin is '{expected_plugin}'"
+        )
+    return plugin, version
+
+
+def read_plugin_version(plugin_dir: Path) -> str | None:
+    """Read the version from a plugin's pyproject.toml."""
+    pyproject = plugin_dir / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    match = re.search(
+        r'^version\s*=\s*"([^"]+)"\s*$',
+        pyproject.read_text().split("[project]", 1)[-1],
+        re.MULTILINE,
+    )
+    return match.group(1) if match else None
+
+
+def read_plugin_init_version(plugin_dir: Path) -> str | None:
+    """Read the version from a plugin's __init__.py."""
+    init_file = plugin_dir / "src" / plugin_dir.name.replace("-", "_") / "__init__.py"
+    if not init_file.is_file():
+        return None
+    match = re.search(r'version\s*=\s*"([^"]+)"', init_file.read_text())
+    return match.group(1) if match else None
+
+
+def read_recipe_version(recipe_path: Path) -> str | None:
+    """Read context.version from a conda recipe.yaml."""
+    if not recipe_path.is_file():
+        return None
+    for line in recipe_path.read_text().splitlines():
+        m = re.match(r'^\s+version:\s*"([^"]+)"', line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def is_official_plugin(plugin_dir: Path) -> bool:
+    """Check if a plugin directory declares official-plugin = true."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    pyproject = plugin_dir / "pyproject.toml"
+    if not pyproject.is_file():
+        return False
+    try:
+        data = tomllib.loads(pyproject.read_text())
+        tool_sc = data.get("tool", {}).get("spectrochempy", {})
+        return tool_sc.get("official-plugin") is True
+    except Exception:
+        return False
+
+
+def discover_official_plugins(plugins_dir: Path) -> list[str]:
+    """Return sorted list of official plugin directory names."""
+    results: list[str] = []
+    if not plugins_dir.is_dir():
+        return results
+    for pyproject in sorted(plugins_dir.glob("spectrochempy-*/pyproject.toml")):
+        if is_official_plugin(pyproject.parent):
+            results.append(pyproject.parent.name)
+    return results
+
+
+def fetch_json(url: str, timeout: int = 30) -> dict | None:
+    """Fetch JSON from a URL, returning None on failure."""
+    try:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError):
+        return None
+
+
+def pypi_versions(package: str) -> list[str]:
+    """Return all versions of a package from PyPI."""
+    data = fetch_json(PYPI_JSON_URL.format(package=package))
+    if data is None:
+        return []
+    return list(data.get("releases", {}).keys())
+
+
+def pypi_latest_version(package: str) -> str | None:
+    """Return the latest version of a package from PyPI."""
+    data = fetch_json(PYPI_JSON_URL.format(package=package))
+    if data is None:
+        return None
+    info = data.get("info", {})
+    return info.get("version")
+
+
+def anaconda_versions(
+    package: str, owner: str = "spectrocat"
+) -> dict[str, list[str]]:
+    """Return {version: [labels]} for a package on Anaconda.org.
+
+    Uses the package /files endpoint, which lists every uploaded file with
+    its channel labels.  Returns empty dict if the package is not found.
+    """
+    data = fetch_json(ANACONDA_FILES_URL.format(owner=owner, package=package))
+    if not isinstance(data, list):
+        return {}
+    result: dict[str, list[str]] = {}
+    for f in data:
+        ver = f.get("version")
+        if not ver:
+            continue
+        labels = []
+        for lbl in f.get("labels") or []:
+            if isinstance(lbl, str):
+                labels.append(lbl)
+            elif isinstance(lbl, dict):
+                labels.append(lbl.get("name", ""))
+        for label in labels:
+            if label not in result.setdefault(ver, []):
+                result[ver].append(label)
+    return result
+
+
+def anaconda_version_labels(
+    package: str, version: str, owner: str = "spectrocat"
+) -> list[str]:
+    """Return the labels for a specific version of a package on Anaconda.org."""
+    return anaconda_versions(package, owner).get(version, [])
+
+
+def git_tag_exists(tag: str, cwd: str | Path = ".") -> bool:
+    """Check if a git tag exists in the repository.
+
+    Checks the remote first; falls back to local tags if no remote is configured.
+    """
+    # Try remote first (works in CI with origin configured)
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag}"],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    if result.returncode == 0 and tag in result.stdout:
+        return True
+
+    # Fallback: check local tags
+    result = subprocess.run(
+        ["git", "tag", "--list", tag],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    return result.returncode == 0 and tag in result.stdout
+
+
+def git_checkout_tag(tag: str, cwd: str | Path = ".") -> bool:
+    """Checkout a specific git tag. Returns True on success."""
+    result = subprocess.run(
+        ["git", "checkout", tag],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    return result.returncode == 0
+
+
+def run_git(*args: str, cwd: str | Path = ".") -> str:
+    """Run a git command and return stdout."""
+    result = subprocess.run(
+        ("git", *args),
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Verification data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PluginReleaseCheck:
+    """Result of checking a single plugin release across all registries."""
+
+    plugin: str
+    version: str
+    github_release: bool
+    pypi_version: str | None
+    conda_main: bool
+    conda_dev: bool
+    conda_labels: list[str] = field(default_factory=list)
+    verdict: str = ""
+
+
+def check_plugin_release_consistency(
+    plugin: str,
+    version: str,
+    *,
+    skip_network: bool = False,
+) -> PluginReleaseCheck:
+    """Check consistency of a plugin release across GitHub / PyPI / Conda.
+
+    Returns a PluginReleaseCheck with the verdict.
+    """
+    github_release = git_tag_exists(f"{plugin}-v{version}")
+
+    pypi_versions_list: list[str] = []
+    conda_versions_map: dict[str, list[str]] = {}
+    conda_labels: list[str] = []
+
+    if not skip_network:
+        pypi_versions_list = pypi_versions(plugin)
+        conda_versions_map = anaconda_versions(plugin)
+        if version in conda_versions_map:
+            conda_labels = conda_versions_map[version]
+
+    conda_main = "main" in conda_labels
+    conda_dev = "dev" in conda_labels
+
+    pypi_present = version in pypi_versions_list
+    pypi_version = version if pypi_present else None
+
+    if not github_release:
+        verdict = "missing_github_release"
+    elif not skip_network and not pypi_present:
+        verdict = "pypi_missing"
+    elif conda_main:
+        verdict = "aligned"
+    elif conda_dev:
+        verdict = "conda_dev_only"
+    else:
+        verdict = "conda_missing"
+
+    return PluginReleaseCheck(
+        plugin=plugin,
+        version=version,
+        github_release=github_release,
+        pypi_version=pypi_version,
+        conda_main=conda_main,
+        conda_dev=conda_dev,
+        conda_labels=conda_labels,
+        verdict=verdict,
+    )
+
+
+def format_verification_report(checks: list[PluginReleaseCheck]) -> str:
+    """Format a list of PluginReleaseCheck into a readable report."""
+    lines = [
+        "## Plugin release consistency report",
+        "",
+        "| Plugin | Version | GitHub | PyPI | Conda `main` | Conda `dev` | Verdict |",
+        "|--------|---------|--------|------|--------------|-------------|---------|",
+    ]
+    for c in checks:
+        gh = "yes" if c.github_release else "no"
+        pypi = c.pypi_version or "not found"
+        main = "yes" if c.conda_main else "no"
+        dev = "yes" if c.conda_dev else "no"
+        verdict_map = {
+            "aligned": ":white_check_mark: aligned",
+            "conda_missing": ":x: stable Conda missing",
+            "conda_dev_only": ":warning: dev-only (no stable)",
+            "pypi_missing": ":x: PyPI version missing",
+            "missing_github_release": ":x: GitHub release missing",
+        }
+        verdict = verdict_map.get(c.verdict, c.verdict)
+        lines.append(
+            f"| {c.plugin} | {c.version} | {gh} | {pypi} | {main} | {dev} | {verdict} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # verify-tag
+    p_tag = sub.add_parser("verify-tag", help="Validate a plugin tag format")
+    p_tag.add_argument("tag", help="Tag to validate (e.g. spectrochempy-nmr-v0.1.1)")
+    p_tag.add_argument("--plugin", help="Expected plugin name")
+
+    # check-release
+    p_check = sub.add_parser(
+        "check-release", help="Check consistency of a plugin release"
+    )
+    p_check.add_argument("plugin", help="Plugin name (e.g. spectrochempy-nmr)")
+    p_check.add_argument("version", help="Version to check (e.g. 0.1.11)")
+    p_check.add_argument(
+        "--skip-network",
+        action="store_true",
+        help="Skip network queries (PyPI / Anaconda.org)",
+    )
+    p_check.add_argument(
+        "--json", action="store_true", dest="as_json", help="Output JSON"
+    )
+
+    # check-all
+    p_all = sub.add_parser(
+        "check-all", help="Check consistency for all official plugins"
+    )
+    p_all.add_argument(
+        "--skip-network",
+        action="store_true",
+        help="Skip network queries (PyPI / Anaconda.org)",
+    )
+    p_all.add_argument(
+        "--json", action="store_true", dest="as_json", help="Output JSON"
+    )
+
+    # list-official
+    sub.add_parser("list-official", help="List official plugin names")
+
+    # is-official
+    p_off = sub.add_parser(
+        "is-official",
+        help=(
+            "Exit 0 if a plugin directory is declared official "
+            "([tool.spectrochempy] official-plugin = true), exit 1 otherwise, "
+            "exit 2 if the marker cannot be evaluated"
+        ),
+    )
+    p_off.add_argument(
+        "plugin_dir", help="Path to plugin directory (e.g. plugins/spectrochempy-nmr)"
+    )
+
+    return parser.parse_args()
+
+
+def cmd_verify_tag(args: argparse.Namespace) -> int:
+    try:
+        plugin, version = validate_tag_format(args.tag, args.plugin)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    print(f"Valid plugin tag: plugin={plugin}, version={version}")
+    return 0
+
+
+def cmd_check_release(args: argparse.Namespace) -> int:
+    check = check_plugin_release_consistency(
+        args.plugin, args.version, skip_network=args.skip_network
+    )
+    if args.as_json:
+        print(json.dumps(asdict(check), indent=2))
+    else:
+        print(format_verification_report([check]))
+    return 0 if check.verdict == "aligned" else 1
+
+
+def cmd_check_all(args: argparse.Namespace) -> int:
+    plugins_dir = Path("plugins")
+    official = discover_official_plugins(plugins_dir)
+    checks: list[PluginReleaseCheck] = []
+    for plugin in official:
+        version = read_plugin_version(plugins_dir / plugin)
+        if not version:
+            continue
+        checks.append(
+            check_plugin_release_consistency(
+                plugin, version, skip_network=args.skip_network
+            )
+        )
+    if args.as_json:
+        print(json.dumps([asdict(c) for c in checks], indent=2))
+    else:
+        print(format_verification_report(checks))
+    return 0 if all(c.verdict == "aligned" for c in checks) else 1
+
+
+def cmd_list_official(_args: argparse.Namespace) -> int:
+    plugins = discover_official_plugins(Path("plugins"))
+    for p in plugins:
+        print(p)
+    return 0
+
+
+def cmd_is_official(args: argparse.Namespace) -> int:
+    try:
+        official = is_official_plugin(Path(args.plugin_dir))
+    except Exception as exc:
+        print(f"::error::Could not evaluate official marker: {exc}", file=sys.stderr)
+        return 2
+    return 0 if official else 1
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "verify-tag":
+        return cmd_verify_tag(args)
+    elif args.command == "check-release":
+        return cmd_check_release(args)
+    elif args.command == "check-all":
+        return cmd_check_all(args)
+    elif args.command == "list-official":
+        return cmd_list_official(args)
+    elif args.command == "is-official":
+        return cmd_is_official(args)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/scripts/conda_publish.py
+++ b/.github/workflows/scripts/conda_publish.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import asdict
@@ -30,6 +32,16 @@ TAG_RE = re.compile(
 
 PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
 ANACONDA_FILES_URL = "https://api.anaconda.org/package/{owner}/{package}/files"
+
+
+class ServiceUnavailableError(RuntimeError):
+    """
+    Raised when a registry (PyPI / Anaconda.org) cannot be queried.
+
+    Distinct from a genuine "not found": an HTTP 404 means the resource does
+    not exist, while network errors, timeouts and 5xx mean the check cannot
+    conclude.  Callers must not turn the latter into a "version missing".
+    """
 
 
 def parse_plugin_tag(tag: str) -> tuple[str, str] | None:
@@ -86,18 +98,37 @@ def read_plugin_init_version(plugin_dir: Path) -> str | None:
 
 
 def read_recipe_version(recipe_path: Path) -> str | None:
-    """Read context.version from a conda recipe.yaml."""
+    """
+    Read the version from a conda recipe.
+
+    Supports both the ``recipe.yaml`` form (``version: "0.1.1"`` under
+    ``context:`` or ``package:``) and the legacy ``meta.yaml`` jinja form
+    (``{% set version = "0.1.1" %}``).
+    """
     if not recipe_path.is_file():
         return None
-    for line in recipe_path.read_text().splitlines():
-        m = re.match(r'^\s+version:\s*"([^"]+)"', line)
-        if m:
-            return m.group(1)
+    text = recipe_path.read_text()
+    match = re.search(r"{%\s*set\s+version\s*=\s*[\"']([^\"']+)[\"']\s*%}", text)
+    if match:
+        return match.group(1)
+    match = re.search(
+        r'^\s*version\s*:\s*(?:"([^"]+)"|\'([^\']+)\'|([^\s#]+))',
+        text,
+        re.MULTILINE,
+    )
+    if match:
+        return match.group(1) or match.group(2) or match.group(3)
     return None
 
 
 def is_official_plugin(plugin_dir: Path) -> bool:
-    """Check if a plugin directory declares official-plugin = true."""
+    """
+    Check if a plugin directory declares official-plugin = true.
+
+    A *missing* pyproject.toml is treated as "not official".  A pyproject
+    that cannot be read or parsed is an evaluation error and raises, so the
+    caller can fail loudly instead of silently skipping the plugin.
+    """
     try:
         import tomllib
     except ImportError:
@@ -108,10 +139,12 @@ def is_official_plugin(plugin_dir: Path) -> bool:
         return False
     try:
         data = tomllib.loads(pyproject.read_text())
-        tool_sc = data.get("tool", {}).get("spectrochempy", {})
-        return tool_sc.get("official-plugin") is True
-    except Exception:
-        return False
+    except Exception as exc:
+        raise ValueError(f"cannot parse {pyproject}: {exc}") from exc
+    tool_sc = data.get("tool", {}).get("spectrochempy", {})
+    if not isinstance(tool_sc, dict):
+        raise ValueError(f"invalid [tool.spectrochempy] table in {pyproject}")
+    return tool_sc.get("official-plugin") is True
 
 
 def discover_official_plugins(plugins_dir: Path) -> list[str]:
@@ -125,21 +158,27 @@ def discover_official_plugins(plugins_dir: Path) -> list[str]:
     return results
 
 
-def fetch_json(url: str, timeout: int = 30) -> dict | None:
-    """Fetch JSON from a URL, returning None on failure."""
+def fetch_json(url: str, timeout: int = 30) -> dict | list | None:
+    """
+    Fetch JSON from a URL.
+
+    Returns None when the resource does not exist (HTTP 404) and raises
+    :class:`ServiceUnavailableError` on any other failure (network error,
+    timeout, HTTP 5xx, unreadable JSON), so that callers can distinguish a
+    genuine "missing" package from an unavailable service.
+    """
     try:
         # URLs are built from https:// API constants only (never user-supplied
         # or file:// schemes), so the urlopen audit is not applicable here.
         req = urllib.request.Request(url, headers={"Accept": "application/json"})  # noqa: S310
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
             return json.loads(resp.read().decode())
-    except (
-        urllib.error.URLError,
-        urllib.error.HTTPError,
-        json.JSONDecodeError,
-        OSError,
-    ):
-        return None
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise ServiceUnavailableError(f"{url}: HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as exc:
+        raise ServiceUnavailableError(f"{url}: {exc}") from exc
 
 
 def pypi_versions(package: str) -> list[str]:
@@ -193,6 +232,61 @@ def anaconda_version_labels(
     return anaconda_versions(package, owner).get(version, [])
 
 
+def list_plugin_tags(cwd: str | Path = ".") -> list[tuple[str, str]]:
+    """
+    Return all (plugin, version) pairs from git release tags.
+
+    Reads the remote tags first and falls back to local tags when no remote
+    is configured.  Annotated tag peel lines (``refs/tags/foo^{}``) are
+    ignored.
+    """
+    # git is a trusted VCS binary (fixed args from the repo config, never
+    # untrusted input), so the subprocess audit is not applicable.
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", "origin"],  # noqa: S603, S607
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    refs = result.stdout if result.returncode == 0 else ""
+
+    tags: set[str] = set()
+    for line in refs.splitlines():
+        if "^{}" in line:
+            continue
+        fields = line.split("\t")
+        if len(fields) == 2 and fields[1].startswith("refs/tags/"):
+            tags.add(fields[1].removeprefix("refs/tags/"))
+
+    seen: set[tuple[str, str]] = set()
+    parsed: list[tuple[str, str]] = []
+    for tag in sorted(tags):
+        match = parse_plugin_tag(tag)
+        if match and match not in seen:
+            seen.add(match)
+            parsed.append(match)
+
+    # The configured remote may not host every plugin tag (e.g. local work
+    # against a fork); fall back to local tags whenever the remote yields no
+    # plugin tags at all.
+    if not parsed:
+        result = subprocess.run(
+            ["git", "tag", "--list"],  # noqa: S603, S607
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+        if result.returncode == 0:
+            for tag in result.stdout.splitlines():
+                match = parse_plugin_tag(tag.strip())
+                if match and match not in seen:
+                    seen.add(match)
+                    parsed.append(match)
+
+    parsed.sort(key=lambda pair: (pair[0], tuple(int(p) for p in pair[1].split("."))))
+    return parsed
+
+
 def git_tag_exists(tag: str, cwd: str | Path = ".") -> bool:
     """
     Check if a git tag exists in the repository.
@@ -236,9 +330,11 @@ class PluginReleaseCheck:
     plugin: str
     version: str
     github_release: bool
-    pypi_version: str | None
-    conda_main: bool
-    conda_dev: bool
+    pypi_available: bool = True
+    conda_available: bool = True
+    pypi_version: str | None = None
+    conda_main: bool = False
+    conda_dev: bool = False
     conda_labels: list[str] = field(default_factory=list)
     verdict: str = ""
 
@@ -252,19 +348,29 @@ def check_plugin_release_consistency(
     """
     Check consistency of a plugin release across GitHub / PyPI / Conda.
 
-    Returns a PluginReleaseCheck with the verdict.
+    Returns a PluginReleaseCheck with the verdict.  ``pypi_unavailable`` /
+    ``conda_unavailable`` verdicts mean the registry could not be queried,
+    so nothing can be concluded for that release.
     """
     github_release = git_tag_exists(f"{plugin}-v{version}")
 
     pypi_versions_list: list[str] = []
     conda_versions_map: dict[str, list[str]] = {}
     conda_labels: list[str] = []
+    pypi_available = True
+    conda_available = True
 
     if not skip_network:
-        pypi_versions_list = pypi_versions(plugin)
-        conda_versions_map = anaconda_versions(plugin)
-        if version in conda_versions_map:
-            conda_labels = conda_versions_map[version]
+        try:
+            pypi_versions_list = pypi_versions(plugin)
+        except ServiceUnavailableError:
+            pypi_available = False
+        try:
+            conda_versions_map = anaconda_versions(plugin)
+            if version in conda_versions_map:
+                conda_labels = conda_versions_map[version]
+        except ServiceUnavailableError:
+            conda_available = False
 
     conda_main = "main" in conda_labels
     conda_dev = "dev" in conda_labels
@@ -274,6 +380,10 @@ def check_plugin_release_consistency(
 
     if not github_release:
         verdict = "missing_github_release"
+    elif not pypi_available:
+        verdict = "pypi_unavailable"
+    elif not conda_available:
+        verdict = "conda_unavailable"
     elif not skip_network and not pypi_present:
         verdict = "pypi_missing"
     elif conda_main:
@@ -287,6 +397,8 @@ def check_plugin_release_consistency(
         plugin=plugin,
         version=version,
         github_release=github_release,
+        pypi_available=pypi_available,
+        conda_available=conda_available,
         pypi_version=pypi_version,
         conda_main=conda_main,
         conda_dev=conda_dev,
@@ -313,6 +425,8 @@ def format_verification_report(checks: list[PluginReleaseCheck]) -> str:
             "conda_missing": ":x: stable Conda missing",
             "conda_dev_only": ":warning: dev-only (no stable)",
             "pypi_missing": ":x: PyPI version missing",
+            "pypi_unavailable": ":warning: PyPI unavailable (cannot conclude)",
+            "conda_unavailable": ":warning: Conda unavailable (cannot conclude)",
             "missing_github_release": ":x: GitHub release missing",
         }
         verdict = verdict_map.get(c.verdict, c.verdict)
@@ -381,6 +495,66 @@ def parse_args() -> argparse.Namespace:
         "plugin_dir", help="Path to plugin directory (e.g. plugins/spectrochempy-nmr)"
     )
 
+    # validate-release
+    p_val = sub.add_parser(
+        "validate-release",
+        help=(
+            "Validate that the versions declared by a plugin checkout "
+            "(pyproject.toml, __init__.py, recipe) match the release tag version"
+        ),
+    )
+    p_val.add_argument(
+        "plugin_dir",
+        help="Path to the plugin directory inside the exact tag checkout",
+    )
+    p_val.add_argument("version", help="Expected version from the release tag")
+
+    # upload-conda
+    p_up = sub.add_parser(
+        "upload-conda",
+        help=(
+            "Safely upload a built Conda artifact to Anaconda.org.  Refuses to "
+            "overwrite an already-published version unless --allow-override is passed."
+        ),
+    )
+    p_up.add_argument("artifact", help="Path to the .conda / .tar.bz2 artifact")
+    p_up.add_argument("--plugin", required=True, help="Expected plugin package name")
+    p_up.add_argument("--version", required=True, help="Expected version")
+    p_up.add_argument("--owner", default="spectrocat")
+    p_up.add_argument("--label", default="main")
+    p_up.add_argument("--token", default="", help="Defaults to ANACONDA_API_TOKEN")
+    p_up.add_argument(
+        "--allow-override",
+        action="store_true",
+        help="Explicit derogation: allow replacing an already-published version",
+    )
+    p_up.add_argument("--dry-run", action="store_true")
+    p_up.add_argument("--no-verify", dest="verify", action="store_false")
+    p_up.add_argument("--retries", type=int, default=8)
+    p_up.add_argument("--delay", type=float, default=15.0)
+
+    # verify-conda
+    p_vc = sub.add_parser(
+        "verify-conda",
+        help="Poll the Anaconda /files API until a version carries a label",
+    )
+    p_vc.add_argument("plugin")
+    p_vc.add_argument("version")
+    p_vc.add_argument("--owner", default="spectrocat")
+    p_vc.add_argument("--label", default="main")
+
+    # conda-state
+    p_cs = sub.add_parser(
+        "conda-state",
+        help=(
+            "Report the labels of a version on Anaconda (0=found, 1=missing, "
+            "2=service unavailable)"
+        ),
+    )
+    p_cs.add_argument("plugin")
+    p_cs.add_argument("version")
+    p_cs.add_argument("--owner", default="spectrocat")
+
     return parser.parse_args()
 
 
@@ -406,13 +580,21 @@ def cmd_check_release(args: argparse.Namespace) -> int:
 
 
 def cmd_check_all(args: argparse.Namespace) -> int:
-    plugins_dir = Path("plugins")
-    official = discover_official_plugins(plugins_dir)
+    """Check consistency for every official plugin release (all git tags)."""
+    tags = list_plugin_tags()
+    if tags:
+        check_keys: list[tuple[str, str]] = tags
+    else:
+        # Fallback when not inside a git checkout: check the versions declared
+        # by the current pyproject.toml files.
+        plugins_dir = Path("plugins")
+        check_keys = []
+        for plugin in discover_official_plugins(plugins_dir):
+            version = read_plugin_version(plugins_dir / plugin)
+            if version:
+                check_keys.append((plugin, version))
     checks: list[PluginReleaseCheck] = []
-    for plugin in official:
-        version = read_plugin_version(plugins_dir / plugin)
-        if not version:
-            continue
+    for plugin, version in check_keys:
         checks.append(
             check_plugin_release_consistency(
                 plugin, version, skip_network=args.skip_network
@@ -441,6 +623,217 @@ def cmd_is_official(args: argparse.Namespace) -> int:
     return 0 if official else 1
 
 
+def cmd_validate_release(args: argparse.Namespace) -> int:
+    """Validate declared versions (pyproject / __init__ / recipe) vs tag version."""
+    plugin_dir = Path(args.plugin_dir)
+    version = args.version
+    try:
+        errors: list[str] = []
+
+        declared = read_plugin_version(plugin_dir)
+        if declared is None:
+            errors.append(f"no version found in {plugin_dir / 'pyproject.toml'}")
+        elif declared != version:
+            errors.append(
+                f"pyproject.toml version ({declared}) != tag version ({version})"
+            )
+
+        init_version = read_plugin_init_version(plugin_dir)
+        if init_version is not None and init_version != version:
+            errors.append(
+                f"__init__.py version ({init_version}) != tag version ({version})"
+            )
+
+        recipe_file = plugin_dir / "recipe.yaml"
+        if not recipe_file.is_file():
+            recipe_file = plugin_dir / "meta.yaml"
+        if not recipe_file.is_file():
+            errors.append(f"no recipe.yaml or meta.yaml found in {plugin_dir}")
+        else:
+            recipe_version = read_recipe_version(recipe_file)
+            if recipe_version is None:
+                errors.append(f"could not read the version from {recipe_file}")
+            elif recipe_version != version:
+                errors.append(
+                    f"recipe version ({recipe_version}) != tag version ({version})"
+                )
+    except Exception as exc:
+        print(f"::error::Could not validate release: {exc}", file=sys.stderr)
+        return 2
+
+    if errors:
+        for err in errors:
+            print(f"::error::{err}", file=sys.stderr)
+        return 1
+
+    print(f"Plugin {plugin_dir.name} releases consistently at version {version}")
+    return 0
+
+
+def artifact_matches(artifact: str | Path, plugin: str, version: str) -> bool:
+    """Return True when the artifact basename starts with '<plugin>-<version>-'."""
+    return Path(artifact).name.startswith(f"{plugin}-{version}-")
+
+
+def verify_conda_upload(
+    plugin: str,
+    version: str,
+    *,
+    owner: str = "spectrocat",
+    label: str = "main",
+    retries: int = 8,
+    delay: float = 15.0,
+) -> bool:
+    """Poll the Anaconda /files API until the version carries the label."""
+    for attempt in range(1, retries + 1):
+        try:
+            labels = anaconda_version_labels(plugin, version, owner)
+        except ServiceUnavailableError:
+            labels = []
+        if label in labels:
+            print(
+                f"Verified: {plugin}=={version} is on Anaconda '{label}' (labels: {labels})"
+            )
+            return True
+        if attempt < retries:
+            print(
+                f"  (attempt {attempt}/{retries}: not yet on '{label}', retrying in {delay:.0f}s)"
+            )
+            time.sleep(delay)
+    print(
+        f"::error::Timed out waiting for {plugin}=={version} on the '{label}' label",
+        file=sys.stderr,
+    )
+    return False
+
+
+def upload_conda(
+    artifact: str | Path,
+    *,
+    plugin: str,
+    version: str,
+    owner: str = "spectrocat",
+    label: str = "main",
+    token: str = "",
+    allow_override: bool = False,
+    dry_run: bool = False,
+    verify: bool = True,
+    retries: int = 8,
+    delay: float = 15.0,
+) -> int:
+    """
+    Safely upload a built Conda artifact to Anaconda.org.  Returns an exit code.
+
+    Guards:
+    - the artifact basename must match ``<plugin>-<version>-`` exactly;
+    - the version must not already exist on the target label unless the
+      operator explicitly passes ``allow_override`` (documented derogation);
+    - ``anaconda upload`` is called without ``--force`` except in that case;
+    - after the upload, the /files API is polled until the label appears.
+    """
+    artifact_path = Path(artifact)
+    if not artifact_path.is_file():
+        print(f"::error::Artifact not found: {artifact}", file=sys.stderr)
+        return 1
+    if not artifact_matches(artifact_path, plugin, version):
+        print(
+            f"::error::Artifact '{artifact_path.name}' does not match {plugin}=={version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not token:
+        token = os.environ.get("ANACONDA_API_TOKEN", "")
+    if not token and not dry_run:
+        print("::error::ANACONDA_API_TOKEN is not set. Cannot upload.", file=sys.stderr)
+        return 1
+
+    try:
+        existing_labels = anaconda_version_labels(plugin, version, owner)
+    except ServiceUnavailableError as exc:
+        print(
+            f"::error::Could not check Anaconda for an existing package: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if label in existing_labels and not allow_override:
+        print(
+            f"::error::{plugin}=={version} already exists on the '{label}' label "
+            f"(labels: {existing_labels}). Use --allow-override (explicit "
+            "derogation) to replace it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if dry_run:
+        action = "re-upload (override)" if label in existing_labels else "upload"
+        print(
+            f"[dry-run] would {action}: {artifact_path.name} -> {owner} label '{label}'"
+        )
+        return 0
+
+    command = ["anaconda", "--token", token, "upload"]
+    if allow_override and label in existing_labels:
+        command.append("--force")
+    command += ["-u", owner, "-l", label, str(artifact_path)]
+    print(f"Uploading {artifact_path.name} to {owner} label '{label}'")
+    # 'anaconda' is the pinned anaconda-client CLI installed in the job; the
+    # token and label come from the workflow, not from untrusted input.
+    result = subprocess.run(command)  # noqa: S603, S607
+    if result.returncode != 0:
+        print(
+            f"::error::anaconda upload failed (exit {result.returncode})",
+            file=sys.stderr,
+        )
+        return result.returncode
+
+    if verify and not verify_conda_upload(
+        plugin, version, owner=owner, label=label, retries=retries, delay=delay
+    ):
+        return 1
+    if not verify:
+        print(f"Uploaded {artifact_path.name} to {owner} label '{label}'")
+    return 0
+
+
+def cmd_upload(args: argparse.Namespace) -> int:
+    return upload_conda(
+        args.artifact,
+        plugin=args.plugin,
+        version=args.version,
+        owner=args.owner,
+        label=args.label,
+        token=args.token,
+        allow_override=args.allow_override,
+        dry_run=args.dry_run,
+        verify=args.verify,
+        retries=args.retries,
+        delay=args.delay,
+    )
+
+
+def cmd_verify_conda(args: argparse.Namespace) -> int:
+    if verify_conda_upload(
+        args.plugin, args.version, owner=args.owner, label=args.label
+    ):
+        return 0
+    return 1
+
+
+def cmd_conda_state(args: argparse.Namespace) -> int:
+    try:
+        labels = anaconda_version_labels(args.plugin, args.version, args.owner)
+    except ServiceUnavailableError as exc:
+        print(f"service_unavailable: {exc}", file=sys.stderr)
+        return 2
+    if not labels:
+        print(f"{args.plugin}=={args.version} not found on any label")
+        return 1
+    print(f"{args.plugin}=={args.version} found on labels: {':'.join(sorted(labels))}")
+    return 0
+
+
 def main() -> int:
     args = parse_args()
     commands = {
@@ -449,6 +842,10 @@ def main() -> int:
         "check-all": cmd_check_all,
         "list-official": cmd_list_official,
         "is-official": cmd_is_official,
+        "validate-release": cmd_validate_release,
+        "upload-conda": cmd_upload,
+        "verify-conda": cmd_verify_conda,
+        "conda-state": cmd_conda_state,
     }
     return commands.get(args.command, lambda _: 1)(args)
 

--- a/.github/workflows/scripts/conda_publish.py
+++ b/.github/workflows/scripts/conda_publish.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # ruff: noqa: T201
-"""Shared helpers for Conda plugin publication and verification.
+"""
+Shared helpers for Conda plugin publication and verification.
 
 Provides functions for:
 - Parsing and validating plugin tags
@@ -18,7 +19,9 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 
 TAG_RE = re.compile(
@@ -37,8 +40,11 @@ def parse_plugin_tag(tag: str) -> tuple[str, str] | None:
     return match.group("plugin"), match.group("version")
 
 
-def validate_tag_format(tag: str, expected_plugin: str | None = None) -> tuple[str, str]:
-    """Validate a plugin tag and return (plugin_name, version).
+def validate_tag_format(
+    tag: str, expected_plugin: str | None = None
+) -> tuple[str, str]:
+    """
+    Validate a plugin tag and return (plugin_name, version).
 
     Raises ValueError with a clear diagnostic if the tag is invalid.
     """
@@ -122,10 +128,17 @@ def discover_official_plugins(plugins_dir: Path) -> list[str]:
 def fetch_json(url: str, timeout: int = 30) -> dict | None:
     """Fetch JSON from a URL, returning None on failure."""
     try:
-        req = urllib.request.Request(url, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        # URLs are built from https:// API constants only (never user-supplied
+        # or file:// schemes), so the urlopen audit is not applicable here.
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})  # noqa: S310
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
             return json.loads(resp.read().decode())
-    except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError):
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        json.JSONDecodeError,
+        OSError,
+    ):
         return None
 
 
@@ -146,10 +159,9 @@ def pypi_latest_version(package: str) -> str | None:
     return info.get("version")
 
 
-def anaconda_versions(
-    package: str, owner: str = "spectrocat"
-) -> dict[str, list[str]]:
-    """Return {version: [labels]} for a package on Anaconda.org.
+def anaconda_versions(package: str, owner: str = "spectrocat") -> dict[str, list[str]]:
+    """
+    Return {version: [labels]} for a package on Anaconda.org.
 
     Uses the package /files endpoint, which lists every uploaded file with
     its channel labels.  Returns empty dict if the package is not found.
@@ -182,13 +194,17 @@ def anaconda_version_labels(
 
 
 def git_tag_exists(tag: str, cwd: str | Path = ".") -> bool:
-    """Check if a git tag exists in the repository.
+    """
+    Check if a git tag exists in the repository.
 
     Checks the remote first; falls back to local tags if no remote is configured.
     """
+    # git is a trusted VCS binary (fixed args from the repo config, never
+    # untrusted input), so the subprocess audit is not applicable.  The tag is
+    # validated earlier against the PEP 440 pattern.
     # Try remote first (works in CI with origin configured)
     result = subprocess.run(
-        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag}"],
+        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag}"],  # noqa: S603, S607
         capture_output=True,
         text=True,
         cwd=cwd,
@@ -198,7 +214,7 @@ def git_tag_exists(tag: str, cwd: str | Path = ".") -> bool:
 
     # Fallback: check local tags
     result = subprocess.run(
-        ["git", "tag", "--list", tag],
+        ["git", "tag", "--list", tag],  # noqa: S603, S607
         capture_output=True,
         text=True,
         cwd=cwd,
@@ -206,29 +222,8 @@ def git_tag_exists(tag: str, cwd: str | Path = ".") -> bool:
     return result.returncode == 0 and tag in result.stdout
 
 
-def git_checkout_tag(tag: str, cwd: str | Path = ".") -> bool:
-    """Checkout a specific git tag. Returns True on success."""
-    result = subprocess.run(
-        ["git", "checkout", tag],
-        capture_output=True,
-        text=True,
-        cwd=cwd,
-    )
-    return result.returncode == 0
-
-
-def run_git(*args: str, cwd: str | Path = ".") -> str:
-    """Run a git command and return stdout."""
-    result = subprocess.run(
-        ("git", *args),
-        check=True,
-        capture_output=True,
-        text=True,
-        cwd=cwd,
-    )
-    return result.stdout.strip()
-
-
+# ---------------------------------------------------------------------------
+# Version reading
 # ---------------------------------------------------------------------------
 # Verification data structures
 # ---------------------------------------------------------------------------
@@ -254,7 +249,8 @@ def check_plugin_release_consistency(
     *,
     skip_network: bool = False,
 ) -> PluginReleaseCheck:
-    """Check consistency of a plugin release across GitHub / PyPI / Conda.
+    """
+    Check consistency of a plugin release across GitHub / PyPI / Conda.
 
     Returns a PluginReleaseCheck with the verdict.
     """
@@ -447,17 +443,14 @@ def cmd_is_official(args: argparse.Namespace) -> int:
 
 def main() -> int:
     args = parse_args()
-    if args.command == "verify-tag":
-        return cmd_verify_tag(args)
-    elif args.command == "check-release":
-        return cmd_check_release(args)
-    elif args.command == "check-all":
-        return cmd_check_all(args)
-    elif args.command == "list-official":
-        return cmd_list_official(args)
-    elif args.command == "is-official":
-        return cmd_is_official(args)
-    return 1
+    commands = {
+        "verify-tag": cmd_verify_tag,
+        "check-release": cmd_check_release,
+        "check-all": cmd_check_all,
+        "list-official": cmd_list_official,
+        "is-official": cmd_is_official,
+    }
+    return commands.get(args.command, lambda _: 1)(args)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/verify_plugin_release_consistency.yml
+++ b/.github/workflows/verify_plugin_release_consistency.yml
@@ -1,0 +1,85 @@
+name: Verify plugin release consistency
+
+# Manual workflow to check that all official plugin releases are present
+# on GitHub, PyPI, and the Conda main label.  Can also be run as a
+# read-only step after any plugin release.
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-consistency:
+    name: Check release consistency
+    runs-on: ubuntu-latest
+    if: github.repository == 'spectrochempy/spectrochempy'
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Check all official plugin releases
+        id: check
+        run: |
+          python3 .github/workflows/scripts/conda_publish.py check-all \
+            --json > /tmp/check-results.json
+
+          # Count issues
+          ALIGNED=$(python3 -c "
+          import json
+          data = json.load(open('/tmp/check-results.json'))
+          print(sum(1 for c in data if c['verdict'] == 'aligned'))
+          ")
+          ISSUES=$(python3 -c "
+          import json
+          data = json.load(open('/tmp/check-results.json'))
+          print(sum(1 for c in data if c['verdict'] != 'aligned'))
+          ")
+
+          echo "aligned=$ALIGNED" >> "$GITHUB_OUTPUT"
+          echo "issues=$ISSUES" >> "$GITHUB_OUTPUT"
+
+          # Print human-readable report
+          python3 .github/workflows/scripts/conda_publish.py check-all
+
+      - name: Write step summary
+        if: always()
+        run: |
+          python3 .github/workflows/scripts/conda_publish.py check-all > /tmp/report.txt
+
+          echo "## Plugin release consistency report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/report.txt >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          ISSUES="${{ steps.check.outputs.issues }}"
+          if [ "$ISSUES" -gt 0 ]; then
+            echo "### Action required" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "$ISSUES plugin(s) have version alignment issues." >> "$GITHUB_STEP_SUMMARY"
+            echo "Use the **Repair plugin Conda publication** workflow to fix missing Conda packages." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo ":white_check_mark: All official plugin releases are aligned across GitHub, PyPI, and Conda." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Fail if issues found
+        if: steps.check.outputs.issues != '0'
+        run: |
+          echo "::error::${{ steps.check.outputs.issues }} plugin(s) have version alignment issues"
+          exit 1

--- a/.github/workflows/verify_plugin_release_consistency.yml
+++ b/.github/workflows/verify_plugin_release_consistency.yml
@@ -1,13 +1,16 @@
 name: Verify plugin release consistency
 
-# Manual workflow to check that all official plugin releases are present
-# on GitHub, PyPI, and the Conda main label.  Can also be run as a
-# read-only step after any plugin release.
+# Read-only workflow checking that every official plugin release tag is
+# present on GitHub, PyPI and the Conda main label.
+#
+# Triggered on a schedule and manually only: running it on every push to
+# master would keep the branch red until historical plugin releases are
+# repaired (see maintainers/release-process.md).  Once the repair workflow
+# has caught up, a push trigger can be re-enabled.
 
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -37,49 +40,102 @@ jobs:
       - name: Check all official plugin releases
         id: check
         run: |
+          # check-all exits 1 when a release is inconsistent or a registry is
+          # unreachable.  Capture the code explicitly so the report and the
+          # counters are still produced before the workflow decides to fail.
+          set +e
           python3 .github/workflows/scripts/conda_publish.py check-all \
             --json > /tmp/check-results.json
+          rc=$?
+          set -e
+          echo "check_rc=$rc" >> "$GITHUB_OUTPUT"
 
-          # Count issues
-          ALIGNED=$(python3 -c "
+          rc="$rc" python3 - <<'PY'
           import json
-          data = json.load(open('/tmp/check-results.json'))
-          print(sum(1 for c in data if c['verdict'] == 'aligned'))
-          ")
-          ISSUES=$(python3 -c "
-          import json
-          data = json.load(open('/tmp/check-results.json'))
-          print(sum(1 for c in data if c['verdict'] != 'aligned'))
-          ")
+          import os
 
-          echo "aligned=$ALIGNED" >> "$GITHUB_OUTPUT"
-          echo "issues=$ISSUES" >> "$GITHUB_OUTPUT"
+          try:
+              data = json.load(open("/tmp/check-results.json"))
+          except Exception as exc:
+              print(f"::warning::Could not read check results: {exc}")
+              data = []
 
-          # Print human-readable report
-          python3 .github/workflows/scripts/conda_publish.py check-all
+          aligned = sum(1 for c in data if c["verdict"] == "aligned")
+          issues = len(data) - aligned
+          # A check that produced no results (e.g. crash) must fail the job.
+          if not data and os.environ.get("rc") != "0":
+              issues = 1
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+              f.write(f"aligned={aligned}\n")
+              f.write(f"issues={issues}\n")
+          print(f"aligned={aligned} issues={issues}")
+          PY
 
       - name: Write step summary
         if: always()
         run: |
-          python3 .github/workflows/scripts/conda_publish.py check-all > /tmp/report.txt
+          python3 - <<'PY'
+          import json
+          import os
 
-          echo "## Plugin release consistency report" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          cat /tmp/report.txt >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          try:
+              data = json.load(open("/tmp/check-results.json"))
+          except Exception:
+              data = []
 
-          ISSUES="${{ steps.check.outputs.issues }}"
-          if [ "$ISSUES" -gt 0 ]; then
-            echo "### Action required" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "$ISSUES plugin(s) have version alignment issues." >> "$GITHUB_STEP_SUMMARY"
-            echo "Use the **Repair plugin Conda publication** workflow to fix missing Conda packages." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo ":white_check_mark: All official plugin releases are aligned across GitHub, PyPI, and Conda." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          vmap = {
+              "aligned": "aligned",
+              "conda_missing": "stable Conda missing",
+              "conda_dev_only": "dev-only (no stable)",
+              "pypi_missing": "PyPI version missing",
+              "pypi_unavailable": "PyPI unavailable",
+              "conda_unavailable": "Conda unavailable",
+              "missing_github_release": "GitHub release missing",
+          }
+
+          lines = ["## Plugin release consistency report", ""]
+          lines.append("| Plugin | Version | GitHub | PyPI | Conda main | Verdict |")
+          lines.append("|--------|---------|--------|------|------------|---------|")
+          for c in data:
+              gh = "yes" if c["github_release"] else "no"
+              pypi = c["pypi_version"] or "not found"
+              main = "yes" if c["conda_main"] else "no"
+              verdict = vmap.get(c["verdict"], c["verdict"])
+              lines.append(
+                  f"| {c['plugin']} | {c['version']} | {gh} | {pypi} | {main} | {verdict} |"
+              )
+          lines.append("")
+
+          if data:
+              issues = sum(1 for c in data if c["verdict"] != "aligned")
+              if issues:
+                  lines.append("### Action required")
+                  lines.append("")
+                  lines.append(
+                      f"{issues} release(s) are not aligned across GitHub, PyPI and Conda."
+                  )
+                  lines.append(
+                      "Use the **Repair plugin Conda publication** workflow to fix "
+                      "missing Conda packages."
+                  )
+              else:
+                  lines.append(
+                      ":white_check_mark: All official plugin releases are aligned "
+                      "across GitHub, PyPI, and Conda."
+                  )
+          else:
+              lines.append(
+                  "_No release data to display (the check failed to produce results). "
+                  "See the step log._"
+              )
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as f:
+              f.write("\n".join(lines) + "\n")
+          PY
 
       - name: Fail if issues found
         if: steps.check.outputs.issues != '0'
         run: |
-          echo "::error::${{ steps.check.outputs.issues }} plugin(s) have version alignment issues"
+          echo "::error::${{ steps.check.outputs.issues }} release(s) have version alignment issues"
           exit 1

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -26,6 +26,12 @@ Bug Fixes
 ~~~~~~~~~
 .. Add here new bug fixes (do not delete this comment)
 
+- Restored publication of official plugins (``[tool.spectrochempy]``
+  ``official-plugin = true``) on Conda, which was silently skipped by the
+  release workflow.  Added a recovery workflow to republish plugin versions
+  that are missing on ``spectrocat/main`` and a consistency check between
+  GitHub releases, PyPI and Conda. (#1611)
+
 
 .. section
 

--- a/docs/sources/whatsnew/index.rst
+++ b/docs/sources/whatsnew/index.rst
@@ -18,6 +18,7 @@ Version 0.12
 .. toctree::
     :maxdepth: 1
 
+    latest
     v0.12.8
     v0.12.7
     v0.12.6

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -6,94 +6,17 @@
 
 :orphan:
 
-What's New in Revision 0.12.8
+What's New in Revision 0.12.9.dev
 ---------------------------------------------------------------------------------------
 
-These are the changes in SpectroChemPy-0.12.8.
+These are the changes in SpectroChemPy-0.12.9.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
-
-New Features
-~~~~~~~~~~~~
-
-- Added ``scp.Pipeline`` for linear, reproducible composition of SpectroChemPy
-  estimators: allowlisted
-  preprocessing transformers optionally followed by a final transformer
-  (``PCA``) or a supervised estimator (``PLSRegression``, ``LSTSQ``, ``NNLS``).
-  Steps are templates cloned on fit (``fitted_steps_`` /
-  ``fitted_named_steps_``); ``transform`` / ``fit_transform`` are available
-  for transformer-final pipelines and ``predict`` / ``score`` for
-  estimator-final pipelines, with nested ``set_params`` support and fitted-state
-  invalidation. (#1590)
-
-- OMNIC ``.spa`` imports now expose additional acquisition metadata in
-  ``dataset.meta`` when available for the file variant: scan and FFT point
-  counts, sample and background scan counts and gains, interferogram peak
-  position, aperture, digitizer bit depth, filter settings, and reference
-  frequency. (#1606)
 
 Bug Fixes
 ~~~~~~~~~
 
-- Fixed ``scp.simpson`` so it always resolves to the public numerical
-  integration function ``simpson(dataset, dim='x')``, even when a plugin
-  contributes a SIMPSON I/O reader; ``scp.read_simpson`` and
-  ``scp.nmr.read_simpson`` remain the explicit file-reading surfaces and
-  ``dataset.simpson()`` is unchanged. (#1599)
-- Corrected OMNIC ``.spa`` interferogram optical-path-difference coordinates by
-  honoring the native header sample-spacing factor instead of always assuming
-  a doubled step. (#1598)
-- Corrected OMNIC SPA metadata decoding: optical velocity now comes from the
-  canonical acquisition-parameter block when available, with a fallback for
-  older files; Raman ``laser_frequency`` now reports the excitation frequency
-  separately from ``reference_frequency``. Experiment Information in SPA and
-  SPG files now correctly distinguishes the path, title, description, and
-  accessory fields. (#1603, #1605, #1606)
-- Recognized library/retrieved OMNIC ``.spa`` variants no longer receive a
-  spurious acquisition date. They use an undated spectrum coordinate instead
-  of interpreting a non-acquisition header value as a timestamp. (#1605)
-- Corrected OMNIC ``.srs`` series time-axis anchoring (it now starts from the
-  recorded series minimum time) and fixed per-spectrum labels, which no longer
-  include binary metadata leaked past the 84-byte record. (#1593)
-- Normalized OMNIC ``.srs`` spectral series to the public ``read_spa``
-  convention: wavenumbers are exposed descending with the intensity data
-  matched to them. Rapid-scan interferograms keep their ascending data-points
-  axis and records with an unrecognized X-axis type are left unchanged with a
-  warning. (#1594, #1595)
-
-Breaking Changes
-~~~~~~~~~~~~~~~~
-
-- Removed ``dataset.meta.omnic_experiment_file`` from OMNIC Experiment
-  Information. Despite its name, this field exposed the native experiment
-  title rather than a reliable filename and could therefore provide incorrect
-  provenance information. It was removed as a metadata-correctness fix rather
-  than retained through the normal deprecation cycle. Use
-  ``dataset.meta.omnic_experiment_title`` for the native title/name field;
-  the separate description is available as
-  ``dataset.meta.omnic_experiment_description``. (#1605)
-
-Deprecations
-~~~~~~~~~~~~
-
-- The ``reverse_x`` keyword argument of ``read_srs`` is deprecated: SRS
-  spectral orientation is now handled automatically. Supplying it (with any
-  value) emits a ``DeprecationWarning`` and is ignored. (#1594, #1595)
-
-Developer
-~~~~~~~~~
-
-MAINT: Refactored the OMNIC SPA reader to separate native parsing, signal
-selection, coordinate construction, metadata attachment, and dataset
-finalization, preserving spectral and standalone/associated interferogram
-reading modes. (#1604, #1606, #1607)
-
-MAINT: Centralized the reserved-root-symbol policy so plugins cannot shadow
-public ``scp`` symbols; conflicting plugin I/O namespaces are rejected at
-registration with a controlled warning while the ``read_<format>`` reader
-remains available through its explicit surfaces. (#1599)
-
-MAINT: Standardized fitted-state inspection, unfitted cloning, and lifecycle
-invalidation for the estimators supported by ``Pipeline``. (#1589)
-
-DOC: Expanded the Pipeline user guide and documented the validated OMNIC SRS
-and SPA file layouts and SPA reader behavior. (#1592, #1596, #1597, #1602, #1607)
+- Restored publication of official plugins (``[tool.spectrochempy]``
+  ``official-plugin = true``) on Conda, which was silently skipped by the
+  release workflow.  Added a recovery workflow to republish plugin versions
+  that are missing on ``spectrocat/main`` and a consistency check between
+  GitHub releases, PyPI and Conda. (#1611)

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -564,6 +564,20 @@ official-plugin = true` dans `pyproject.toml` pour identifier les plugins
 officiels.  Ce même marqueur est utilisé par `publish_plugins.yml` (PyPI)
 et `plugin_release_status.py` (tableau de statut).
 
+Avant la construction, le job de release exécute désormais
+`conda_publish.py validate-release` **sur le checkout exact du tag** :
+les versions de `pyproject.toml`, de `__init__.py` (lorsqu'il déclare une
+version) et de la recette conda (`recipe.yaml` / `meta.yaml`) doivent
+toutes correspondre à la version du tag, sinon la publication est
+bloquée (`exit 1`) ou l'évaluation échoue (`exit 2`).
+
+L'upload utilise `conda_publish.py upload-conda` qui refuse de remplacer
+une version déjà publiée sur le label `main` **sauf** dérogation explicite
+(`--allow-override`), vérifie le nom/version exact de l'artifact
+(`<plugin>-<version>-…`), n'appelle `anaconda upload --force` que dans ce
+cas de dérogation, et confirme l'apparition du label via l'API `/files`
+après l'upload.
+
 #### Vérification post-release
 
 Après chaque release de plugin, vérifier la présence sur les trois
@@ -582,7 +596,12 @@ anaconda show spectrocat/spectrochempy-XXX
 
 Ou utiliser le workflow automatisé **Verify plugin release consistency**
 (`verify_plugin_release_consistency.yml`) qui produit un tableau comparatif
-GitHub / PyPI / Conda pour tous les plugins officiels.
+GitHub / PyPI / Conda pour **tous les tags de release historiques** des
+plugins officiels (`conda_publish.py check-all`, basé sur `git tag`).
+Il est déclenché manuellement et sur un planning hebdomadaire (lundi
+03:00 UTC) : un déclenchement à chaque push sur `master` maintiendrait la
+branche rouge tant que les releases historiques ne sont pas réparées.
+Une fois la récupération terminée, ce trigger peut être réactivé.
 
 #### En cas d'échec de publication Conda
 
@@ -608,6 +627,11 @@ Si la publication PyPI a réussi mais que la publication Conda a échoué
    - Sélectionner le mode dry-run par défaut pour valider la construction
    - Vérifier l'artifact produit
    - Relancer avec `dry_run=false` et `confirm_upload=true` pour publier
+   - Le workflow valide la release depuis le **checkout exact du tag**
+     (outillage stocké depuis `master` avant le détachement du tag) et
+     refuse de remplacer une version déjà publiée sur `main` sauf à
+     cocher explicitement `allow_override=true` (dérogation documentée,
+     ignorée en dry-run)
    - Le workflow utilise un environnement GitHub dédié (`conda-publish`)
      avec approbation obligatoire
 
@@ -619,9 +643,22 @@ Le script `.github/workflows/scripts/conda_publish.py` fournit des
 fonctions réutilisables pour :
 
 - Valider le format des tags plugins (`verify-tag`)
+- Vérifier le marqueur de plugin officiel (`is-official`) — un
+  `pyproject.toml` illisible provoque une erreur (`exit 2`), jamais un
+  « non officiel » silencieux
 - Vérifier la cohérence d'une release sur GitHub / PyPI / Conda
-  (`check-release`, `check-all`)
+  (`check-release`, `check-all` — historique, sur tous les tags plugins)
+- Valider une release sur le checkout du tag (`validate-release`, bloquant)
+- Publier un artifact Conda en toute sécurité (`upload-conda` — refuse le
+  remplacement sans dérogation, `--force` uniquement en cas de dérogation)
+- Confirmer une publication (`verify-conda`, poll des labels) et lire
+  l'état d'une version (`conda-state`)
 - Lister les plugins officiels (`list-official`)
+
+Une indisponibilité de PyPI ou d'Anaconda.org (réseau, timeout, 5xx) est
+distinguée d'une version réellement absente (`ServiceUnavailableError` /
+verdicts `pypi_unavailable` / `conda_unavailable`) : on ne peut pas
+conclure « version manquante » quand le registraire est injoignable.
 
 Ces fonctions sont utilisées par les workflows de vérification et de
 récupération, et sont testées dans
@@ -642,7 +679,11 @@ Python 3.11.
 
 Le job de découverte utilise désormais `conda_publish.py is-official`
 (module testé) avec `actions/setup-python` 3.11, et un échec du check
-fait échouer le job au lieu d'être silencieusement ignoré.
+fait échouer le job au lieu d'être silencieusement ignoré.  Depuis la
+vérification cartographiée ci-dessous, la publication est de plus
+validée de façon **bloquante** depuis le tag et ne peut plus écraser une
+version publiée (voir « Comment la publication Conda fonctionne-t-elle »
+au-dessus).
 
 Vérifié le 2026-09-10 via `conda_publish.py check-all` : les versions
 stables suivantes existent sur GitHub et PyPI mais **ne sont pas sur

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -551,6 +551,117 @@ pip install spectrochempy-XXX==X.Y.Z
 anaconda show spectrocat/spectrochempy-XXX
 ```
 
+### Publication Conda des plugins : garanties et récupération
+
+#### Comment la publication Conda fonctionne-t-elle pour les plugins ?
+
+Lorsqu'une release de plugin est publiée (tag `spectrochempy-XXX-vX.Y.Z`),
+le workflow `build_package.yml` détecte automatiquement le tag plugin et
+publie le paquet Conda sur le label `main` d'Anaconda.org (`spectrocat`).
+
+Le mécanisme de découverte utilise le marqueur `[tool.spectrochempy]
+official-plugin = true` dans `pyproject.toml` pour identifier les plugins
+officiels.  Ce même marqueur est utilisé par `publish_plugins.yml` (PyPI)
+et `plugin_release_status.py` (tableau de statut).
+
+#### Vérification post-release
+
+Après chaque release de plugin, vérifier la présence sur les trois
+registraires :
+
+```bash
+# GitHub
+gh release view spectrochempy-XXX-vX.Y.Z --repo spectrochempy/spectrochempy
+
+# PyPI
+pip install spectrochempy-XXX==X.Y.Z
+
+# Conda
+anaconda show spectrocat/spectrochempy-XXX
+```
+
+Ou utiliser le workflow automatisé **Verify plugin release consistency**
+(`verify_plugin_release_consistency.yml`) qui produit un tableau comparatif
+GitHub / PyPI / Conda pour tous les plugins officiels.
+
+#### En cas d'échec de publication Conda
+
+Si la publication PyPI a réussi mais que la publication Conda a échoué
+(le paquet n'est pas sur `spectrocat/main`) :
+
+1. **Ne pas créer une nouvelle version** pour masquer l'échec de
+   publication.  La version existante sur PyPI et GitHub est correcte ;
+   seul le paquet Conda est manquant.
+
+2. **Ne pas recréer ou déplacer un tag existant.**
+
+3. **Ne pas republier sur PyPI.**
+
+4. Utiliser temporairement les paquets PyPI :
+   ```bash
+   pip install spectrochempy-XXX==X.Y.Z
+   ```
+
+5. Pour publier rétroactivement le paquet Conda manquant, utiliser le
+   workflow **Repair plugin Conda publication**
+   (`repair_conda_plugin_release.yml`) :
+   - Sélectionner le mode dry-run par défaut pour valider la construction
+   - Vérifier l'artifact produit
+   - Relancer avec `dry_run=false` et `confirm_upload=true` pour publier
+   - Le workflow utilise un environnement GitHub dédié (`conda-publish`)
+     avec approbation obligatoire
+
+6. Vérifier la publication avec `anaconda show spectrocat/spectrochempy-XXX`.
+
+#### Rôle de `conda_publish.py`
+
+Le script `.github/workflows/scripts/conda_publish.py` fournit des
+fonctions réutilisables pour :
+
+- Valider le format des tags plugins (`verify-tag`)
+- Vérifier la cohérence d'une release sur GitHub / PyPI / Conda
+  (`check-release`, `check-all`)
+- Lister les plugins officiels (`list-official`)
+
+Ces fonctions sont utilisées par les workflows de vérification et de
+récupération, et sont testées dans
+`tests/test_core/test_scripts/test_conda_publish.py`.
+
+#### Cause racine historique et versions manquantes
+
+L'échec historique de publication Conda (ex. `spectrochempy-carroucell
+v0.1.7`) provenait du job `discover-conda-plugins` de `build_package.yml`
+qui vérifiait le marqueur `[tool.spectrochempy] official-plugin = true` via
+un `python3 -c "import tomllib ..."` inline **sans installer Python 3.11**.
+Sur l'image runner (Python 3.10 par défaut), `import tomllib` échouait
+systématiquement, et l'erreur était masquée par `2>/dev/null` : tous les
+plugins étaient alors ignorés (« not declared official ») alors que le
+marqueur était bien présent dans le tag.  La publication PyPI, elle,
+réussissait car le job de découverte de `publish_plugins.yml` installe bien
+Python 3.11.
+
+Le job de découverte utilise désormais `conda_publish.py is-official`
+(module testé) avec `actions/setup-python` 3.11, et un échec du check
+fait échouer le job au lieu d'être silencieusement ignoré.
+
+Vérifié le 2026-09-10 via `conda_publish.py check-all` : les versions
+stables suivantes existent sur GitHub et PyPI mais **ne sont pas sur
+`spectrocat/main`** (à publier avec le workflow de récupération) :
+
+| Plugin | Versions manquantes sur Conda `main` |
+|--------|---------------------------------------|
+| `spectrochempy-carroucell`   | `0.1.7`, `0.1.8` |
+| `spectrochempy-hypercomplex` | `0.1.7`, `0.1.8` |
+| `spectrochempy-iris`         | `0.1.7`, `0.1.8` |
+| `spectrochempy-nmr`          | `0.1.8`, `0.1.10`, `0.1.11` |
+| `spectrochempy-tensor`       | `0.1.4`, `0.1.5` |
+| `spectrochempy-perkinelmer`  | toutes (aucun paquet Conda ; **recette manquante** à ajouter avant récupération) |
+
+`spectrochempy-perkinelmer` n'a jamais eu de `recipe.yaml`/`meta.yaml`
+dans le dépôt : même corrigé, le job de découverte ne peut pas le publier.
+L'ajout d'une recette Conda pour ce plugin est un préalable nécessaire à
+sa publication sur `spectrocat`.
+
 ---
 
 ## Zenodo and plugin releases
@@ -687,6 +798,8 @@ entrées sont incorrectes car :
       vérifier que la release plugin n'affiche pas le badge "Latest")
 - [ ] Vérifier PyPI : `pip install spectrochempy-XXX==X.Y.Z`
 - [ ] Vérifier Anaconda : `anaconda show spectrocat/spectrochempy-XXX`
+- [ ] Si le paquet Conda est absent de `main`, lancer **Repair plugin Conda publication**
+      en mode dry-run pour diagnostiquer, puis publier après review
 - [ ] Répéter pour chaque plugin (nmr → iris → tensor → hypercomplex → carroucell)
 - [ ] Réactiver l'intégration GitHub → Zenodo (avant la prochaine release core)
 
@@ -735,6 +848,45 @@ entrées sont incorrectes car :
       release plugin
 - [ ] Si des entrées plugins existent dans Zenodo, les supprimer
       (voir `emergency-recovery.md`)
+
+---
+
+## Interdictions en cas d'échec de publication
+
+Lorsqu'un échec de publication est détecté (par exemple un paquet présent
+sur PyPI mais absent de Conda) :
+
+1. **Ne jamais créer une nouvelle version** uniquement pour corriger un
+   échec de publication.  La version existante est correcte sur GitHub et
+   PyPI ; seul le canal de distribution manquant doit être réparé.
+
+2. **Ne jamais recréer ou déplacer un tag existant.**  Les tags sont
+   immuables et leur déplacement romprait les liens depuis PyPI, les
+   documents citant la version, et les caches des utilisateurs.
+
+3. **Ne jamais republier un paquet sur PyPI** sous la même version.  PyPI
+   est immuable : une version publiée ne peut pas être remplacée.
+
+4. **Ne jamais modifier une Release GitHub existante** pour corriger un
+   échec de publication externe.  La Release GitHub est un point d'entrée
+   readonly une fois publiée.
+
+5. **Utiliser les mécanismes de récupération dédiés** (workflow
+   `repair_conda_plugin_release.yml`) pour republier uniquement sur le
+   canal Conda manquant.
+
+### Recommandation temporaire
+
+Tant que les versions Conda historiques ne sont pas toutes réparées, les
+utilisateurs doivent privilégier les paquets PyPI :
+
+```bash
+pip install spectrochempy-XXX==X.Y.Z
+```
+
+Cette recommandation sera levée une fois que le workflow
+**Verify plugin release consistency** confirme l'alignement de toutes les
+versions stables sur GitHub, PyPI et Conda.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ exclude = ["~*"] # Exclude files and directories. "tests/**"
   "S101", # Use of assert detected. The enclosed code will be executed only when the assertion fails.
   "S603", # subprocess call with shell=True identified, security issue.
   "S607", # subprocess call with a partial executable path (tests invoke git intentionally).
+  "S106", # Hardcoded dummy tokens passed to guarded upload_conda() in tests.
   "T201", # print statement found.
   "D205", # 1 blank line required between summary line and description.
   "D401", # First line should be in imperative mood; try rephrasing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ exclude = ["~*"] # Exclude files and directories. "tests/**"
 "tests/**/*" = [
   "S101", # Use of assert detected. The enclosed code will be executed only when the assertion fails.
   "S603", # subprocess call with shell=True identified, security issue.
+  "S607", # subprocess call with a partial executable path (tests invoke git intentionally).
   "T201", # print statement found.
   "D205", # 1 blank line required between summary line and description.
   "D401", # First line should be in imperative mood; try rephrasing.

--- a/tests/test_core/test_scripts/test_conda_publish.py
+++ b/tests/test_core/test_scripts/test_conda_publish.py
@@ -1,0 +1,584 @@
+"""Tests for .github/workflows/scripts/conda_publish.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).parents[3]
+    / ".github"
+    / "workflows"
+    / "scripts"
+    / "conda_publish.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("conda_publish", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Tag parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParsePluginTag:
+    def test_valid_tag(self):
+        module = load_module()
+        result = module.parse_plugin_tag("spectrochempy-nmr-v0.1.11")
+        assert result == ("spectrochempy-nmr", "0.1.11")
+
+    def test_valid_tag_carroucell(self):
+        module = load_module()
+        result = module.parse_plugin_tag("spectrochempy-carroucell-v0.1.7")
+        assert result == ("spectrochempy-carroucell", "0.1.7")
+
+    def test_core_tag_returns_none(self):
+        module = load_module()
+        assert module.parse_plugin_tag("spectrochempy-v0.12.0") is None
+
+    def test_invalid_format_returns_none(self):
+        module = load_module()
+        assert module.parse_plugin_tag("v0.1.0") is None
+        assert module.parse_plugin_tag("spectrochempy-nmr") is None
+        assert module.parse_plugin_tag("random-tag") is None
+
+    def test_version_with_patch(self):
+        module = load_module()
+        result = module.parse_plugin_tag("spectrochempy-iris-v1.2.3")
+        assert result == ("spectrochempy-iris", "1.2.3")
+
+
+# ---------------------------------------------------------------------------
+# Tag validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTagFormat:
+    def test_valid_tag(self):
+        module = load_module()
+        plugin, version = module.validate_tag_format("spectrochempy-nmr-v0.1.11")
+        assert plugin == "spectrochempy-nmr"
+        assert version == "0.1.11"
+
+    def test_valid_tag_with_expected_plugin(self):
+        module = load_module()
+        plugin, version = module.validate_tag_format(
+            "spectrochempy-nmr-v0.1.11", expected_plugin="spectrochempy-nmr"
+        )
+        assert plugin == "spectrochempy-nmr"
+
+    def test_wrong_plugin_raises(self):
+        module = load_module()
+        with pytest.raises(ValueError, match="belongs to plugin"):
+            module.validate_tag_format(
+                "spectrochempy-nmr-v0.1.11", expected_plugin="spectrochempy-iris"
+            )
+
+    def test_invalid_tag_raises(self):
+        module = load_module()
+        with pytest.raises(ValueError, match="does not match"):
+            module.validate_tag_format("spectrochempy-v0.12.0")
+
+
+# ---------------------------------------------------------------------------
+# Plugin version reading
+# ---------------------------------------------------------------------------
+
+
+class TestReadPluginVersion:
+    def test_read_from_pyproject(self, tmp_path):
+        module = load_module()
+        plugin_dir = tmp_path / "spectrochempy-nmr"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            '[project]\nname = "spectrochempy-nmr"\nversion = "0.1.11"\n'
+        )
+        assert module.read_plugin_version(plugin_dir) == "0.1.11"
+
+    def test_read_from_init(self, tmp_path):
+        module = load_module()
+        plugin_dir = tmp_path / "spectrochempy-nmr"
+        init_dir = plugin_dir / "src" / "spectrochempy_nmr"
+        init_dir.mkdir(parents=True)
+        (init_dir / "__init__.py").write_text('    version = "0.1.11"\n')
+        assert module.read_plugin_init_version(plugin_dir) == "0.1.11"
+
+    def test_read_recipe_version(self, tmp_path):
+        module = load_module()
+        recipe = tmp_path / "recipe.yaml"
+        recipe.write_text(
+            'context:\n  name: spectrochempy-nmr\n  version: "0.1.11"\n'
+        )
+        assert module.read_recipe_version(recipe) == "0.1.11"
+
+    def test_missing_pyproject(self, tmp_path):
+        module = load_module()
+        assert module.read_plugin_version(tmp_path / "nonexistent") is None
+
+    def test_missing_init(self, tmp_path):
+        module = load_module()
+        assert module.read_plugin_init_version(tmp_path / "nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Official plugin discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverOfficialPlugins:
+    def test_finds_official_plugins(self, tmp_path, monkeypatch):
+        module = load_module()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        # Official plugin
+        official = plugins_dir / "spectrochempy-nmr"
+        official.mkdir()
+        (official / "pyproject.toml").write_text(
+            '[project]\nname = "spectrochempy-nmr"\n'
+            "[tool.spectrochempy]\nofficial-plugin = true\n"
+        )
+
+        # Non-official plugin
+        non_official = plugins_dir / "spectrochempy-cantera"
+        non_official.mkdir()
+        (non_official / "pyproject.toml").write_text(
+            '[project]\nname = "spectrochempy-cantera"\n'
+        )
+
+        # Plugin template (excluded)
+        template = plugins_dir / "plugin-template"
+        template.mkdir()
+        (template / "pyproject.toml").write_text(
+            '[project]\nname = "plugin-template"\n'
+            "[tool.spectrochempy]\nofficial-plugin = true\n"
+        )
+
+        monkeypatch.chdir(tmp_path)
+        result = module.discover_official_plugins(plugins_dir)
+        assert result == ["spectrochempy-nmr"]
+
+    def test_empty_dir(self, tmp_path, monkeypatch):
+        module = load_module()
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        assert module.discover_official_plugins(plugins_dir) == []
+
+    def test_nonexistent_dir(self):
+        module = load_module()
+        assert module.discover_official_plugins(Path("/nonexistent")) == []
+
+
+# ---------------------------------------------------------------------------
+# is_official_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestIsOfficialPlugin:
+    def test_official(self, tmp_path):
+        module = load_module()
+        plugin_dir = tmp_path / "spectrochempy-nmr"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            "[tool.spectrochempy]\nofficial-plugin = true\n"
+        )
+        assert module.is_official_plugin(plugin_dir) is True
+
+    def test_not_official(self, tmp_path):
+        module = load_module()
+        plugin_dir = tmp_path / "spectrochempy-cantera"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            '[project]\nname = "spectrochempy-cantera"\n'
+        )
+        assert module.is_official_plugin(plugin_dir) is False
+
+
+class TestIsOfficialCli:
+    """Exercise the `is-official` CLI as the discovery job does."""
+
+    def _run(self, *args):
+        import subprocess
+
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "is-official", *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_official_exit_zero(self, tmp_path):
+        plugin_dir = tmp_path / "spectrochempy-nmr"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            "[tool.spectrochempy]\nofficial-plugin = true\n"
+        )
+        result = self._run(str(plugin_dir))
+        assert result.returncode == 0
+
+    def test_not_official_exit_one(self, tmp_path):
+        plugin_dir = tmp_path / "spectrochempy-cantera"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            '[project]\nname = "spectrochempy-cantera"\n'
+        )
+        result = self._run(str(plugin_dir))
+        assert result.returncode == 1
+
+    def test_missing_pyproject_exit_one(self, tmp_path):
+        result = self._run(str(tmp_path))
+        assert result.returncode == 1
+
+    def test_parse_error_exit_one(self, tmp_path):
+        """Malformed TOML is treated as 'not official' by the module."""
+        plugin_dir = tmp_path / "spectrochempy-cantera"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text("[tool.spectrochempy\n")
+        result = self._run(str(plugin_dir))
+        assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# Release consistency (network-independent)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPluginReleaseConsistency:
+    def test_aligned_local_check(self, tmp_path, monkeypatch):
+        """Simulate a release that exists on GitHub (tag present) with skip_network."""
+        module = load_module()
+        monkeypatch.chdir(tmp_path)
+
+        # Create a fake git repo with the tag
+        import subprocess
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "file.txt").write_text("init")
+        subprocess.run(["git", "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "tag", "spectrochempy-nmr-v0.1.11"],
+            check=True,
+            capture_output=True,
+        )
+
+        check = module.check_plugin_release_consistency(
+            "spectrochempy-nmr", "0.1.11", skip_network=True
+        )
+        assert check.github_release is True
+        assert check.verdict == "conda_missing"
+
+    def test_missing_github_release(self, tmp_path, monkeypatch):
+        """Simulate a release with no GitHub tag."""
+        module = load_module()
+        monkeypatch.chdir(tmp_path)
+
+        import subprocess
+
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "file.txt").write_text("init")
+        subprocess.run(["git", "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init"], check=True, capture_output=True
+        )
+
+        check = module.check_plugin_release_consistency(
+            "spectrochempy-nmr", "0.1.11", skip_network=True
+        )
+        assert check.github_release is False
+        assert check.verdict == "missing_github_release"
+
+
+class TestAnacondaVersions:
+    def _plugin(self, monkeypatch):
+        module = load_module()
+        monkeypatch.setattr(module, "fetch_json", lambda url, timeout=30: None)
+        return module
+
+    def test_str_labels(self, monkeypatch):
+        module = load_module()
+
+        def fake_fetch(url, timeout=30):
+            return [
+                {"version": "0.1.0", "labels": ["dev"]},
+                {"version": "0.1.1", "labels": ["dev", "main"]},
+                {"version": "0.1.1", "labels": ["main"]},
+            ]
+
+        monkeypatch.setattr(module, "fetch_json", fake_fetch)
+        assert module.anaconda_versions("spectrochempy-nmr") == {
+            "0.1.0": ["dev"],
+            "0.1.1": ["dev", "main"],
+        }
+
+    def test_dict_labels(self, monkeypatch):
+        module = load_module()
+        monkeypatch.setattr(
+            module,
+            "fetch_json",
+            lambda url, timeout=30: [
+                {"version": "0.1.2", "labels": [{"name": "main"}]}
+            ],
+        )
+        assert module.anaconda_versions("spectrochempy-nmr") == {
+            "0.1.2": ["main"]
+        }
+
+    def test_package_not_found(self, monkeypatch):
+        module = self._plugin(monkeypatch)
+        assert module.anaconda_versions("spectrochempy-perkinelmer") == {}
+
+    def test_version_labels_uses_versions_map(self, monkeypatch):
+        module = load_module()
+        monkeypatch.setattr(
+            module,
+            "fetch_json",
+            lambda url, timeout=30: [
+                {"version": "0.1.1", "labels": ["dev", "main"]}
+            ],
+        )
+        assert module.anaconda_version_labels("spectrochempy-nmr", "0.1.1") == [
+            "dev",
+            "main",
+        ]
+        assert module.anaconda_version_labels("spectrochempy-nmr", "0.9.9") == []
+
+
+class TestCheckPluginReleaseConsistencyNetwork:
+    def _make_repo(self, tmp_path, tag):
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "file.txt").write_text("init")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init"], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(["git", "tag", tag], cwd=tmp_path, check=True, capture_output=True)
+
+    def test_aligned(self, tmp_path, monkeypatch):
+        module = load_module()
+        self._make_repo(tmp_path, "spectrochempy-nmr-v0.1.11")
+        monkeypatch.chdir(tmp_path)
+
+        def fake_fetch(url, timeout=30):
+            if "pypi.org" in url:
+                return {"releases": {"0.1.11": [], "0.1.8": []}}
+            if "anaconda.org" in url:
+                return [{"version": "0.1.11", "labels": ["main"]}]
+            return None
+
+        monkeypatch.setattr(module, "fetch_json", fake_fetch)
+        check = module.check_plugin_release_consistency("spectrochempy-nmr", "0.1.11")
+        assert check.verdict == "aligned"
+        assert check.pypi_version == "0.1.11"
+        assert check.conda_main is True
+
+    def test_pypi_missing(self, tmp_path, monkeypatch):
+        module = load_module()
+        self._make_repo(tmp_path, "spectrochempy-nmr-v0.1.11")
+        monkeypatch.chdir(tmp_path)
+
+        def fake_fetch(url, timeout=30):
+            if "pypi.org" in url:
+                return {"releases": {"0.1.8": []}}
+            if "anaconda.org" in url:
+                return [{"version": "0.1.11", "labels": ["main"]}]
+            return None
+
+        monkeypatch.setattr(module, "fetch_json", fake_fetch)
+        check = module.check_plugin_release_consistency("spectrochempy-nmr", "0.1.11")
+        assert check.verdict == "pypi_missing"
+        assert check.pypi_version is None
+
+    def test_conda_dev_only(self, tmp_path, monkeypatch):
+        module = load_module()
+        self._make_repo(tmp_path, "spectrochempy-nmr-v0.1.11")
+        monkeypatch.chdir(tmp_path)
+
+        def fake_fetch(url, timeout=30):
+            if "pypi.org" in url:
+                return {"releases": {"0.1.11": []}}
+            if "anaconda.org" in url:
+                return [{"version": "0.1.11", "labels": ["dev"]}]
+            return None
+
+        monkeypatch.setattr(module, "fetch_json", fake_fetch)
+        check = module.check_plugin_release_consistency("spectrochempy-nmr", "0.1.11")
+        assert check.verdict == "conda_dev_only"
+        assert check.conda_dev is True
+
+
+# ---------------------------------------------------------------------------
+# Format verification report
+# ---------------------------------------------------------------------------
+
+
+class TestFormatVerificationReport:
+    def test_aligned_report(self):
+        module = load_module()
+        check = module.PluginReleaseCheck(
+            plugin="spectrochempy-nmr",
+            version="0.1.11",
+            github_release=True,
+            pypi_version="0.1.11",
+            conda_main=True,
+            conda_dev=False,
+            conda_labels=["main"],
+            verdict="aligned",
+        )
+        report = module.format_verification_report([check])
+        assert "spectrochempy-nmr" in report
+        assert "0.1.11" in report
+        assert "aligned" in report
+
+    def test_missing_conda_report(self):
+        module = load_module()
+        check = module.PluginReleaseCheck(
+            plugin="spectrochempy-carroucell",
+            version="0.1.7",
+            github_release=True,
+            pypi_version="0.1.7",
+            conda_main=False,
+            conda_dev=False,
+            conda_labels=[],
+            verdict="conda_missing",
+        )
+        report = module.format_verification_report([check])
+        assert "stable Conda missing" in report
+
+
+# ---------------------------------------------------------------------------
+# No-upload protection
+# ---------------------------------------------------------------------------
+
+
+class TestNoUploadProtection:
+    """Ensure test environment cannot trigger real uploads."""
+
+    def test_upload_function_not_called_in_tests(self):
+        """Verify anaconda upload is never executed during test runs."""
+        module = load_module()
+        # The module should not have any subprocess call to anaconda upload
+        # at import time or during pure logic functions.
+        source = SCRIPT_PATH.read_text()
+        # The upload command should only appear inside workflow shell scripts
+        # (in the YAML files), not in the Python module's functions.
+        # This is a structural check — the Python module uses urllib for reads
+        # and never calls anaconda CLI directly.
+        assert "subprocess.run" in source  # git commands use subprocess
+        # But no anaconda upload calls
+        assert "anaconda upload" not in source
+
+    def test_fetch_json_uses_read_only_urls(self):
+        """Verify fetch_json only accesses read-only API endpoints."""
+        module = load_module()
+        # The URLs in the module should be read-only API endpoints
+        assert "pypi.org/pypi" in module.PYPI_JSON_URL
+        assert "api.anaconda.org" in module.ANACONDA_FILES_URL
+
+
+# ---------------------------------------------------------------------------
+# Tag regex patterns
+# ---------------------------------------------------------------------------
+
+
+class TestTagRegex:
+    def test_plugin_tag_pattern(self):
+        module = load_module()
+        assert module.TAG_RE.match("spectrochempy-nmr-v0.1.11") is not None
+        assert module.TAG_RE.match("spectrochempy-carroucell-v0.1.7") is not None
+        assert module.TAG_RE.match("spectrochempy-tensor-v0.1.5") is not None
+
+    def test_core_tag_does_not_match(self):
+        module = load_module()
+        assert module.TAG_RE.match("spectrochempy-v0.12.0") is None
+
+    def test_invalid_patterns(self):
+        module = load_module()
+        assert module.TAG_RE.match("v0.1.0") is None
+        assert module.TAG_RE.match("spectrochempy-nmr") is None
+        assert module.TAG_RE.match("spectrochempy-nmr-v") is None
+        assert module.TAG_RE.match("spectrochempy-nmr-vabc") is None
+
+
+# ---------------------------------------------------------------------------
+# Concurrency key behavior (structural test)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrencyKeyBehavior:
+    """Verify the workflow YAML uses per-tag concurrency that doesn't cancel stable builds."""
+
+    def test_build_package_yml_concurrency(self):
+        workflow = (
+            Path(__file__).parents[3]
+            / ".github"
+            / "workflows"
+            / "build_package.yml"
+        ).read_text()
+        # Should NOT cancel in-progress for stable releases
+        assert "cancel-in-progress:" in workflow
+        # Should have conditional cancel logic
+        assert "startsWith(github.ref_name, 'spectrochempy-v')" in workflow
+
+    def test_no_unconditional_cancel(self):
+        workflow = (
+            Path(__file__).parents[3]
+            / ".github"
+            / "workflows"
+            / "build_package.yml"
+        ).read_text()
+        # The cancel-in-progress should not be simply "true"
+        lines = [
+            l.strip()
+            for l in workflow.splitlines()
+            if "cancel-in-progress" in l
+        ]
+        assert len(lines) >= 1
+        for line in lines:
+            assert line != "cancel-in-progress: true"

--- a/tests/test_core/test_scripts/test_conda_publish.py
+++ b/tests/test_core/test_scripts/test_conda_publish.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import sys
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -232,13 +234,13 @@ class TestIsOfficialCli:
         result = self._run(str(tmp_path))
         assert result.returncode == 1
 
-    def test_parse_error_exit_one(self, tmp_path):
-        """Malformed TOML is treated as 'not official' by the module."""
+    def test_parse_error_exit_two(self, tmp_path):
+        """Malformed TOML is an evaluation error (exit 2), not silently 'not official'."""
         plugin_dir = tmp_path / "spectrochempy-cantera"
         plugin_dir.mkdir()
         (plugin_dir / "pyproject.toml").write_text("[tool.spectrochempy\n")
         result = self._run(str(plugin_dir))
-        assert result.returncode == 1
+        assert result.returncode == 2
 
 
 # ---------------------------------------------------------------------------
@@ -444,6 +446,328 @@ class TestCheckPluginReleaseConsistencyNetwork:
         assert check.verdict == "conda_dev_only"
         assert check.conda_dev is True
 
+    def test_pypi_unavailable(self, tmp_path, monkeypatch):
+        """A PyPI query failure must yield pypi_unavailable, not pypi_missing."""
+        module = load_module()
+        self._make_repo(tmp_path, "spectrochempy-nmr-v0.1.11")
+        monkeypatch.chdir(tmp_path)
+
+        def fake_fetch(url, timeout=30):
+            if "pypi.org" in url:
+                raise module.ServiceUnavailableError("pypi.org: connection reset")
+            if "anaconda.org" in url:
+                return [{"version": "0.1.11", "labels": ["main"]}]
+            return None
+
+        monkeypatch.setattr(module, "fetch_json", fake_fetch)
+        check = module.check_plugin_release_consistency("spectrochempy-nmr", "0.1.11")
+        assert check.verdict == "pypi_unavailable"
+        assert check.pypi_version is None
+
+    def test_conda_unavailable(self, tmp_path, monkeypatch):
+        """An Anaconda query failure must yield conda_unavailable, not conda_missing."""
+        module = load_module()
+        self._make_repo(tmp_path, "spectrochempy-nmr-v0.1.11")
+        monkeypatch.chdir(tmp_path)
+
+        def fake_fetch(url, timeout=30):
+            if "pypi.org" in url:
+                return {"releases": {"0.1.11": []}}
+            if "anaconda.org" in url:
+                raise module.ServiceUnavailableError("api.anaconda.org: HTTP 503")
+            return None
+
+        monkeypatch.setattr(module, "fetch_json", fake_fetch)
+        check = module.check_plugin_release_consistency("spectrochempy-nmr", "0.1.11")
+        assert check.verdict == "conda_unavailable"
+        assert check.conda_main is False
+
+
+class TestFetchJsonAvailability:
+    def test_http_404_returns_none(self, monkeypatch):
+        """An HTTP 404 must be treated as 'not found', not as an error."""
+        module = load_module()
+
+        class FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return b"{}"
+
+            def decode(self):
+                return "{}"
+
+        def fake_urlopen(req, timeout=30):
+            raise urllib.error.HTTPError(
+                "https://api.anaconda.org/package/x/y/versions",
+                404,
+                "Not Found",
+                {},
+                None,
+            )
+
+        monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+        assert (
+            module.fetch_json("https://api.anaconda.org/package/x/y/versions") is None
+        )
+
+    def test_network_error_raises(self, monkeypatch):
+        """A network failure must raise ServiceUnavailableError."""
+        module = load_module()
+
+        def fake_urlopen(req, timeout=30):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+        with pytest.raises(module.ServiceUnavailableError):
+            module.fetch_json("https://example.org/x.json")
+
+    def test_http_503_raises(self, monkeypatch):
+        module = load_module()
+
+        def fake_urlopen(req, timeout=30):
+            raise urllib.error.HTTPError(
+                "https://x", 503, "Service Unavailable", {}, None
+            )
+
+        monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+        with pytest.raises(module.ServiceUnavailableError):
+            module.fetch_json("https://x")
+
+
+class TestListPluginTags:
+    def _make_tagged_repo(self, tmp_path, tags):
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        (tmp_path / "file.txt").write_text("init")
+        subprocess.run(
+            ["git", "add", "."], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        for tag in tags:
+            subprocess.run(
+                ["git", "tag", tag], cwd=tmp_path, check=True, capture_output=True
+            )
+
+    def test_returns_plugin_tags_only(self, tmp_path, monkeypatch):
+        module = load_module()
+        self._make_tagged_repo(
+            tmp_path,
+            ["spectrochempy-nmr-v0.1.11", "spectrochempy-nmr-v0.1.8", "v0.2.0"],
+        )
+        monkeypatch.chdir(tmp_path)
+        assert module.list_plugin_tags() == [
+            ("spectrochempy-nmr", "0.1.8"),
+            ("spectrochempy-nmr", "0.1.11"),
+        ]
+
+
+class TestValidateRelease:
+    def _plugin_with_version(self, tmp_path, version):
+        plugin_dir = tmp_path / "spectrochempy-nmr"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            f'[project]\nname = "spectrochempy-nmr"\nversion = "{version}"\n'
+        )
+        init_dir = plugin_dir / "src" / "spectrochempy_nmr"
+        init_dir.mkdir(parents=True)
+        (init_dir / "__init__.py").write_text(f'    version = "{version}"\n')
+        (plugin_dir / "recipe.yaml").write_text(
+            f'context:\n  name: spectrochempy-nmr\n  version: "{version}"\n'
+        )
+        return plugin_dir
+
+    def test_consistent_exit_zero(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_with_version(tmp_path, "0.1.11")
+        assert (
+            module.cmd_validate_release(
+                argparse.Namespace(plugin_dir=str(plugin_dir), version="0.1.11")
+            )
+            == 0
+        )
+
+    def test_pyproject_mismatch_exit_one(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_with_version(tmp_path, "0.1.11")
+        assert (
+            module.cmd_validate_release(
+                argparse.Namespace(plugin_dir=str(plugin_dir), version="0.1.8")
+            )
+            == 1
+        )
+
+    def test_recipe_mismatch_exit_one(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_with_version(tmp_path, "0.1.11")
+        (plugin_dir / "recipe.yaml").write_text(
+            'context:\n  name: spectrochempy-nmr\n  version: "0.1.8"\n'
+        )
+        assert (
+            module.cmd_validate_release(
+                argparse.Namespace(plugin_dir=str(plugin_dir), version="0.1.11")
+            )
+            == 1
+        )
+
+    def test_missing_recipe_exit_one(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_with_version(tmp_path, "0.1.11")
+        (plugin_dir / "recipe.yaml").unlink()
+        assert (
+            module.cmd_validate_release(
+                argparse.Namespace(plugin_dir=str(plugin_dir), version="0.1.11")
+            )
+            == 1
+        )
+
+    def test_meta_yaml_jinja_version(self, tmp_path):
+        module = load_module()
+        plugin_dir = tmp_path / "spectrochempy-nmr"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            '[project]\nname = "spectrochempy-nmr"\nversion = "0.1.11"\n'
+        )
+        (plugin_dir / "meta.yaml").write_text(
+            '{% set version = "0.1.11" %}\npackage:\n  name: spectrochempy-nmr\n  version: "{{ version }}"\n'
+        )
+        assert (
+            module.cmd_validate_release(
+                argparse.Namespace(plugin_dir=str(plugin_dir), version="0.1.11")
+            )
+            == 0
+        )
+
+
+class TestUploadConda:
+    def _artifact(self, tmp_path, name="spectrochempy-nmr-0.1.11-0_abc.conda"):
+        path = tmp_path / name
+        path.write_text("dummy")
+        return path
+
+    def test_refuses_existing_version_without_override(self, tmp_path, monkeypatch):
+        module = load_module()
+        artifact = self._artifact(tmp_path)
+        monkeypatch.setattr(
+            module, "anaconda_version_labels", lambda *a, **k: ["dev", "main"]
+        )
+        assert (
+            module.upload_conda(
+                artifact, plugin="spectrochempy-nmr", version="0.1.11", dry_run=False
+            )
+            == 1
+        )
+
+    def test_allow_override_forces_reupload(self, tmp_path, monkeypatch):
+        module = load_module()
+        artifact = self._artifact(tmp_path)
+        calls = []
+
+        def fake_labels(*a, **k):
+            return ["main"]
+
+        def fake_verify(*a, **k):
+            return True
+
+        def fake_subprocess(cmd, *a, **k):
+            calls.append(cmd)
+            return type("R", (), {"returncode": 0})()
+
+        monkeypatch.setattr(module, "anaconda_version_labels", fake_labels)
+        monkeypatch.setattr(module, "verify_conda_upload", fake_verify)
+        monkeypatch.setattr(module.subprocess, "run", fake_subprocess)
+        assert (
+            module.upload_conda(
+                artifact,
+                plugin="spectrochempy-nmr",
+                version="0.1.11",
+                token="tok",
+                allow_override=True,
+            )
+            == 0
+        )
+        assert calls and "--force" in calls[0]
+        assert "-l" in calls[0] and "main" in calls[0]
+
+    def test_fresh_version_uploads_without_force(self, tmp_path, monkeypatch):
+        module = load_module()
+        artifact = self._artifact(tmp_path)
+        calls = []
+
+        def fake_labels(*a, **k):
+            return []
+
+        def fake_verify(*a, **k):
+            return True
+
+        def fake_subprocess(cmd, *a, **k):
+            calls.append(cmd)
+            return type("R", (), {"returncode": 0})()
+
+        monkeypatch.setattr(module, "anaconda_version_labels", fake_labels)
+        monkeypatch.setattr(module, "verify_conda_upload", fake_verify)
+        monkeypatch.setattr(module.subprocess, "run", fake_subprocess)
+        assert (
+            module.upload_conda(
+                artifact,
+                plugin="spectrochempy-nmr",
+                version="0.1.11",
+                token="tok",
+            )
+            == 0
+        )
+        assert calls and "--force" not in calls[0]
+
+    def test_artifact_version_mismatch(self, tmp_path, monkeypatch):
+        module = load_module()
+        artifact = self._artifact(tmp_path, name="spectrochempy-nmr-0.1.8-0_abc.conda")
+        assert (
+            module.upload_conda(
+                artifact, plugin="spectrochempy-nmr", version="0.1.11", dry_run=True
+            )
+            == 1
+        )
+
+    def test_dry_run_skips_upload(self, tmp_path, monkeypatch):
+        module = load_module()
+        artifact = self._artifact(tmp_path)
+        monkeypatch.setattr(module, "anaconda_version_labels", lambda *a, **k: [])
+        called = []
+
+        def fake_subprocess(cmd, *a, **k):
+            called.append(cmd)
+
+        monkeypatch.setattr(module.subprocess, "run", fake_subprocess)
+        assert (
+            module.upload_conda(
+                artifact, plugin="spectrochempy-nmr", version="0.1.11", dry_run=True
+            )
+            == 0
+        )
+        assert called == []
+
 
 # ---------------------------------------------------------------------------
 # Format verification report
@@ -493,17 +817,19 @@ class TestNoUploadProtection:
     """Ensure test environment cannot trigger real uploads."""
 
     def test_upload_function_not_called_in_tests(self):
-        """Verify anaconda upload is never executed during test runs."""
-        # The module should not have any subprocess call to anaconda upload
-        # at import time or during pure logic functions.
+        """Verify test runs can never trigger a real upload outside guarded paths."""
+        # The module invokes subprocess for read-only git/registry checks…
         source = SCRIPT_PATH.read_text()
-        # The upload command should only appear inside workflow shell scripts
-        # (in the YAML files), not in the Python module's functions.
-        # This is a structural check — the Python module uses urllib for reads
-        # and never calls anaconda CLI directly.
-        assert "subprocess.run" in source  # git commands use subprocess
-        # But no anaconda upload calls
-        assert "anaconda upload" not in source
+        assert "subprocess.run" in source
+        # …and the anaconda CLI is reached only through the explicitly-guarded
+        # upload_conda() path (token from the environment, refusal to overwrite
+        # without allow_override). No other command builds an upload command.
+        assert "subprocess.run(command)" in source
+        assert "allow_override" in source
+        # The upload subprocess invokes a bare list command, never a shell
+        # string that could smuggle arguments from an artifact name.
+        assert "subprocess.run(command)" in source
+        assert "shell=True" not in source
 
     def test_fetch_json_uses_read_only_urls(self):
         """Verify fetch_json only accesses read-only API endpoints."""

--- a/tests/test_core/test_scripts/test_conda_publish.py
+++ b/tests/test_core/test_scripts/test_conda_publish.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 import importlib.util
-import json
 import sys
 from pathlib import Path
 
 import pytest
 
 SCRIPT_PATH = (
-    Path(__file__).parents[3]
-    / ".github"
-    / "workflows"
-    / "scripts"
-    / "conda_publish.py"
+    Path(__file__).parents[3] / ".github" / "workflows" / "scripts" / "conda_publish.py"
 )
 
 
@@ -117,9 +112,7 @@ class TestReadPluginVersion:
     def test_read_recipe_version(self, tmp_path):
         module = load_module()
         recipe = tmp_path / "recipe.yaml"
-        recipe.write_text(
-            'context:\n  name: spectrochempy-nmr\n  version: "0.1.11"\n'
-        )
+        recipe.write_text('context:\n  name: spectrochempy-nmr\n  version: "0.1.11"\n')
         assert module.read_recipe_version(recipe) == "0.1.11"
 
     def test_missing_pyproject(self, tmp_path):
@@ -275,9 +268,7 @@ class TestCheckPluginReleaseConsistency:
         )
         (tmp_path / "file.txt").write_text("init")
         subprocess.run(["git", "add", "."], check=True, capture_output=True)
-        subprocess.run(
-            ["git", "commit", "-m", "init"], check=True, capture_output=True
-        )
+        subprocess.run(["git", "commit", "-m", "init"], check=True, capture_output=True)
         subprocess.run(
             ["git", "tag", "spectrochempy-nmr-v0.1.11"],
             check=True,
@@ -310,9 +301,7 @@ class TestCheckPluginReleaseConsistency:
         )
         (tmp_path / "file.txt").write_text("init")
         subprocess.run(["git", "add", "."], check=True, capture_output=True)
-        subprocess.run(
-            ["git", "commit", "-m", "init"], check=True, capture_output=True
-        )
+        subprocess.run(["git", "commit", "-m", "init"], check=True, capture_output=True)
 
         check = module.check_plugin_release_consistency(
             "spectrochempy-nmr", "0.1.11", skip_network=True
@@ -352,9 +341,7 @@ class TestAnacondaVersions:
                 {"version": "0.1.2", "labels": [{"name": "main"}]}
             ],
         )
-        assert module.anaconda_versions("spectrochempy-nmr") == {
-            "0.1.2": ["main"]
-        }
+        assert module.anaconda_versions("spectrochempy-nmr") == {"0.1.2": ["main"]}
 
     def test_package_not_found(self, monkeypatch):
         module = self._plugin(monkeypatch)
@@ -365,9 +352,7 @@ class TestAnacondaVersions:
         monkeypatch.setattr(
             module,
             "fetch_json",
-            lambda url, timeout=30: [
-                {"version": "0.1.1", "labels": ["dev", "main"]}
-            ],
+            lambda url, timeout=30: [{"version": "0.1.1", "labels": ["dev", "main"]}],
         )
         assert module.anaconda_version_labels("spectrochempy-nmr", "0.1.1") == [
             "dev",
@@ -394,11 +379,18 @@ class TestCheckPluginReleaseConsistencyNetwork:
             capture_output=True,
         )
         (tmp_path / "file.txt").write_text("init")
-        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
         subprocess.run(
-            ["git", "commit", "-m", "init"], cwd=tmp_path, check=True, capture_output=True
+            ["git", "add", "."], cwd=tmp_path, check=True, capture_output=True
         )
-        subprocess.run(["git", "tag", tag], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "tag", tag], cwd=tmp_path, check=True, capture_output=True
+        )
 
     def test_aligned(self, tmp_path, monkeypatch):
         module = load_module()
@@ -502,7 +494,6 @@ class TestNoUploadProtection:
 
     def test_upload_function_not_called_in_tests(self):
         """Verify anaconda upload is never executed during test runs."""
-        module = load_module()
         # The module should not have any subprocess call to anaconda upload
         # at import time or during pure logic functions.
         source = SCRIPT_PATH.read_text()
@@ -556,10 +547,7 @@ class TestConcurrencyKeyBehavior:
 
     def test_build_package_yml_concurrency(self):
         workflow = (
-            Path(__file__).parents[3]
-            / ".github"
-            / "workflows"
-            / "build_package.yml"
+            Path(__file__).parents[3] / ".github" / "workflows" / "build_package.yml"
         ).read_text()
         # Should NOT cancel in-progress for stable releases
         assert "cancel-in-progress:" in workflow
@@ -568,16 +556,13 @@ class TestConcurrencyKeyBehavior:
 
     def test_no_unconditional_cancel(self):
         workflow = (
-            Path(__file__).parents[3]
-            / ".github"
-            / "workflows"
-            / "build_package.yml"
+            Path(__file__).parents[3] / ".github" / "workflows" / "build_package.yml"
         ).read_text()
         # The cancel-in-progress should not be simply "true"
         lines = [
-            l.strip()
-            for l in workflow.splitlines()
-            if "cancel-in-progress" in l
+            line.strip()
+            for line in workflow.splitlines()
+            if "cancel-in-progress" in line
         ]
         assert len(lines) >= 1
         for line in lines:


### PR DESCRIPTION
## Summary

Restores Conda publication for official SpectroChemPy plugins and adds
safe recovery tooling for the historically missing packages.

### Root cause (confirmed)

The `discover-conda-plugins` job in `build_package.yml` checked the
`[tool.spectrochempy] official-plugin = true` marker with an inline
`python3 -c "import tomllib ..."` **without installing Python 3.11**. On the
runner default `python3` (3.10), `import tomllib` fails for *every* plugin,
and the error was hidden by `2>/dev/null`. Result: all plugins were skipped
as "not declared official" even though the marker is present at every tag
(verified by reproducing the check at `d578d7c16`). Because the marker
replaced the old Trove classifier, **no plugin Conda release has reached
`spectrocat/main` since then**. PyPI kept working because
`publish_plugins.yml` *does* set up Python 3.11.

### What this PR fixes automatically

- **`discover-conda-plugins`**: uses the shared, tested `conda_publish.py
  is-official` check with `actions/setup-python 3.11`; a marker-check crash
  now fails the job loudly instead of silently skipping plugins.
- **New `detect-release-scope` job** classifies core/plugin/non-release refs
  so discovery no longer depends on the core build.
- **New `build_and_publish_plugin_conda_release` job** builds and publishes
  *only* the released plugin from its exact tag commit, uploads exclusively
  to the `main` label, and verifies the upload.
- **`build_and_publish_conda_plugins`** now handles push/PR events only
  (core artifact dependency unchanged).
- Concurrency only cancels in-progress builds for draft/dev refs, never for
  stable release tags.
- Fixed a latent bug: the plugin-release job referenced a non-existent
  `needs.detect-scope.*` (job is `detect-release-scope`) in 12 places —
  that job would have errored on the first plugin release.
- `conda_publish.py`'s Anaconda queries now use the `/files` endpoint (the
  previous parse assumed `versions` to be objects; the API returns strings),
  and the PyPI verdict checks the checked version's presence instead of
  comparing against the latest.

### New workflows

- **`repair_conda_plugin_release.yml`** – manual recovery for a specific
  tag. Dry-run by default, build from the exact tag commit, artifact kept
  before upload, upload only on `dry_run=false` **and** `confirm_upload=true`,
  gated by a locked `conda-publish` GitHub environment.
- **`verify_plugin_release_consistency.yml`** – read-only report comparing
  GitHub / PyPI / Conda `main` for all official plugins.

### Verified missing versions (audit)

Checked 2026-09-10 against Anaconda `spectrocat`, PyPI and git tags with
`conda_publish.py check-all`. Present on GitHub **and** PyPI, missing from
`spectrocat/main`:

| Plugin | Missing on Conda `main` |
|--------|--------------------------|
| `spectrochempy-carroucell` | `0.1.7`, `0.1.8` |
| `spectrochempy-hypercomplex` | `0.1.7`, `0.1.8` |
| `spectrochempy-iris` | `0.1.7`, `0.1.8` |
| `spectrochempy-nmr` | `0.1.8`, `0.1.10`, `0.1.11` |
| `spectrochempy-tensor` | `0.1.4`, `0.1.5` |
| `spectrochempy-perkinelmer` | **all** (never had a Conda recipe; required before recovery) |

### Manual actions required after merge

1. Add a Conda recipe (`recipe.yaml`) for `spectrochempy-perkinelmer`
   (separate follow-up — without it the plugin cannot be published).
2. For each missing version above, run **Repair plugin Conda publication**
   in dry-run mode, inspect the artifact, then run with
   `dry_run=false` and `confirm_upload=true`.
3. Re-run **Verify plugin release consistency** to confirm `main`.

### Guarantees

- This PR **creates no new version, moves no tag, republishes nothing on
  PyPI, and modifies no GitHub release**.
- All new tooling is read-only by default (`verify` workflow), or dry-run by
  default with explicit confirmation + environment approval (repair
  workflow).
- The recovery workflow builds each package from the *existing* release tag,
  so the published artifacts match the released source exactly.

### Validation

- `python -m pytest tests/test_core/test_scripts -q` → **55 passed**
  (25 existing + 30 new test cases).
- All 17 workflow YAML files parse successfully.
- `git diff --check` clean; `pre-commit run ruff --all-files` passes.
- Live checks with the fixed module: `check-all` reports the 6 latest
  plugin versions as `conda_missing` (correct); `check-release
  spectrochempy-carroucell 0.1.7` reports `conda_missing`.