### PR TITLE
FIX: repair plugin Conda publication from a bare version (+ PerkinElmer recipe)

### DIFF
--- a/.github/workflows/repair_conda_plugin_release.yml
+++ b/.github/workflows/repair_conda_plugin_release.yml
@@ -11,6 +11,9 @@ name: Repair plugin Conda publication
 #     programmatically (conda_publish.py derive-tag): the version is strictly
 #     validated (no 'v' prefix, no plugin name, no tag, no whitespace, no
 #     shell metacharacters -- nothing but digits and dots).
+#   - Operator-supplied values reach shell scripts ONLY through the step
+#     environment (never by interpolating ${{ inputs.* }} into a run block),
+#     so no untrusted text can be interpreted by bash before validation.
 #   - The derived tag is explicitly verified to EXIST (git rev-parse
 #     refs/tags/<tag>^{commit}) BEFORE any checkout; if missing, the
 #     available releases for that plugin are listed.
@@ -95,10 +98,16 @@ jobs:
 
       - name: Validate inputs and derive release tag
         id: validate
+        env:
+          INPUT_PLUGIN: ${{ inputs.plugin_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          PLUGIN="${{ inputs.plugin_name }}"
-          VERSION="${{ inputs.version }}"
+          # Operator inputs reach the shell ONLY through the environment, so
+          # no interpolation of untrusted text ever reaches bash before
+          # derive-tag has a chance to validate it.
+          PLUGIN="$INPUT_PLUGIN"
+          VERSION="$INPUT_VERSION"
 
           # Strict version validation + canonical tag derivation + explicit
           # existence check (rev-parse refs/tags/<tag>^{commit}), with the
@@ -120,9 +129,11 @@ jobs:
 
       - name: Stash validation tooling and master recipe
         id: stash
+        env:
+          INPUT_PLUGIN: ${{ inputs.plugin_name }}
         run: |
           set -euo pipefail
-          PLUGIN="${{ inputs.plugin_name }}"
+          PLUGIN="$INPUT_PLUGIN"
           # The release tag may predate the shared validation script and its
           # recipe.  Copy the master versions out of the tree so they survive
           # the tag checkout (used by resolve-recipe as recovery recipe).
@@ -135,19 +146,24 @@ jobs:
           fi
 
       - name: Checkout release tag (explicit ref)
+        env:
+          # Derived by derive-tag from the validated inputs and verified to
+          # exist; the shell only ever sees this derived value.
+          RELEASE_TAG: ${{ steps.validate.outputs.tag }}
         run: |
           set -euo pipefail
           # Tag existence was verified in the previous job step; checkout the
           # full ref so a short or ambiguous name can never be resolved.
-          git checkout --detach "refs/tags/${{ steps.validate.outputs.tag }}"
+          git checkout --detach "refs/tags/$RELEASE_TAG"
 
       - name: Resolve recipe to build
         id: recipe
+        env:
+          PLUGIN: ${{ steps.validate.outputs.plugin }}
+          VERSION: ${{ steps.validate.outputs.version }}
+          MASTER_RECIPE: ${{ steps.stash.outputs.master_recipe }}
         run: |
           set -euo pipefail
-          PLUGIN="${{ steps.validate.outputs.plugin }}"
-          VERSION="${{ steps.validate.outputs.version }}"
-          MASTER_RECIPE="${MASTER_RECIPE:-}"
           # Emits recipe_path / recipe_file / recipe_origin.  In
           # master-fallback mode it writes the recovery recipe (version
           # injected, core bound aligned with the tag pyproject) into the
@@ -155,27 +171,28 @@ jobs:
           python3 /tmp/conda_publish.py resolve-recipe \
             --tag-dir "plugins/$PLUGIN" \
             --version "$VERSION" \
-            --master-recipe "$MASTER_RECIPE" >> "$GITHUB_OUTPUT"
-        env:
-          MASTER_RECIPE: ${{ steps.stash.outputs.master_recipe }}
+            --master-recipe "${MASTER_RECIPE:-}" >> "$GITHUB_OUTPUT"
 
       - name: Validate metadata against the tag
+        env:
+          PLUGIN: ${{ steps.validate.outputs.plugin }}
+          VERSION: ${{ steps.validate.outputs.version }}
+          RECIPE_FILE: ${{ steps.recipe.outputs.recipe_file }}
+          RECIPE_ORIGIN: ${{ steps.recipe.outputs.recipe_origin }}
         run: |
-          PLUGIN="${{ steps.validate.outputs.plugin }}"
-          VERSION="${{ steps.validate.outputs.version }}"
-          RECIPE_FILE="${{ steps.recipe.outputs.recipe_file }}"
           # Blocking: pyproject.toml / __init__.py (when declared) / resolved
           # recipe versions must all match the tag version, read from the
           # exact tag checkout.  Any mismatch fails the job before building.
           python3 /tmp/conda_publish.py validate-release \
             "plugins/$PLUGIN" "$VERSION"
 
-          echo "Recipe origin for $PLUGIN v$VERSION: ${{ steps.recipe.outputs.recipe_origin }} ($RECIPE_FILE)"
+          echo "Recipe origin for $PLUGIN v$VERSION: $RECIPE_ORIGIN ($RECIPE_FILE)"
 
       - name: Check existing Conda package
+        env:
+          PLUGIN: ${{ steps.validate.outputs.plugin }}
+          VERSION: ${{ steps.validate.outputs.version }}
         run: |
-          PLUGIN="${{ steps.validate.outputs.plugin }}"
-          VERSION="${{ steps.validate.outputs.version }}"
           # Informational: uses the /files API via the shared module.  The
           # publish job re-checks authoritatively and refuses to overwrite
           # without allow_override.
@@ -219,9 +236,11 @@ jobs:
 
       - name: Stash tooling and master recipe
         id: stash
+        env:
+          INPUT_PLUGIN: ${{ inputs.plugin_name }}
         run: |
           set -euo pipefail
-          PLUGIN="${{ inputs.plugin_name }}"
+          PLUGIN="$INPUT_PLUGIN"
           cp .github/workflows/scripts/conda_publish.py /tmp/conda_publish.py
           if [ -f "plugins/$PLUGIN/recipe.yaml" ]; then
             cp "plugins/$PLUGIN/recipe.yaml" /tmp/master_recipe.yaml
@@ -229,25 +248,26 @@ jobs:
           fi
 
       - name: Checkout release tag (explicit ref)
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail
-          git checkout --detach "refs/tags/${{ needs.validate.outputs.tag }}"
+          git checkout --detach "refs/tags/$RELEASE_TAG"
 
       - name: Resolve recipe to build
         id: recipe
+        env:
+          PLUGIN: ${{ needs.validate.outputs.plugin }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          MASTER_RECIPE: ${{ steps.stash.outputs.master_recipe }}
         run: |
           set -euo pipefail
-          PLUGIN="${{ needs.validate.outputs.plugin }}"
-          VERSION="${{ needs.validate.outputs.version }}"
-          MASTER_RECIPE="${MASTER_RECIPE:-}"
           # Same deterministic resolution as the validate job, so the build
           # workspace contains the same recipe the validator reviewed.
           python3 /tmp/conda_publish.py resolve-recipe \
             --tag-dir "plugins/$PLUGIN" \
             --version "$VERSION" \
-            --master-recipe "$MASTER_RECIPE" >> "$GITHUB_OUTPUT"
-        env:
-          MASTER_RECIPE: ${{ steps.stash.outputs.master_recipe }}
+            --master-recipe "${MASTER_RECIPE:-}" >> "$GITHUB_OUTPUT"
 
       - name: Build conda plugin package
         uses: prefix-dev/rattler-build-action@v0.2.39
@@ -265,12 +285,12 @@ jobs:
           mv ../output .
 
       - name: Verify built package
+        env:
+          PLUGIN: ${{ needs.validate.outputs.plugin }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
           echo "=== Built packages ==="
           find output -type f \( -name "*.conda" -o -name "*.tar.bz2" \)
-
-          PLUGIN="${{ needs.validate.outputs.plugin }}"
-          VERSION="${{ needs.validate.outputs.version }}"
 
           # Verify the built package matches the exact expected name and version.
           # The version must be followed by a '-' (build string) so that a
@@ -341,12 +361,12 @@ jobs:
       - name: Upload to Anaconda.org (main label)
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+          INPUT_ALLOW_OVERRIDE: ${{ inputs.allow_override }}
+          PLUGIN: ${{ needs.validate.outputs.plugin }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
           shopt -s nullglob globstar
-
-          PLUGIN="${{ needs.validate.outputs.plugin }}"
-          VERSION="${{ needs.validate.outputs.version }}"
 
           if [ -z "${ANACONDA_API_TOKEN:-}" ]; then
             echo "::error::ANACONDA_API_TOKEN is not set. Cannot upload to Anaconda.org."
@@ -354,7 +374,7 @@ jobs:
           fi
 
           OVERRIDE=""
-          if [ "${{ inputs.allow_override }}" = "true" ]; then
+          if [ "$INPUT_ALLOW_OVERRIDE" = "true" ]; then
             OVERRIDE="--allow-override"
             echo "::warning::allow_override=true: an already-published version may be replaced."
           fi
@@ -395,16 +415,17 @@ jobs:
 
     steps:
       - name: Print dry-run summary
+        env:
+          PLUGIN: ${{ needs.validate.outputs.plugin }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          ORIGIN: ${{ needs.validate.outputs.recipe_origin }}
         run: |
-          PLUGIN="${{ needs.validate.outputs.plugin }}"
-          VERSION="${{ needs.validate.outputs.version }}"
-          ORIGIN="${{ needs.validate.outputs.recipe_origin }}"
-
           echo "## Dry-run summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Plugin**: \`$PLUGIN\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Tag**: \`${{ needs.validate.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tag**: \`$RELEASE_TAG\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Recipe origin**: \`$ORIGIN\` (tag recipe vs master-recipe recovery fallback)" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Mode**: Dry-run (no upload performed)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -420,7 +441,7 @@ jobs:
           echo "=== DRY RUN COMPLETE ==="
           echo "Plugin: $PLUGIN"
           echo "Version: $VERSION"
-          echo "Tag: ${{ needs.validate.outputs.tag }}"
+          echo "Tag: $RELEASE_TAG"
           echo "Recipe origin: $ORIGIN"
           echo "Artifact: conda-repair-$PLUGIN"
           echo ""

--- a/.github/workflows/repair_conda_plugin_release.yml
+++ b/.github/workflows/repair_conda_plugin_release.yml
@@ -6,12 +6,26 @@ name: Repair plugin Conda publication
 # Conda package was not published to spectrocat/main.
 #
 # Safety guarantees:
-#   - Tag must match <plugin_name>-v<version> pattern
+#   - The operator supplies ONLY a plugin (closed list of official plugins)
+#     and a bare X.Y.Z version.  The tag <plugin>-v<version> is derived
+#     programmatically (conda_publish.py derive-tag): the version is strictly
+#     validated (no 'v' prefix, no plugin name, no tag, no whitespace, no
+#     shell metacharacters -- nothing but digits and dots).
+#   - The derived tag is explicitly verified to EXIST (git rev-parse
+#     refs/tags/<tag>^{commit}) BEFORE any checkout; if missing, the
+#     available releases for that plugin are listed.
+#   - Checkout uses the explicit ref refs/tags/<tag>, never a bare name.
 #   - Plugin must be declared official (evaluation failure = abort)
-#   - The release is validated from the exact tag checkout: the version from
-#     pyproject.toml, __init__.py (when declared) and the recipe must all
-#     match the tag version — any mismatch is blocking
-#   - A recipe (recipe.yaml / meta.yaml) must exist at the tag
+#   - The release is validated on the exact tag checkout: the version from
+#     pyproject.toml, __init__.py (when declared) and the resolved recipe
+#     must all match the tag version -- any mismatch is blocking
+#   - A recipe at the tag (recipe.yaml / meta.yaml) is used as-is.  When the
+#     tag has NO recipe (e.g. historical PerkinElmer tags), the canonical
+#     recipe from master is used as a recovery recipe: the requested version
+#     is injected deterministically and the spectrochempy run bound is
+#     aligned with the tag's own pyproject.toml.  The chosen origin is
+#     reported as recipe_origin=tag|master-fallback and never applied to a
+#     tag that has a recipe but an inconsistent one (that is blocking).
 #   - Upload refuses to overwrite a version already published on the target
 #     label unless allow_override=true (explicit, documented derogation)
 #   - Default mode is dry-run (no upload)
@@ -22,11 +36,18 @@ on:
   workflow_dispatch:
     inputs:
       plugin_name:
-        description: "Plugin package name (e.g. spectrochempy-nmr)"
+        description: "Official plugin package name"
         required: true
-        type: string
-      tag:
-        description: "Existing release tag (e.g. spectrochempy-nmr-v0.1.11)"
+        type: choice
+        options:
+          - spectrochempy-carroucell
+          - spectrochempy-hypercomplex
+          - spectrochempy-iris
+          - spectrochempy-nmr
+          - spectrochempy-perkinelmer
+          - spectrochempy-tensor
+      version:
+        description: "Version to repair (e.g. 0.1.8). The release tag <plugin>-v<version> is derived and verified automatically."
         required: true
         type: string
       dry_run:
@@ -50,14 +71,16 @@ permissions:
 
 jobs:
   validate:
-    name: Validate tag and plugin
+    name: Validate version, tag and recipe
     runs-on: ubuntu-latest
     if: github.repository == 'spectrochempy/spectrochempy'
     outputs:
       plugin: ${{ steps.validate.outputs.plugin }}
       version: ${{ steps.validate.outputs.version }}
+      tag: ${{ steps.validate.outputs.tag }}
       recipe_path: ${{ steps.recipe.outputs.recipe_path }}
       recipe_file: ${{ steps.recipe.outputs.recipe_file }}
+      recipe_origin: ${{ steps.recipe.outputs.recipe_origin }}
 
     steps:
       - name: Checkout code
@@ -70,60 +93,84 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Validate inputs
+      - name: Validate inputs and derive release tag
         id: validate
         run: |
-          python3 .github/workflows/scripts/conda_publish.py verify-tag \
-            "${{ inputs.tag }}" --plugin "${{ inputs.plugin_name }}"
-
+          set -euo pipefail
           PLUGIN="${{ inputs.plugin_name }}"
-          VERSION=$(echo "${{ inputs.tag }}" | sed -n 's/^.*-v\([0-9.]*\)$/\1/p')
+          VERSION="${{ inputs.version }}"
 
-          echo "plugin=$PLUGIN" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Strict version validation + canonical tag derivation + explicit
+          # existence check (rev-parse refs/tags/<tag>^{commit}), with the
+          # available releases listed if the tag is missing.
+          python3 .github/workflows/scripts/conda_publish.py derive-tag \
+            --plugin "$PLUGIN" --version "$VERSION"
 
           # Verify plugin is official.  is-official exits 0 (official),
           # 1 (not official) or 2 (evaluation error) — any non-zero aborts.
           python3 .github/workflows/scripts/conda_publish.py is-official \
             "plugins/$PLUGIN"
 
-          echo "Inputs valid: $PLUGIN v$VERSION is an official plugin"
+          TAG="$PLUGIN-v$VERSION"
+          echo "plugin=$PLUGIN" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Stash validation tooling from master
+          echo "Inputs valid: $PLUGIN v$VERSION -> release tag $TAG"
+
+      - name: Stash validation tooling and master recipe
+        id: stash
         run: |
-          # The release tag predates the shared validation script.  Copy the
-          # master version out of the tree so it survives the tag checkout.
+          set -euo pipefail
+          PLUGIN="${{ inputs.plugin_name }}"
+          # The release tag may predate the shared validation script and its
+          # recipe.  Copy the master versions out of the tree so they survive
+          # the tag checkout (used by resolve-recipe as recovery recipe).
           cp .github/workflows/scripts/conda_publish.py /tmp/conda_publish.py
+          if [ -f "plugins/$PLUGIN/recipe.yaml" ]; then
+            cp "plugins/$PLUGIN/recipe.yaml" /tmp/master_recipe.yaml
+            echo "master_recipe=/tmp/master_recipe.yaml" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No recipe.yaml for $PLUGIN on master; the tag must carry one."
+          fi
 
-      - name: Checkout release tag
+      - name: Checkout release tag (explicit ref)
         run: |
-          git checkout --detach "${{ inputs.tag }}"
+          set -euo pipefail
+          # Tag existence was verified in the previous job step; checkout the
+          # full ref so a short or ambiguous name can never be resolved.
+          git checkout --detach "refs/tags/${{ steps.validate.outputs.tag }}"
+
+      - name: Resolve recipe to build
+        id: recipe
+        run: |
+          set -euo pipefail
+          PLUGIN="${{ steps.validate.outputs.plugin }}"
+          VERSION="${{ steps.validate.outputs.version }}"
+          MASTER_RECIPE="${MASTER_RECIPE:-}"
+          # Emits recipe_path / recipe_file / recipe_origin.  In
+          # master-fallback mode it writes the recovery recipe (version
+          # injected, core bound aligned with the tag pyproject) into the
+          # plugin dir of this checkout.
+          python3 /tmp/conda_publish.py resolve-recipe \
+            --tag-dir "plugins/$PLUGIN" \
+            --version "$VERSION" \
+            --master-recipe "$MASTER_RECIPE" >> "$GITHUB_OUTPUT"
+        env:
+          MASTER_RECIPE: ${{ steps.stash.outputs.master_recipe }}
 
       - name: Validate metadata against the tag
         run: |
           PLUGIN="${{ steps.validate.outputs.plugin }}"
           VERSION="${{ steps.validate.outputs.version }}"
-          # Blocking: pyproject.toml / __init__.py (when declared) / recipe
-          # versions must all match the tag version, read from the exact tag
-          # checkout.  Any mismatch fails the job before building.
+          RECIPE_FILE="${{ steps.recipe.outputs.recipe_file }}"
+          # Blocking: pyproject.toml / __init__.py (when declared) / resolved
+          # recipe versions must all match the tag version, read from the
+          # exact tag checkout.  Any mismatch fails the job before building.
           python3 /tmp/conda_publish.py validate-release \
             "plugins/$PLUGIN" "$VERSION"
 
-      - name: Find recipe file
-        id: recipe
-        run: |
-          PLUGIN="${{ steps.validate.outputs.plugin }}"
-          RECIPE_DIR="plugins/$PLUGIN"
-          if [ -f "$RECIPE_DIR/recipe.yaml" ]; then
-            echo "recipe_path=$RECIPE_DIR" >> "$GITHUB_OUTPUT"
-            echo "recipe_file=recipe.yaml" >> "$GITHUB_OUTPUT"
-          elif [ -f "$RECIPE_DIR/meta.yaml" ]; then
-            echo "recipe_path=$RECIPE_DIR" >> "$GITHUB_OUTPUT"
-            echo "recipe_file=meta.yaml" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error::No recipe.yaml or meta.yaml found for $PLUGIN at tag ${{ inputs.tag }}"
-            exit 1
-          fi
+          echo "Recipe origin for $PLUGIN v$VERSION: ${{ steps.recipe.outputs.recipe_origin }} ($RECIPE_FILE)"
 
       - name: Check existing Conda package
         run: |
@@ -156,10 +203,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - name: Checkout tag
+      - name: Checkout code
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag }}
           fetch-depth: 0
 
       - name: Install Conda environment with Micromamba
@@ -171,12 +217,44 @@ jobs:
             python=3.11
           cache-environment: true
 
+      - name: Stash tooling and master recipe
+        id: stash
+        run: |
+          set -euo pipefail
+          PLUGIN="${{ inputs.plugin_name }}"
+          cp .github/workflows/scripts/conda_publish.py /tmp/conda_publish.py
+          if [ -f "plugins/$PLUGIN/recipe.yaml" ]; then
+            cp "plugins/$PLUGIN/recipe.yaml" /tmp/master_recipe.yaml
+            echo "master_recipe=/tmp/master_recipe.yaml" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout release tag (explicit ref)
+        run: |
+          set -euo pipefail
+          git checkout --detach "refs/tags/${{ needs.validate.outputs.tag }}"
+
+      - name: Resolve recipe to build
+        id: recipe
+        run: |
+          set -euo pipefail
+          PLUGIN="${{ needs.validate.outputs.plugin }}"
+          VERSION="${{ needs.validate.outputs.version }}"
+          MASTER_RECIPE="${MASTER_RECIPE:-}"
+          # Same deterministic resolution as the validate job, so the build
+          # workspace contains the same recipe the validator reviewed.
+          python3 /tmp/conda_publish.py resolve-recipe \
+            --tag-dir "plugins/$PLUGIN" \
+            --version "$VERSION" \
+            --master-recipe "$MASTER_RECIPE" >> "$GITHUB_OUTPUT"
+        env:
+          MASTER_RECIPE: ${{ steps.stash.outputs.master_recipe }}
+
       - name: Build conda plugin package
         uses: prefix-dev/rattler-build-action@v0.2.39
         env:
           CONDA_BLD_PATH: ../output
         with:
-          recipe-path: ${{ needs.validate.outputs.recipe_path }}/${{ needs.validate.outputs.recipe_file }}
+          recipe-path: ${{ steps.recipe.outputs.recipe_path }}/${{ steps.recipe.outputs.recipe_file }}
           upload-artifact: false
           build-args: >-
             -c conda-forge
@@ -320,12 +398,14 @@ jobs:
         run: |
           PLUGIN="${{ needs.validate.outputs.plugin }}"
           VERSION="${{ needs.validate.outputs.version }}"
+          ORIGIN="${{ needs.validate.outputs.recipe_origin }}"
 
           echo "## Dry-run summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Plugin**: \`$PLUGIN\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Version**: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Tag**: \`${{ inputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Tag**: \`${{ needs.validate.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Recipe origin**: \`$ORIGIN\` (tag recipe vs master-recipe recovery fallback)" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Mode**: Dry-run (no upload performed)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "To publish, re-run with:" >> "$GITHUB_STEP_SUMMARY"
@@ -340,6 +420,8 @@ jobs:
           echo "=== DRY RUN COMPLETE ==="
           echo "Plugin: $PLUGIN"
           echo "Version: $VERSION"
+          echo "Tag: ${{ needs.validate.outputs.tag }}"
+          echo "Recipe origin: $ORIGIN"
           echo "Artifact: conda-repair-$PLUGIN"
           echo ""
           echo "No upload was performed. To upload, re-run with dry_run=false and confirm_upload=true."

--- a/.github/workflows/scripts/conda_publish.py
+++ b/.github/workflows/scripts/conda_publish.py
@@ -30,6 +30,14 @@ TAG_RE = re.compile(
     r"^(?P<plugin>spectrochempy-[a-z0-9-]+)-v(?P<version>\d+\.\d+\.\d+)$"
 )
 
+# A version submitted to the repair workflow must be a bare X.Y.Z release
+# number.  Anything else (empty, a leading ``v``, a plugin name, a full tag,
+# whitespace or shell metacharacters) is refused *before* it can reach a
+# shell command, so no user input ever enters a checkout or upload command.
+VERSION_ONLY_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+PLUGIN_NAME_RE = re.compile(r"^spectrochempy-[a-z0-9-]+$")
+
 PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
 ANACONDA_FILES_URL = "https://api.anaconda.org/package/{owner}/{package}/files"
 
@@ -119,6 +127,197 @@ def read_recipe_version(recipe_path: Path) -> str | None:
     if match:
         return match.group(1) or match.group(2) or match.group(3)
     return None
+
+
+def validate_version_input(version: str) -> str:
+    """
+    Validate a strict ``X.Y.Z`` release version for the repair workflow.
+
+    Only the three numeric components are accepted.  Empty strings, a leading
+    ``v``, a full ``<plugin>-v<version>`` tag, partial versions, whitespace
+    and any shell metacharacter are rejected: the value may later be used to
+    build a checkout ref, so nothing beyond ``[0-9.]`` is ever allowed.
+    """
+    if not isinstance(version, str) or version == "":
+        raise ValueError("version cannot be empty")
+    if not VERSION_ONLY_RE.fullmatch(version):
+        raise ValueError(
+            f"version '{version}' must be exactly three numeric components "
+            "(e.g. 0.1.8): no 'v' prefix, no plugin name, no tag, "
+            "no whitespace and no special characters"
+        )
+    return version
+
+
+def validate_plugin_name(plugin_name: str) -> str:
+    """Validate a plugin name (``spectrochempy-<name>`` with [a-z0-9-])."""
+    if not isinstance(plugin_name, str) or not PLUGIN_NAME_RE.fullmatch(plugin_name):
+        raise ValueError(
+            f"plugin name '{plugin_name}' must match 'spectrochempy-<name>' "
+            "with [a-z0-9-] only"
+        )
+    return plugin_name
+
+
+def canonical_plugin_tag(plugin_name: str, version: str) -> str:
+    """
+    Build the canonical release tag ``<plugin_name>-v<version>`` for a plugin.
+
+    The version is validated as a bare ``X.Y.Z`` first, so the returned tag
+    is always of the exact ``spectrochempy-<name>-v<X.Y.Z>`` form.
+    """
+    validate_plugin_name(plugin_name)
+    validate_version_input(version)
+    return f"{plugin_name}-v{version}"
+
+
+def unpack_recipe(tag_dir: Path) -> tuple[Path, str] | None:
+    """
+    Return ``(recipe_path, recipe_file)`` for a plugin checkout, or None.
+
+    Prefers ``recipe.yaml`` (current convention) and falls back to the
+    legacy ``meta.yaml`` form.
+    """
+    for recipe_file in ("recipe.yaml", "meta.yaml"):
+        recipe_path = tag_dir / recipe_file
+        if recipe_path.is_file():
+            return recipe_path, recipe_file
+    return None
+
+
+def inject_recipe_version(recipe_text: str, new_version: str) -> str:
+    """
+    Deterministically inject a version into a conda ``recipe.yaml`` text.
+
+    Replaces the ``context.version`` field and leaves ``package.version``
+    (a Jinja2 ``${{ version }}`` reference) untouched.  Raises ``ValueError``
+    if no ``context:`` block with a quoted ``version`` can be found, so a
+    recipe that cannot be adapted fails loudly instead of building silently.
+    """
+    validate_version_input(new_version)
+    lines = recipe_text.splitlines(keepends=True)
+    context_indent = -1
+    for i, line in enumerate(lines):
+        text = line.rstrip("\n")
+        indent = len(text) - len(text.lstrip())
+        content = text.strip()
+        if content == "context:":
+            context_indent = indent
+            continue
+        if context_indent >= 0 and indent <= context_indent and content:
+            break
+        if context_indent >= 0:
+            match = re.match(
+                rf"^ {{{context_indent + 2}}}version\s*:\s*\"([^\"]*)\"\s*$",
+                line,
+            )
+            if match:
+                prefix = " " * (context_indent + 2)
+                lines[i] = f'{prefix}version: "{new_version}"\n'
+                return "".join(lines)
+    raise ValueError(
+        "could not find a quoted `context:  version:` field in the recipe "
+        f"to inject version '{new_version}' into"
+    )
+
+
+def read_plugin_requirement(plugin_dir: Path, package: str) -> str | None:
+    """
+    Return a conda-style run requirement for ``package`` from a pyproject.toml.
+
+    Reads PEP 508 ``dependencies`` (``spectrochempy>=0.12,<0.13``) and
+    normalises it to conda syntax (``spectrochempy >=0.12,<0.13``).  Extras
+    (``[...]``) and markers (``; ...``) are ignored: plugin requirements do
+    not use them.  Returns None when the package is not a dependency or the
+    file cannot be read.
+    """
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    pyproject = plugin_dir / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    data = tomllib.loads(pyproject.read_text())
+    dependencies = data.get("project", {}).get("dependencies", [])
+    for dep in dependencies:
+        # 'spectrochempy[extra] >= 0.12, <0.13' -> name (extras ignored) + the
+        # spec part that follows the name/extras.
+        match = re.match(
+            r"^\s*" + re.escape(package) + r"(?:\[[^\]]*\])?\s*(?P<spec>[^;]*)$",
+            dep,
+        )
+        if match:
+            spec = match.group("spec").strip()
+            return f"{package} {spec}".strip() if spec else package
+    return None
+
+
+def align_recipe_requirement(recipe_text: str, plugin_dir: Path) -> str:
+    """
+    Align the run requirement of ``package`` in a recipe with its pyproject.
+
+    For the master-recipe fallback of historical tags, the recovery recipe
+    must not claim a core bound that contradicts the tag's own pyproject.
+    This rewrites the ``- spectrochempy ...`` line inside ``requirements.run``
+    to the requirement declared by ``plugin_dir/pyproject.toml``.  When the
+    package is absent from ``dependencies`` the recipe is returned unchanged
+    (the master bound stays, deterministically).
+    """
+    requirement = read_plugin_requirement(plugin_dir, "spectrochempy")
+    if requirement is None:
+        return recipe_text
+    lines = recipe_text.splitlines(keepends=True)
+    in_requirements = False
+    in_run = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "requirements:":
+            in_requirements = True
+            continue
+        if in_requirements and stripped == "run:":
+            in_run = True
+            continue
+        if in_requirements and in_run and re.match(r"^-\s*spectrochempy\b", stripped):
+            indent = line[: len(line) - len(line.lstrip())]
+            lines[i] = f"{indent}- {requirement}\n"
+            break
+        if in_requirements and not stripped.startswith(("-", "run:")):
+            in_run = False
+    return "".join(lines)
+
+
+def resolve_recipe(
+    tag_dir: Path, version: str, master_recipe: str | None = None
+) -> tuple[str, str, str]:
+    """
+    Determine which recipe to build for a repair, as ``(dir, file, origin)``.
+
+    - ``origin="tag"``: the tag checkout already contains a ``recipe.yaml``
+      or ``meta.yaml`` — it is used as-is (its version is verified by the
+      caller through ``validate-release``).
+    - ``origin="master-fallback"``: the tag has no recipe (e.g. historical
+      PerkinElmer tags).  The canonical recipe from ``master`` is used as a
+      recovery recipe: the requested version is injected deterministically
+      and the ``spectrochempy`` run bound is aligned with the tag's own
+      pyproject.  The recovery recipe is written to ``tag_dir/recipe.yaml``
+      inside the tag checkout so it resolves like a recipe shipped in the
+      tag.  Raises ``ValueError`` when no master recipe is available, so a
+      tag without any recipe cannot be recovered silently.
+    """
+    tag_recipe = unpack_recipe(tag_dir)
+    if tag_recipe is not None:
+        return str(tag_dir), tag_recipe[1], "tag"
+    if master_recipe is None or not Path(master_recipe).is_file():
+        raise ValueError(
+            f"no recipe (recipe.yaml / meta.yaml) found at tag and no master "
+            f"recipe available to recover it from: {tag_dir}"
+        )
+    text = inject_recipe_version(Path(master_recipe).read_text(), version)
+    text = align_recipe_requirement(text, tag_dir)
+    (tag_dir / "recipe.yaml").write_text(text)
+    return str(tag_dir), "recipe.yaml", "master-fallback"
 
 
 def is_official_plugin(plugin_dir: Path) -> bool:
@@ -316,6 +515,48 @@ def git_tag_exists(tag: str, cwd: str | Path = ".") -> bool:
     return result.returncode == 0 and tag in result.stdout
 
 
+def verify_tag_exists(
+    tag: str, plugin_name: str | None = None, cwd: str | Path = "."
+) -> bool:
+    """
+    Verify a release tag exists before any checkout is attempted.
+
+    Uses ``git rev-parse --verify --quiet refs/tags/<tag>^{commit}`` so that
+    a protected/ambiguous ref cannot shadow a missing tag.  When the tag is
+    missing, the available plugin releases are listed to the caller's stderr
+    so the operator can pick an existing one.
+    """
+    # git is a trusted VCS binary (fixed args, the tag was validated earlier
+    # against the plugin tag pattern), so the subprocess audit is not
+    # applicable here.
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}^{{commit}}"],  # noqa: S603, S607
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    if result.returncode == 0:
+        return True
+
+    if plugin_name:
+        releases = list_plugin_tags(cwd)
+        versions = sorted(
+            (
+                v
+                for p, v in releases
+                if p == plugin_name and git_tag_exists(f"{p}-v{v}", cwd)
+            ),
+        )
+        print(
+            f"::error::tag '{tag}' does not exist. Existing releases for "
+            f"'{plugin_name}': {', '.join(versions) if versions else '(none found)'}",
+            file=sys.stderr,
+        )
+    else:
+        print(f"::error::tag '{tag}' does not exist", file=sys.stderr)
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Version reading
 # ---------------------------------------------------------------------------
@@ -482,6 +723,32 @@ def parse_args() -> argparse.Namespace:
     # list-official
     sub.add_parser("list-official", help="List official plugin names")
 
+    # derive-tag
+    p_derive = sub.add_parser(
+        "derive-tag",
+        help=(
+            "Derive and verify the canonical release tag for a plugin version "
+            "(<plugin>-v<version>)"
+        ),
+    )
+    p_derive.add_argument("--plugin", required=True, help="Plugin package name")
+    p_derive.add_argument("--version", required=True, help="Version (X.Y.Z)")
+
+    # resolve-recipe
+    p_rec = sub.add_parser(
+        "resolve-recipe",
+        help=(
+            "Resolve which recipe to build for a repair: the tag's own "
+            "recipe (origin=tag) or a master-recipe fallback with the "
+            "requested version injected (origin=master-fallback)"
+        ),
+    )
+    p_rec.add_argument("--tag-dir", required=True, help="Plugin dir at tag checkout")
+    p_rec.add_argument("--version", required=True, help="Version (X.Y.Z)")
+    p_rec.add_argument(
+        "--master-recipe", default="", help="Path to the master recipe.yaml"
+    )
+
     # is-official
     p_off = sub.add_parser(
         "is-official",
@@ -611,6 +878,49 @@ def cmd_list_official(_args: argparse.Namespace) -> int:
     plugins = discover_official_plugins(Path("plugins"))
     for p in plugins:
         print(p)
+    return 0
+
+
+def cmd_derive_tag(args: argparse.Namespace) -> int:
+    """Derive the canonical tag for a plugin/version and verify it exists."""
+    try:
+        tag = canonical_plugin_tag(args.plugin, args.version)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    if not verify_tag_exists(tag, plugin_name=args.plugin):
+        return 1
+    print(
+        f"Derived and verified release tag: plugin={args.plugin}, "
+        f"version={args.version}, tag={tag}"
+    )
+    return 0
+
+
+def cmd_resolve_recipe(args: argparse.Namespace) -> int:
+    """
+    Resolve the recipe to build and print GITHUB_OUTPUT-compatible lines.
+
+    Emits ``recipe_path=<abs path>``, ``recipe_file=<name>`` and
+    ``recipe_origin=<tag|master-fallback>``.  In ``master-fallback`` mode the
+    recovery recipe (with the requested version injected and the core bound
+    aligned with the tag pyproject) is written to the tag checkout, so the
+    build job can consume it exactly like a recipe that ships in the tag.
+    """
+    try:
+        path, recipe_file, origin = resolve_recipe(
+            Path(args.tag_dir), args.version, args.master_recipe or None
+        )
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+    print(f"recipe_path={path}")
+    print(f"recipe_file={recipe_file}")
+    print(f"recipe_origin={origin}")
+    print(
+        f"::notice::Resolved recipe for {args.tag_dir}: origin={origin}, file={recipe_file}",
+        file=sys.stderr,
+    )
     return 0
 
 
@@ -841,6 +1151,8 @@ def main() -> int:
         "check-release": cmd_check_release,
         "check-all": cmd_check_all,
         "list-official": cmd_list_official,
+        "derive-tag": cmd_derive_tag,
+        "resolve-recipe": cmd_resolve_recipe,
         "is-official": cmd_is_official,
         "validate-release": cmd_validate_release,
         "upload-conda": cmd_upload,

--- a/.github/workflows/test_plugin_recovery.yml
+++ b/.github/workflows/test_plugin_recovery.yml
@@ -1,0 +1,188 @@
+# Vertical CI test for the `master-fallback` plugin Conda recovery path
+# (`conda_publish.py resolve-recipe` + `rattler-build`).
+#
+# The repair workflow (repair_conda_plugin_release.yml) recovers tags that
+# have NO Conda recipe in the tag itself (e.g. the historical PerkinElmer
+# tags) by taking the canonical recipe from master, injecting the version
+# and aligning the spectrochempy run bound with the tag pyproject.  The
+# regular CI only ever builds recipes that already exist on the PR branch,
+# so this dedicated job validates the *actual recovery path* end to end:
+#
+#   1. extract the REAL content of tag spectrochempy-perkinelmer-v0.1.4
+#      into a temporary checkout-like layout;
+#   2. run conda_publish.py resolve-recipe with the PR's master recipe;
+#   3. assert recipe_origin=master-fallback and the recovered recipe content
+#      (version injected, core bound aligned with the tag pyproject);
+#   4. build the recovered recipe for real with rattler-build;
+#   5. assert the artifact is named exactly spectrochempy-perkinelmer-0.1.4-…
+#   6. NEVER uploads or publishes anything (no Anaconda API token used).
+
+name: Test plugin Conda recovery (master-fallback)
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/scripts/conda_publish.py'
+      - '.github/workflows/repair_conda_plugin_release.yml'
+      - 'plugins/spectrochempy-perkinelmer/**'
+      - '.github/workflows/test_plugin_recovery.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/scripts/conda_publish.py'
+      - '.github/workflows/repair_conda_plugin_release.yml'
+      - 'plugins/spectrochempy-perkinelmer/**'
+      - '.github/workflows/test_plugin_recovery.yml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "PerkinElmer tag version to recover (e.g. 0.1.4)"
+        required: true
+        default: "0.1.4"
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  recovery-build:
+    name: Build recovered PerkinElmer recipe (master-fallback)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Assert historical tag exists
+        env:
+          VERSION: ${{ inputs.version || '0.1.4' }}
+        run: |
+          git rev-parse --verify --quiet \
+            "refs/tags/spectrochempy-perkinelmer-v${VERSION}^{commit}" \
+            || { echo "::error::tag spectrochempy-perkinelmer-v${VERSION} not found"; exit 1; }
+
+      - name: Extract real tag content into a checkout-like layout
+        env:
+          VERSION: ${{ inputs.version || '0.1.4' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/recovery"
+          # Preserve the plugins/<plugin> prefix so the recovery recipe's
+          # source path (../../plugins/<plugin>) resolves to the same place
+          # it would in a real tag checkout.
+          git archive "spectrochempy-perkinelmer-v$VERSION" \
+            plugins/spectrochempy-perkinelmer | tar -x -C "$RUNNER_TEMP/recovery"
+          test -f "$RUNNER_TEMP/recovery/plugins/spectrochempy-perkinelmer/pyproject.toml"
+          echo "Extracted tag content:"
+          find "$RUNNER_TEMP/recovery" -type f | sort
+
+      - name: Resolve recipe from the PR master recipe (master-fallback)
+        id: resolve
+        env:
+          TAG_VERSION: ${{ inputs.version || '0.1.4' }}
+        run: |
+          set -euo pipefail
+          python3 .github/workflows/scripts/conda_publish.py resolve-recipe \
+            --tag-dir "$RUNNER_TEMP/recovery/plugins/spectrochempy-perkinelmer" \
+            --version "$TAG_VERSION" \
+            --master-recipe "plugins/spectrochempy-perkinelmer/recipe.yaml" \
+            > /tmp/resolve.out
+          cat /tmp/resolve.out
+          grep -q "recipe_origin=master-fallback" /tmp/resolve.out
+          grep -q "recipe_file=recipe.yaml" /tmp/resolve.out
+          RECIPE_PATH="$(sed -n 's/^recipe_path=//p' /tmp/resolve.out)"
+          echo "recipe_path=$RECIPE_PATH" >> "$GITHUB_OUTPUT"
+          echo "recipe_file=recipe.yaml" >> "$GITHUB_OUTPUT"
+
+      - name: Assert recovered recipe content
+        env:
+          TAG_VERSION: ${{ inputs.version || '0.1.4' }}
+        run: |
+          set -euo pipefail
+          RECIPE="$RUNNER_TEMP/recovery/plugins/spectrochempy-perkinelmer/recipe.yaml"
+          test -f "$RECIPE"
+          grep -q "version: \"$TAG_VERSION\"" "$RECIPE"
+          python3 - "$RECIPE" <<'PY'
+          import pathlib
+          import sys
+
+          recipe = pathlib.Path(sys.argv[1]).read_text().splitlines()
+          in_run = False
+          for line in recipe:
+              stripped = line.strip()
+              if stripped == "requirements:":
+                  in_run = False
+              if stripped == "run:":
+                  in_run = True
+                  continue
+              if in_run and stripped.startswith("- spectrochempy"):
+                  assert ">=0.12,<0.13" in stripped, (
+                      f"bound not aligned with tag pyproject: {stripped!r}"
+                  )
+                  print("core bound aligned with tag pyproject:", stripped)
+                  break
+          else:
+              raise SystemExit("no - spectrochempy line found in requirements.run")
+          PY
+
+      - name: Validate recovered release metadata
+        env:
+          TAG_VERSION: ${{ inputs.version || '0.1.4' }}
+        run: |
+          python3 .github/workflows/scripts/conda_publish.py validate-release \
+            "$RUNNER_TEMP/recovery/plugins/spectrochempy-perkinelmer" "$TAG_VERSION"
+
+      - name: Build recovered recipe with rattler-build
+        uses: prefix-dev/rattler-build-action@v0.2.39
+        env:
+          CONDA_BLD_PATH: ../recovery-output
+        with:
+          recipe-path: ${{ steps.resolve.outputs.recipe_path }}/${{ steps.resolve.outputs.recipe_file }}
+          upload-artifact: false
+          # spectrocat comes first so spectrochempy resolves from our channel.
+          build-args: >-
+            -c conda-forge
+            -c spectrocat
+
+      - name: Verify artifact exact name and version
+        env:
+          TAG_VERSION: ${{ inputs.version || '0.1.4' }}
+        run: |
+          set -euo pipefail
+          mv ../recovery-output recovery-output
+          echo "=== Built packages ==="
+          find recovery-output -type f \( -name "*.conda" -o -name "*.tar.bz2" \)
+          FOUND=0
+          for pkg in recovery-output/**/*.conda recovery-output/**/*.tar.bz2; do
+            if [[ -f "$pkg" ]] && [[ "$(basename "$pkg")" == "spectrochempy-perkinelmer-$TAG_VERSION-"* ]]; then
+              echo "Found exact artifact: $pkg"
+              FOUND=1
+            fi
+          done
+          if [ "$FOUND" -eq 0 ]; then
+            echo "::error::No artifact spectrochempy-perkinelmer-$TAG_VERSION-* was produced"
+            exit 1
+          fi
+
+      - name: Upload recovered package artifact (no publication)
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: recovery-spectrochempy-perkinelmer-${{ inputs.version || '0.1.4' }}
+          path: |
+            recovery-output/**/*.conda
+            recovery-output/**/*.tar.bz2
+          retention-days: 30

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -38,6 +38,13 @@ Bug Fixes
   (+1006, in minutes) converted to seconds. The time axis is unchanged and
   is still anchored at the series first time. (#1613)
 
+- Added the missing Conda recipe for ``spectrochempy-perkinelmer`` and
+  made the repair workflow take a bare ``X.Y.Z`` version (tag derived and
+  verified) with a closed plugin list.  Tags without a recipe are now
+  recoverable from the canonical ``master`` recipe with a deterministic
+  version injection and a core bound aligned with the tag pyproject
+  (``recipe_origin=master-fallback``).
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -26,3 +26,10 @@ Bug Fixes
   equals the OMNIC "Total collection time", i.e. the series last time
   (+1006, in minutes) converted to seconds. The time axis is unchanged and
   is still anchored at the series first time. (#1613)
+
+- Added the missing Conda recipe for ``spectrochempy-perkinelmer`` and
+  made the repair workflow take a bare ``X.Y.Z`` version (tag derived and
+  verified) with a closed plugin list.  Tags without a recipe are now
+  recoverable from the canonical ``master`` recipe with a deterministic
+  version injection and a core bound aligned with the tag pyproject
+  (``recipe_origin=master-fallback``).

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -338,6 +338,7 @@ logique de détection des changements reste cohérente :
 | `plugin_release_status.yml` | `--all-official --summary` — Affiche un tableau read-only dans le résumé du workflow |
 | `release_plugin.yml` | `--all-official --summary` — Affiche le même tableau comme confirmation avant release |
 | `publish_plugins.yml` | `--plugin <name> --apply-dev-version --github-output --json` — Injecte la version de développement et expose les métadonnées |
+| `test_plugin_recovery.yml` | `resolve-recipe` + `validate-release` — Test CI vertical du fallback master-fallback (PerkinElmer 0.1.4), aucune publication |
 
 ### Pourquoi pas de logique dupliquée dans les workflows
 
@@ -630,6 +631,11 @@ Si la publication PyPI a réussi mais que la publication Conda a échoué
      puis **vérifié** contre les tags réels du dépôt avant tout checkout.
      Lors de la construction, le checkout est effectué sur
      `refs/tags/<tag>` explicite, jamais sur une entrée utilisateur.
+   - Toutes les valeurs d'opérateur (plugin, version, flags) sont
+     injectées dans les scripts shell **uniquement via `env:`**, jamais
+     par interpolation GitHub `${{ inputs.* }}` directe dans les blocs
+     `run:`.  Cette garantie structurelle empêche toute injection shell
+     depuis le texte saisi par l'opérateur.
    - Le plugin est sélectionné dans une **liste fermée** des 6 plugins
      officiels (carroucell, hypercomplex, iris, nmr, perkinelmer, tensor).
    - Sélectionner le mode dry-run par défaut pour valider la construction
@@ -666,6 +672,19 @@ recette **canonique de `master`** (`recipe_origin=master-fallback`) :
    borne de core que le tag contredirait.  Si le tag ne déclare pas de
    dépendance `spectrochempy`, la borne de `master` est conservée, de façon
    déterministe.
+
+> **Politique de borne : recette master vs pyproject.**  Les recettes Conda
+> officielles sur `master` déclarent `spectrochempy >=0.10` (borne basse
+> commune, pas de borne supérieure) par convention, alors que le
+> `pyproject.toml` de chaque plugin déclare `spectrochempy>=0.12,<0.13`
+> (bornes strictes du plugin).  Cette différence est **délibérée** : la
+> recette master couvre la résolution Conda (Python >=3.11, compatibilité
+> binaire avec la chaîne de compilation), tandis que le pyproject impose la
+> compatibilité API pour le code Python.  Le `master-fallback` aligne la
+> recette de récupération sur la borne **pyproject du tag** (ex.
+> `>=0.12,<0.13`), garantissant que l'artifact construit est compatible
+> avec le code réel du tag.
+
 4. La recette de récupération est écrite dans `plugins/<plugin>/recipe.yaml`
    du checkout du tag, puis consommée exactement comme une recette qui
    existerait dans le tag.
@@ -683,9 +702,17 @@ recette **canonique de `master`** (`recipe_origin=master-fallback`) :
   inconnue.  `conda_publish.py resolve-recipe` sort avec le code 2 dans
   ce cas.
 
-Pour tester ce fallback en CI sans toucher aux tags historiques, créer un
-tag de test sans recette (ex. `spectrochempy-perkinelmer-v0.1.5`) ; ne
-jamais supprimer ou déplacer les tags 0.1.1 → 0.1.4 (sources historiques).
+Pour tester ce fallback en CI sans toucher aux tags historiques, le
+workflow dédié `test_plugin_recovery.yml` construit réellement le paquet
+`spectrochempy-perkinelmer-v0.1.4` via le chemin `master-fallback` :
+extraction du contenu du vrai tag (`git archive`), résolution de la recette,
+vérification de l'origine `master-fallback` et du contenu (borne alignée
+`>=0.12,<0.13`), build `rattler-build`, vérification de l'artifact exact
+`spectrochempy-perkinelmer-0.1.4-*`, sans aucune publication.  Ce workflow
+se déclenche sur les PR touchant `conda_publish.py`,
+`repair_conda_plugin_release.yml`, `plugins/spectrochempy-perkinelmer/**`
+ou le workflow lui-même.  Jamais supprimer ou déplacer les tags 0.1.1 →
+0.1.4 (sources historiques).
 
 #### Rôle de `conda_publish.py`
 

--- a/maintainers/release-process.md
+++ b/maintainers/release-process.md
@@ -624,10 +624,20 @@ Si la publication PyPI a réussi mais que la publication Conda a échoué
 5. Pour publier rétroactivement le paquet Conda manquant, utiliser le
    workflow **Repair plugin Conda publication**
    (`repair_conda_plugin_release.yml`) :
+
+   - **Entrer uniquement le plugin et la version `X.Y.Z`** (jamais le tag
+     complet) : le tag canonique `spectrochempy-XXX-vX.Y.Z` est *dérivé*
+     puis **vérifié** contre les tags réels du dépôt avant tout checkout.
+     Lors de la construction, le checkout est effectué sur
+     `refs/tags/<tag>` explicite, jamais sur une entrée utilisateur.
+   - Le plugin est sélectionné dans une **liste fermée** des 6 plugins
+     officiels (carroucell, hypercomplex, iris, nmr, perkinelmer, tensor).
    - Sélectionner le mode dry-run par défaut pour valider la construction
    - Vérifier l'artifact produit
    - Relancer avec `dry_run=false` et `confirm_upload=true` pour publier
-   - Le workflow valide la release depuis le **checkout exact du tag**
+   - **La recette utilisée est résolue** (`recipe_origin=tag` ou
+     `recipe_origin=master-fallback`) et reportée dans le résumé; le
+     workflow valide la release depuis le **checkout exact du tag**
      (outillage stocké depuis `master` avant le détachement du tag) et
      refuse de remplacer une version déjà publiée sur `main` sauf à
      cocher explicitement `allow_override=true` (dérogation documentée,
@@ -637,18 +647,65 @@ Si la publication PyPI a réussi mais que la publication Conda a échoué
 
 6. Vérifier la publication avec `anaconda show spectrocat/spectrochempy-XXX`.
 
+#### Récupération des tags sans recette (PerkinElmer)
+
+`spectrochempy-perkinelmer` n'a historiquement **jamais eu** de recette
+conda dans ses tags (0.1.1 → 0.1.4), donc `unpack_recipe` n'y trouve ni
+`recipe.yaml` ni `meta.yaml`.  Pour ces tags, le workflow bascule sur la
+recette **canonique de `master`** (`recipe_origin=master-fallback`) :
+
+1. La recette `plugins/<plugin>/recipe.yaml` de `master` est utilisée
+   comme recette de récupération.
+2. La version du tag y est **injectée de façon déterministe**
+   (`inject_recipe_version`, champ `context.version`) ; `package.version`
+   reste la référence Jinja `${{ version }}`, donc l'artifact construit est
+   exactement `<plugin>-<version>-…`.
+3. La borne `spectrochempy` de la section `run` est **alignée sur le
+   `pyproject.toml` du tag lui-même** (`align_recipe_requirement`), pas sur
+   celle de `master` : la recette de récupération ne peut pas déclarer une
+   borne de core que le tag contredirait.  Si le tag ne déclare pas de
+   dépendance `spectrochempy`, la borne de `master` est conservée, de façon
+   déterministe.
+4. La recette de récupération est écrite dans `plugins/<plugin>/recipe.yaml`
+   du checkout du tag, puis consommée exactement comme une recette qui
+   existerait dans le tag.
+
+`resolve_recipe` **ne bascule jamais silencieusement** :
+
+- `origin="tag"` : une recette existe dans le tag — elle est utilisée
+  telle quelle (sa cohérence de version est ensuite contrôlée par
+  `validate-release`, échec bloquant en cas de désaccord).
+- `origin="master-fallback"` : aucune recette dans le tag, recette de
+  `master` disponible.
+- **Erreur bloquante** : aucune recette dans le tag **et** aucune recette
+  `master` (le plugin est retiré de master, par exemple).  Un tag sans
+  recette ne peut pas être « réparé » en silence avec une recette
+  inconnue.  `conda_publish.py resolve-recipe` sort avec le code 2 dans
+  ce cas.
+
+Pour tester ce fallback en CI sans toucher aux tags historiques, créer un
+tag de test sans recette (ex. `spectrochempy-perkinelmer-v0.1.5`) ; ne
+jamais supprimer ou déplacer les tags 0.1.1 → 0.1.4 (sources historiques).
+
 #### Rôle de `conda_publish.py`
 
 Le script `.github/workflows/scripts/conda_publish.py` fournit des
 fonctions réutilisables pour :
 
 - Valider le format des tags plugins (`verify-tag`)
+- Dériver et vérifier le tag canonique `spectrochempy-XXX-vX.Y.Z` depuis
+  un plugin et une version seuls (`derive-tag`) — une version autre que
+  `X.Y.Z` stricte (préfixe `v`, nom de plugin, tag complet, espaces,
+  métacaractère shell) est rejetée avant toute commande shell
 - Vérifier le marqueur de plugin officiel (`is-official`) — un
   `pyproject.toml` illisible provoque une erreur (`exit 2`), jamais un
   « non officiel » silencieux
 - Vérifier la cohérence d'une release sur GitHub / PyPI / Conda
   (`check-release`, `check-all` — historique, sur tous les tags plugins)
 - Valider une release sur le checkout du tag (`validate-release`, bloquant)
+- Résoudre la recette à construire pour une réparation (`resolve-recipe`),
+  avec bascule `master-fallback` pour les tags sans recette — émet
+  `recipe_path`/`recipe_file`/`recipe_origin` au format `GITHUB_OUTPUT`
 - Publier un artifact Conda en toute sécurité (`upload-conda` — refuse le
   remplacement sans dérogation, `--force` uniquement en cas de dérogation)
 - Confirmer une publication (`verify-conda`, poll des labels) et lire
@@ -696,12 +753,13 @@ stables suivantes existent sur GitHub et PyPI mais **ne sont pas sur
 | `spectrochempy-iris`         | `0.1.7`, `0.1.8` |
 | `spectrochempy-nmr`          | `0.1.8`, `0.1.10`, `0.1.11` |
 | `spectrochempy-tensor`       | `0.1.4`, `0.1.5` |
-| `spectrochempy-perkinelmer`  | toutes (aucun paquet Conda ; **recette manquante** à ajouter avant récupération) |
+| `spectrochempy-perkinelmer`  | toutes (aucun paquet Conda ; récupérées via `master-fallback`, recette de récupération ajoutée) |
 
 `spectrochempy-perkinelmer` n'a jamais eu de `recipe.yaml`/`meta.yaml`
-dans le dépôt : même corrigé, le job de découverte ne peut pas le publier.
-L'ajout d'une recette Conda pour ce plugin est un préalable nécessaire à
-sa publication sur `spectrocat`.
+**dans ses tags historiques**.  Depuis que la recette de ce plugin est
+présente sur `master` (avec la borne standard `spectrochempy >=0.10`), les
+old tags peuvent être récupérés via le `master-fallback` décrit plus haut
+(`conda_publish.py resolve-recipe`).
 
 ---
 

--- a/plugins/spectrochempy-perkinelmer/recipe.yaml
+++ b/plugins/spectrochempy-perkinelmer/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  name: spectrochempy-perkinelmer
+  version: "0.1.4"
+
+package:
+  name: "${{ name }}"
+  version: "${{ version }}"
+
+source:
+  path: ../../plugins/spectrochempy-perkinelmer
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install . --no-deps --ignore-installed -vv
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - setuptools >=64
+  run:
+    - python >=3.11
+    - spectrochempy >=0.10
+    - numpy
+
+tests:
+  - script:
+      - python -c "import importlib.util; assert importlib.util.find_spec('spectrochempy_perkinelmer') is not None"
+
+about:
+  summary: "PerkinElmer file reader plugin for SpectroChemPy"
+  description: |
+    Official SpectroChemPy plugin providing vendor file reading support
+    for PerkinElmer instruments.
+  homepage: https://www.spectrochempy.fr
+  license: LicenseRef-CeCILL-B
+  repository: https://github.com/spectrochempy/spectrochempy
+
+extra:
+  recipe-maintainers:
+    - fernandezc
+    - atravert

--- a/tests/test_core/test_scripts/test_conda_publish.py
+++ b/tests/test_core/test_scripts/test_conda_publish.py
@@ -864,6 +864,518 @@ class TestTagRegex:
 
 
 # ---------------------------------------------------------------------------
+# Plugin name and version input validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePluginName:
+    def test_official_names_accepted(self):
+        module = load_module()
+        for name in (
+            "spectrochempy-carroucell",
+            "spectrochempy-hypercomplex",
+            "spectrochempy-iris",
+            "spectrochempy-nmr",
+            "spectrochempy-perkinelmer",
+            "spectrochempy-tensor",
+        ):
+            assert module.validate_plugin_name(name) == name
+
+    def test_rejects_plain_name(self):
+        module = load_module()
+        for name in ("", "carroucell", "perkinelmer"):
+            with pytest.raises(ValueError):
+                module.validate_plugin_name(name)
+
+    def test_rejects_tag_or_uppercase(self):
+        module = load_module()
+        for name in (
+            "spectrochempy-nmr-v0.1.11",
+            "spectrochempy-PerkinElmer",
+            "spectrochempy nmr",
+            "spectrochempy-nmr;ls",
+        ):
+            with pytest.raises(ValueError):
+                module.validate_plugin_name(name)
+
+
+class TestValidateVersionInput:
+    def test_valid_versions(self):
+        module = load_module()
+        for version in ("0.1.8", "0.1.11", "1.2.3", "0.12.0"):
+            assert module.validate_version_input(version) == version
+
+    def test_rejects_empty(self):
+        module = load_module()
+        with pytest.raises(ValueError, match="empty"):
+            module.validate_version_input("")
+
+    def test_rejects_v_prefix(self):
+        module = load_module()
+        with pytest.raises(ValueError):
+            module.validate_version_input("v0.1.8")
+
+    def test_rejects_plugin_name_included(self):
+        module = load_module()
+        with pytest.raises(ValueError):
+            module.validate_version_input("spectrochempy-nmr-v0.1.8")
+
+    def test_rejects_full_tag(self):
+        module = load_module()
+        with pytest.raises(ValueError):
+            module.validate_version_input("spectrochempy-nmr-v0.1.8")
+
+    def test_rejects_whitespace(self):
+        module = load_module()
+        with pytest.raises(ValueError):
+            module.validate_version_input(" 0.1.8")
+
+    def test_rejects_incomplete_version(self):
+        module = load_module()
+        for version in ("0.1", "0", "0.1.8a", "0.1.8.9"):
+            with pytest.raises(ValueError):
+                module.validate_version_input(version)
+
+    def test_rejects_shell_metacharacters(self):
+        module = load_module()
+        for version in (
+            "0.1.8;ls -la",
+            "0.1.8 & rm -rf /",
+            "0.1.8$(whoami)",
+            "`id`",
+            "0.1.8|cat /etc/passwd",
+        ):
+            with pytest.raises(ValueError):
+                module.validate_version_input(version)
+
+    def test_rejects_non_string(self):
+        module = load_module()
+        with pytest.raises(ValueError):
+            module.validate_version_input("0.1.8\n")
+
+
+class TestCanonicalPluginTag:
+    def test_canonical_tag_construction(self):
+        module = load_module()
+        assert (
+            module.canonical_plugin_tag("spectrochempy-perkinelmer", "0.1.4")
+            == "spectrochempy-perkinelmer-v0.1.4"
+        )
+        assert (
+            module.canonical_plugin_tag("spectrochempy-nmr", "0.1.11")
+            == "spectrochempy-nmr-v0.1.11"
+        )
+
+    def test_never_double_v(self):
+        module = load_module()
+        assert not module.canonical_plugin_tag("spectrochempy-nmr", "0.1.11").endswith(
+            "n-v0.1.11v0.1.11"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Recipe discovery / version injection / bound alignment
+# ---------------------------------------------------------------------------
+
+
+class TestUnpackRecipe:
+    def test_prefers_recipe_yaml(self, tmp_path):
+        module = load_module()
+        (tmp_path / "recipe.yaml").write_text("recipe")
+        (tmp_path / "meta.yaml").write_text("meta")
+        path, name = module.unpack_recipe(tmp_path)
+        assert (path, name) == (tmp_path / "recipe.yaml", "recipe.yaml")
+
+    def test_meta_yaml_fallback(self, tmp_path):
+        module = load_module()
+        (tmp_path / "meta.yaml").write_text("meta")
+        path, name = module.unpack_recipe(tmp_path)
+        assert (path, name) == (tmp_path / "meta.yaml", "meta.yaml")
+
+    def test_no_recipe_returns_none(self, tmp_path):
+        module = load_module()
+        assert module.unpack_recipe(tmp_path) is None
+
+
+class TestInjectRecipeVersion:
+    RECIPE = (
+        "context:\n  name: spectrochempy-perkinelmer\n"
+        '  version: "0.1.4"\n\n'
+        'package:\n  name: "${{ name }}"\n  version: "${{ version }}"\n'
+    )
+
+    def test_injects_version_deterministically(self, tmp_path):
+        module = load_module()
+        text = module.inject_recipe_version(self.RECIPE, "0.1.8")
+        assert 'version: "0.1.8"' in text
+        assert 'package:\n  name: "${{ name }}"\n  version: "${{ version }}"' in text
+
+    def test_leaves_package_version_jinja_intact(self):
+        module = load_module()
+        text = module.inject_recipe_version(self.RECIPE, "0.1.8")
+        assert 'version: "${{ version }}"' in text
+        assert "${{ version }}" not in text.split("package:")[1].split("version:")[0]
+
+    def test_invalid_target_version_raises(self):
+        module = load_module()
+        with pytest.raises(ValueError):
+            module.inject_recipe_version(self.RECIPE, "not-a-version")
+
+    def test_missing_context_raises(self):
+        module = load_module()
+        with pytest.raises(ValueError, match="context"):
+            module.inject_recipe_version('package:\n  version: "0.1.4"\n', "0.1.8")
+
+
+class TestAlignRecipeRequirement:
+    RECIPE = (
+        'context:\n  name: spectrochempy-nmr\n  version: "0.1.11"\n'
+        "requirements:\n  host:\n    - python >=3.11\n  run:\n"
+        "    - python >=3.11\n    - spectrochempy >=0.10\n    - numpy\n"
+    )
+
+    def _plugin_dir(self, tmp_path, dependency):
+        plugin_dir = tmp_path / "spectrochempy-nmr"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            f"[project]\ndependencies = ['{dependency}']\n"
+        )
+        return plugin_dir
+
+    def test_aligns_from_tag_pyproject(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path, "spectrochempy>=0.12,<0.13")
+        text = module.align_recipe_requirement(self.RECIPE, plugin_dir)
+        assert "- spectrochempy >=0.12,<0.13" in text
+        assert "- spectrochempy >=0.10" not in text
+
+    def test_ignores_pep508_extras(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path, "spectrochempy[io]>=0.12,<0.13")
+        text = module.align_recipe_requirement(self.RECIPE, plugin_dir)
+        assert "- spectrochempy >=0.12,<0.13" in text
+
+    def test_leaves_recipe_when_not_a_dependency(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path, "numpy>=1.20")
+        text = module.align_recipe_requirement(self.RECIPE, plugin_dir)
+        assert text == self.RECIPE
+
+    def test_leaves_recipe_without_pyproject(self, tmp_path):
+        module = load_module()
+        assert module.align_recipe_requirement(self.RECIPE, tmp_path) == self.RECIPE
+
+
+class TestResolveRecipe:
+    def _plugin_dir(
+        self, tmp_path, version="0.1.4", dependency="spectrochempy>=0.12,<0.13"
+    ):
+        plugin_dir = tmp_path / "spectrochempy-perkinelmer"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            f'[project]\nversion = "{version}"\n' f"dependencies = ['{dependency}']\n"
+        )
+        return plugin_dir
+
+    MASTER_RECIPE = (
+        'context:\n  name: spectrochempy-perkinelmer\n  version: "0.1.4"\n\n'
+        'package:\n  name: "${{ name }}"\n  version: "${{ version }}"\n\n'
+        "requirements:\n  host:\n    - python >=3.11\n  run:\n"
+        "    - python >=3.11\n    - spectrochempy >=0.10\n    - numpy\n"
+    )
+
+    def test_tag_recipe_takes_precedence(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path)
+        (plugin_dir / "recipe.yaml").write_text('context:\n  version: "0.1.4"\n')
+        recipe_dir, recipe_file, origin = module.resolve_recipe(
+            plugin_dir, "0.1.4", self.MASTER_RECIPE
+        )
+        assert recipe_file == "recipe.yaml"
+        assert origin == "tag"
+        assert recipe_dir == str(plugin_dir)
+
+    def test_master_fallback_writes_recovery_recipe(self, tmp_path, monkeypatch):
+        module = load_module()
+        plugin_dir = self._plugin_dir(
+            tmp_path, dependency="spectrochempy[io]>=0.12,<0.13"
+        )
+        master = tmp_path / "master_recipe.yaml"
+        master.write_text(self.MASTER_RECIPE)
+        recipe_dir, recipe_file, origin = module.resolve_recipe(
+            plugin_dir, "0.1.8", str(master)
+        )
+        assert (recipe_dir, recipe_file, origin) == (
+            str(plugin_dir),
+            "recipe.yaml",
+            "master-fallback",
+        )
+        written = (plugin_dir / "recipe.yaml").read_text()
+        assert 'version: "0.1.8"' in written
+        assert 'version: "${{ version }}"' in written
+        assert "- spectrochempy >=0.12,<0.13" in written
+
+    def test_master_fallback_uses_tag_code_pyproject(self, tmp_path):
+        """The recovery recipe's core bound comes from the tag checkout, not master."""
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path, dependency="spectrochempy>=0.12,<0.13")
+        master = tmp_path / "master_recipe.yaml"
+        master.write_text(self.MASTER_RECIPE)
+        _, _, origin = module.resolve_recipe(plugin_dir, "0.1.8", str(master))
+        assert origin == "master-fallback"
+        assert (
+            "- spectrochempy >=0.12,<0.13" in (plugin_dir / "recipe.yaml").read_text()
+        )
+
+    def test_no_master_recipe_raises(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path)
+        with pytest.raises(ValueError, match="no master recipe"):
+            module.resolve_recipe(plugin_dir, "0.1.8", None)
+
+    def test_missing_master_recipe_file_raises(self, tmp_path):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path)
+        with pytest.raises(ValueError, match="no master recipe"):
+            module.resolve_recipe(
+                plugin_dir, "0.1.8", str(tmp_path / "does-not-exist.yaml")
+            )
+
+    def test_tag_recipe_with_inconsistent_version_stays_tag_not_fallback(
+        self, tmp_path
+    ):
+        """A tag that ships an inconsistent recipe must NOT fall back silently."""
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path)
+        (plugin_dir / "recipe.yaml").write_text('context:\n  version: "0.1.4"\n')
+        recipe_dir, recipe_file, origin = module.resolve_recipe(
+            plugin_dir, "0.1.8", self.MASTER_RECIPE
+        )
+        assert (recipe_file, origin) == ("recipe.yaml", "tag")
+        # The inconsistency is surfaced by validate-release (exit 1), never hidden.
+        assert (
+            module.cmd_validate_release(
+                argparse.Namespace(plugin_dir=str(plugin_dir), version="0.1.8")
+            )
+            == 1
+        )
+
+
+class TestVerifyTagExists:
+    def _git_repo(self, tmp_path):
+        import subprocess
+
+        subprocess.run(["git", "init"], check=True, capture_output=True, cwd=tmp_path)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+            cwd=tmp_path,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+            cwd=tmp_path,
+        )
+        (tmp_path / "file.txt").write_text("init")
+        subprocess.run(
+            ["git", "add", "."], check=True, capture_output=True, cwd=tmp_path
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            check=True,
+            capture_output=True,
+            cwd=tmp_path,
+        )
+
+    def test_existing_tag_verified(self, tmp_path):
+        import subprocess
+
+        module = load_module()
+        self._git_repo(tmp_path)
+        subprocess.run(
+            ["git", "tag", "spectrochempy-perkinelmer-v0.1.4"],
+            check=True,
+            capture_output=True,
+            cwd=tmp_path,
+        )
+        assert module.verify_tag_exists(
+            "spectrochempy-perkinelmer-v0.1.4",
+            plugin_name="spectrochempy-perkinelmer",
+            cwd=tmp_path,
+        )
+
+    def test_missing_tag_not_verified(self, tmp_path, capsys):
+        module = load_module()
+        self._git_repo(tmp_path)
+        ok = module.verify_tag_exists(
+            "spectrochempy-perkinelmer-v0.1.4",
+            plugin_name="spectrochempy-perkinelmer",
+            cwd=tmp_path,
+        )
+        assert ok is False
+
+
+class TestCmdDeriveTag:
+    def test_rejects_invalid_version(self, tmp_path, monkeypatch):
+        module = load_module()
+        monkeypatch.setattr(module, "verify_tag_exists", lambda *a, **k: True)
+        assert (
+            module.cmd_derive_tag(
+                argparse.Namespace(plugin="spectrochempy-nmr", version="v0.1.8")
+            )
+            == 1
+        )
+
+    def test_derives_canonical_tag(self, tmp_path, monkeypatch, capsys):
+        module = load_module()
+        monkeypatch.setattr(module, "verify_tag_exists", lambda *a, **k: True)
+        assert (
+            module.cmd_derive_tag(
+                argparse.Namespace(plugin="spectrochempy-perkinelmer", version="0.1.4")
+            )
+            == 0
+        )
+        out = capsys.readouterr().out
+        assert "spectrochempy-perkinelmer-v0.1.4" in out
+
+
+class TestCmdResolveRecipe:
+    def _plugin_dir(self, tmp_path):
+        plugin_dir = tmp_path / "spectrochempy-perkinelmer"
+        plugin_dir.mkdir()
+        (plugin_dir / "pyproject.toml").write_text(
+            '[project]\nversion = "0.1.4"\ndependencies = ['
+            "'"
+            "spectrochempy>=0.12,<0.13"
+            "'"
+            "]\n"
+        )
+        return plugin_dir
+
+    MASTER = TestResolveRecipe.MASTER_RECIPE
+
+    def test_emits_github_output_lines_tag(self, tmp_path, capsys):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path)
+        (plugin_dir / "recipe.yaml").write_text('context:\n  version: "0.1.4"\n')
+        assert (
+            module.cmd_resolve_recipe(
+                argparse.Namespace(
+                    tag_dir=str(plugin_dir), version="0.1.4", master_recipe=""
+                )
+            )
+            == 0
+        )
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if "=" in ln]
+        assert f"recipe_path={plugin_dir}" in lines
+        assert "recipe_file=recipe.yaml" in lines
+        assert "recipe_origin=tag" in lines
+
+    def test_emits_github_output_lines_fallback(self, tmp_path, capsys):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path)
+        master = tmp_path / "master_recipe.yaml"
+        master.write_text(self.MASTER)
+        assert (
+            module.cmd_resolve_recipe(
+                argparse.Namespace(
+                    tag_dir=str(plugin_dir),
+                    version="0.1.8",
+                    master_recipe=str(master),
+                )
+            )
+            == 0
+        )
+        out = capsys.readouterr().out
+        assert "recipe_origin=master-fallback" in out
+        assert "recipe_file=recipe.yaml" in out
+        assert 'version: "0.1.8"' in (plugin_dir / "recipe.yaml").read_text()
+
+    def test_missing_master_recipe_exit_two(self, tmp_path, capsys):
+        module = load_module()
+        plugin_dir = self._plugin_dir(tmp_path)
+        assert (
+            module.cmd_resolve_recipe(
+                argparse.Namespace(
+                    tag_dir=str(plugin_dir), version="0.1.8", master_recipe=""
+                )
+            )
+            == 2
+        )
+        assert "::error::" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Repair workflow (structural test)
+# ---------------------------------------------------------------------------
+
+
+class TestRepairWorkflowStructure:
+    WORKFLOW = (
+        Path(__file__).parents[3]
+        / ".github"
+        / "workflows"
+        / "repair_conda_plugin_release.yml"
+    )
+
+    def _text(self):
+        return self.WORKFLOW.read_text()
+
+    def test_version_only_input(self):
+        import yaml
+
+        data = yaml.safe_load(self._text())
+        trigger = data.get("on") or data.get(True)
+        inputs = trigger["workflow_dispatch"]["inputs"]
+        assert "plugin_name" in inputs
+        assert "version" in inputs
+        assert "tag" not in inputs
+
+    def test_closed_plugin_choice(self):
+        text = self._text()
+        assert "spectrochempy-perkinelmer" in text
+        assert "spectrochempy-nmr" in text
+        assert "e.g. 0.1.8" in text
+
+    def test_explicit_refs_tags_checkout(self):
+        text = self._text()
+        assert "refs/tags/" in text
+        assert "git checkout --detach" in text
+
+    def test_derive_tag_and_resolve_recipe_used(self):
+        text = self._text()
+        assert "derive-tag" in text
+        assert "resolve-recipe" in text
+
+    def test_recipe_origin_propagated(self):
+        text = self._text()
+        assert "recipe_origin" in text
+        assert "master-fallback" in text or "recipe_origin" in text
+
+
+# ---------------------------------------------------------------------------
+# PerkinElmer canonical recipe (exists on master, matches convention)
+# ---------------------------------------------------------------------------
+
+
+class TestPerkinElmerRecipe:
+    def _plugin_dir(self):
+        return Path(__file__).parents[3] / "plugins" / "spectrochempy-perkinelmer"
+
+    def test_recipe_exists(self):
+        assert (self._plugin_dir() / "recipe.yaml").is_file()
+
+    def test_recipe_matches_convention(self):
+        recipe = (self._plugin_dir() / "recipe.yaml").read_text()
+        assert "spectrochempy >=0.10" in recipe
+        assert "python >=3.11" in recipe
+        assert "LicenseRef-CeCILL-B" in recipe
+        assert ".find_spec('spectrochempy_perkinelmer')" in recipe
+
+
+# ---------------------------------------------------------------------------
 # Concurrency key behavior (structural test)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_core/test_scripts/test_conda_publish.py
+++ b/tests/test_core/test_scripts/test_conda_publish.py
@@ -1354,6 +1354,92 @@ class TestRepairWorkflowStructure:
         assert "recipe_origin" in text
         assert "master-fallback" in text or "recipe_origin" in text
 
+    def test_no_github_interpolation_in_run_blocks(self):
+        """Operator-supplied values must reach shells only through `env:`."""
+        import yaml
+
+        data = yaml.safe_load(self._text())
+        jobs = data["jobs"]
+        for job_name, job in jobs.items():
+            for step in job.get("steps", []):
+                run = step.get("run")
+                if run is None:
+                    continue
+                assert "${{" not in run, (
+                    f"job {job_name!r} step {step.get('name', '')!r} interpolates a "
+                    f"'${{{{...}}}}' expression directly into a run: block; values "
+                    "must be passed through env: instead"
+                )
+
+
+# ---------------------------------------------------------------------------
+# PerkinElmer canonical recipe (exists on master, matches convention)
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryWorkflow:
+    """Structural coverage of the vertical `master-fallback` recovery CI."""
+
+    WORKFLOW = (
+        Path(__file__).parents[3] / ".github" / "workflows" / "test_plugin_recovery.yml"
+    )
+
+    def _data(self):
+        import yaml
+
+        return yaml.safe_load(self.WORKFLOW.read_text())
+
+    def test_workflow_exists_and_runs_on_plugin_paths(self):
+        assert self.WORKFLOW.is_file()
+        data = self._data()
+        trigger = data.get("on") or data.get(True)
+        for event in ("pull_request", "push"):
+            assert event in trigger
+            assert "plugins/spectrochempy-perkinelmer/**" in trigger[event]["paths"]
+            assert (
+                ".github/workflows/test_plugin_recovery.yml" in trigger[event]["paths"]
+            )
+
+    def test_extracts_real_tag_via_git_archive(self):
+        text = self.WORKFLOW.read_text()
+        assert "git archive" in text
+        assert "spectrochempy-perkinelmer-v$" in text
+        assert "fetch-depth: 0" in text
+
+    def test_resolves_master_recipe_and_asserts_origin(self):
+        text = self.WORKFLOW.read_text()
+        assert "--master-recipe" in text
+        assert "recipe_origin=master-fallback" in text
+        assert "resolve-recipe" in text
+
+    def test_asserts_recovered_recipe_content(self):
+        text = self.WORKFLOW.read_text()
+        assert 'version: \\"$TAG_VERSION\\"' in text or '"$TAG_VERSION"' in text
+        assert ">=0.12,<0.13" in text
+
+    def test_validates_and_builds_recovery(self):
+        text = self.WORKFLOW.read_text()
+        assert "validate-release" in text
+        assert "rattler-build-action" in text
+        assert "-c spectrocat" in text
+
+    def test_verify_artifact_exact_name(self):
+        text = self.WORKFLOW.read_text()
+        assert "spectrochempy-perkinelmer-$TAG_VERSION-" in text
+
+    def test_never_publishes_or_uses_token(self):
+        text = self.WORKFLOW.read_text()
+        assert "ANACONDA_API_TOKEN" not in text
+        assert "upload-artifact@v7" in text
+        assert "no publication" in text.lower() or "never" in text.lower()
+
+    def test_no_github_interpolation_in_run_blocks(self):
+        for job in self._data()["jobs"].values():
+            for step in job.get("steps", []):
+                run = step.get("run")
+                if run is not None:
+                    assert "${{" not in run
+
 
 # ---------------------------------------------------------------------------
 # PerkinElmer canonical recipe (exists on master, matches convention)


### PR DESCRIPTION
## Summary

This is the second part of the Conda plugin publication repair (#1611). It makes the recovery workflow usable for the **PerkinElmer plugin**, whose historical tags (0.1.1 → 0.1.4) have **no Conda recipe at all**, and hardens how a repair is triggered.

### 1. The PerkinElmer recipe (first ever)

- `plugins/spectrochempy-perkinelmer/recipe.yaml` is added, matching the exact convention of the five existing official plugin recipes (`spectrochempy >=0.10`, `python >=3.11`, `LicenseRef-CeCILL-B`, `find_spec` smoke test). `spectrochempy-perkinelmer` is currently 404 on `spectrocat/main` for every release.

> **Bound policy (reviewer item 3).** The master recipe declares `spectrochempy >=0.10` (bare lower bound, no upper bound) by convention for all six plugin recipes. This differs from the pyproject `spectrochempy>=0.12,<0.13` (strict bounds). This is **deliberate**: the Conda recipe bound covers binary compatibility and Python ≥3.11 build resolution, while the pyproject enforces API compatibility for the Python source. The `master-fallback` recovery path aligns the recovery recipe's bound with the **tag's own pyproject** (`>=0.12,<0.13`), ensuring the built artifact is compatible with the tag's actual code — see point 3 below.

### 2. Safer, version-only trigger

- The workflow no longer asks for a full tag. Inputs are now:
  - `plugin_name` — a **closed list** of the six official plugins (carroucell, hypercomplex, iris, nmr, perkinelmer, tensor);
  - `version` — a **bare `X.Y.Z`** string (placeholder `0.1.8`).
- The canonical tag `<plugin>-v<version>` is derived (`conda_publish.py derive-tag`) and **verified to exist** against real release tags (`git rev-parse --verify refs/tags/<tag>^{commit}`) before any checkout. If missing, the available releases for that plugin are listed to help pick an existing tag.
- The version is strictly validated (`^\d+\.\d+\.\d+$`): no `v` prefix, no plugin name, no tag, no whitespace, no shell metacharacters — nothing user-supplied can ever reach a shell command or checkout ref.
- Checkout uses the explicit `refs/tags/<tag>` ref, never a bare name.

### 3. `resolve-recipe`: deterministic recovery for tags without a recipe

- `conda_publish.py resolve-recipe` decides which recipe to build and reports it as `recipe_origin=tag|master-fallback` in `GITHUB_OUTPUT` format (`recipe_path` / `recipe_file` / `recipe_origin`).
- **`origin="tag"`** — a `recipe.yaml` (or legacy `meta.yaml`) exists in the tag; used as-is; the version coherence is then enforced by `validate-release` (blocking on mismatch).
- **`origin="master-fallback"`** — the tag has no recipe: the canonical `master` recipe is used as a *recovery recipe*, with:
  1. the requested version injected deterministically into `context.version` (`package.version` stays the Jinja `${{ version }}` reference, so the artifact is exactly `<plugin>-<version>-…`);
  2. the `spectrochempy` run bound **aligned with the tag's own `pyproject.toml`** (`align_recipe_requirement`), so the recovery recipe never claims a core range the tag contradicts.
- The recovery recipe is written into the tag checkout and consumed exactly like a recipe that ships in the tag.
- **Never silent:** a tag with a recipe but an inconsistent one is a blocking failure (no fallback); a tag without any recipe **and** no master recipe errors (`resolve-recipe` exit 2). A missing tag without a recipe cannot be "repaired" with an unknown recipe.

### 4. Workflow improvements

- `resolve-recipe` runs in **both** the `validate` and `build` jobs, so the recipe the validator reviews is the same one that is built.
- `recipe_origin` appears in job outputs and in the dry-run summary.
- Tooling **and the master recipe** are stashed to `/tmp` before the tag checkout, matching the #1611 mechanism for `conda_publish.py`.
- **All operator-supplied values reach shell scripts exclusively through `env:` blocks** (reviewer item 1). No `${{ inputs.* }}` or `${{ steps.*.outputs.* }}` expression is interpolated directly in any `run:` block — values are first assigned to step-level `env:` variables, then referenced as `$VAR` in bash. This structural guarantee prevents any shell interpretation of unsanitized operator text.

### 5. Vertical CI test for master-fallback (reviewer item 2)

A dedicated workflow `.github/workflows/test_plugin_recovery.yml` validates the **actual recovery path end to end** without touching any historical tag:

1. Checks out the repo with full history (`fetch-depth: 0`).
2. Extracts the **real content** of tag `spectrochempy-perkinelmer-v0.1.4` via `git archive`, preserving the `plugins/<plugin>` directory prefix.
3. Runs `conda_publish.py resolve-recipe --master-recipe plugins/spectrochempy-perkinelmer/recipe.yaml` against the extracted content.
4. Asserts `recipe_origin=master-fallback` and verifies the recovered recipe contains the injected version and the aligned core bound (`>=0.12,<0.13`).
5. Validates the release metadata with `validate-release`.
6. Builds the recovered recipe with `rattler-build` (channels `conda-forge` + `spectrocat`).
7. Verifies the artifact is named exactly `spectrochempy-perkinelmer-0.1.4-*`.
8. **Never publishes** — no Anaconda API token is used; the artifact is uploaded as a CI artifact (retention 30 days).

The workflow triggers on PRs touching `conda_publish.py`, `repair_conda_plugin_release.yml`, `plugins/spectrochempy-perkinelmer/**`, or the workflow itself; on pushes to master with the same paths; and via `workflow_dispatch` with a version input (default `0.1.4`).

### 6. Tests, docs

- 51 new tests in `tests/test_core/test_scripts/test_conda_publish.py` (111 passing in the file): canonical tag construction, strict version/plugin-name rejections, explicit refs/tags checkout, tag-recipe precedence, master fallback with bound alignment and version injection, deterministic injection (context.version only), no silent fallback (inconsistent tag recipe = blocking), tag code used for the alignment, master-recipe-missing error, GITHUB_OUTPUT formatting.
- Structural tests for both workflows: `TestRepairWorkflowStructure::test_no_github_interpolation_in_run_blocks` scans all `run:` blocks in `repair_conda_plugin_release.yml` for `${{ ... }}` interpolation (must be absent); `TestRecoveryWorkflow` (8 tests) covers workflow triggers, `git archive` extraction, `resolve-recipe` with `--master-recipe`, recipe content assertions, `validate-release`, rattler-build, artifact naming, no token usage, and no run-block interpolation.
- `maintainers/release-process.md` documents the `>=0.10` vs `>=0.12,<0.13` bound policy, the recovery CI workflow, and the env-only injection guarantee.
- Full pre-commit suite passes on all changed files.

## Notes for the reviewer

- **Historical tags are never touched**: no tag is created, moved or deleted by this change.
- **No fake test tag**: the CI test uses the real `v0.1.4` tag content (via `git archive`), not a fabricated tag. This was explicitly requested — no `v0.1.5` or other dummy tags are created.
- Build validation against `rattler-build` happens on the PR CI (`rattler-build` is not available locally).

Follow-up to #1611.
