### PR TITLE
ENH: expose SRS acquisition date and per-spectrum datetime labels

### DIFF
--- a/docs/sources/devguide/file_formats/omnic/srs.rst
+++ b/docs/sources/devguide/file_formats/omnic/srs.rst
@@ -569,12 +569,15 @@ Absolute series anchor (``Collected``) and derived datetimes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``[ESTABLISHED]`` for the RapidScan, HighSpeed and TGA samples examined, the
-series additionally carries a native absolute acquisition instant at
+series additionally carries a native absolute series timestamp at
 **file-relative offset 296**: a UInt32 OMNIC-epoch timestamp (seconds since
 1899-12-31 00:00:00 UTC, unsigned little-endian) following the same
-convention as the SPA/SPG timestamps. It equals the series ``Collected`` time
-reported by OMNIC: the SPA serialization of the independently controlled
-series stores the same instant as the timestamp of its first exported record.
+convention as the SPA/SPG timestamps. It equals the series ``Collected``
+timestamp reported by OMNIC.  The per-spectrum timestamps OMNIC writes when
+exporting the series spectra as SPA files follow Model A below: the first
+exported spectrum's timestamp is ``Collected + time_min`` (≈ ``time_min`` ≈
+4.96 s after ``Collected`` in the controlled TGA series), **not**
+``Collected`` itself.
 
 The field has header-relative copies that the reader verifies against before
 trusting it (the offsets differ between families):
@@ -585,10 +588,12 @@ trusting it (the offsets differ between families):
 ``[OBSERVED]`` The copy-check prevents false positives: GC files, whose
 offset 296 holds unrelated bytes (ASCII text / assorted values), and
 reprocessed RapidScan files, whose field is zeroed, yield *no* absolute
-anchor (``None``) rather than a fabricated date.
+anchor (``None``) rather than a fabricated date. The reader only accepts the
+evidence-backed copy locations listed above; a layout with different copy
+offsets is unsupported and yields ``None``.
 
 Combined with the regular time model above, the per-spectrum absolute
-instants follow Model A
+datetimes follow Model A
 
 .. code-block:: text
 
@@ -599,8 +604,11 @@ computed in full precision from the native float32 ``time_min`` (+1002) and
 rounded three-decimal Y coordinate. Their whole-second truncation matches the
 timestamps OMNIC writes when exporting the series spectra as SPA files. The
 reader exposes the anchor through the standard ``acquisition_date``
-convention and the derived instants as an additional Y-label column (see
-:ref:`srs-implementation-references`).
+convention and the derived datetimes as an additional Y-label column (see
+:ref:`srs-implementation-references`).  Which acquisition event (integration
+start, midpoint, end, ...) the OMNIC timestamp corresponds to is not
+experimentally established (see the Open questions section); no physical
+start/end interpretation is implied.
 
 .. _srs-spectral-sample-order:
 
@@ -882,6 +890,12 @@ Open questions
   (series) entry, and of the per-entry trailing bytes?
 * What is the structure and role of the trailer's copied "series metadata"
   region?
+* Which acquisition event (integration start, midpoint, end, ...) does the
+  per-spectrum OMNIC timestamp correspond to physically? The arithmetic
+  mapping (Model A) is established, but the physical semantics of the native
+  timestamp are not; a controlled experiment comparing very short and very
+  long acquisitions (e.g. 2 vs 1024 scans) with independently noted start/end
+  times is planned to answer this.
 
 .. _srs-implementation-references:
 

--- a/docs/sources/devguide/file_formats/omnic/srs.rst
+++ b/docs/sources/devguide/file_formats/omnic/srs.rst
@@ -5,97 +5,72 @@ OMNIC SRS file format
 
 .. note::
 
-   This is an independently reverse-engineered, unofficial description of the
-   OMNIC SRS format. See :ref:`omnic-file-formats` for provenance,
-   limitations, and certainty-level definitions. Contributors with access to
-   other OMNIC ``.srs`` variants are encouraged to report differences so that
-   this reference can be improved.
+   This is an unofficial interoperability reference for the OMNIC ``.srs``
+   format. It is based on independent controlled binary and oracle analysis
+   across several observed SRS variants. OMNIC producers and versions may use
+   different subsets of these structures. The certainty tags below describe
+   the strength and scope of each claim; they do not turn this page into an
+   official vendor specification. See :ref:`omnic-file-formats` for
+   provenance and the definitions of the certainty levels. Contributors with
+   access to other OMNIC ``.srs`` variants are encouraged to report
+   differences so that this reference can be improved.
 
-.. _srs-tested-files:
+Evidence and scope
+------------------
 
-Tested files and evidence
--------------------------
+This reference separates structural evidence from semantic interpretation:
 
-The observations below are based on the public SpectroChemPy test fixtures and
-on one independently controlled series (see the note at the end of this
-section).
+* ``[ESTABLISHED]`` means that a structure or relationship is supported by
+  independent binary/oracle evidence, controlled behavior, or exact
+  arithmetic in multiple native cases.
+* ``[OBSERVED]`` means that a reproducible structure or correlation was seen
+  in the analyzed variants but is not established as universal.
+* ``[HYPOTHESIS]`` means that a semantic interpretation is plausible but not
+  demonstrated.
+* ``[UNKNOWN]`` means that the position or structure may be known while its
+  meaning remains unresolved.
 
-.. list-table:: Tested ``.srs`` files
-   :header-rows: 1
-
-   * - File
-     - Acquisition family
-     - Content
-     - Format structures exercised
-   * - ``rapid_scan.srs``
-     - RapidScan
-     - interferograms (643 × 4160)
-     - repeated-record layout; interferogram (data-points) axis; inter-spectrum
-       trailer
-   * - ``rapid_scan_reprocessed.srs``
-     - RapidScan (reprocessed)
-     - spectral (643 × 3734)
-     - repeated-record layout; spectral axis; pristine/reprocessed flag
-   * - ``high_speed.srs``
-     - HighSpeed
-     - spectral (897 × 13898)
-     - repeated-record layout; spectral axis; 4-occurrence detection signature
-   * - ``GC_Demo.srs``
-     - TG/GC
-     - spectral (788 × 1738)
-     - repeated-record layout; background record; spectral axis
-   * - ``TGA_demo.srs``
-     - TGA
-     - spectral (485 × 3630)
-     - repeated-record layout; background record; spectral axis
-   * - ``TGAIR-unreadable.srs``
-     - TG/GC
-     - spectral (335 × 1868)
-     - repeated-record layout; spectral axis
-
-``[ESTABLISHED]`` The repeated-record layout ``84 + nx*4 + 16`` bytes
-reproduces the data arrays exactly in independent binary reconstruction for
-all of the files above and all four acquisition families, covering both
-spectra and rapid-scan interferograms (see :ref:`Repeated spectrum records
-<srs-repeated-records>`).
-
-In addition, **one independently controlled TG/GC series** was used as a
-physical validation oracle. Individual spectra of that series were exported by
-OMNIC as SPA files and compared against the raw SRS samples: the match is
-``correlation = 1.000000`` and ``RMSE = 0.000000`` in the correct physical
-order (see :ref:`srs-spectral-sample-order`). The same series also exercised
-the trailer's SeriesProfile, Gram-Schmidt, and Area structures. The source
-files of that series are **not** distributed with SpectroChemPy; only the
-public fixtures listed above are.
+The evidence derives from independent controlled binary and oracle analysis
+across several observed SRS variants, spanning the RapidScan, HighSpeed and
+TG/GC acquisition families: ordinary spectral series, rapid-scan
+interferogram series, reprocessed series, and background-containing variants.
+One independently controlled TG/GC series served as a physical validation
+oracle: its individual spectra were exported by OMNIC as SPA files and
+compared against the raw SRS samples (see :ref:`srs-spectral-sample-order`),
+and the same series also exercised the trailer's SeriesProfile, Gram-Schmidt
+and Area structures (see :ref:`srs-seriesprofile`). These descriptions are
+generic; they do not depend on particular proprietary files or on the
+availability of OMNIC-distributed examples. Specimen-level provenance and the
+detailed audit records behind these claims are maintained outside this
+reference.
 
 Overall file organization
 -------------------------
 
+A ``.srs`` file is organized as a fixed file header followed by a counted
+table of 16-byte key records (the same key-table model as the SPA/SPG
+families). The first key record references the series metadata region; the
+spectral data are stored as a sequence of repeated fixed-stride records.
+
 .. code-block:: text
 
-    OMNIC SRS layout (regions currently understood)
-    ===================================================
+   file header / key-table region
+   ├── file magic at file offset 0
+   ├── level-of-processing flag at file offset 292
+   ├── nlines (number of key records) at file offset 294
+   ├── native series-level 'Collected' timestamp at file offset 296
+   └── key records beginning at file offset 304
 
-    +------------------+   file header / key-table region:
-    | file header /    |   file magic, file-level flags, key table
-    | key-table region |   (first 304 bytes + entries)
-    +------------------+                  ^
-    | series metadata /|------------------+-- series-header base at the
-    | header region    |                     key[0] entry position (+2),
-    +------------------+                     152 bytes before the first
-                                             detection signature
-    | background header |   its own X endpoints
-    | / background data |
-    +------------------+
-    | repeated spectrum records:
-    |   [84-byte prefix | nx * 4-byte float32 payload | 16-byte trailer]
-    |   ... x ny
-    +------------------+
-    | post-series profile region (observed in the controlled series):
-    |                  Gram-Schmidt-related data
-    |                  copied series metadata
-    |                  SeriesProfile block(s), one per profile
-    +------------------+
+   referenced blocks
+   ├── series metadata region (through the first key record)
+   │     └── series-header base: key[0] position, 152 bytes before the first
+   │         detection signature
+   ├── background header / background data (when a background is present)
+   ├── repeated spectrum records: [84-byte prefix | nx * 4-byte float32
+   │     payload | 16-byte trailer] repeated ny times
+   ├── post-series profile region: Gram-Schmidt-related data, copied series
+   │     metadata, SeriesProfile block(s)
+   └── other variant-dependent blocks
 
 The diagram is logical, not to scale: it shows only regions and boundaries
 whose relationships are reproducibly observed. The metadata associated with
@@ -124,6 +99,7 @@ File header / key-table region (file-relative)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
+   :widths: 10 6 6 58 20
    :header-rows: 1
 
    * - Offset
@@ -134,8 +110,8 @@ File header / key-table region (file-relative)
    * - 0
      - 18
      - ASCII
-     - File magic ``"Spectral Exte File"`` (followed by ``\r\n``). The SPA/SPG
-       sibling formats use ``"Spectral Data File"`` instead.
+     - File magic ``"Spectral Exte File"`` (followed by ``\r\n``). The
+       SPA/SPG sibling formats use ``"Spectral Data File"`` instead.
      - ``[ESTABLISHED]``
    * - 18
      - 274
@@ -146,23 +122,22 @@ File header / key-table region (file-relative)
      - 1
      - UInt8
      - Level-of-processing flag: ``0x27`` pristine, ``0x0f`` reprocessed
-       (verified for the RapidScan family; other families show both values
-       too; ``0x48`` also observed on a TGA specimen).
+       in the observed variants; other values also occur.
      - ``[OBSERVED]``
    * - 294
      - 2
      - UInt16
-     - Number of key-table entries (24–33 in the files examined).
+     - Number of key-table entries (24–33 in the observed variants).
      - ``[OBSERVED]``
    * - 296
      - 4
      - UInt32
      - Native series-level acquisition timestamp (``Collected``): seconds
        since the OMNIC epoch (1899-12-31 00:00:00 UTC), unsigned
-       little-endian. This is the canonical series-absolute anchor used by
-       the reader (see :ref:`srs-time-representation`). Zeroed in
+       little-endian. This is the canonical series-absolute anchor used
+       by the reader (see :ref:`srs-time-representation`). Zeroed in
        reprocessed files; holds unrelated bytes in GC variants.
-     - ``[ESTABLISHED]`` for RapidScan / HighSpeed / TGA samples;
+     - ``[ESTABLISHED]`` for RapidScan / HighSpeed / TGA;
        ``[OBSERVED]`` absence for GC
    * - 304
      - n × 16
@@ -178,10 +153,10 @@ OMNIC key-record layout also used by the SPA/SPG families (see
 :ref:`spa-format`): a 1-byte key, a reserved/variant byte, a 4-byte
 file-relative block position, a 4-byte block length and 6
 trailing/variant-dependent bytes. Only the first entry — the **series**
-entry — is interpreted here; the positions, lengths and trailing data of the
-other entries remain largely unresolved.
+entry — is interpreted here; the remaining entries are unresolved.
 
 .. list-table::
+   :widths: 10 6 6 58 20
    :header-rows: 1
 
    * - Offset
@@ -198,40 +173,43 @@ other entries remain largely unresolved.
    * - 1
      - 1
      - UInt8
-     - Reserved / variant-dependent byte (0 in the files examined).
+     - Reserved / variant-dependent byte (0 in the observed variants).
      - ``[OBSERVED]``
    * - 2
      - 4
      - UInt32
-     - File-relative position of the referenced block. For the first entry
-       this is the series-header base, exactly 152 bytes before the first
-       detection signature (identical in all files examined).
+     - File-relative position of the referenced block. For the first
+       entry this is the series-header base, exactly 152 bytes before the
+       first detection signature (identical in all observed variants).
      - ``[ESTABLISHED]`` for the first entry
    * - 6
      - 4
      - UInt32
-     - Referenced block length in bytes (0 for the first entry in the files
-       examined).
+     - Referenced block length in bytes (0 for the first entry in the
+       observed variants).
      - ``[OBSERVED]`` value / ``[UNKNOWN]`` role
    * - 10
      - 6
      - bytes
-     - Trailing / variant-dependent data; ``8c 00 00 00 01 00`` (the UInt32
-       pair ``0x008c0000`` / ``0x00010000`` at entry offsets +8/+12) for the
-       first entry in all files examined.
+     - Trailing / variant-dependent data; ``8c 00 00 00 01 00`` for the
+       first entry in all observed variants.
      - ``[OBSERVED]``
 
 Series metadata
 ---------------
 
-In the files examined, the series-header base is located 152 bytes before the
-first detection signature (see :ref:`srs-detection-signatures`). Offsets in the
-tables below are relative to that base. The metadata associated with the series
-extend well beyond the first 152 bytes: the exact subdivision into OMNIC
-internal blocks is only partially understood. Only the fields listed below
-have been interpreted so far; the rest of the region is unmapped.
+In the observed variants, the series-header base is located 152 bytes before
+the first detection signature (see :ref:`srs-detection-signatures`). Offsets
+in the tables below are relative to that base. The metadata associated with
+the series extend well beyond the first 152 bytes: the exact subdivision into
+OMNIC internal blocks is only partially understood. Only the fields listed
+below have been interpreted so far; the rest of the region is unmapped.
 
-.. list-table:: Series-header fields (offsets relative to the series-header base)
+Signal and acquisition fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 10 6 6 58 20
    :header-rows: 1
 
    * - Offset
@@ -254,13 +232,15 @@ have been interpreted so far; the rest of the region is unmapped.
      - UInt8
      - X-unit code: 1 = cm⁻¹, 2 = data points (interferogram), 3 = nm,
        4 = µm, 32 = Raman shift (cm⁻¹).
-     - ``[ESTABLISHED]`` for codes 1 and 2; ``[OBSERVED]`` for the others
+     - ``[ESTABLISHED]`` for codes 1 and 2; ``[OBSERVED]`` for the
+       others
    * - 12
      - 1
      - UInt8
      - Y/data-unit code: 0x11 absorbance, 0x10 transmittance (%),
        0x0F single beam, 0x16 detector signal (V), 0x1A photoacoustic,
-       0x1F Raman intensity, among others shared with the SPA/SPG readers.
+       0x1F Raman intensity, among others shared with the SPA/SPG
+       readers.
      - ``[OBSERVED]``
    * - 16
      - 4
@@ -275,7 +255,7 @@ have been interpreted so far; the rest of the region is unmapped.
    * - 24
      - 4
      - Float32
-     - Per-file varying, registration-like factor; see
+     - Per-variant varying, registration-like factor; see
        :ref:`srs-unknown-fields`.
      - ``[HYPOTHESIS]`` / ``[UNKNOWN]``
    * - 28
@@ -286,8 +266,8 @@ have been interpreted so far; the rest of the region is unmapped.
    * - 32
      - 4
      - UInt32
-     - Interferogram peak position (matches OMNIC's series-info field of the
-       same name in all files examined). Equivalence with the physical
+     - Interferogram peak position (matches OMNIC's series-info field
+       in all observed variants). Equivalence with the physical
        zero-path-difference position is not established.
      - ``[ESTABLISHED]``
    * - 36
@@ -303,16 +283,17 @@ have been interpreted so far; the rest of the region is unmapped.
    * - 56
      - 4
      - Float32
-     - 1.0 in non-RapidScan, 0.0 in RapidScan files examined; see
-       :ref:`srs-unknown-fields`.
+     - Value pattern that differs between RapidScan and other observed
+       variants; see :ref:`srs-unknown-fields`.
      - ``[OBSERVED]`` (correlated only)
    * - 68
      - 4
      - UInt32
-     - General-header *collection length* in 1/100 s. This is the shared
-       acquisition-time field of the OMNIC header family; it must **not** be
-       conflated with the series minimum/first time at +1002 (nor with the
-       public SRS ``collection_length`` derived from +1006).
+     - General-header *collection length* in 1/100 s. This is the
+       shared acquisition-time field of the OMNIC header family; it must
+       **not** be conflated with the series minimum/first time at +1002
+       (nor with the public SRS ``collection_length`` derived from
+       +1006).
      - ``[OBSERVED]``
    * - 80
      - 4
@@ -322,17 +303,15 @@ have been interpreted so far; the rest of the region is unmapped.
    * - 84
      - 4
      - Float32
-     - OMNIC **sample spacing** (matches the series-info field of the same
-       name in all files examined). Varies with acquisition configuration,
-       not with the acquisition family: 2.0 in the RapidScan, HighSpeed and
-       TGA files examined, 1.0 in the GC file.
+     - OMNIC **sample spacing** (matches the series-info field of the
+       same name in all observed variants). Varies with acquisition
+       configuration, not with the acquisition family.
      - ``[ESTABLISHED]``
    * - 184
      - 4
      - Float32
-     - Not covered by OMNIC's reported series-info fields; value differs from
-       +84 in two of the five files examined (2.0 in the RapidScan files,
-       1.0 in the HighSpeed, GC and TGA files); see
+     - Not covered by OMNIC's reported series-info fields; in some
+       observed variants its value differs from that of +84; see
        :ref:`srs-unknown-fields`.
      - ``[OBSERVED]`` value / ``[UNKNOWN]`` semantic
    * - 188
@@ -343,9 +322,22 @@ have been interpreted so far; the rest of the region is unmapped.
    * - 208
      - var
      - text
-     - Spectrum history text; a record whose text starts with ``Background``
-       marks a background header.
+     - Spectrum history text; a record whose text starts with
+       ``Background`` marks a background header.
      - ``[ESTABLISHED]`` string presence; ``[OBSERVED]`` role
+
+Series identity and time-model fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 10 6 6 58 20
+   :header-rows: 1
+
+   * - Offset
+     - Size
+     - Type
+     - Meaning
+     - Certainty
    * - 296
      - 8
      - UInt64
@@ -359,25 +351,25 @@ have been interpreted so far; the rest of the region is unmapped.
    * - 1002
      - 4
      - Float32
-     - **Series minimum / first time, in minutes** — the time-axis anchor.
-       Historically misinterpreted as a "collection length"; the general-header
-       collection-length field is the one at +68 (not to be conflated either).
-       The public ``collection_length`` for SRS series is derived from the
-       series maximum / last time at +1006 (see the 1006 row), not from this
-       field.
+     - **Series minimum / first time, in minutes** — the time-axis
+       anchor. Historically misinterpreted as a "collection length";
+       the general-header collection-length field is the one at +68 (not
+       to be conflated either). The public ``collection_length`` for SRS
+       series is derived from +1006, not from this field.
      - ``[ESTABLISHED]``
    * - 1006
      - 4
      - Float32
-     - Series maximum / last time, in minutes. Converted to seconds (× 60) it
-       is the OMNIC "Total collection time" and the public ``collection_length``
-       exposed by the reader for SRS series.
+     - Series maximum / last time, in minutes. Converted to seconds
+       (× 60) it is the OMNIC "Total collection time" and the public
+       ``collection_length`` exposed by the reader for SRS series.
      - ``[ESTABLISHED]``
    * - 1010
      - 4
      - Float32
-     - **Regular time step, in minutes** (historically misnamed ``firsty``;
-       it is *not* the series minimum). See :ref:`srs-time-representation`.
+     - **Regular time step, in minutes** (historically misnamed
+       ``firsty``; it is *not* the series minimum). See
+       :ref:`srs-time-representation`.
      - ``[ESTABLISHED]``
    * - 1026
      - 4
@@ -392,49 +384,48 @@ have been interpreted so far; the rest of the region is unmapped.
    * - 1036
      - 4
      - Float32
-     - Flow-cell temperature (°C; TG/GC files only). Matches OMNIC's reported
-       series-info value in the TG/GC files examined (200.0–220.0); 0.0 in
-       the other files.
-     - ``[ESTABLISHED]`` (TG/GC files examined)
+     - Flow-cell temperature (°C; TG/GC variants only). Matches
+       OMNIC's reported series-info value in the TG/GC variants; 0.0
+       in the other variants.
+     - ``[ESTABLISHED]`` (TG/GC variants)
    * - 1040
      - 4
      - Float32
-     - Transfer-line temperature (°C; TG/GC files only). Matches OMNIC's
-       reported series-info value in the TG/GC files examined
-       (200.0–220.0); 0.0 in the other files.
-     - ``[ESTABLISHED]`` (TG/GC files examined)
+     - Transfer-line temperature (°C; TG/GC variants only). Matches
+       OMNIC's reported series-info value in the TG/GC variants; 0.0
+       in the other variants.
+     - ``[ESTABLISHED]`` (TG/GC variants)
    * - 1044
      - 2
      - UInt16
-     - Gram-Schmidt offset (10 in the tested family); see
-       :ref:`srs-gram-schmidt`.
+     - Gram-Schmidt offset; see :ref:`srs-gram-schmidt`.
      - ``[OBSERVED]`` value / ``[UNKNOWN]`` semantic
    * - 1046
      - 2
      - UInt16
-     - Gram-Schmidt interferogram points (100 in the tested family); see
-       :ref:`srs-gram-schmidt`.
+     - Gram-Schmidt interferogram points; see :ref:`srs-gram-schmidt`.
      - ``[OBSERVED]`` / ``[HYPOTHESIS]``
    * - 1048
      - 2
      - UInt16
-     - 200 in the tested files; see :ref:`srs-unknown-fields`.
+     - Constant value in the observed variants; see
+       :ref:`srs-unknown-fields`.
      - ``[UNKNOWN]``
    * - 1200
      - var
      - text
-     - Initial history text (pristine files). Reprocessed files carry their
-       updated history at the end of the file after a 16-byte ``0xff``
-       sequence.
+     - Initial history text (pristine variants). Reprocessed variants
+       carry their updated history at the end of the file after a
+       16-byte ``0xff`` sequence.
      - ``[OBSERVED]``
 
 Background data
 ---------------
 
-``[OBSERVED]`` Spectral backgrounds have their own header, located through the
-second detection signature (signature position − 152), with their own X
-endpoints. In the tested background records where both headers were decoded,
-the **endpoint ordering can differ from that of the series header**: spectral
+``[OBSERVED]`` Spectral backgrounds have their own header, located through
+the second detection signature (signature position − 152), with their own X
+endpoints. In the observed variants where both headers were decoded, the
+**endpoint ordering can differ from that of the series header**: spectral
 background headers store raw ``firstx < lastx`` (ascending) while the
 corresponding spectral series headers store raw ``firstx > lastx``
 (descending). No single raw-order rule has been observed to apply to the
@@ -450,27 +441,32 @@ for some background record shapes).
 Repeated spectrum records
 -------------------------
 
-``[ESTABLISHED]`` In the tested SRS series, each spectrum record has the
+``[ESTABLISHED]`` In the observed SRS series, each spectrum record has the
 following layout. The same repeated-record structure is also observed for the
-rapid-scan interferograms in ``rapid_scan.srs``, so the description below is
-generic to both spectral series and interferogram records:
+rapid-scan interferogram records, so the description below is generic to both
+spectral series and interferogram records:
 
 .. code-block:: text
 
-    data record
-    ├── 84-byte prefix
-    ├── nx × 4-byte float32 intensity payload
-    └── 16-byte trailer
+   data record
+   ├── 84-byte prefix
+   ├── nx × 4-byte float32 intensity payload
+   └── 16-byte trailer
 
 * ``[ESTABLISHED]`` The **spectrum name is null-terminated inside the
   84-byte prefix**; the prefix also carries binary metadata (per-file mostly
   constant fields and a per-spectrum minimum-Y value).
 * ``[ESTABLISHED]`` The payload boundaries reproduce the data arrays exactly
   in independent binary reconstruction (stride
-  `84 + nx·4 + 16` bytes per record).
-* ``[ESTABLISHED]`` The trailer size (16 bytes) holds for all tested files.
+  ``84 + nx·4 + 16`` bytes per record).
+* ``[ESTABLISHED]`` The trailer size (16 bytes) holds for all observed
+  variants.
 
-.. list-table:: 84-byte record prefix (record-relative offsets)
+84-byte record prefix (record-relative offsets)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 12 6 6 56 20
    :header-rows: 1
 
    * - Offset
@@ -481,12 +477,13 @@ generic to both spectral series and interferogram records:
    * - 0 .. null
      - var
      - ASCII
-     - Spectrum name, null-terminated (e.g. ``Linked spectrum at 0.025 min.``).
+     - Spectrum name, null-terminated.
      - ``[ESTABLISHED]``
    * - 22 .. 75
      - var
      - bytes
-     - Mostly per-file constant metadata; semantics not fully interpreted.
+     - Mostly per-file constant metadata; semantics not fully
+       interpreted.
      - ``[OBSERVED]`` values / ``[UNKNOWN]`` semantics
    * - 76
      - 4
@@ -499,7 +496,7 @@ generic to both spectral series and interferogram records:
 Inter-spectrum trailer (16 bytes; trailer-relative offsets)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``[ESTABLISHED]`` Tested records (both spectral series and rapid-scan
+``[ESTABLISHED]`` Observed records (both spectral series and rapid-scan
 interferograms) are followed by a 16-byte trailer.
 
 ``[OBSERVED]`` One uint32 field in this trailer behaves as a **cumulative
@@ -509,6 +506,7 @@ the series time axis).
 ``[UNKNOWN]`` The remaining trailer fields are not fully interpreted.
 
 .. list-table::
+   :widths: 10 6 6 58 20
    :header-rows: 1
 
    * - Offset
@@ -519,7 +517,7 @@ the series time axis).
    * - 0
      - 4
      - UInt32
-     - ``0x20`` (32) in the tested files.
+     - ``0x20`` (32) in the observed variants.
      - ``[OBSERVED]``
    * - 4
      - 4
@@ -530,8 +528,115 @@ the series time axis).
    * - 8
      - 8
      - UInt64
-     - Zeros in the tested files.
+     - Zeros in the observed variants.
      - ``[OBSERVED]``
+
+.. _srs-detection-signatures:
+
+Detection signatures and positioning observations
+-------------------------------------------------
+
+``[OBSERVED]`` In the observed variants, each acquisition family is preceded
+by a recognizable 10–16 byte signature:
+
+* **RapidScan** — ``\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00\x48\x43\x00\x50\x43\x47``,
+  occurring 3 times;
+* **HighSpeed** — ``\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00\x48\x43\x00\xc8\xaf\x47``,
+  occurring 4 times;
+* **TG/GC** — ``\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00`` (first 10 bytes),
+  occurring 3 times; the following bytes vary between files.
+
+Positioning relationships (all values verified in the observed variants):
+
+* the **first** signature occurs 152 bytes after the series-header base
+  (the position field of the ``key[0]`` entry — entry offset +2 — points at
+  the same header: ``[ESTABLISHED]`` for ``key[0]`` across the observed
+  variants; ``[OBSERVED]`` as a general rule);
+* the **second** signature occurs 152 bytes before the background header;
+* the **last** signature occurs 60 bytes before the series spectral-data
+  start (data = signature position + 60);
+* in HighSpeed variants, the third occurrence's role is not understood and
+  the fourth is the data-position one.
+
+These are **observed** positioning relationships, not guaranteed layout
+invariants. The exact significance of the 60-byte offset and the exact roles
+of the third/fourth signatures remain only partially understood.
+
+.. _srs-seriesprofile:
+
+SeriesProfile structures
+------------------------
+
+``[HYPOTHESIS]`` A recurring trailer structure interpreted as an OMNIC
+**SeriesProfile** block has been identified in the observed variants. The
+block boundaries and value shapes are reproducible; their full meaning is
+not.
+
+.. list-table::
+   :widths: 12 6 6 56 20
+   :header-rows: 1
+
+   * - Offset
+     - Size
+     - Type
+     - Meaning
+     - Certainty
+   * - 0
+     - 4
+     - UInt32
+     - ``ny`` marker equal to the series spectrum count — a reliable
+       block boundary marker.
+     - ``[ESTABLISHED]`` boundary; ``[OBSERVED]`` value
+   * - 4
+     - 4
+     - UInt32
+     - Profile-type code: 6 for "peak area of one peak" (Area), 0 for
+       Chemigram, in the observed variants.
+     - ``[HYPOTHESIS]`` (higher confidence for code 6, medium for
+       code 0)
+   * - 8
+     - 4
+     - UInt32
+     - Gram-Schmidt offset, copied unchanged from the series metadata
+       into every block examined.
+     - ``[OBSERVED]`` value / ``[UNKNOWN]`` semantic
+   * - 12
+     - 4
+     - Float32
+     - Series minimum time, copied into every block examined.
+     - ``[OBSERVED]``
+   * - 16
+     - 4
+     - Float32
+     - Series maximum time, copied into every block examined.
+     - ``[OBSERVED]``
+   * - 20
+     - ~26
+     - ASCII
+     - Human-readable profile label, e.g. ``Area [lo, hi]`` or
+       ``Chemigram: ...``.
+     - ``[ESTABLISHED]`` string; ``[OBSERVED]`` content
+   * - after header
+     - var
+     - padding
+     - Header padding to a fixed block-relative data offset in the
+       observed version.
+     - ``[OBSERVED]``
+   * - data offset
+     - ny × 4
+     - Float32[]
+     - Per-spectrum profile values vector.
+     - ``[ESTABLISHED]`` vector shape; semantics ``[HYPOTHESIS]``
+
+``[OBSERVED]`` In the observed variants the block boundaries, the
+per-spectrum vector shape, and the correspondence between the ASCII label
+and the vector are reproducible, and a series defines one block per profile.
+The exact byte stride and header/data grouping are **version-dependent**: a
+fixed stride observed in one OMNIC-written file was absent in a file re-saved
+by a different OMNIC version (headers packed together, data vectors grouped
+separately). A parser must therefore discover the profile blocks dynamically
+(e.g. via the ``ny`` markers and the ASCII labels) rather than assume a fixed
+count or stride.
 
 .. _srs-time-representation:
 
@@ -545,25 +650,25 @@ Four quantities describe the series time axis; they must not be conflated:
 * **Last / max time** — header +1006 (Float32, minutes).
 * **Regular time step** — header +1010 (Float32, minutes). In the
   independently controlled series this equals ``(last time − first time) /
-  (ny − 1)`` exactly to float32 precision, which confirms it is a step, not a
-  minimum (the historical ``firsty`` misreading).
+  (ny − 1)`` exactly to float32 precision, which confirms it is a step, not
+  a minimum (the historical ``firsty`` misreading).
 * **Number of spectra** — ``ny`` (header +1026).
 
 ``[OBSERVED]`` the time axis follows the regular model
 
 .. code-block:: text
 
-    T[i] = time_min + i * step        (i = 0 .. ny-1)
+   T[i] = time_min + i * step        (i = 0 .. ny-1)
 
 where ``time_min`` reads from +1002 and ``step`` from +1010.
 
 The trailer's centisecond counter provides an independent confirmation:
 ``[OBSERVED]`` the counter stored in the trailer of spectrum *i* holds the
-elapsed time of spectrum *i+1*, quantized to integer centiseconds; dividing by
-6000 (centiseconds per minute) reproduces the time axis and matches the
-3-decimal times embedded in the spectrum names. In the RapidScan test file the
+elapsed time of spectrum *i+1*, quantized to integer centiseconds; dividing
+by 6000 (centiseconds per minute) reproduces the time axis and matches the
+3-decimal times embedded in the spectrum names. In the RapidScan variant the
 per-spectrum increment equals the collection period; in the independently
-controlled series the increment is the regular time step above.
+controlled series the increment equals the regular time step above.
 
 Absolute series anchor (``Collected``) and derived datetimes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -601,9 +706,9 @@ datetimes follow Model A
 
 computed in full precision from the native float32 ``time_min`` (+1002) and
 ``step`` (+1010) fields (microsecond resolution), not from the already
-rounded three-decimal Y coordinate. Their whole-second truncation matches the
-timestamps OMNIC writes when exporting the series spectra as SPA files. The
-reader exposes the anchor through the standard ``acquisition_date``
+rounded three-decimal Y coordinate. Their whole-second truncation matches
+the timestamps OMNIC writes when exporting the series spectra as SPA files.
+The reader exposes the anchor through the standard ``acquisition_date``
 convention and the derived datetimes as an additional Y-label column (see
 :ref:`srs-implementation-references`).  Which acquisition event (integration
 start, midpoint, end, ...) the OMNIC timestamp corresponds to is not
@@ -617,19 +722,13 @@ Spectral sample order
 
 ``[OBSERVED]``
 
-In the SRS files examined, spectral intensity samples are stored in
+In the SRS variants examined, spectral intensity samples are stored in
 **ascending-wavenumber physical order** (sample 0 = lowest wavenumber). This
 ordering was independently confirmed for one controlled series against
-individual spectra exported by OMNIC as SPA files. It should not yet be
-treated as a guaranteed invariant for every SRS producer/version.
-
-The independent comparison established:
-
-* correlation = 1.000000
-* RMSE = 0.000000
-
-for matching raw SRS samples against the OMNIC-exported SPA data in the
-correct physical order (the reversed orientation does not match).
+individual spectra exported by OMNIC as SPA files: the raw SRS samples match
+the OMNIC-exported SPA data exactly in the correct physical order, while the
+reversed orientation does not match. It should not yet be treated as a
+guaranteed invariant for every SRS producer/version.
 
 This page describes the **raw storage order**. Presentational conventions of
 particular software are separate: SpectroChemPy, for instance, presents SRS
@@ -640,9 +739,10 @@ convention) while the raw file order is ascending (see
 Rapid-scan interferograms
 -------------------------
 
-``rapid_scan.srs`` contains rapid-scan interferograms. ``[OBSERVED]`` These
-interferogram records carry an X-axis of type "data points" (x-unit code 2,
-no physical wavenumber unit), stored with ascending data-points coordinates.
+RapidScan variants contain rapid-scan interferogram records. ``[OBSERVED]``
+These interferogram records carry an X-axis of type "data points" (x-unit
+code 2, no physical wavenumber unit), stored with ascending data-points
+coordinates.
 
 Do **not** equate "no xunit code" with "interferogram": a record whose X-unit
 code is unrecognized also lacks a physical xunit, yet is not a data-points
@@ -650,86 +750,11 @@ interferogram. The current reader therefore distinguishes three cases:
 
 * a known spectral axis (x-unit codes 1/3/4/32);
 * an explicit data-points interferogram (x-unit code 2);
-* an unknown X-axis type (unrecognized code), which is neither treated as an
-  interferogram nor spectral-normalized.
+* an unknown X-axis type (unrecognized code), which is neither treated as
+  an interferogram nor spectral-normalized.
 
 This three-way distinction is presented as the current observed evidence for
-the files examined, not as a universal OMNIC invariant.
-
-.. _srs-seriesprofile:
-
-SeriesProfile structures
-------------------------
-
-``[HYPOTHESIS]`` A recurring trailer structure interpreted as an OMNIC
-**SeriesProfile** block has been identified in the tested files. The block
-boundaries and value shapes are reproducible; their full meaning is not.
-
-.. list-table:: SeriesProfile block (block-relative offsets)
-   :header-rows: 1
-
-   * - Offset
-     - Size
-     - Type
-     - Meaning
-     - Certainty
-   * - 0
-     - 4
-     - UInt32
-     - ``ny`` marker equal to the series spectrum count — a reliable block
-       boundary marker.
-     - ``[ESTABLISHED]`` boundary; ``[OBSERVED]`` value
-   * - 4
-     - 4
-     - UInt32
-     - Profile-type code: 6 for "peak area of one peak" (Area), 0 for
-       Chemigram, in the observed files.
-     - ``[HYPOTHESIS]`` (higher confidence for code 6, medium for code 0)
-   * - 8
-     - 4
-     - UInt32
-     - Gram-Schmidt offset, copied unchanged from the series metadata into
-       every block examined.
-     - ``[OBSERVED]`` value / ``[UNKNOWN]`` semantic
-   * - 12
-     - 4
-     - Float32
-     - Series minimum time, copied into every block examined.
-     - ``[OBSERVED]``
-   * - 16
-     - 4
-     - Float32
-     - Series maximum time, copied into every block examined.
-     - ``[OBSERVED]``
-   * - 20
-     - ~26
-     - ASCII
-     - Human-readable profile label, e.g. ``Area [lo, hi]`` or
-       ``Chemigram: ...``. No numeric copy of the integration limits has been
-       identified in the structures examined; in the tested blocks, the limits
-       are present in the label.
-     - ``[ESTABLISHED]`` string; ``[OBSERVED]`` content
-   * - after header
-     - var
-     - padding
-     - Header padding to a fixed block-relative data offset in the tested
-       version.
-     - ``[OBSERVED]``
-   * - data offset
-     - ny × 4
-     - Float32[]
-     - Per-spectrum profile values vector.
-     - ``[ESTABLISHED]`` vector shape; semantics ``[HYPOTHESIS]``
-
-``[OBSERVED]`` In the tested files the block boundaries, the per-spectrum
-vector shape, and the correspondence between the ASCII label and the vector
-are reproducible, and a series defines one block per profile. The exact byte
-stride and header/data grouping are **version-dependent**: a fixed stride
-observed in one OMNIC-written file was absent in a file re-saved by a
-different OMNIC version (headers packed together, data vectors grouped
-separately). A parser must therefore discover the profile blocks dynamically
-(e.g. via the ``ny`` markers and the ASCII labels) rather than assume a fixed
-count or stride.
+the variants examined, not as a universal OMNIC invariant.
 
 Gram-Schmidt / Chemigram / Area structures
 ------------------------------------------
@@ -740,69 +765,33 @@ Gram-Schmidt data
 ~~~~~~~~~~~~~~~~~
 
 ``[OBSERVED]`` In the independently controlled series examined, the
-post-series trailer/profile region begins with a Gram-Schmidt-related region:
-a small header of two uint32 values (``ny`` and the number of Gram-Schmidt
-points) followed by a matrix of ``ny × gs_points`` float32 values (5331 × 100
-in that series). Whether every SRS family places this region first in the
-trailer has not been verified.
+post-series trailer/profile region begins with a Gram-Schmidt-related
+region: a small header of two uint32 values (``ny`` and the number of
+Gram-Schmidt points) followed by a matrix of ``ny × gs_points`` float32
+values. Whether every SRS family places this region first in the trailer
+has not been verified.
 
 ``[OBSERVED]`` The number of Gram-Schmidt interferogram points also appears
-as a series-header field at +1046 (UInt16 = 100 in the tested family), and
-the Gram-Schmidt offset value (header +1044, UInt16 = 10) is copied into every
-SeriesProfile block examined. ``[UNKNOWN]`` The exact meaning of the offset and the
+as a series-header field at +1046 (UInt16), and the Gram-Schmidt offset
+value (header +1044, UInt16) is copied into every SeriesProfile block
+examined. ``[UNKNOWN]`` The exact meaning of the offset and the
 reconstruction role of the matrix are not yet established.
 
 Chemigram / Area observations (experimental)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This subsection records reverse-engineering evidence, not a formal binary
-definition.
-
 ``[OBSERVED]`` Profile vectors whose areas were recomputed from the spectral
 data reproduce the stored vectors: one region matched exactly, the others
-within a ≤ 0.6 % affine residual (linear correlation ~1.00000).
+within a small affine residual (linear correlation ~1.00000).
 
 ``[HYPOTHESIS]`` The stored "Area" profile values follow a
 baseline-subtracted integral of the intensity over the labelled region
-(``Area = ∫(I − baseline) dx`` using the ascending-wavenumber raw order, with
-the baseline joining the region-endpoint intensities). The small residual is
-consistent with a slight difference in the boundary-point selection at the
-integration limits. No numeric copy of the integration limits has been
-identified in the structures examined; in the tested blocks, the limits are
-present in the ASCII label.
-
-.. _srs-detection-signatures:
-
-Detection signatures and positioning observations
--------------------------------------------------
-
-``[OBSERVED]`` In the files examined, each acquisition family is preceded by a
-recognizable 10–16 byte signature. The tested files show:
-
-* **RapidScan** — ``\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00\x48\x43\x00\x50\x43\x47``,
-  occurring 3 times;
-* **HighSpeed** — ``\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00\x48\x43\x00\xc8\xaf\x47``,
-  occurring 4 times;
-* **TG/GC** — ``\x02\x00\x00\x00\x18\x00\x00\x00\x00\x00`` (first 10 bytes),
-  occurring 3 times; the following bytes vary between files.
-
-Positioning relationships (all values verified in the tested corpus):
-
-* the **first** signature occurs 152 bytes after the series-header base
-  (the position field of the ``key[0]`` entry — entry offset +2 — points at
-  the same header: ``[ESTABLISHED]`` for ``key[0]`` across the files
-  examined; ``[OBSERVED]`` as a general rule);
-* the **second** signature occurs 152 bytes before the background header;
-* the **last** signature occurs 60 bytes before the series spectral-data
-  start (data = signature position + 60);
-* in HighSpeed files, the third occurrence's role is not understood and the
-  fourth is the data-position one.
-
-Careful wording is intentional here: these are **observed** positioning
-relationships, not guaranteed layout invariants. The exact significance of the
-60-byte offset and the exact roles of the third/fourth signatures remain only
-partially understood, and the signatures themselves could differ in other
-OMNIC versions.
+(``Area = ∫(I − baseline) dx`` using the ascending-wavenumber raw order,
+with the baseline joining the region-endpoint intensities). The small
+residual is consistent with a slight difference in the boundary-point
+selection at the integration limits. No numeric copy of the integration
+limits has been identified in the structures examined; in the examined
+blocks, the limits are present in the ASCII label.
 
 .. _srs-unknown-fields:
 
@@ -814,6 +803,7 @@ reverse-engineers even though their meaning is not established. They are
 listed as correlated observations only; no unsupported semantic is assigned.
 
 .. list-table::
+   :widths: 18 6 6 50 20
    :header-rows: 1
 
    * - Location
@@ -824,112 +814,103 @@ listed as correlated observations only; no unsupported semantic is assigned.
    * - Series header +24
      - 4
      - Float32
-     - Nonzero, per-file varying (≈ 0.001–0.023) in non-RapidScan files, 0.0
-       in the RapidScan files examined; registration-like.
+     - Nonzero and per-file varying in non-RapidScan variants, 0.0 in
+       the RapidScan variants examined; registration-like.
      - ``[HYPOTHESIS]`` / ``[UNKNOWN]``
    * - Series header +56
      - 4
      - Float32
-     - 1.0 in non-RapidScan, 0.0 in RapidScan files examined.
+     - 0.0 in RapidScan variants, 1.0 in the other variants examined.
      - ``[OBSERVED]`` (correlated only)
    * - Series header +184
      - 4
      - Float32
-     - 2.0 in the RapidScan files, 1.0 in the HighSpeed, GC and TGA files
-       examined; not covered by OMNIC's reported series-info fields.
+     - 2.0 in RapidScan variants, 1.0 in the other variants examined;
+       not covered by OMNIC's reported series-info fields.
      - ``[OBSERVED]`` (correlated only)
    * - Series header +1048
      - 2
      - UInt16
-     - 200 in the tested files.
+     - Constant value in the observed variants.
      - ``[UNKNOWN]``
-   * - Key-table entries other than the first
+   * - Key-table entries other
+       than the first
      - 16 each
      - record
-     - Key values, referenced positions, lengths and trailing data not yet
-       interpreted.
+     - Key values, referenced positions, lengths and trailing data not
+       yet interpreted.
      - ``[UNKNOWN]``
    * - Record prefix +22..75
      - var
      - bytes
      - Mostly per-file constant metadata.
      - ``[OBSERVED]`` values / ``[UNKNOWN]`` semantics
-   * - Trailer, all fields except the centisecond counter
+   * - Trailer, all fields
+       except the centisecond
+       counter
      - 12
      - mixed
-     - ``0x20`` constant and a zero uint64 in the tested files.
+     - ``0x20`` constant and a zero uint64 in the observed variants.
      - ``[OBSERVED]`` values / ``[UNKNOWN]`` semantics
 
-Confound warning: in the current corpus, RapidScan is the only family
-observed with a distinct value pattern for the correlated fields listed above
-(``+24``, ``+56``, ``+184``); the HighSpeed and TG/GC samples
-(``TGA_demo.srs`` shares the TG/GC structure) all share the same pattern.
-These fields therefore "correlate" with the acquisition family in this sample
-without being independently confirmed as family markers. They are more
-plausibly measurement-mode or axis-registration fields, but nothing beyond the
-correlation is established.
+Confound warning: in the observed variants, RapidScan is the only family
+with a distinct value pattern for the correlated fields listed above
+(``+24``, ``+56``, ``+184``); the HighSpeed and TG/GC samples all share the
+same pattern. These fields therefore "correlate" with the acquisition family
+in this sample without being independently confirmed as family markers. They
+are more plausibly measurement-mode or axis-registration fields, but nothing
+beyond the correlation is established.
 
-Open questions
---------------
+Open questions and limitations
+------------------------------
 
-* Is ascending-wavenumber raw storage universal for every SRS producer and
-  OMNIC version? Only one independently controlled series has SPA ground
-  truth so far.
-* What are the trailer fields other than the centisecond counter?
-* What is the complete SeriesProfile type-code enum (only Area = 6 and
-  Chemigram = 0 observed)?
-* What is the meaning of the Gram-Schmidt offset (= 10) and what role does the
-  Gram-Schmidt matrix play?
 * Which boundary-point selection does OMNIC use at the area integration
-  limits?
-* What is the exact significance of the +60 data-position offset and of the
-  third HighSpeed signature occurrence?
-* Do the detection signatures and the −152 / +60 positioning relationships
-  generalize across OMNIC versions?
-* What is the meaning and structure of the key-table entries beyond the first
-  (series) entry, and of the per-entry trailing bytes?
-* What is the structure and role of the trailer's copied "series metadata"
-  region?
+  limits? The computed Area values reproduce the stored values within a
+  small residual, but the exact boundary-point treatment at the
+  integration limits has not been isolated.
 * Which acquisition event (integration start, midpoint, end, ...) does the
   per-spectrum OMNIC timestamp correspond to physically? The arithmetic
-  mapping (Model A) is established, but the physical semantics of the native
-  timestamp are not; a controlled experiment comparing very short and very
-  long acquisitions (e.g. 2 vs 1024 scans) with independently noted start/end
-  times is planned to answer this.
+  mapping (Model A) is established, but the physical semantics of the
+  native timestamp are not.
 
 .. _srs-implementation-references:
 
-SpectroChemPy implementation references
----------------------------------------
+SpectroChemPy implementation
+----------------------------
 
-SpectroChemPy implements the knowledge above in
-``src/spectrochempy/core/readers/read_omnic.py``:
+The reader is implemented in ``src/spectrochempy/core/readers/read_omnic.py``.
+:func:`spectrochempy.read_srs` is the public entry point for ``.srs``
+files; it delegates to the OMNIC importer with the ``.srs`` file-type
+constraint.
 
-* :func:`spectrochempy.read_srs` is the public entry point for ``.srs`` files;
-* the internal functions ``_read_srs``, ``_read_header`` and
-  ``_read_srs_spectra`` apply the record layout, header decoding, and
-  normalization described in this page;
-* the series-level absolute anchor (file offset 296) is read and validated by
-  ``_read_srs_acquisition_date`` through the header-relative copies described
-  in :ref:`srs-time-representation`;
-* when the anchor is valid the dataset exposes it as ``acquisition_date``
-  (the standard SPA convention) and the Y coordinate gains a second label
-  column holding the per-spectrum absolute datetimes derived by
-  ``_srs_datetime_labels`` (Model A above), alongside the unchanged spectrum
-  names. Variants without a valid anchor keep the current single-column
+Format-to-public-behaviour mapping:
+
+* Spectral series are presented with a **descending wavenumber** X axis
+  (high to low), matching the convention used by ``read_spa``. The
+  normalization is applied per-spectrum from each record's own
+  ``firstx``/``lastx`` endpoints.
+* Rapid-scan interferograms retain the raw **ascending data-points**
+  coordinate. These records are flagged internally (``meta.interferogram``)
+  with a ZPD index and laser frequency set from the X coordinate.
+* Records with an unrecognized X-unit code are left in raw storage
+  orientation with an informational message; they are neither treated as
+  interferograms nor spectral-normalized.
+* The Y coordinate is **relative series time in minutes** (``time_min``
+  to ``lasty``, rounded to 3 decimal places; title "Time", units
+  "minute").
+* When a validated native ``Collected`` timestamp exists at file offset
+  296 (see :ref:`srs-time-representation`), the reader exposes it through
+  ``dataset.acquisition_date`` (the standard SPA convention). The Y
+  coordinate then gains a second label column with the per-spectrum
+  absolute datetimes derived as
+  ``Collected + timedelta(minutes=time_min + i * step)`` in full
+  precision from the native series fields.
+* Variants without a valid absolute anchor (GC, reprocessed RapidScan)
+  leave ``acquisition_date`` unset and keep single-column
   names-only Y labels.
-
-The public presentation conventions of the reader are distinct from the raw
-storage order documented here:
-
-* spectral records are presented with a **descending** wavenumber axis
-  (matching ``read_spa``), with data matched to that axis;
-* interferogram records keep the raw ascending data-points coordinate;
-* records with an unknown X-axis type are left in raw storage orientation
-  with a warning;
-* the historical ``reverse_x`` option is deprecated and is a no-op.
-
-The public regression tests in ``tests/test_core/test_readers/test_read_omnic.py``
-and the public test-data files listed in :ref:`Tested files and evidence
-<srs-tested-files>` serve as reference evidence for the interpretations on
-this page. The independently controlled validation series is not distributed.
+* The public ``collection_length`` metadata attribute is derived from
+  header +1006 (series last time × 60), not from the general-header
+  field at +68.
+* The historical ``reverse_x`` keyword is a deprecated no-op:
+  spectral orientation is handled automatically and supplying the
+  keyword emits a ``DeprecationWarning``.

--- a/docs/sources/devguide/file_formats/omnic/srs.rst
+++ b/docs/sources/devguide/file_formats/omnic/srs.rst
@@ -154,6 +154,16 @@ File header / key-table region (file-relative)
      - UInt16
      - Number of key-table entries (24–33 in the files examined).
      - ``[OBSERVED]``
+   * - 296
+     - 4
+     - UInt32
+     - Native series-level acquisition timestamp (``Collected``): seconds
+       since the OMNIC epoch (1899-12-31 00:00:00 UTC), unsigned
+       little-endian. This is the canonical series-absolute anchor used by
+       the reader (see :ref:`srs-time-representation`). Zeroed in
+       reprocessed files; holds unrelated bytes in GC variants.
+     - ``[ESTABLISHED]`` for RapidScan / HighSpeed / TGA samples;
+       ``[OBSERVED]`` absence for GC
    * - 304
      - n × 16
      - KeyTable[]
@@ -555,6 +565,43 @@ elapsed time of spectrum *i+1*, quantized to integer centiseconds; dividing by
 per-spectrum increment equals the collection period; in the independently
 controlled series the increment is the regular time step above.
 
+Absolute series anchor (``Collected``) and derived datetimes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``[ESTABLISHED]`` for the RapidScan, HighSpeed and TGA samples examined, the
+series additionally carries a native absolute acquisition instant at
+**file-relative offset 296**: a UInt32 OMNIC-epoch timestamp (seconds since
+1899-12-31 00:00:00 UTC, unsigned little-endian) following the same
+convention as the SPA/SPG timestamps. It equals the series ``Collected`` time
+reported by OMNIC: the SPA serialization of the independently controlled
+series stores the same instant as the timestamp of its first exported record.
+
+The field has header-relative copies that the reader verifies against before
+trusting it (the offsets differ between families):
+
+* ``pos_info + 836`` for RapidScan / HighSpeed;
+* ``pos_info + 368`` and ``pos_info + 828`` for TG/GC-family TGA files.
+
+``[OBSERVED]`` The copy-check prevents false positives: GC files, whose
+offset 296 holds unrelated bytes (ASCII text / assorted values), and
+reprocessed RapidScan files, whose field is zeroed, yield *no* absolute
+anchor (``None``) rather than a fabricated date.
+
+Combined with the regular time model above, the per-spectrum absolute
+instants follow Model A
+
+.. code-block:: text
+
+    datetime[i] = Collected + timedelta(minutes=time_min + i * step)
+
+computed in full precision from the native float32 ``time_min`` (+1002) and
+``step`` (+1010) fields (microsecond resolution), not from the already
+rounded three-decimal Y coordinate. Their whole-second truncation matches the
+timestamps OMNIC writes when exporting the series spectra as SPA files. The
+reader exposes the anchor through the standard ``acquisition_date``
+convention and the derived instants as an additional Y-label column (see
+:ref:`srs-implementation-references`).
+
 .. _srs-spectral-sample-order:
 
 Spectral sample order
@@ -847,7 +894,16 @@ SpectroChemPy implements the knowledge above in
 * :func:`spectrochempy.read_srs` is the public entry point for ``.srs`` files;
 * the internal functions ``_read_srs``, ``_read_header`` and
   ``_read_srs_spectra`` apply the record layout, header decoding, and
-  normalization described in this page.
+  normalization described in this page;
+* the series-level absolute anchor (file offset 296) is read and validated by
+  ``_read_srs_acquisition_date`` through the header-relative copies described
+  in :ref:`srs-time-representation`;
+* when the anchor is valid the dataset exposes it as ``acquisition_date``
+  (the standard SPA convention) and the Y coordinate gains a second label
+  column holding the per-spectrum absolute datetimes derived by
+  ``_srs_datetime_labels`` (Model A above), alongside the unchanged spectrum
+  names. Variants without a valid anchor keep the current single-column
+  names-only Y labels.
 
 The public presentation conventions of the reader are distinct from the raw
 storage order documented here:

--- a/docs/sources/devguide/file_formats/omnic/srs.rst
+++ b/docs/sources/devguide/file_formats/omnic/srs.rst
@@ -34,8 +34,8 @@ The evidence derives from independent controlled binary and oracle analysis
 across several observed SRS variants, spanning the RapidScan, HighSpeed and
 TG/GC acquisition families: ordinary spectral series, rapid-scan
 interferogram series, reprocessed series, and background-containing variants.
-One independently controlled TG/GC series served as a physical validation
-oracle: its individual spectra were exported by OMNIC as SPA files and
+One independently controlled TG/GC series served as a controlled OMNIC
+export oracle: its individual spectra were exported by OMNIC as SPA files and
 compared against the raw SRS samples (see :ref:`srs-spectral-sample-order`),
 and the same series also exercised the trailer's SeriesProfile, Gram-Schmidt
 and Area structures (see :ref:`srs-seriesprofile`). These descriptions are
@@ -62,7 +62,7 @@ spectral data are stored as a sequence of repeated fixed-stride records.
    └── key records beginning at file offset 304
 
    referenced blocks
-   ├── series metadata region (through the first key record)
+   ├── series metadata region (referenced by the first key record)
    │     └── series-header base: key[0] position, 152 bytes before the first
    │         detection signature
    ├── background header / background data (when a background is present)
@@ -200,10 +200,13 @@ Series metadata
 
 In the observed variants, the series-header base is located 152 bytes before
 the first detection signature (see :ref:`srs-detection-signatures`). Offsets
-in the tables below are relative to that base. The metadata associated with
-the series extend well beyond the first 152 bytes: the exact subdivision into
-OMNIC internal blocks is only partially understood. Only the fields listed
-below have been interpreted so far; the rest of the region is unmapped.
+in the tables below are relative to that base (so the ``+296`` row below is a
+series-header-relative field, unrelated to the file-relative offset 296 —
+the native ``Collected`` timestamp — of the header table above). The metadata
+associated with the series extend well beyond the first 152 bytes: the exact
+subdivision into OMNIC internal blocks is only partially understood. Only the
+fields listed below have been interpreted so far; the rest of the region is
+unmapped.
 
 Signal and acquisition fields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -341,7 +344,8 @@ Series identity and time-model fields
    * - 296
      - 8
      - UInt64
-     - Raw file size.
+     - Raw file size (series-header-relative; not to be confused with the
+       file-relative offset 296 ``Collected`` timestamp above).
      - ``[HYPOTHESIS]``
    * - 938
      - ≤ 256
@@ -499,9 +503,10 @@ Inter-spectrum trailer (16 bytes; trailer-relative offsets)
 ``[ESTABLISHED]`` Observed records (both spectral series and rapid-scan
 interferograms) are followed by a 16-byte trailer.
 
-``[OBSERVED]`` One uint32 field in this trailer behaves as a **cumulative
-time counter in centiseconds** (values increase with spectrum index and track
-the series time axis).
+``[OBSERVED]`` One uint32 field in the trailer of the *non-final* records
+behaves as a **cumulative time counter in centiseconds** (values increase
+with spectrum index and track the series time axis). The final record's
+trailer is instead repurposed for series statistics.
 
 ``[UNKNOWN]`` The remaining trailer fields are not fully interpreted.
 
@@ -523,7 +528,8 @@ the series time axis).
      - 4
      - UInt32
      - Cumulative elapsed-time counter in centiseconds for the **next**
-       spectrum (see :ref:`srs-time-representation`).
+       spectrum (non-final records only; see
+       :ref:`srs-time-representation`).
      - ``[OBSERVED]``
    * - 8
      - 8
@@ -555,12 +561,11 @@ Positioning relationships (all values verified in the observed variants):
 * the **second** signature occurs 152 bytes before the background header;
 * the **last** signature occurs 60 bytes before the series spectral-data
   start (data = signature position + 60);
-* in HighSpeed variants, the third occurrence's role is not understood and
-  the fourth is the data-position one.
+* in HighSpeed variants, the fourth signature occurrence is the
+  data-position one.
 
 These are **observed** positioning relationships, not guaranteed layout
-invariants. The exact significance of the 60-byte offset and the exact roles
-of the third/fourth signatures remain only partially understood.
+invariants.
 
 .. _srs-seriesprofile:
 
@@ -663,12 +668,14 @@ Four quantities describe the series time axis; they must not be conflated:
 where ``time_min`` reads from +1002 and ``step`` from +1010.
 
 The trailer's centisecond counter provides an independent confirmation:
-``[OBSERVED]`` the counter stored in the trailer of spectrum *i* holds the
-elapsed time of spectrum *i+1*, quantized to integer centiseconds; dividing
-by 6000 (centiseconds per minute) reproduces the time axis and matches the
-3-decimal times embedded in the spectrum names. In the RapidScan variant the
-per-spectrum increment equals the collection period; in the independently
-controlled series the increment equals the regular time step above.
+``[OBSERVED]`` for non-final records, the counter stored in the trailer of
+spectrum *i* holds the elapsed time of spectrum *i+1*, quantized to integer
+centiseconds; dividing by 6000 (centiseconds per minute) reproduces the time
+axis and matches the 3-decimal times embedded in the spectrum names. The
+final record's trailer is instead repurposed for series statistics. In the
+RapidScan variant the per-spectrum increment equals the collection period; in
+the independently controlled series the increment equals the regular time
+step above.
 
 Absolute series anchor (``Collected``) and derived datetimes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -685,10 +692,12 @@ exported spectrum's timestamp is ``Collected + time_min`` (≈ ``time_min`` ≈
 ``Collected`` itself.
 
 The field has header-relative copies that the reader verifies against before
-trusting it (the offsets differ between families):
+trusting it (the offsets differ between families, and are relative to the
+series-header base):
 
-* ``pos_info + 836`` for RapidScan / HighSpeed;
-* ``pos_info + 368`` and ``pos_info + 828`` for TG/GC-family TGA files.
+* series-header base + 836 for RapidScan / HighSpeed;
+* series-header base + 368 and series-header base + 828 for TG/GC-family
+  TGA files.
 
 ``[OBSERVED]`` The copy-check prevents false positives: GC files, whose
 offset 296 holds unrelated bytes (ASCII text / assorted values), and
@@ -705,9 +714,12 @@ datetimes follow Model A
     datetime[i] = Collected + timedelta(minutes=time_min + i * step)
 
 computed in full precision from the native float32 ``time_min`` (+1002) and
-``step`` (+1010) fields (microsecond resolution), not from the already
-rounded three-decimal Y coordinate. Their whole-second truncation matches
-the timestamps OMNIC writes when exporting the series spectra as SPA files.
+``step`` (+1010) fields, preserving the full precision represented by the
+native float32 timing fields rather than the already-rounded three-decimal
+public Y coordinate. The derived datetimes agree with the OMNIC-exported
+SPA timestamps at their serialization precision (whole seconds), while
+SpectroChemPy retains the full precision derived from the native series
+fields.
 The reader exposes the anchor through the standard ``acquisition_date``
 convention and the derived datetimes as an additional Y-label column (see
 :ref:`srs-implementation-references`).  Which acquisition event (integration
@@ -781,8 +793,8 @@ Chemigram / Area observations (experimental)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``[OBSERVED]`` Profile vectors whose areas were recomputed from the spectral
-data reproduce the stored vectors: one region matched exactly, the others
-within a small affine residual (linear correlation ~1.00000).
+data closely reproduce the stored vectors, with small residuals where
+applicable.
 
 ``[HYPOTHESIS]`` The stored "Area" profile values follow a
 baseline-subtracted integral of the intensity over the labelled region
@@ -857,9 +869,8 @@ Confound warning: in the observed variants, RapidScan is the only family
 with a distinct value pattern for the correlated fields listed above
 (``+24``, ``+56``, ``+184``); the HighSpeed and TG/GC samples all share the
 same pattern. These fields therefore "correlate" with the acquisition family
-in this sample without being independently confirmed as family markers. They
-are more plausibly measurement-mode or axis-registration fields, but nothing
-beyond the correlation is established.
+in this sample without being independently confirmed as family markers;
+nothing beyond the correlation is established.
 
 Open questions and limitations
 ------------------------------
@@ -890,8 +901,10 @@ Format-to-public-behaviour mapping:
   normalization is applied per-spectrum from each record's own
   ``firstx``/``lastx`` endpoints.
 * Rapid-scan interferograms retain the raw **ascending data-points**
-  coordinate. These records are flagged internally (``meta.interferogram``)
-  with a ZPD index and laser frequency set from the X coordinate.
+  coordinate. These records are flagged internally (``meta.interferogram``);
+  their ZPD index is the data-derived peak index, and the laser frequency is
+  set to the reader's standard default rather than derived from these
+  records' coordinate or data.
 * Records with an unrecognized X-unit code are left in raw storage
   orientation with an informational message; they are neither treated as
   interferograms nor spectral-normalized.

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,7 +19,7 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
-- :func:`read_srs` now exposes the OMNIC ``Collected`` acquisition instant of
+- :func:`read_srs` now exposes the OMNIC ``Collected`` series timestamp of
   SRS series through the standard ``acquisition_date`` dataset property (same
   convention as :func:`read_spa`), and the Y coordinate of dated series gains
   a per-spectrum absolute `datetime` label column derived in full precision

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -27,7 +27,7 @@ New Features
   i * step)``.  The numeric relative time axis and the spectrum-name labels
   are unchanged.  Series without a valid native anchor (GC variants,
   reprocessed RapidScan files) leave ``acquisition_date`` unset and keep the
-  names-only Y labels.
+  names-only Y labels. (#1617)
 
 
 .. section

--- a/docs/sources/whatsnew/changelog.rst
+++ b/docs/sources/whatsnew/changelog.rst
@@ -19,6 +19,16 @@ New Features
 ~~~~~~~~~~~~
 .. Add here new public features (do not delete this comment)
 
+- :func:`read_srs` now exposes the OMNIC ``Collected`` acquisition instant of
+  SRS series through the standard ``acquisition_date`` dataset property (same
+  convention as :func:`read_spa`), and the Y coordinate of dated series gains
+  a per-spectrum absolute `datetime` label column derived in full precision
+  from the native series fields as ``Collected + timedelta(minutes=time_min +
+  i * step)``.  The numeric relative time axis and the spectrum-name labels
+  are unchanged.  Series without a valid native anchor (GC variants,
+  reprocessed RapidScan files) leave ``acquisition_date`` unset and keep the
+  names-only Y labels.
+
 
 .. section
 

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -23,7 +23,7 @@ New Features
   i * step)``.  The numeric relative time axis and the spectrum-name labels
   are unchanged.  Series without a valid native anchor (GC variants,
   reprocessed RapidScan files) leave ``acquisition_date`` unset and keep the
-  names-only Y labels.
+  names-only Y labels. (#1617)
 
 Bug Fixes
 ~~~~~~~~~

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -15,7 +15,7 @@ See :ref:`release` for a full changelog, including other versions of SpectroChem
 New Features
 ~~~~~~~~~~~~
 
-- :func:`read_srs` now exposes the OMNIC ``Collected`` acquisition instant of
+- :func:`read_srs` now exposes the OMNIC ``Collected`` series timestamp of
   SRS series through the standard ``acquisition_date`` dataset property (same
   convention as :func:`read_spa`), and the Y coordinate of dated series gains
   a per-spectrum absolute `datetime` label column derived in full precision

--- a/docs/sources/whatsnew/latest.rst
+++ b/docs/sources/whatsnew/latest.rst
@@ -12,6 +12,19 @@ What's New in Revision 0.12.9.dev
 These are the changes in SpectroChemPy-0.12.9.dev.
 See :ref:`release` for a full changelog, including other versions of SpectroChemPy.
 
+New Features
+~~~~~~~~~~~~
+
+- :func:`read_srs` now exposes the OMNIC ``Collected`` acquisition instant of
+  SRS series through the standard ``acquisition_date`` dataset property (same
+  convention as :func:`read_spa`), and the Y coordinate of dated series gains
+  a per-spectrum absolute `datetime` label column derived in full precision
+  from the native series fields as ``Collected + timedelta(minutes=time_min +
+  i * step)``.  The numeric relative time axis and the spectrum-name labels
+  are unchanged.  Series without a valid native anchor (GC variants,
+  reprocessed RapidScan files) leave ``acquisition_date`` unset and keep the
+  names-only Y labels.
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -551,8 +551,8 @@ def read_srs(*paths, **kwargs):
        data-points coordinate and are not treated as spectral data.
 
     .. note::
-       Series that carry a native absolute acquisition timestamp (the OMNIC
-       ``Collected`` instant stored at file offset 296; RapidScan, HighSpeed
+       Series that carry a native absolute series timestamp (the OMNIC
+       ``Collected`` timestamp stored at file offset 296; RapidScan, HighSpeed
        and TGA samples) expose it through the standard ``acquisition_date``
        convention, and their Y coordinate gains an extra label column with
        the per-spectrum absolute `datetime` objects derived as
@@ -1496,7 +1496,7 @@ def _read_srs(*args, **kwargs):
                 # but the data are those of an ifg... For now need more examples
                 return None
 
-    # Read the native series-level acquisition instant ('Collected').
+    # Read the native series-level 'Collected' timestamp.
     # This is used for the non-bg path only but is computed here because
     # pos_info_data and is_tg are set by all variant branches above.
     if not return_bg:
@@ -1660,24 +1660,22 @@ def _decode_omnic_timestamp(raw):
 
 def _read_srs_acquisition_date(fid, pos_info, tg_family):
     """
-    Return the native SRS series ``Collected`` instant, or ``None``.
+    Return the native SRS series-level ``Collected`` timestamp, or ``None``.
 
     The native UInt32 OMNIC timestamp at **file offset 296** is the
-    canonical series-level acquisition anchor for every SRS variant that
-    carries the field (RapidScan / HighSpeed families and TGA).  The
-    field has header-relative copies at:
+    series-level ``Collected`` anchor for the controlled variants examined
+    (RapidScan / HighSpeed families and TG/GC-family TGA).  Only the
+    evidence-backed header-relative copy locations are accepted:
 
     * ``pos_info + 836`` for RapidScan / HighSpeed;
     * ``pos_info + 368`` and ``pos_info + 828`` for TG/GC-family TGA.
 
-    Variants without the field (GC) hold unrelated bytes at offset 296;
-    reprocessed files carry a zeroed field.  Both must yield ``None``
-    rather than a fabricated date.
-
-    The copy-check prevents false positives in GC (ASCII text at offset
-    296) while remaining tolerant of unseen variants whose single-file
-    header-relative copy offsets differ slightly from the controlled
-    corpus.
+    An unsupported or unrecognized layout (different header-relative copy
+    offsets, or none) yields ``None``; this conservative behavior is
+    intentional -- only the known copy locations are checked so that no
+    date is fabricated for an unseen variant.  Variants without the field
+    (GC) hold unrelated bytes at offset 296, and reprocessed files carry a
+    zeroed field; both yield ``None`` rather than a fabricated date.
 
     Parameters
     ----------
@@ -1718,9 +1716,12 @@ def _srs_datetime_labels(acquisition_date, info):
     from the already-rounded three-decimal Y coordinate.  The resulting
     ``datetime`` objects carry microsecond resolution (inherited from
     Python's ``timedelta`` float arithmetic); no second-truncation is
-    applied so the labels faithfully represent the physically-derived
-    acquisition instants rather than mimicking the whole-second
-    serialization format of OMNIC-exported SPA timestamps.
+    applied, so the labels faithfully represent the derived per-spectrum
+    absolute datetimes rather than mimicking the whole-second
+    serialization format of OMNIC-exported SPA timestamps.  No claim is
+    made about which acquisition event (start, midpoint, end, ...) the
+    OMNIC timestamp corresponds to; only the arithmetic relationship is
+    established.
     """
     ny = int(info["ny"])
     time_min = float(info["time_min"])

--- a/src/spectrochempy/core/readers/read_omnic.py
+++ b/src/spectrochempy/core/readers/read_omnic.py
@@ -550,6 +550,17 @@ def read_srs(*paths, **kwargs):
        endpoints. Rapid-scan interferograms keep their ascending
        data-points coordinate and are not treated as spectral data.
 
+    .. note::
+       Series that carry a native absolute acquisition timestamp (the OMNIC
+       ``Collected`` instant stored at file offset 296; RapidScan, HighSpeed
+       and TGA samples) expose it through the standard ``acquisition_date``
+       convention, and their Y coordinate gains an extra label column with
+       the per-spectrum absolute `datetime` objects derived as
+       ``Collected + timedelta(minutes=time_min + i * step)`` in full
+       precision from the native series fields. Variants without a valid
+       anchor (GC, reprocessed RapidScan) leave ``acquisition_date`` unset
+       and keep the single-column names-only Y labels.
+
     reverse_x : bool, optional
         .. deprecated::
             No longer needed. Spectral orientation is handled automatically as
@@ -775,10 +786,7 @@ def _read_spg(*args, **kwargs):
         # and the acquisition date
         fid.seek(spa_title_pos + 256)
         timestamp = fromfile(fid, dtype="uint32", count=1)
-        # since 31/12/1899, 00:00
-        acqdate = datetime(1899, 12, 31, 0, 0, tzinfo=UTC) + timedelta(
-            seconds=int(timestamp),
-        )
+        acqdate = _decode_omnic_timestamp(int(timestamp))
         acquisitiondates.append(acqdate)
         timestamps.append(acqdate.timestamp())
 
@@ -968,9 +976,7 @@ def _parse_spa_native(fid, return_ifg):
         acquisition_date = None
         timestamp = 0.0
     else:
-        acquisition_date = datetime(1899, 12, 31, 0, 0, tzinfo=UTC) + timedelta(
-            seconds=raw_timestamp
-        )
+        acquisition_date = _decode_omnic_timestamp(raw_timestamp)
         timestamp = acquisition_date.timestamp()
 
     comments = []
@@ -1490,6 +1496,14 @@ def _read_srs(*args, **kwargs):
                 # but the data are those of an ifg... For now need more examples
                 return None
 
+    # Read the native series-level acquisition instant ('Collected').
+    # This is used for the non-bg path only but is computed here because
+    # pos_info_data and is_tg are set by all variant branches above.
+    if not return_bg:
+        acquisition_date = _read_srs_acquisition_date(fid, pos_info_data, is_tg)
+    else:
+        acquisition_date = None
+
     # Create NDDataset object for the series / background.
     #
     # The raw SRS spectral intensity array is stored ascending-wavenumber, but
@@ -1556,11 +1570,15 @@ def _read_srs(*args, **kwargs):
     # specific infos for series data
     if not return_bg:
         dataset.name = info["name"]
+        if acquisition_date is not None:
+            labels = [_srs_datetime_labels(acquisition_date, info), names]
+        else:
+            labels = names
         _y = Coord(
             np.around(np.linspace(info["time_min"], info["lasty"], info["ny"]), 3),
             title="Time",
             units="minute",
-            labels=names,
+            labels=labels,
         )
 
     else:
@@ -1582,6 +1600,9 @@ def _read_srs(*args, **kwargs):
     dataset.meta.laser_frequency = info["reference_frequency"] * ur("cm^-1")
     dataset.meta.collection_length = info["collection_length"] * ur("s")
     dataset.meta.optical_velocity = info["optical_velocity"]
+
+    if not return_bg and acquisition_date is not None:
+        dataset.acquisition_date = acquisition_date
 
     if dataset.x.units is None and dataset.x.title == "data points":
         # interferogram
@@ -1625,6 +1646,88 @@ def _readbtext(fid, pos, size):
         except UnicodeDecodeError:  # pragma: no cover
             text = btext.decode(encoding="utf-8", errors="ignore")
     return text
+
+
+def _decode_omnic_timestamp(raw):
+    """
+    Decode a native OMNIC UInt32 timestamp (seconds since 1899-12-31 UTC).
+
+    The OMNIC/SPA epoch is 1899-12-31 00:00:00 UTC.  The raw value is
+    interpreted as unsigned little-endian UInt32.
+    """
+    return datetime(1899, 12, 31, 0, 0, tzinfo=UTC) + timedelta(seconds=raw)
+
+
+def _read_srs_acquisition_date(fid, pos_info, tg_family):
+    """
+    Return the native SRS series ``Collected`` instant, or ``None``.
+
+    The native UInt32 OMNIC timestamp at **file offset 296** is the
+    canonical series-level acquisition anchor for every SRS variant that
+    carries the field (RapidScan / HighSpeed families and TGA).  The
+    field has header-relative copies at:
+
+    * ``pos_info + 836`` for RapidScan / HighSpeed;
+    * ``pos_info + 368`` and ``pos_info + 828`` for TG/GC-family TGA.
+
+    Variants without the field (GC) hold unrelated bytes at offset 296;
+    reprocessed files carry a zeroed field.  Both must yield ``None``
+    rather than a fabricated date.
+
+    The copy-check prevents false positives in GC (ASCII text at offset
+    296) while remaining tolerant of unseen variants whose single-file
+    header-relative copy offsets differ slightly from the controlled
+    corpus.
+
+    Parameters
+    ----------
+    fid : file-like
+        Open SRS binary stream positioned anywhere.
+    pos_info : int
+        Series header base position (``pos_info_data`` from the reader).
+    tg_family : bool
+        ``True`` for TG/GC-family files, ``False`` for RapidScan /
+        HighSpeed families.
+
+    Returns
+    -------
+    datetime or None
+    """
+    fid.seek(296)
+    raw = int(fromfile(fid, dtype="uint32", count=1))
+    if raw == 0:
+        return None
+    copy_offsets = (pos_info + 368, pos_info + 828) if tg_family else (pos_info + 836,)
+    for offset in copy_offsets:
+        fid.seek(offset)
+        if int(fromfile(fid, dtype="uint32", count=1)) == raw:
+            return _decode_omnic_timestamp(raw)
+    return None
+
+
+def _srs_datetime_labels(acquisition_date, info):
+    """
+    Derive per-spectrum absolute datetimes from native series fields.
+
+    Model A::
+
+        datetime[i] = acquisition_date + timedelta(minutes=time_min + i*step)
+
+    computed in full precision from the native float32 header fields
+    ``time_min`` (+1002) and ``firsty`` (+1010, the regular step), **not**
+    from the already-rounded three-decimal Y coordinate.  The resulting
+    ``datetime`` objects carry microsecond resolution (inherited from
+    Python's ``timedelta`` float arithmetic); no second-truncation is
+    applied so the labels faithfully represent the physically-derived
+    acquisition instants rather than mimicking the whole-second
+    serialization format of OMNIC-exported SPA timestamps.
+    """
+    ny = int(info["ny"])
+    time_min = float(info["time_min"])
+    step = float(info["firsty"])
+    return [
+        acquisition_date + timedelta(minutes=time_min + i * step) for i in range(ny)
+    ]
 
 
 def _nextline(pos):

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -7,6 +7,8 @@
 
 import io
 import struct
+from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -15,6 +17,7 @@ import pytest
 import spectrochempy as scp
 from spectrochempy.application.preferences import preferences as prefs
 from spectrochempy.core.dataset.nddataset import NDDataset
+from spectrochempy.utils.datetimeutils import UTC
 from spectrochempy.utils.testing import assert_dataset_equal
 
 DATADIR = prefs.datadir
@@ -872,3 +875,135 @@ def test_read_srs_unknown_xunits_not_interferogram(monkeypatch):
     np.testing.assert_allclose(
         np.asarray(unknown.data)[:, ::-1], np.asarray(spectral.data)
     )
+
+
+# ---------------------------------------------------------------------------
+# SRS native series-level acquisition date and derived per-spectrum datetimes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("rapid_scan.srs", datetime(2020, 11, 24, 10, 21, 29, tzinfo=UTC)),
+        ("high_speed.srs", datetime(2023, 10, 22, 7, 2, 13, tzinfo=UTC)),
+        ("TGA_demo.srs", datetime(2006, 2, 24, 18, 34, 57, tzinfo=UTC)),
+    ],
+)
+def test_read_srs_native_acquisition_date(name, expected):
+    """SRS series with a valid native timestamp expose the OMNIC `Collected`
+    instant through the same `acquisition_date` convention as SPA: the stored
+    value is a timezone-aware Python datetime in UTC that matches the native
+    UInt32 decoding (OMNIC epoch 1899-12-31 UTC)."""
+    nd = scp.read_srs(IRDATA / "omnic_series" / name)
+
+    # Stored value: timezone-aware Python datetime in UTC.
+    assert isinstance(nd._acquisition_date, datetime)
+    assert nd._acquisition_date.tzinfo is not None
+    assert nd._acquisition_date.utcoffset() == timedelta(0)
+    assert nd._acquisition_date == expected
+
+    # Public property: same instant, ISO-string rendering in the dataset
+    # timezone (the SPA convention, which renders in `_timezone`).
+    assert nd.acquisition_date is not None
+    rendered = datetime.fromisoformat(nd.acquisition_date.replace(" ", "T"))
+    assert rendered == expected.astimezone(rendered.tzinfo)
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+@pytest.mark.parametrize("name", ["rapid_scan_reprocessed.srs", "GC_Demo.srs"])
+def test_read_srs_absent_or_zero_timestamp_leaves_date_unset(name):
+    """A zeroed native field (reprocessed RapidScan) or a variant without the
+    field (GC: offset 296 holds unrelated bytes) must leave
+    `dataset.acquisition_date` unset -- never the OMNIC epoch."""
+    nd = scp.read_srs(IRDATA / "omnic_series" / name)
+
+    assert nd._acquisition_date is None
+    assert nd.acquisition_date is None
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_y_coordinate_invariant_with_datetime_labels():
+    """Adding absolute datetime labels must not alter the numeric relative Y
+    coordinate: same values, same minutes units, same endpoint anchors.
+
+    The reader stores ``np.around(linspace(...), 3)`` and ``Coord.data``
+    returns the display-linearized variant (sigdigits=4), which may differ
+    by up to ~0.001 on interior points; endpoints are exact.
+    """
+    path = IRDATA / "omnic_series" / "TGA_demo.srs"
+    info = _srs_header(path)
+    nd = scp.read_srs(path)
+
+    y = nd.y.data
+    assert nd.y.units == "minute"
+    assert len(y) == info["ny"]
+    expected = np.around(np.linspace(info["time_min"], info["lasty"], info["ny"]), 3)
+    np.testing.assert_allclose(y, expected, atol=1.5e-3)
+    assert y[0] == pytest.approx(np.around(info["time_min"], 3), abs=0.5e-3)
+    assert y[-1] == pytest.approx(np.around(info["lasty"], 3), abs=0.5e-3)
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_datetime_labels_follow_full_precision_native_formula():
+    """Per-spectrum datetime labels are derived with
+
+        datetime[i] = acquisition_date + timedelta(minutes=time_min + i*step)
+
+    in full precision from the native +1002/+1010 series fields (not from the
+    rounded 3-decimal Y coordinate), and their whole-second truncation matches
+    OMNIC's exported SPA serialization.
+
+    `TGA_demo.srs` is the public fixture of the controlled TGA series whose
+    full 485-spectrum OMNIC SPA export established Model A (export oracle):
+    the exported native SPA stamps for records 0/415/484 are 2006-02-24
+    18:35:01 / 19:09:23 / 19:15:05 UTC.
+    """
+    path = IRDATA / "omnic_series" / "TGA_demo.srs"
+    info = _srs_header(path)
+    nd = scp.read_srs(path)
+
+    collected = datetime(2006, 2, 24, 18, 34, 57, tzinfo=UTC)
+    time_min = float(info["time_min"])
+    step = float(info["firsty"])
+
+    labels = nd.y.labels
+    assert labels.shape == (info["ny"], 2)
+    # Column 0: absolute datetime objects; column 1: unchanged spectrum names.
+    assert all(isinstance(labels[i, 0], datetime) for i in (0, info["ny"] // 2, -1))
+    assert all(isinstance(labels[i, 1], str) for i in (0, info["ny"] // 2, -1))
+    assert labels[0, 1].startswith("Linked spectrum at")
+
+    # Full-precision native formula, first/interior/last records.
+    for i in (0, info["ny"] // 2, info["ny"] - 1):
+        expected_dt = collected + timedelta(minutes=time_min + i * step)
+        assert labels[i, 0] == expected_dt
+        # Sub-second precision is preserved (no artificial whole-second
+        # truncation mimicking the export serialization).
+        assert labels[i, 0].microsecond == expected_dt.microsecond
+
+    # Evidence-pinned whole-second exported SPA instants (records 0/415/484).
+    exported = {
+        0: datetime(2006, 2, 24, 18, 35, 1, tzinfo=UTC),
+        415: datetime(2006, 2, 24, 19, 9, 23, tzinfo=UTC),
+        484: datetime(2006, 2, 24, 19, 15, 5, tzinfo=UTC),
+    }
+    for i, stamp in exported.items():
+        label = labels[i, 0]
+        assert label.replace(microsecond=0) == stamp
+
+
+@pytest.mark.usefixtures("_skip_if_no_testdata")
+def test_read_srs_undated_labels_keep_single_column_names():
+    """Variants without a native absolute anchor keep the current single-column
+    Y labels exactly as before (spectrum names only, no datetime column)."""
+    path = IRDATA / "omnic_series" / "GC_Demo.srs"
+    info = _srs_header(path)
+    nd = scp.read_srs(path)
+
+    labels = nd.y.labels
+    assert labels.shape == (info["ny"],)
+    assert labels[0] == "Linked spectrum at 0.025 min."
+    assert labels[1] == "Linked spectrum at 0.051 min."
+    assert all(isinstance(label, str) for label in labels)

--- a/tests/test_core/test_readers/test_read_omnic.py
+++ b/tests/test_core/test_readers/test_read_omnic.py
@@ -893,7 +893,7 @@ def test_read_srs_unknown_xunits_not_interferogram(monkeypatch):
 )
 def test_read_srs_native_acquisition_date(name, expected):
     """SRS series with a valid native timestamp expose the OMNIC `Collected`
-    instant through the same `acquisition_date` convention as SPA: the stored
+    timestamp through the same `acquisition_date` convention as SPA: the stored
     value is a timezone-aware Python datetime in UTC that matches the native
     UInt32 decoding (OMNIC epoch 1899-12-31 UTC)."""
     nd = scp.read_srs(IRDATA / "omnic_series" / name)
@@ -983,7 +983,7 @@ def test_read_srs_datetime_labels_follow_full_precision_native_formula():
         # truncation mimicking the export serialization).
         assert labels[i, 0].microsecond == expected_dt.microsecond
 
-    # Evidence-pinned whole-second exported SPA instants (records 0/415/484).
+    # Evidence-pinned whole-second exported SPA timestamps (records 0/415/484).
     exported = {
         0: datetime(2006, 2, 24, 18, 35, 1, tzinfo=UTC),
         415: datetime(2006, 2, 24, 19, 9, 23, tzinfo=UTC),

--- a/tests/test_core/test_readers/test_reader_semantic_characterization.py
+++ b/tests/test_core/test_readers/test_reader_semantic_characterization.py
@@ -370,21 +370,28 @@ class TestOmnicCharacterization:
         if dataset.meta.omnic_experiment_title is not None:
             assert isinstance(dataset.meta.omnic_experiment_title, str)
 
-    def test_srs_currently_sets_origin_and_history(self, omnic_srs_dataset):
+    def test_srs_sets_origin_history_and_acquisition_date(self, omnic_srs_dataset):
         dataset = omnic_srs_dataset
 
+        # `rapid_scan.srs` carries a native series-level timestamp, so the
+        # dataset exposes it through the standard `acquisition_date` convention
+        # and the Y coordinate carries absolute datetime labels in addition to
+        # the OMNIC spectrum names.
         assert_dataset_provenance(
             dataset,
             origin="omnic",
-            acquisition_date_present=False,
+            acquisition_date_present=True,
         )
         if dataset.history:
             history_text = " ".join(str(entry) for entry in dataset.history).lower()
             assert "srs file" in history_text
         assert_coordinate_semantics(dataset, "x")
-        assert_coordinate_semantics(dataset, "y")
-        if dataset.y.labels is not None:
-            assert_label_structure(dataset.y)
+        y = assert_coordinate_semantics(dataset, "y", units="min")
+        # The relative Y data is untouched (minutes); only the labels gain the
+        # datetime column.
+        labels = assert_label_structure(y, shape=(dataset.y.size, 2))
+        assert isinstance(labels[0, 0], datetime)
+        assert isinstance(labels[0, 1], str)
         assert "laser_frequency" in dataset.meta
         assert "collection_length" in dataset.meta
         assert "optical_velocity" in dataset.meta


### PR DESCRIPTION
## Summary

`read_srs` now exposes the OMNIC series-level `Collected` timestamp for SRS files that carry a native timestamp:

- **`dataset.acquisition_date`** — the native UInt32 OMNIC ``Collected`` timestamp at file offset 296 (seconds since 1899-12-31 UTC), validated through its header-relative copies (series-header base +836 for RapidScan/HighSpeed, series-header base +368/+828 for TG/GC-family TGA) before being trusted.
- **Y coordinate datetime labels** — dated series gain a second label column with per-spectrum absolute datetimes derived in full precision as `Collected + timedelta(minutes=time_min + i * step)` from the native series fields (+1002/+1010). The numeric relative time axis and the spectrum-name labels are unchanged.
- **Danger-proof negative cases** — GC variants (offset 296 holds unrelated bytes) and reprocessed RapidScan files (zeroed field) yield `None`, never the OMNIC epoch.

The existing SPA/SPG timestamp decoding is factored into a shared `_decode_omnic_timestamp` helper with identical behavior.

## Evidence

Controlled corpus: the independent TGA series (export oracle) established Model A — `datetime[i] = Collected + timedelta(minutes=time_min + i * step)`. The derived timestamps agree with the OMNIC-exported SPA stamps at whole-second serialization precision; a universal simple-truncation rule is not established across this small second-boundary test suite. The public `TGA_demo.srs` is the fixture of the controlled series and pins records 0/415/484 → 18:35:01 / 19:09:23 / 19:15:05 UTC (n.b.: the underlying `Collected` anchor is 2006-02-24 18:34:57 UTC).

## Validation

- Full OMNIC reader suite (47 cases, incl. 26 SRS-specific) + semantic characterization (34 cases): 80 passed, 1 skipped at PR head.
- `pre-commit run --all-files`: passed (incl. regenerated `latest.rst`); full CI matrix green on the final head.

## Changelog

New Features entry added in `docs/sources/whatsnew/changelog.rst` (regenerated `latest.rst` included).
