### PR TITLE
DOC: rewrite the Why SpectroChemPy? page to match the current code and the future publication introduction

### DIFF
--- a/docs/sources/gettingstarted/whyscpy.rst
+++ b/docs/sources/gettingstarted/whyscpy.rst
@@ -10,61 +10,201 @@ Why SpectroChemPy?
    :local:
    :depth: 2
 
-The `SpectroChemPy` project was developed to provide advanced spectroscopic data processing and analysis tools initially for internal purposes in the `LCS <https://www.lcs.ensicaen.fr/>`__, for the following reasons:
+`SpectroChemPy` is an open-source Python framework for processing, analyzing,
+and modeling spectroscopic data in chemistry. It is still mainly developed at the
+`LCS <https://www.lcs.ensicaen.fr/>`__ (Laboratoire Catalyse et Spectrochimie)
+in Caen, but is now used and potentially extended by a wider community.
+This page explains
+the problems SpectroChemPy addresses, what it provides, and the cases in which
+another tool may be more appropriate.
 
-Designed for Open Science
+The spectroscopy workflow problem
+=================================
+
+A spectrum is more than a list of numbers. The numerical intensities only make
+sense together with the meaning of each axis (wavenumber, wavelength, frequency,
+chemical shift, time, temperature, ...), the physical units, the identity of the
+sample, and the acquisition conditions under which the measurement was made.
+
+A realistic analysis is rarely a single algorithm. Instrumental files must be
+read and organized, axes identified, units assigned, and metadata retained.
+Data are then selected, smoothed, baseline-corrected, filtered, normalized, or
+repeatedly transformed before visualization and univariate or multivariate
+analysis. For a time-resolved or temperature-resolved series, every operation
+must preserve the correspondence between each spectrum and the experimental
+variable that produced it.
+
+Commercial software packages provide powerful and easy-to-use graphical
+interfaces, but they generally keep the underlying algorithms undisclosed.
+For most routine use this is acceptable; for detailed scientific work, however,
+the spectroscopist may need to know exactly what was done to the data. The
+"click, drag and drop" approach also makes it difficult to reproduce a
+treatment or to trace the history of a dataset.
+
+What spreadsheets and plain arrays do not provide
+==================================================
+
+Tabular tools (spreadsheets, data frames) handle data that fit naturally into a
+rectangular structure and that are treated the same way row by row. Their
+strength is uniformity, but they do not carry the scientific meaning of each
+axis or distinguish intensities, coordinates, units, and metadata. Such
+information lives in separate columns, separate files, or nowhere at all.
+
+Plain numerical arrays (NumPy arrays, for example) are the foundation of
+scientific computing with Python, but by themselves they carry no axes, units,
+masks, or labels. The meaning of the data must be re-established by convention
+at every step: the axis order, the unit conversion, the meaning of each column.
+These conventions remain implicit, which makes a workflow harder to inspect,
+compare, reuse, or turn into a reproducible record.
+
+What NDDataset provides
+=======================
+
+The central object of SpectroChemPy, :class:`~spectrochempy.NDDataset`,
+associates a multidimensional numerical array with everything needed to
+interpret it:
+
+- **named dimensions** with explicit `dimension` names (for example ``x`` for
+  the spectral axis and ``y`` for the observation axis) that provide stable
+  handles for operations;
+- **coordinates** (`Coord` objects, grouped in a `CoordSet`) that carry the
+  physical positions along each dimension, together with their titles and
+  units;
+- **coordinate-aware selection**: a region can be chosen by integer index, by a
+  physical interval of a coordinate, or by a label;
+- **units** on the data values and on each coordinate, with conversion of
+  compatible units and rejection of incompatible ones;
+- **labels** attaching categorical identifiers (for instance a sample name) to
+  individual points;
+- **masks** marking values that should be treated as invalid or absent, for
+  example a saturated detector region;
+- **metadata** describing the experimental and acquisition context when the
+  imported format provides it;
+- **history** recording the timestamped transformations applied to a dataset
+  since its creation.
+
+Because the scientific context is part of the object, ordinary operations
+preserve or update it instead of discarding it. Slicing, transposition, unit
+conversion, and arithmetic carry the relevant coordinates, units, and masks
+along, and the dataset history keeps an inspectable trace of what was done.
+The :ref:`user_guide` details
+this data model and its boundaries.
+
+From import to models: one environment
+======================================
+
+SpectroChemPy provides a coherent set of interfaces built on this data model.
+
+- **Importing**: readers translate a wide range of instrumental and exchange
+  formats into the common representation, including OMNIC, OPUS, LabSpec,
+  PerkinElmer, WDF, SPC, JCAMP-DX, MAT, DDR, and directory scans, keeping the
+  coordinates and metadata that can be determined from each file. Datasets can
+  also be exported to CSV, JCAMP-DX, MATLAB, or converted to xarray datasets and
+  NetCDF.
+- **Processing**: unit-aware arithmetic, slicing and coordinate-based
+  selection, baseline correction, automatic subtraction, smoothing and
+  filtering, derivative calculation, normalization and scaling, denoising,
+  FFT and Fourier-related operations, and masking.
+- **Analysis**: SVD, PCA, EFA, MCR-ALS (with the usual constraints), PLS,
+  NMF, ICA, SIMPLISMA, peak finding and integration, and curve fitting with a
+  large set of lineshape models.
+- **Visualization**: a plotting interface adapted to 1D, 2D, and 3D
+  spectroscopic data, with multiple styles and reusable preferences.
+- **Workflows**: estimators follow a scikit-learn-compatible interface, and
+  :class:`~spectrochempy.analysis.pipeline.Pipeline` composes supported
+  preprocessing steps with PCA, PLS, or other estimators in one reproducible
+  definition.
+
+Many examples covering these features are collected in the
+:ref:`gallery of examples <examples-index>`, which can be run as Jupyter
+notebooks.
+
+Designed for open science
 =========================
 
-While commercial software typically provides powerful and easy-to-use graphical user interfaces (GUIs), basic algorithms such as baseline correction schemes, automatic subtraction, peak detection, curve fitting, etc. are not typically disclosed to the user.
+SpectroChemPy is fully open source under the
+`CeCILL-B license <https://cecill.info/index.en.html>`__, similar to BSD
+licenses. The license requires strong attribution and citation of the software,
+in return for the freedom to use, study, modify, and redistribute it.
 
-Although they can generally be trusted (it is in the sole interest of these companies to provide reliable tools), the spectroscopist sometimes needs to know the details of the processing or analysis of the data provided. These details are usually neither given in the software manual nor disclosed by the company's technical staff.
-
-In addition, the "click, drag and drop" approach of many graphical user interfaces often prevents full reproducibility. This is the case, for example, with advanced integration or basic editing in many commercial software packages. Some of them do not always allow checking the data history, which is also problematic for checking data integrity and reproducibility.
-
-In particular, `SpectroChemPy` :
-
-- is fully open source and relies on algorithms documented in the code.
-- allows following the complete history of data sets and analyses ("history" field)
-- allows integrating the content of a particular job (data, scripts, notebooks, ...) into a dedicated data structure   ("Project"), guaranteeing a complete follow-up from the import of raw data to the final results..
+Because the algorithms are documented in the code, a treatment can be inspected
+instead of being taken on trust. Processing is scriptable, so a complete
+analysis can be written, versioned, and shared as a script or notebook. The
+dataset ``history`` field and the :ref:`Project <userguide.objects>` facilities
+help keeping track of a job from the import of raw data to the final results.
 
 .. note::
 
-   SpectroChemPy does not guarantee "data integrity," in the sense that the validity of the raw data and the correct use of the processing and analysis tools are the responsibility of the user.
+   SpectroChemPy does not guarantee "data integrity": the validity of the raw
+   data and the appropriate use of the tools remain the responsibility of the
+   user. It is open-source software that may contain bugs; critical bugs
+   affecting data integrity, if any, are documented for the version concerned.
 
-   SpectroChemPy is probably not free of bugs in some (hopefully rare) cases. In any case, critical bugs affecting data     integrity will be reported in the documentation for the version(s) of `SpectroChemPy` concerned, allowing the source of these errors to be traced.
+Part of the scientific Python ecosystem
+=======================================
 
-Open Source and Free
-====================
+SpectroChemPy is built on NumPy and interoperates with the wider Python
+ecosystem. It is not a replacement for it. Datasets can be converted to NumPy
+arrays or to xarray datasets, and the complete data model interoperates with
+libraries that accept these representations. The scikit-learn-compatible
+estimator and pipeline interfaces allow SpectroChemPy operations to be combined
+with general statistical learning tools.
 
-`SpectroChemPy` is free software under the `CeCILL-B License <https://cecill.info/index.en.html>`__,
-similar to BSD licenses. The license requires:
+A **scientific core** is separated from optional **plugins** that cover
+domain-specific needs: readers for NMR experiments, PerkinElmer instruments,
+and Carroucell systems, as well as hypercomplex data, tensor learning, and
+2D-IRIS analysis tools. Plugins are installed when needed and are listed in the
+:ref:`plugin documentation <plugins>`.
 
-* Strong citation requirements
-* Attribution in derivative works
-* Web presence attribution
+See the :ref:`See also <see_also>` page for complementary projects and
+:ref:`bibliography <bibliography>` for scientific works using or relating to
+SpectroChemPy.
 
-In return, users can freely use and modify the software.
+When another tool is more appropriate
+=====================================
 
-Python-Powered Analysis
-=======================
+You might NOT want to use SpectroChemPy if:
 
-Benefits of using Python:
+- you prefer a purely graphical workflow and wish to avoid scripting. As an
+  API, SpectroChemPy requires writing commands and small scripts; the notebooks
+  and examples of the gallery should make this accessible, but it is a
+  programming interface.
+- the data you work with is well described by a simple tabular model and the
+  scientific context (axes, units, masks, history) does not need to be carried
+  through the analysis. A spreadsheet or a data-frame library may then be all
+  you need.
+- you work on spectroscopic data that are difficult to process with
+  SpectroChemPy, which is currently mainly focused on optical spectroscopy and
+  NMR. Missing readers or methods can be suggested
+  (:ref:`contributing.bugs_report`); requests are considered to broaden the
+  supported scope.
+- you work on very sensitive applications (health, chemical safety, plant
+  production, ...) where the risk of using software under active development
+  cannot be accepted. That is a legitimate choice.
+- you are fully satisfied with your current tools. We do not dispute that, and
+  we remain open to your opinion and suggestions
+  (:ref:`contributing.bugs_report`).
 
-* Popular in data science
-* Cross-platform compatibility
-* Extensive scientific libraries (numpy, scipy, matplotlib)
-* Active community support
-* Easy integration with other tools
+Limitations
+===========
 
-Why NOT SpectroChemPy ?
-=======================
+- The richness of imported metadata depends on the source format: a reader can
+  only map the information the file actually provides.
+- The ``history`` field records what was done to a dataset object; it is not a
+  complete provenance record. Reproducing a workflow also requires archiving
+  the scripts, input data, parameters, software versions, and execution
+  environment.
+- Not every combination of coordinates, units, labels, masks, or metadata is
+  supported by every operation, and features are documented for the version in
+  which they are available.
+- Supported formats and methods may be provided by the core or by a plugin;
+  check the exact software environment for the claims you rely on.
 
-You might **NOT** want to use `SpectroChemPy` if:
+Getting started
+===============
 
-- You are averse to command line code (Python) or scripting. Since `SpectroChemPy` is essentially an Application Programming Interface (API), it requires writing commands and small scripts. Its documentation and resources contain fully documented examples (see :ref:`examples-index`) and tutorials (see :ref:`user_guide`), which should be easy to translate into your own data. In particular, the use of Jupyter notebooks mixing text, code blocks, and figures means that basic procedures (data import, basic processing, analysis, etc.) do not require much programming knowledge.
-
-- you are working on spectroscopic data that are difficult to process with `SpectroChemPy` (currently mainly   focused on optical spectroscopy and NMR) because some components or tools (e.g., importing your raw data, ...) are   missing: please suggest new features that should be added (:ref:`contributing.bugs_report`). We will take into   consideration all suggestions to make `SpectroChemPy` more widely and easily usable.
-
-- You are working on very sensitive data (health, chemical safety, plant production, ...) and cannot take the risk to   use software under development and subject to bugs and changes before   "maturity". We do not dispute that!
-
-- You are fully satisfied with your current tools. "The heart has its reasons, of which the reason knows nothing." We   don't dispute that either, but we are open to your opinion and suggestions (:ref:`contributing.bugs_report`)!
+* :ref:`Installation guide <installation>`
+* :ref:`Gallery of examples <examples-index>`
+* :ref:`User's guide and tutorials <user_guide>`
+* :ref:`Getting help <getting_help>`
+* :ref:`How to cite <citing>` and :ref:`papers using SpectroChemPy <papers>`

--- a/docs/sources/gettingstarted/whyscpy.rst
+++ b/docs/sources/gettingstarted/whyscpy.rst
@@ -34,28 +34,27 @@ analysis. For a time-resolved or temperature-resolved series, every operation
 must preserve the correspondence between each spectrum and the experimental
 variable that produced it.
 
-Commercial software packages provide powerful and easy-to-use graphical
-interfaces, but they generally keep the underlying algorithms undisclosed.
-For most routine use this is acceptable; for detailed scientific work, however,
-the spectroscopist may need to know exactly what was done to the data. The
-"click, drag and drop" approach also makes it difficult to reproduce a
-treatment or to trace the history of a dataset.
+Commercial and graphical software can provide efficient environments for
+routine and exploratory analysis. Depending on the software, however, the exact
+algorithms, parameters, intermediate states, or processing history may not be
+fully accessible or readily exportable. This can make detailed inspection and
+reproduction of an analysis more difficult.
 
 What spreadsheets and plain arrays do not provide
 ==================================================
 
-Tabular tools (spreadsheets, data frames) handle data that fit naturally into a
-rectangular structure and that are treated the same way row by row. Their
-strength is uniformity, but they do not carry the scientific meaning of each
-axis or distinguish intensities, coordinates, units, and metadata. Such
-information lives in separate columns, separate files, or nowhere at all.
+Tabular tools are well suited to observations and variables that fit naturally
+into rows and columns. Multidimensional spectroscopic datasets, however, may
+require several experimental coordinates per dimension, physical units, masks,
+acquisition metadata, and domain-specific conventions that are not represented
+by a conventional table alone.
 
-Plain numerical arrays (NumPy arrays, for example) are the foundation of
-scientific computing with Python, but by themselves they carry no axes, units,
-masks, or labels. The meaning of the data must be re-established by convention
-at every step: the axis order, the unit conversion, the meaning of each column.
-These conventions remain implicit, which makes a workflow harder to inspect,
-compare, reuse, or turn into a reproducible record.
+Plain ``numpy.ndarray`` objects are the foundation of scientific computing with
+Python, but by themselves they carry no axes, units, masks, or labels. The
+meaning of the data must be re-established by convention at every step: the
+axis order, the unit conversion, the meaning of each column. These conventions
+remain implicit, which makes a workflow harder to inspect, compare, reuse, or
+turn into a reproducible record.
 
 What NDDataset provides
 =======================
@@ -80,14 +79,17 @@ interpret it:
   example a saturated detector region;
 - **metadata** describing the experimental and acquisition context when the
   imported format provides it;
-- **history** recording the timestamped transformations applied to a dataset
-  since its creation.
+- **history** recording timestamped entries for the operations that
+  participate in the history contract since the dataset creation.
 
-Because the scientific context is part of the object, ordinary operations
-preserve or update it instead of discarding it. Slicing, transposition, unit
-conversion, and arithmetic carry the relevant coordinates, units, and masks
-along, and the dataset history keeps an inspectable trace of what was done.
-The :ref:`user_guide` details
+Because the scientific context is part of the object, operations implemented
+for :class:`~spectrochempy.NDDataset` are designed to preserve or update the
+relevant context according to their documented contracts. Slicing,
+transposition, unit conversion, and arithmetic carry the relevant coordinates,
+units, and masks along. This behavior is operation-dependent and should be
+checked for the version and workflow being used, and operations that
+participate in the history contract add an inspectable entry describing what
+was done. The :ref:`user_guide` details
 this data model and its boundaries.
 
 From import to models: one environment
@@ -95,25 +97,29 @@ From import to models: one environment
 
 SpectroChemPy provides a coherent set of interfaces built on this data model.
 
-- **Importing**: readers translate a wide range of instrumental and exchange
-  formats into the common representation, including OMNIC, OPUS, LabSpec,
-  PerkinElmer, WDF, SPC, JCAMP-DX, MAT, DDR, and directory scans, keeping the
-  coordinates and metadata that can be determined from each file. Datasets can
-  also be exported to CSV, JCAMP-DX, MATLAB, or converted to xarray datasets and
+- **Importing**: readers provided by the core package and by optional plugins
+  translate supported instrumental and exchange formats into the common
+  representation, including core readers such as OMNIC, OPUS, LabSpec, WDF,
+  SPC, JCAMP-DX, MAT, DDR, and directory scans, as well as plugin readers such
+  as those for NMR and PerkinElmer instruments. The coordinates and metadata
+  that can be determined from each file are kept, and datasets can also be
+  exported to CSV, JCAMP-DX, MATLAB, or converted to xarray datasets and
   NetCDF.
 - **Processing**: unit-aware arithmetic, slicing and coordinate-based
   selection, baseline correction, automatic subtraction, smoothing and
   filtering, derivative calculation, normalization and scaling, denoising,
   FFT and Fourier-related operations, and masking.
 - **Analysis**: SVD, PCA, EFA, MCR-ALS (with the usual constraints), PLS,
-  NMF, ICA, SIMPLISMA, peak finding and integration, and curve fitting with a
-  large set of lineshape models.
+  NMF, ICA, SIMPLISMA, peak finding and integration, and curve fitting with
+  documented lineshape models.
 - **Visualization**: a plotting interface adapted to 1D, 2D, and 3D
   spectroscopic data, with multiple styles and reusable preferences.
 - **Workflows**: estimators follow a scikit-learn-compatible interface, and
-  :class:`~spectrochempy.analysis.pipeline.Pipeline` composes supported
-  preprocessing steps with PCA, PLS, or other estimators in one reproducible
-  definition.
+  :class:`~spectrochempy.analysis.pipeline.Pipeline` provides a linear
+  composition of allowlisted preprocessing steps and supported terminal
+  estimators. This makes the sequence and parameters explicit, but does not by
+  itself capture the input data, software environment, or every requirement for
+  reproducibility.
 
 Many examples covering these features are collected in the
 :ref:`gallery of examples <examples-index>`, which can be run as Jupyter
@@ -122,16 +128,18 @@ notebooks.
 Designed for open science
 =========================
 
-SpectroChemPy is fully open source under the
-`CeCILL-B license <https://cecill.info/index.en.html>`__, similar to BSD
-licenses. The license requires strong attribution and citation of the software,
-in return for the freedom to use, study, modify, and redistribute it.
+SpectroChemPy is distributed under the
+`CeCILL-B license <https://cecill.info/index.en.html>`__, a free-software
+license that permits use, modification, and redistribution under its stated
+conditions. Users of the software in scientific work are also asked to cite the
+project as described in the :ref:`citation guidelines <citing>`.
 
-Because the algorithms are documented in the code, a treatment can be inspected
-instead of being taken on trust. Processing is scriptable, so a complete
-analysis can be written, versioned, and shared as a script or notebook. The
-dataset ``history`` field and the :ref:`Project <userguide.objects>` facilities
-help keeping track of a job from the import of raw data to the final results.
+Processing is scriptable, so a complete analysis can be written, versioned, and
+shared as a script or notebook. The dataset ``history`` field provides an
+inspectable record for supported operations. :ref:`Project <userguide.objects>`
+can organize related datasets and subprojects, but complete reproducibility
+still requires the scripts, parameters, input files, software versions, and
+execution environment to be archived separately.
 
 .. note::
 
@@ -144,9 +152,10 @@ Part of the scientific Python ecosystem
 =======================================
 
 SpectroChemPy is built on NumPy and interoperates with the wider Python
-ecosystem. It is not a replacement for it. Datasets can be converted to NumPy
-arrays or to xarray datasets, and the complete data model interoperates with
-libraries that accept these representations. The scikit-learn-compatible
+ecosystem. It is not a replacement for it. Numerical values can be exposed as
+NumPy arrays, and datasets can be converted to xarray representations. The
+scientific context preserved by each conversion depends on the target
+representation and the documented mapping. The scikit-learn-compatible
 estimator and pipeline interfaces allow SpectroChemPy operations to be combined
 with general statistical learning tools.
 
@@ -178,8 +187,8 @@ You might NOT want to use SpectroChemPy if:
   NMR. Missing readers or methods can be suggested
   (:ref:`contributing.bugs_report`); requests are considered to broaden the
   supported scope.
-- you work on very sensitive applications (health, chemical safety, plant
-  production, ...) where the risk of using software under active development
+- you work on very sensitive applications (health, chemical safety, ...) where
+  the risk of using software under active development
   cannot be accepted. That is a legitimate choice.
 - you are fully satisfied with your current tools. We do not dispute that, and
   we remain open to your opinion and suggestions

--- a/docs/sources/gettingstarted/whyscpy.rst
+++ b/docs/sources/gettingstarted/whyscpy.rst
@@ -51,30 +51,31 @@ by a conventional table alone.
 
 Plain ``numpy.ndarray`` objects are the foundation of scientific computing with
 Python, but by themselves they carry no axes, units, masks, or labels. The
-meaning of the data must be re-established by convention at every step: the
-axis order, the unit conversion, the meaning of each column. These conventions
-remain implicit, which makes a workflow harder to inspect, compare, reuse, or
-turn into a reproducible record.
+meaning of the data must be re-established at every step: the axis order, the
+unit conversion, the meaning of each column. That context must therefore be
+managed separately by the surrounding code or conventions.
 
 What NDDataset provides
 =======================
 
 The central object of SpectroChemPy, :class:`~spectrochempy.NDDataset`,
-associates a multidimensional numerical array with everything needed to
-interpret it:
+associates a multidimensional numerical array with the relevant scientific
+context needed to interpret it:
 
 - **named dimensions** with explicit `dimension` names (for example ``x`` for
   the spectral axis and ``y`` for the observation axis) that provide stable
   handles for operations;
 - **coordinates** (`Coord` objects, grouped in a `CoordSet`) that carry the
-  physical positions along each dimension, together with their titles and
-  units;
+  physical positions along each dimension — for example, the set of
+  wavenumbers and their unit for the ``x`` dimension — together with their
+  titles and other coordinate metadata;
 - **coordinate-aware selection**: a region can be chosen by integer index, by a
   physical interval of a coordinate, or by a label;
-- **units** on the data values and on each coordinate, with conversion of
-  compatible units and rejection of incompatible ones;
-- **labels** attaching categorical identifiers (for instance a sample name) to
-  individual points;
+- **units** associated with the data values and coordinates; they can be
+  converted to compatible units and help determine whether operations on the
+  dataset are dimensionally valid;
+- **labels** attaching identifiers or other non-numerical information, such
+  as sample names or acquisition datetimes, to individual coordinate points;
 - **masks** marking values that should be treated as invalid or absent, for
   example a saturated detector region;
 - **metadata** describing the experimental and acquisition context when the
@@ -92,8 +93,8 @@ participate in the history contract add an inspectable entry describing what
 was done. The :ref:`user_guide` details
 this data model and its boundaries.
 
-From import to models: one environment
-======================================
+From import to models: a common data model
+==========================================
 
 SpectroChemPy provides a coherent set of interfaces built on this data model.
 
@@ -116,7 +117,7 @@ SpectroChemPy provides a coherent set of interfaces built on this data model.
 - **Workflows**: many SpectroChemPy analysis estimators follow a
   scikit-learn-compatible interface, and
   :class:`~spectrochempy.analysis.pipeline.Pipeline` provides a linear
-  composition of an approved set of preprocessing steps and supported terminal
+  composition of a supported set of preprocessing steps and terminal
   estimators. This makes the sequence and parameters explicit, but does not by
   itself capture the input data, software environment, or every requirement for
   reproducibility.
@@ -135,8 +136,8 @@ modification, and redistribution under its stated conditions. Users of the
 software in scientific work are also asked to cite the project as described in
 the :ref:`citation guidelines <citing>`.
 
-Processing is scriptable, so a complete analysis can be written, versioned, and
-shared as a script or notebook. The dataset ``history`` field provides an
+Processing is scriptable, so an analysis workflow can be written, versioned,
+and shared as a script or notebook. The dataset ``history`` field provides an
 inspectable record for supported operations. :ref:`Project <userguide.objects>`
 can organize related datasets and subprojects, but complete reproducibility
 still requires the scripts, parameters, input files, software versions, and

--- a/docs/sources/gettingstarted/whyscpy.rst
+++ b/docs/sources/gettingstarted/whyscpy.rst
@@ -30,9 +30,9 @@ A realistic analysis is rarely a single algorithm. Instrumental files must be
 read and organized, axes identified, units assigned, and metadata retained.
 Data are then selected, smoothed, baseline-corrected, filtered, normalized, or
 repeatedly transformed before visualization and univariate or multivariate
-analysis. For a time-resolved or temperature-resolved series, every operation
-must preserve the correspondence between each spectrum and the experimental
-variable that produced it.
+analysis. For a time-resolved or temperature-resolved series, operations must
+preserve or explicitly transform the correspondence between spectra and the
+experimental variables associated with them.
 
 Commercial and graphical software can provide efficient environments for
 routine and exploratory analysis. Depending on the software, however, the exact
@@ -109,14 +109,14 @@ SpectroChemPy provides a coherent set of interfaces built on this data model.
   selection, baseline correction, automatic subtraction, smoothing and
   filtering, derivative calculation, normalization and scaling, denoising,
   FFT and Fourier-related operations, and masking.
-- **Analysis**: SVD, PCA, EFA, MCR-ALS (with the usual constraints), PLS,
-  NMF, ICA, SIMPLISMA, peak finding and integration, and curve fitting with
-  documented lineshape models.
+- **Analysis**: SVD, PCA, EFA, MCR-ALS, PLS, NMF, ICA, SIMPLISMA, peak finding
+  and integration, and curve fitting with documented lineshape models.
 - **Visualization**: a plotting interface adapted to 1D, 2D, and 3D
   spectroscopic data, with multiple styles and reusable preferences.
-- **Workflows**: estimators follow a scikit-learn-compatible interface, and
+- **Workflows**: many SpectroChemPy analysis estimators follow a
+  scikit-learn-compatible interface, and
   :class:`~spectrochempy.analysis.pipeline.Pipeline` provides a linear
-  composition of allowlisted preprocessing steps and supported terminal
+  composition of an approved set of preprocessing steps and supported terminal
   estimators. This makes the sequence and parameters explicit, but does not by
   itself capture the input data, software environment, or every requirement for
   reproducibility.
@@ -130,9 +130,10 @@ Designed for open science
 
 SpectroChemPy is distributed under the
 `CeCILL-B license <https://cecill.info/index.en.html>`__, a free-software
-license that permits use, modification, and redistribution under its stated
-conditions. Users of the software in scientific work are also asked to cite the
-project as described in the :ref:`citation guidelines <citing>`.
+license with characteristics similar to BSD licenses, which permits use,
+modification, and redistribution under its stated conditions. Users of the
+software in scientific work are also asked to cite the project as described in
+the :ref:`citation guidelines <citing>`.
 
 Processing is scriptable, so a complete analysis can be written, versioned, and
 shared as a script or notebook. The dataset ``history`` field provides an
@@ -145,8 +146,9 @@ execution environment to be archived separately.
 
    SpectroChemPy does not guarantee "data integrity": the validity of the raw
    data and the appropriate use of the tools remain the responsibility of the
-   user. It is open-source software that may contain bugs; critical bugs
-   affecting data integrity, if any, are documented for the version concerned.
+   user. It is open-source software that may contain bugs; users should consult
+   the release notes and known issues for information about identified problems
+   affecting the versions they use.
 
 Part of the scientific Python ecosystem
 =======================================

--- a/docs/sources/index.rst.tmpl
+++ b/docs/sources/index.rst.tmpl
@@ -83,6 +83,7 @@ SpectroChemPy: Advanced Spectroscopic Data Analysis
     :hidden:
     :caption: 🚀 Getting Started
 
+    Why SpectroChemPy? <gettingstarted/whyscpy>
     5-minute quickstart <gettingstarted/quickstart>
     Installation guide <gettingstarted/install/index>
     Example's gallery <gettingstarted/examples/index>


### PR DESCRIPTION
Editorial documentation update, no functional/code change.

**Goal**

Align the public "Why SpectroChemPy?" documentation page
(`docs/sources/gettingstarted/whyscpy.rst`) with the current code base. The
previous page was obsolete: it described the project at the level of the early
releases and missed the plugin architecture, the I/O surface, the chemometrics
toolset, `Pipeline`, and ecosystem interoperability. The page shares its
framing with the future Research Article introduction
(`spectrochempy_publication#7`), while each text keeps its own purpose,
audience, and depth.

**Changes**

- `docs/sources/gettingstarted/whyscpy.rst` — rewritten with a grounded
  progression: the spectroscopy workflow problem → limits of tabular tools and
  plain `numpy.ndarray` → what `NDDataset` provides → a common data model from
  import to models → designed for open science → part of the scientific Python
  ecosystem (incl. plugins) → when another tool is more appropriate → limits →
  getting-started links. The honest "Why NOT" section is retained.
- `docs/sources/index.rst.tmpl` — add the page as the first entry of the
  "Getting Started" toctree (it was previously only reachable from a home-page
  bullet).

**Maintainer review refinements (commits `af0368ac9`, `2f8744116`, `0e2943bf4`)**

Precision pass on the claims, following the maintainer note
`notes/audits/docs-why-spectrochempy-audit-2026-09-11.md` (active audit,
`spectrochempy_maintainer#44`):

- commercial/graphical software: no longer described categorically (algorithms
  "generally undisclosed", "click, drag and drop" not reproducible);
- tabular tools: the limits are now scoped to multidimensional spectroscopic
  datasets instead of a general statement about data frames; "NumPy arrays" is
  now "plain `numpy.ndarray`";
- time-resolved series: "every operation must preserve the correspondence"
  replaced by "operations must preserve or explicitly transform the
  correspondence", since some operations intentionally reduce a dimension;
- plain `numpy.ndarray`: the paragraph now concludes that the missing context
  "must therefore be managed separately by the surrounding code or conventions"
  instead of implying that implicit conventions make NumPy arrays deficient;
- `NDDataset`: the guarantee is framed as operation-dependent per the
  documented contracts; the introduction now says "the relevant scientific
  context needed to interpret it" (not "everything"); the `history` field only
  records entries for operations that participate in the history contract; the
  coordinates bullet gives the concrete wavenumber example, the units bullet
  covers conversion and dimensional validity, and the labels bullet covers
  non-numerical information such as sample names or acquisition datetimes;
- readers: the import bullet states that readers come from the core package
  and from optional plugins (NMR, PerkinElmer) and no longer claims an
  unquantified "wide range";
- `Pipeline`: described as a linear composition of a supported set of
  preprocessing steps and terminal estimators (Arnaud's point: no
  "allowlisted" jargon on a user-facing page), and its reproducibility scope is
  delimited explicitly; analysis estimators are scoped as "many … follow a
  scikit-learn-compatible interface";
- analysis list: "MCR-ALS (with the usual constraints)" — the vague parenthesis
  is removed;
- license: the CeCILL-B entry uses "a free-software license with characteristics
  similar to BSD licenses, which permits use, modification, and redistribution
  under its stated conditions", followed by the academic-citation request — the
  legal obligations and the citation request stay distinct;
- critical bugs: "critical bugs affecting data integrity, if any, are
  documented for the version concerned" replaced by "users should consult the
  release notes and known issues for information about identified problems
  affecting the versions they use";
- `Project`: no longer presented as tracking a full job from import to final
  results (script integration was removed in 0.10.0); it is described as an
  organizer of related datasets and subprojects, with reproducibility requiring
  scripts, parameters, inputs, software versions, and environment to be archived
  separately;
- interoperability: conversion to NumPy/xarray no longer claims the complete
  data model is carried over — the preserved context depends on the target
  representation;
- "complete analysis" replaced by "an analysis workflow", avoiding an absolute
  claim while keeping the dataset history / `Project` / reproducibility
  distinction;
- section title: "From import to models: one environment" replaced by "From
  import to models: a common data model" (the distinctive element is the shared
  spectroscopy-aware data model, not a self-contained environment);
- editorial: removed "plant production" example, "large set of lineshape
  models", and "algorithms are documented in the code".

**Verification (final commit `0e2943bf4`)**

- `pre-commit run --all-files`: passed (all hooks, including the local
  regenerate/version hooks, trailing-whitespace, codespell, ruff and
  ruff-format).
- `git diff --check`: clean.
- `python docs/make.py html --no-exec --no-api`: build succeeded with 6
  warnings; none originates from `whyscpy.rst`. The 6 warnings are pre-existing
  and unrelated (`pypandoc` unavailable; deprecated `scp.IRIS` alias;
  `plugins.rst` and `whatsnew/index.rst` not in a toctree; two missing bibtex
  keys `macchietti:2026`, `rezaeian:2026`).
- Rendered `whyscpy.html` inspected: `NDDataset` bullet list, the new section
  title, RST roles/inline literals, wrapping and punctuation all render as
  intended.
- Automated CI will re-run on the pushed commit `0e2943bf4`; the previous run
  on `2f8744116` was green for docs build and pre-commit (tests unchanged,
  docs-only PR).

**Maintainer note**

The rationale and verification detail are recorded in
`spectrochempy_maintainer/notes/audits/docs-why-spectrochempy-audit-2026-09-11.md`
(PR `spectrochempy_maintainer#44`, to be finalized with the final merged SHA of
this PR).

**Checklist**

- [x] Tests: no test change (docs only).
- [x] Title follows the prefix convention defined in `CONTRIBUTING.md` (DOC).
- [X] Changelog entry: intentionally omitted — docs-only PR (label `no-changelog` applied).
