### PR TITLE
FIX: correct SRS meta.collection_length to the total series collection time

### DIFF
--- a/docs/sources/devguide/file_formats/omnic/srs.rst
+++ b/docs/sources/devguide/file_formats/omnic/srs.rst
@@ -301,7 +301,8 @@ have been interpreted so far; the rest of the region is unmapped.
      - UInt32
      - General-header *collection length* in 1/100 s. This is the shared
        acquisition-time field of the OMNIC header family; it must **not** be
-       conflated with the series minimum/first time at +1002.
+       conflated with the series minimum/first time at +1002 (nor with the
+       public SRS ``collection_length`` derived from +1006).
      - ``[OBSERVED]``
    * - 80
      - 4
@@ -349,16 +350,19 @@ have been interpreted so far; the rest of the region is unmapped.
      - 4
      - Float32
      - **Series minimum / first time, in minutes** — the time-axis anchor.
-       This field was historically misinterpreted as a "collection length";
-       the general-header collection-length field is the one at +68. Some
-       implementations expose it as a collection duration in seconds
-       (value × 60) for backward compatibility.
+       Historically misinterpreted as a "collection length"; the general-header
+       collection-length field is the one at +68 (not to be conflated either).
+       The public ``collection_length`` for SRS series is derived from the
+       series maximum / last time at +1006 (see the 1006 row), not from this
+       field.
      - ``[ESTABLISHED]``
    * - 1006
      - 4
      - Float32
-     - Series maximum / last time, in minutes.
-     - ``[OBSERVED]``
+     - Series maximum / last time, in minutes. Converted to seconds (× 60) it
+       is the OMNIC "Total collection time" and the public ``collection_length``
+       exposed by the reader for SRS series.
+     - ``[ESTABLISHED]``
    * - 1010
      - 4
      - Float32

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -32,6 +32,12 @@ Bug Fixes
   that are missing on ``spectrocat/main`` and a consistency check between
   GitHub releases, PyPI and Conda. (#1611)
 
+- Corrected the SRS series ``meta.collection_length``: it was the series
+  first time (+1002, in minutes) incorrectly converted to seconds; it now
+  equals the OMNIC "Total collection time", i.e. the series last time
+  (+1006, in minutes) converted to seconds. The time axis is unchanged and
+  is still anchored at the series first time.
+
 
 .. section
 

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -36,7 +36,7 @@ Bug Fixes
   first time (+1002, in minutes) incorrectly converted to seconds; it now
   equals the OMNIC "Total collection time", i.e. the series last time
   (+1006, in minutes) converted to seconds. The time axis is unchanged and
-  is still anchored at the series first time.
+  is still anchored at the series first time. (#1613)
 
 
 .. section

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -20,3 +20,9 @@ Bug Fixes
   release workflow.  Added a recovery workflow to republish plugin versions
   that are missing on ``spectrocat/main`` and a consistency check between
   GitHub releases, PyPI and Conda. (#1611)
+
+- Corrected the SRS series ``meta.collection_length``: it was the series
+  first time (+1002, in minutes) incorrectly converted to seconds; it now
+  equals the OMNIC "Total collection time", i.e. the series last time
+  (+1006, in minutes) converted to seconds. The time axis is unchanged and
+  is still anchored at the series first time.

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -25,4 +25,4 @@ Bug Fixes
   first time (+1002, in minutes) incorrectly converted to seconds; it now
   equals the OMNIC "Total collection time", i.e. the series last time
   (+1006, in minutes) converted to seconds. The time axis is unchanged and
-  is still anchored at the series first time.
+  is still anchored at the series first time. (#1613)

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -1694,7 +1694,7 @@ def _read_header(fid, pos, is_first_spectrum=True):
         - general-header collection length in 1/100th of sec (UInt32), 68
           bytes behind. This is the shared acquisition-time field; for srs
           series the public "collection length" is derived from the series
-          minimum time at +1002 (see below), not from this field.
+          last time at +1006 (see below), not from this field.
         - ... unknown
         - reference frequency (float32), 80 bytes behind
         - ...
@@ -1706,11 +1706,11 @@ def _read_header(fid, pos, is_first_spectrum=True):
 
         - series name (text), 938 bytes behind
         - series minimum / first time in minutes (float32), 1002 bytes
-          behind. Historically described as "collection length": the public
-          `collection_length` is this value converted to seconds (x60), while
-          `time_min` keeps it in minutes and is used as the time-axis anchor.
-          Do not conflate it with the general-header collection length at +68.
-        - series maximum / last time in minutes (float32), 1006 bytes behind
+          behind. `time_min` keeps it in minutes and is used as the time-axis
+          anchor. Do not conflate it with the collection length at +68.
+        - series maximum / last time in minutes (float32), 1006 bytes behind,
+          converted to seconds (x60) it is the OMNIC "Total collection time"
+          and the public `collection_length` for srs series.
         - regular time step in minutes (float32), 1010 bytes behind. This
           field was historically misnamed "first y": it is the series step,
           not the minimum (the minimum is the +1002 field above).
@@ -1847,14 +1847,15 @@ def _read_header(fid, pos, is_first_spectrum=True):
         out["name"] = out["name"].split("\n")[0]
         fid.seek(pos + 1002)
         # The stored float32 at +1002 is the OMNIC series *minimum / first time*
-        # (in minutes). `collection_length` keeps the historical public meaning
-        # (that value converted to seconds); `time_min` is the same field kept in
-        # minutes, used as the time-axis start. Do not conflate the two.
-        collection_length = fromfile(fid, "float32", 1)
-        out["collection_length"] = collection_length * 60
-        out["time_min"] = collection_length
+        # in minutes; `time_min` keeps it in minutes and anchors the time axis.
+        out["time_min"] = fromfile(fid, "float32", 1)
         fid.seek(pos + 1006)
+        # +1006 is the OMNIC series *maximum / last time* in minutes. Converted
+        # to seconds it is the OMNIC "Total collection time", exposed as the
+        # public `collection_length` for SRS series. Do not conflate it with the
+        # +1002 first time (nor with the general-header +68 field).
         out["lasty"] = fromfile(fid, "float32", 1)
+        out["collection_length"] = out["lasty"] * 60
         fid.seek(pos + 1010)
         out["firsty"] = fromfile(fid, "float32", 1)
         fid.seek(pos + 1026)

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -604,9 +604,57 @@ def test_read_srs_time_axis_anchored_at_time_min():
     assert y[-1] == np.around(info["lasty"], 3)
 
     # Guard the field separation: `firsty` is the step, not the axis start, and
-    # `time_min` is the same header field as `collection_length` kept in minutes.
-    assert info["time_min"] == np.float32(info["collection_length"] / 60)
+    # `collection_length` is the total series time derived from the series last
+    # time (+1006), not from the first time (+1002) kept in `time_min`.
+    assert info["time_min"] != info["lasty"]
     assert info["time_min"] != info["firsty"]
+    assert info["collection_length"] == np.float32(info["lasty"] * 60)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "rapid_scan.srs",
+        "rapid_scan_reprocessed.srs",
+        "GC_Demo.srs",
+        "high_speed.srs",
+        "TGA_demo.srs",
+    ],
+)
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_collection_length_is_total_series_time(name):
+    """The SRS `meta.collection_length` must be the total series collection
+    time — the series last time (+1006, minutes) converted to seconds —
+    matching the OMNIC "Total collection time", not the first-time value
+    (+1002) converted to seconds.
+
+    Controlled SRS/TXT validation established +1006 as the OMNIC total
+    collection time across the five public fixtures; this test pins the
+    metadata value to `+1006 * 60` and keeps the time axis anchored at the
+    series first time (+1002).
+    """
+    from spectrochempy.core.units import ur
+
+    path = IRDATA / "omnic_series" / name
+    info = _srs_header(path)
+    nd = scp.read_srs(path)
+
+    # Total series collection time, derived from the series last time (+1006).
+    assert info["collection_length"] == np.float32(info["lasty"] * 60)
+    assert nd.meta.collection_length.magnitude == np.float64(info["collection_length"])
+    assert nd.meta.collection_length.units == ur("s")
+    # ...and strictly larger than the historical (wrong) first-time value.
+    assert nd.meta.collection_length.magnitude > np.float32(info["time_min"]) * 60
+
+    # Y-axis start still comes from the series first time (+1002) and the axis
+    # still ends at the series last time (+1006). The axis is rounded to 3
+    # decimals (see `_read_srs`), hence the 0.5e-3 tolerance.
+    assert nd.y.data[0] == pytest.approx(
+        np.around(float(info["time_min"]), 3), abs=0.5e-3
+    )
+    assert nd.y.data[-1] == pytest.approx(
+        np.around(float(info["lasty"]), 3), abs=0.5e-3
+    )
 
 
 @pytest.mark.usefixtures("_skip_if_no_testdata")


### PR DESCRIPTION
## Summary

The SRS reader exposed `dataset.meta.collection_length` as the series **minimum** time (header `+1002`, minutes) converted to seconds. That value is not a collection duration, so the metadata misrepresented the series total collection time.

It now equals the OMNIC **"Total collection time"**, i.e. the series **maximum** time (header `+1006`, minutes) converted to seconds.

The time axis is unchanged: it is still built from the series first time (`+1002`, `time_min`, minutes) to the series last time (`+1006`, minutes), as `_read_srs` does.

Controlled SRS/TXT validation across the five public `omnic_series` fixtures established `+1006 × 60` as the OMNIC total collection time. SPA/SPG collection-length semantics (general-header `+68`) are untouched.

## Changes

- `src/spectrochempy/core/readers/read_omnic.py` — SRS branch of `_read_header`: `collection_length` now derives from `+1006` (`lasty × 60`), `time_min` keeps `+1002` in minutes; docstring updated.
- `tests/test_core/test_readers/test_read_omnic.py` — updated the field-separation guard in the time-axis test and added a parametrized regression test over the five public SRS fixtures pinning `meta.collection_length` to `+1006 × 60` s (and > the historical first-time value), with Y-axis bounds anchored at `+1002`/`+1006`.
- `docs/sources/devguide/file_formats/omnic/srs.rst` — corrected the `+1002`/`+1006`/`+68` rows of the SRS format reference.
- `docs/sources/whatsnew/changelog.rst` — bug-fix entry (regenerated `latest.rst`).

## Validation

- `pytest tests/test_core/test_readers/test_omnic...` — 15 SRS tests pass
- `pytest tests/test_core/test_readers/test_read_omnic.py` — 38 passed, 1 skipped
- `pytest tests/test_core/test_readers/test_reader_semantic_characterization.py` — 34 passed
- `pytest tests/test_core/test_readers/` — 211 passed, 1 skipped, 1 deselected (pre-existing `test_read_opus` units-rendering failure, reproduced on pristine `upstream/master`, unrelated)
- `pre-commit run --all-files` — clean

## Changelog

Added under Bug Fixes in `changelog.rst` (user-facing correction).